### PR TITLE
feat: add a iOS entrypoint for native storybooks

### DIFF
--- a/.storybook.native/index.ios.js
+++ b/.storybook.native/index.ios.js
@@ -1,0 +1,16 @@
+import { AppRegistry, NativeModules } from 'react-native';
+import { getStorybookUI, configure } from '@storybook/react-native';
+import { loadStories } from './story-loader';
+import './addons';
+import url from 'url';
+
+configure(loadStories, module);
+
+const { hostname } = url.parse(NativeModules.SourceCode.scriptURL);
+
+const StorybookUI = getStorybookUI({
+  port: 7007,
+  host: hostname,
+});
+
+AppRegistry.registerComponent('storybooknative', () => StorybookUI);


### PR DESCRIPTION
Created a simple entrypoint to enable running React Native storybooks in
the iOS simulator/device