### PR TITLE
chore: Introduces hoisting for dependencies of lerna packages (components)

### DIFF
--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = variables => ({
-  name: "@times-components/" + variables.packageName,
+  name: "@timescomponents/" + variables.packageName,
   version: variables.version || "0.0.1",
   description: variables.packageDescription,
   main: variables.packageName + ".js",

--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -1,21 +1,21 @@
 "use strict";
 
 module.exports = variables => ({
-  name: "@timescomponents/" + variables.packageName,
+  name: "@times-components/" + variables.packageName,
   version: variables.version || "0.0.1",
   description: variables.packageDescription,
   main: variables.packageName + ".js",
   scripts: {
-    flow: "node_modules/flow-bin/cli.js",
+    "flow": "node_modules/flow-bin/cli.js",
     "test:dev": "jest --bail --verbose --watch",
-    test: "jest --bail --ci --coverage"
+    "test": "jest --bail --ci --coverage"
   },
   jest: {
-    preset: "react-native"
+    "preset": "react-native"
   },
   repository: {
-    type: "git",
-    url: "git+https://github.com/newsuk/times-components.git"
+    "type": "git",
+    "url: "git+https://github.com/newsuk/times-components.git"
   },
   keywords: [
     "react-native-web",
@@ -38,14 +38,14 @@ module.exports = variables => ({
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
     "flow-bin": "0.42.0",
-    jest: "20.0.4",
+    "jest": "20.0.4",
     "react-native": "0.44.2",
     "react-test-renderer": "15.5.4",
-    webpack: "2.6.1"
+    "webpack": "2.6.1"
   },
   dependencies: {
-    react: "16.0.0-alpha.6",
+    "react": "16.0.0-alpha.6",
     "react-dom": "15.5.4",
-    "react-native-web": "0.0.96"
+    "react-native-web": "0.0.97"
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "times-components",
+  "name": "timescomponents",
   "version": "0.0.1",
   "description": "A collection of presentational components for locate a location",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "16.0.0-alpha.6",
     "react-dom": "15.5.4",
     "react-native": "0.44.2",
+    "react-native-web": "0.0.97",
     "react-native-storybook-loader": "1.3.1",
     "rimraf": "^2.6.1",
     "url": "0.11.0"
@@ -66,7 +67,6 @@
     "lodash": "4.17.4",
     "mkdirp": "^0.5.1",
     "pre-commit": "1.2.2",
-    "react-native-web": "0.0.97",
     "sort-pkg": "1.1.0",
     "subcommander": "1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "storybook:publish": "./lib/publish_storybook.sh",
     "prettier:diff": "prettier --list-different 'packages/*/*.js'",
     "packages:publish": "lerna publish --conventional-commits",
-    "update-deps": "lerna bootstrap --npm-client=yarn --concurrency=1",
+    "update-deps": "lerna bootstrap --hoisting --npm-client=yarn --concurrency=1",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "postinstall": "npm run update-deps --silent"
   },
@@ -54,7 +54,7 @@
     "prettier": "1.4.2",
     "react": "16.0.0-alpha.6",
     "react-dom": "15.5.4",
-    "react-native": "0.44.1",
+    "react-native": "0.44.2",
     "react-native-storybook-loader": "1.3.1",
     "rimraf": "^2.6.1",
     "url": "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,15 +1633,9 @@ browserslist@^2.1.3:
     caniuse-lite "^1.0.30000670"
     electron-to-chromium "^1.3.11"
 
-bser@1.0.2:
+bser@1.0.2, bser@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
-  dependencies:
-    node-int64 "^0.4.0"
-
-bser@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.3.tgz#d63da19ee17330a0e260d2a34422b21a89520317"
   dependencies:
     node-int64 "^0.4.0"
 
@@ -3957,16 +3951,6 @@ jest-environment-node@^20.0.3:
     jest-mock "^20.0.3"
     jest-util "^20.0.3"
 
-jest-haste-map@19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-19.0.0.tgz#adde00b62b1fe04432a104b3254fc5004514b55e"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.6"
-    micromatch "^2.3.11"
-    sane "~1.5.0"
-    worker-farm "^1.3.1"
-
 jest-haste-map@^20.0.4:
   version "20.0.4"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.4.tgz#653eb55c889ce3c021f7b94693f20a4159badf03"
@@ -4644,13 +4628,13 @@ mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
-mime-types@2.1.11, mime-types@~2.1.7:
+mime-types@2.1.11, mime-types@~2.1.11, mime-types@~2.1.7:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.6, mime-types@~2.1.9:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.6, mime-types@~2.1.9:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
@@ -5783,9 +5767,9 @@ react-native-web@0.0.97:
     prop-types "^15.5.8"
     react-timer-mixin "^0.13.3"
 
-react-native@0.44.1:
-  version "0.44.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.44.1.tgz#9e346dca520188c6123148855132cba72bb5fe44"
+react-native@0.44.2:
+  version "0.44.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.44.2.tgz#c8dfb747b88e6276a991980c57c50b860a98cf0e"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"
@@ -5826,7 +5810,7 @@ react-native@0.44.1:
     immutable "~3.7.6"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
-    jest-haste-map "19.0.0"
+    jest-haste-map "^20.0.4"
     joi "^6.6.1"
     json-stable-stringify "^1.0.1"
     json5 "^0.4.0"
@@ -6249,18 +6233,6 @@ sane@~1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.4.1.tgz#88f763d74040f5f0c256b6163db399bf110ac715"
   dependencies:
-    exec-sh "^0.2.0"
-    fb-watchman "^1.8.0"
-    minimatch "^3.0.2"
-    minimist "^1.1.1"
-    walker "~1.0.5"
-    watch "~0.10.0"
-
-sane@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-1.5.0.tgz#a4adeae764d048621ecb27d5f9ecf513101939f3"
-  dependencies:
-    anymatch "^1.3.0"
     exec-sh "^0.2.0"
     fb-watchman "^1.8.0"
     minimatch "^3.0.2"


### PR DESCRIPTION
With this PR if a component dependency version matches the version of the main module (or another package) dependency it gets installed into the `root/node_modules` folder instead of the component folder.

This removes duplicated dependencies living under each component folder, reducing time and space when doing an install.

Keep in mind that for this to work, dependency versions must match for those to be hoisted.

**The process works as follows:**

- Common dependencies will be installed only to the top-level node_modules, and omitted from individual package node_modules.
- Mostly-common dependencies are still hoisted, but outlier packages with different versions will get a normal, local node_modules installation of the necessary dependencies.
- In this instance, lerna bootstrap will always use npm install with the --global-style flag, regardless of client configuration.
- Binaries from those common packages are symlinked to individual package node_modules/.bin directories, so that package.json scripts continue to work unmodified.
- Well-behaved Node-based software should continue to work unmodified.

##### Sourced from [here](https://github.com/lerna/lerna/blob/master/doc/hoist.md) (also more info inside)
