### PR TITLE
fix: use style array to merge image styles

### DIFF
--- a/packages/card/__snapshots__/card.test.js.snap
+++ b/packages/card/__snapshots__/card.test.js.snap
@@ -29,10 +29,13 @@ exports[`renders horizontal by default 1`] = `
           }
         }
         style={
-          Object {
-            "height": 0,
-            "width": 0,
-          }
+          Array [
+            Object {},
+            Object {
+              "height": 0,
+              "width": 0,
+            },
+          ]
         }
       />
     </View>
@@ -145,12 +148,7 @@ exports[`renders vertical above breakpoint 1`] = `
           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
         }
       }
-      style={
-        Object {
-          "height": 0,
-          "width": 0,
-        }
-      }
+      style={Object {}}
     />
   </View>
   <View

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -12,10 +12,13 @@ exports[`renders correctly with no dimensions and given URI 1`] = `
       }
     }
     style={
-      Object {
-        "height": 0,
-        "width": 0,
-      }
+      Array [
+        Object {},
+        Object {
+          "height": 0,
+          "width": 0,
+        },
+      ]
     }
   />
 </View>
@@ -33,10 +36,13 @@ exports[`sets the expected dimensions for a given state 1`] = `
       }
     }
     style={
-      Object {
-        "height": 300,
-        "width": 100,
-      }
+      Array [
+        Object {},
+        Object {
+          "height": 300,
+          "width": 100,
+        },
+      ]
     }
   />
 </View>

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import stylePropType from "react-style-proptype";
 import { View, Image } from "react-native";
-import merge from "lodash.merge";
 import placeholder from "./placeholder";
 
 class ImageComponent extends React.Component {
@@ -36,17 +35,17 @@ class ImageComponent extends React.Component {
   }
 
   render() {
-    const style = merge(this.props.style, {
+    const style = {
       width: this.state.width,
       height: this.state.height
-    });
+    };
 
     return (
       <View onLayout={this.handleLayout}>
         <Image
           onError={this.handleError}
           source={this.state.source}
-          style={style}
+          style={[this.props.style, style]}
         />
       </View>
     );

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -33,4 +33,13 @@ storiesOf("Image", module)
     <View>
       <Image source={exampleNonImage} aspectRatio={0.67} />
     </View>
+  )
+  .add("Apply style to image", () =>
+    <View style={{ width: 100 }}>
+      <Image
+        style={{ borderRadius: 50 }}
+        source={exampleImage}
+        aspectRatio={1}
+      />
+    </View>
   );

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "jest-cli": "20.0.4",
-    "lodash.merge": "4.6.0",
     "prop-types": "15.5.10",
     "react": "16.0.0-alpha.6",
     "react-dom": "15.5.4",


### PR DESCRIPTION
`Stylesheet` compiles the style and returns a number. To properly merge styles the style property should be set to an array of the styles to merge.