### PR TITLE
Fix/specify bc tests

### DIFF
--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -4,7 +4,7 @@
   "main": "article-summary.js",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
-    "test:dev": "jest --bail --verbose --watchAll",
+    "test:watch": "jest --bail --verbose --watchAll",
     "test": "jest --bail --ci --coverage"
   },
   "jest": {

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -4,13 +4,15 @@
   "main": "brightcove-video.js",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
-    "test:dev": "jest __tests__/ --bail --verbose --watch",
-    "test": "jest __tests__/ --bail --ci --coverage"
+    "test:dev": "jest --bail --verbose --watchAll",
+    "test": "jest --bail --ci --coverage"
   },
   "jest": {
     "preset": "react-native",
     "rootDir": "../../",
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "transformIgnorePatterns": ["node_modules/(?!@times-components)/"],
+    "testMatch": ["<rootDir>/packages/brightcove-video/__tests__/*"]
   },
   "repository": {
     "type": "git",

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -4,7 +4,7 @@
   "main": "brightcove-video.js",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
-    "test:dev": "jest --bail --verbose --watchAll",
+    "test:watch": "jest --bail --verbose --watchAll",
     "test": "jest --bail --ci --coverage"
   },
   "jest": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -4,7 +4,7 @@
   "main": "card.js",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
-    "test:dev": "jest --bail --verbose --watchAll",
+    "test:watch": "jest --bail --verbose --watchAll",
     "test": "jest --bail --ci --coverage"
   },
   "jest": {

--- a/packages/gpt/package.json
+++ b/packages/gpt/package.json
@@ -5,7 +5,7 @@
   "main": "gpt.js",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
-    "test:dev": "jest --bail --verbose --watchAll",
+    "test:watch": "jest --bail --verbose --watchAll",
     "test": "jest --bail --ci --coverage"
   },
   "jest": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -4,7 +4,7 @@
   "main": "image.js",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
-    "test:dev": "jest --bail --verbose --watchAll",
+    "test:watch": "jest --bail --verbose --watchAll",
     "test": "jest --bail --ci --coverage"
   },
   "jest": {


### PR DESCRIPTION
We moved to `test:watch` via the CLI, so update old version of `test:dev`
Bring Brightcove inline with other script files re:test config