### PR TITLE
feat: replace aspect ratio for resize mode on image

### DIFF
--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -125,8 +125,8 @@ exports[`renders a snapshot 1`] = `
         style={
           Array [
             Object {
-              "height": "100%",
-              "width": "100%",
+              "height": 1,
+              "width": 750,
             },
             Object {
               "borderColor": "#FFF",
@@ -304,8 +304,8 @@ exports[`renders a snapshot with data 1`] = `
         style={
           Array [
             Object {
-              "height": "100%",
-              "width": "100%",
+              "height": 1,
+              "width": 750,
             },
             Object {
               "borderColor": "#FFF",

--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -114,7 +114,9 @@ exports[`renders a snapshot 1`] = `
       onLayout={[Function]}
     >
       <Image
+        aspectRatio={1}
         onError={[Function]}
+        onLoad={[Function]}
         source={
           Object {
             "uri": "",
@@ -123,15 +125,15 @@ exports[`renders a snapshot 1`] = `
         style={
           Array [
             Object {
+              "height": "100%",
+              "width": "100%",
+            },
+            Object {
               "borderColor": "#FFF",
               "borderRadius": 50,
               "borderWidth": 5,
               "height": 100,
               "width": 100,
-            },
-            Object {
-              "height": 0,
-              "width": 0,
             },
           ]
         }
@@ -291,7 +293,9 @@ exports[`renders a snapshot with data 1`] = `
       onLayout={[Function]}
     >
       <Image
+        aspectRatio={1}
         onError={[Function]}
+        onLoad={[Function]}
         source={
           Object {
             "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
@@ -300,15 +304,15 @@ exports[`renders a snapshot with data 1`] = `
         style={
           Array [
             Object {
+              "height": "100%",
+              "width": "100%",
+            },
+            Object {
               "borderColor": "#FFF",
               "borderRadius": 50,
               "borderWidth": 5,
               "height": 100,
               "width": 100,
-            },
-            Object {
-              "height": 0,
-              "width": 0,
             },
           ]
         }

--- a/packages/card/__snapshots__/card.test.js.snap
+++ b/packages/card/__snapshots__/card.test.js.snap
@@ -18,27 +18,23 @@ exports[`renders horizontal by default 1`] = `
       }
     }
   >
-    <View
-      onLayout={[Function]}
-    >
-      <Image
-        onError={[Function]}
-        source={
+    <Image
+      onError={[Function]}
+      source={
+        Object {
+          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+        }
+      }
+      style={
+        Array [
           Object {
-            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-          }
-        }
-        style={
-          Array [
-            Object {},
-            Object {
-              "height": 0,
-              "width": 0,
-            },
-          ]
-        }
-      />
-    </View>
+            "height": "100%",
+            "width": "100%",
+          },
+          undefined,
+        ]
+      }
+    />
   </View>
   <View
     style={
@@ -136,19 +132,17 @@ exports[`renders vertical above breakpoint 1`] = `
   <View
     style={
       Object {
-        "flexBasis": "auto",
+        "flexBasis": 256,
         "flexGrow": 1,
       }
     }
   >
     <ImageComponent
-      aspectRatio={0.75}
       source={
         Object {
           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
         }
       }
-      style={Object {}}
     />
   </View>
   <View

--- a/packages/card/__snapshots__/card.test.js.snap
+++ b/packages/card/__snapshots__/card.test.js.snap
@@ -18,25 +18,28 @@ exports[`renders horizontal by default 1`] = `
       }
     }
   >
-    <Image
-      onError={[Function]}
-      source={
-        Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+    <View
+      onLayout={[Function]}
+    >
+      <Image
+        onError={[Function]}
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+          }
         }
-      }
-      style={
-        Array [
-          Object {
-            "height": "100%",
-            "width": "100%",
-          },
-          Object {
-            "flex": 1,
-          },
-        ]
-      }
-    />
+        style={
+          Array [
+            Object {
+              "height": "100%",
+              "width": "100%",
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
   </View>
   <View
     style={
@@ -134,7 +137,7 @@ exports[`renders vertical above breakpoint 1`] = `
   <View
     style={
       Object {
-        "flexBasis": 256,
+        "flexBasis": "auto",
         "flexGrow": 1,
       }
     }
@@ -143,11 +146,6 @@ exports[`renders vertical above breakpoint 1`] = `
       source={
         Object {
           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Object {
-          "flex": 1,
         }
       }
     />

--- a/packages/card/__snapshots__/card.test.js.snap
+++ b/packages/card/__snapshots__/card.test.js.snap
@@ -32,8 +32,8 @@ exports[`renders horizontal by default 1`] = `
         style={
           Array [
             Object {
-              "height": "100%",
-              "width": "100%",
+              "height": 1,
+              "width": 750,
             },
             undefined,
           ]

--- a/packages/card/__snapshots__/card.test.js.snap
+++ b/packages/card/__snapshots__/card.test.js.snap
@@ -31,7 +31,9 @@ exports[`renders horizontal by default 1`] = `
             "height": "100%",
             "width": "100%",
           },
-          undefined,
+          Object {
+            "flex": 1,
+          },
         ]
       }
     />
@@ -141,6 +143,11 @@ exports[`renders vertical above breakpoint 1`] = `
       source={
         Object {
           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+        }
+      }
+      style={
+        Object {
+          "flex": 1,
         }
       }
     />

--- a/packages/card/card.js
+++ b/packages/card/card.js
@@ -11,6 +11,9 @@ const getStyles = isHorizontal =>
       display: "flex",
       flexDirection: isHorizontal ? "row" : "column"
     },
+    image: {
+      flex: 1
+    },
     imageContainer: {
       flexGrow: isHorizontal ? 2 : 1,
       flexBasis: isHorizontal ? 0 : 256
@@ -43,7 +46,7 @@ class CardComponent extends React.Component {
     return (
       <View onLayout={this.handleLayout} style={styles.container}>
         <View style={styles.imageContainer}>
-          <Image source={image} />
+          <Image style={styles.image} source={image} />
         </View>
         <View style={styles.summaryContainer}>
           <ArticleSummary

--- a/packages/card/card.js
+++ b/packages/card/card.js
@@ -13,7 +13,7 @@ const getStyles = isHorizontal =>
     },
     imageContainer: {
       flexGrow: isHorizontal ? 2 : 1,
-      flexBasis: isHorizontal ? 0 : "auto"
+      flexBasis: isHorizontal ? 0 : 256
     },
     summaryContainer: {
       flexGrow: isHorizontal ? 3 : 1,

--- a/packages/card/card.js
+++ b/packages/card/card.js
@@ -11,12 +11,9 @@ const getStyles = isHorizontal =>
       display: "flex",
       flexDirection: isHorizontal ? "row" : "column"
     },
-    image: {
-      flex: 1
-    },
     imageContainer: {
       flexGrow: isHorizontal ? 2 : 1,
-      flexBasis: isHorizontal ? 0 : 256
+      flexBasis: isHorizontal ? 0 : "auto"
     },
     summaryContainer: {
       flexGrow: isHorizontal ? 3 : 1,

--- a/packages/card/card.stories.js
+++ b/packages/card/card.stories.js
@@ -17,7 +17,7 @@ const props = {
 };
 
 storiesOf("Card", module).add("Card", () =>
-  <View style={{ width: "100%" }}>
+  <View>
     <Card {...props} />
   </View>
 );

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -1,49 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly with no dimensions and given URI 1`] = `
-<View
-  onLayout={[Function]}
->
-  <Image
-    onError={[Function]}
-    source={
+<Image
+  aspectRatio={1.5}
+  onError={[Function]}
+  source={
+    Object {
+      "uri": "http://example.com/image.jpg",
+    }
+  }
+  style={
+    Array [
       Object {
-        "uri": "http://example.com/image.jpg",
-      }
-    }
-    style={
-      Array [
-        Object {},
-        Object {
-          "height": 0,
-          "width": 0,
-        },
-      ]
-    }
-  />
-</View>
-`;
-
-exports[`sets the expected dimensions for a given state 1`] = `
-<View
-  onLayout={[Function]}
->
-  <Image
-    onError={[Function]}
-    source={
-      Object {
-        "uri": "http://example.com/image.jpg",
-      }
-    }
-    style={
-      Array [
-        Object {},
-        Object {
-          "height": 300,
-          "width": 100,
-        },
-      ]
-    }
-  />
-</View>
+        "height": "100%",
+        "width": "100%",
+      },
+      undefined,
+    ]
+  }
+/>
 `;

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -15,8 +15,8 @@ exports[`renders correctly with no dimensions and given URI 1`] = `
     style={
       Array [
         Object {
-          "height": "100%",
-          "width": "100%",
+          "height": 1,
+          "width": 750,
         },
         undefined,
       ]

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -1,22 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly with no dimensions and given URI 1`] = `
-<Image
-  aspectRatio={1.5}
-  onError={[Function]}
-  source={
-    Object {
-      "uri": "http://example.com/image.jpg",
-    }
-  }
-  style={
-    Array [
+<View
+  onLayout={[Function]}
+>
+  <Image
+    onError={[Function]}
+    onLoad={[Function]}
+    source={
       Object {
-        "height": "100%",
-        "width": "100%",
-      },
-      undefined,
-    ]
-  }
-/>
+        "uri": "http://example.com/image.jpg",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "height": "100%",
+          "width": "100%",
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
 `;

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,6 +1,8 @@
 import React from "react";
-import { Image, View } from "react-native";
+import { Dimensions, Image, View } from "react-native";
 import placeholder from "./placeholder";
+
+const window = Dimensions.get('window');
 
 class ImageComponent extends React.Component {
   constructor(props) {
@@ -8,8 +10,8 @@ class ImageComponent extends React.Component {
 
     this.state = {
       source: props.source,
-      width: "100%",
-      height: "100%"
+      width: window.width,
+      height: 1
     };
 
     this.getSize = Image.getSize;
@@ -21,10 +23,6 @@ class ImageComponent extends React.Component {
   calculateDimensions(props) {
     const state = Object.assign({}, this.state, props);
     if (!state.layout) {
-      return this.setState(props);
-    }
-
-    if (state.width === "100%" || state.height === "100%") {
       return this.setState(props);
     }
 

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,29 +1,23 @@
 import React from "react";
-import PropTypes from "prop-types";
-import stylePropType from "react-style-proptype";
-import { View, Image } from "react-native";
+import { Image, StyleSheet, ViewPropTypes } from "react-native";
 import placeholder from "./placeholder";
+
+const styles = StyleSheet.create({
+  image: {
+    width: "100%",
+    height: "100%"
+  }
+});
 
 class ImageComponent extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      source: props.source,
-      width: 0,
-      height: 0
+      source: props.source
     };
 
-    this.handleLayout = this.handleLayout.bind(this);
     this.handleError = this.handleError.bind(this);
-  }
-
-  handleLayout(event) {
-    const containerWidth = event.nativeEvent.layout.width;
-    this.setState({
-      width: containerWidth,
-      height: containerWidth * this.props.aspectRatio
-    });
   }
 
   handleError() {
@@ -35,34 +29,16 @@ class ImageComponent extends React.Component {
   }
 
   render() {
-    const style = {
-      width: this.state.width,
-      height: this.state.height
-    };
+    const props = Object.assign({}, this.props, this.state, {
+      style: [styles.image, this.props.style]
+    });
 
-    return (
-      <View onLayout={this.handleLayout}>
-        <Image
-          onError={this.handleError}
-          source={this.state.source}
-          style={[this.props.style, style]}
-        />
-      </View>
-    );
+    return <Image {...props} onError={this.handleError} />;
   }
 }
 
-ImageComponent.propTypes = {
-  aspectRatio: PropTypes.number,
-  source: PropTypes.shape({
-    uri: PropTypes.string.isRequired
-  }).isRequired,
-  style: stylePropType
-};
-
-ImageComponent.defaultProps = {
-  aspectRatio: 0.75,
-  style: {}
-};
+ImageComponent.propTypes = Object.assign({}, Image.propTypes, {
+  containerStyle: ViewPropTypes.style
+});
 
 export default ImageComponent;

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,44 +1,91 @@
 import React from "react";
-import { Image, StyleSheet, ViewPropTypes } from "react-native";
+import { Image, View } from "react-native";
 import placeholder from "./placeholder";
-
-const styles = StyleSheet.create({
-  image: {
-    width: "100%",
-    height: "100%"
-  }
-});
 
 class ImageComponent extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      source: props.source
+      source: props.source,
+      width: "100%",
+      height: "100%"
     };
 
+    this.getSize = Image.getSize;
     this.handleError = this.handleError.bind(this);
+    this.handleLayout = this.handleLayout.bind(this);
+    this.handleLoad = this.handleLoad.bind(this);
+  }
+
+  calculateDimensions(props) {
+    const state = Object.assign({}, this.state, props);
+    if (!state.layout) {
+      return this.setState(props);
+    }
+
+    if (state.width === "100%" || state.height === "100%") {
+      return this.setState(props);
+    }
+
+    return this.setState(
+      Object.assign(state, {
+        width: state.layout.width,
+        height: state.layout.width * state.height / state.width
+      })
+    );
   }
 
   handleError() {
-    this.setState({
+    this.calculateDimensions({
       source: {
         uri: placeholder
+      },
+      width: 800,
+      height: 600
+    });
+  }
+
+  handleLoad() {
+    return this.getSize(this.state.source.uri, (width, height) =>
+      this.calculateDimensions({
+        width,
+        height
+      })
+    );
+  }
+
+  handleLayout({ nativeEvent }) {
+    const { height, width } = nativeEvent.layout;
+
+    this.calculateDimensions({
+      layout: {
+        width,
+        height
       }
     });
   }
 
   render() {
-    const props = Object.assign({}, this.props, this.state, {
-      style: [styles.image, this.props.style]
+    const props = Object.assign({}, this.props, {
+      source: this.state.source,
+      style: [
+        {
+          height: this.state.height,
+          width: this.state.width
+        },
+        this.props.style
+      ]
     });
 
-    return <Image {...props} onError={this.handleError} />;
+    return (
+      <View onLayout={this.handleLayout}>
+        <Image {...props} onError={this.handleError} onLoad={this.handleLoad} />
+      </View>
+    );
   }
 }
 
-ImageComponent.propTypes = Object.assign({}, Image.propTypes, {
-  containerStyle: ViewPropTypes.style
-});
+ImageComponent.propTypes = Image.propTypes;
 
 export default ImageComponent;

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -37,11 +37,16 @@ storiesOf("Image", module)
       <Image source={exampleNonImage} />
     </View>
   )
+  .add("Show default image on error centered", () =>
+    <View>
+      <Image style={{ resizeMode: "center" }} source={exampleNonImage} />
+    </View>
+  )
   .add("Apply style to image", () =>
     <View style={{ width: 100, height: 100 }}>
       <Image
         resizeMode={"cover"}
-        style={{ borderRadius: 50 }}
+        style={{ borderRadius: 50, width: 100, height: 100 }}
         source={exampleImage}
       />
     </View>

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -23,8 +23,8 @@ const styles = StyleSheet.create({
 
 storiesOf("Image", module)
   .add("Adjusted to parent view size", () =>
-    <View style={styles.container}>
-      <Image source={exampleImage} />
+    <View style={[styles.container]}>
+      <Image style={{ resizeMode: "center" }} source={exampleImage} />
     </View>
   )
   .add("Resized to half of full width, keeping aspect ratio", () =>

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -13,6 +13,9 @@ const exampleNonImage = {
 };
 
 const styles = StyleSheet.create({
+  container: {
+    height: 256
+  },
   halfWidthView: {
     width: "50%"
   }
@@ -20,26 +23,26 @@ const styles = StyleSheet.create({
 
 storiesOf("Image", module)
   .add("Adjusted to parent view size", () =>
-    <View>
-      <Image source={exampleImage} aspectRatio={0.67} />
+    <View style={styles.container}>
+      <Image source={exampleImage} />
     </View>
   )
   .add("Resized to half of full width, keeping aspect ratio", () =>
-    <View style={styles.halfWidthView}>
-      <Image source={exampleImage} aspectRatio={0.67} />
+    <View style={[styles.container, styles.halfWidthView]}>
+      <Image source={exampleImage} />
     </View>
   )
   .add("Show default image on error", () =>
-    <View>
-      <Image source={exampleNonImage} aspectRatio={0.67} />
+    <View style={styles.container}>
+      <Image source={exampleNonImage} />
     </View>
   )
   .add("Apply style to image", () =>
-    <View style={{ width: 100 }}>
+    <View style={{ width: 100, height: 100 }}>
       <Image
+        resizeMode={"cover"}
         style={{ borderRadius: 50 }}
         source={exampleImage}
-        aspectRatio={1}
       />
     </View>
   );

--- a/packages/image/image.test.js
+++ b/packages/image/image.test.js
@@ -9,8 +9,7 @@ it("renders correctly with no dimensions and given URI", () => {
   const props = {
     source: {
       uri: "http://example.com/image.jpg"
-    },
-    aspectRatio: 3 / 2
+    }
   };
   const tree = renderer.create(<Image {...props} />).toJSON();
   expect(tree).toMatchSnapshot();
@@ -30,4 +29,105 @@ it("use placeholder image when image is not reachable", done => {
   };
 
   comp.handleError();
+});
+
+it("calculates width and height based on layout dimensions", done => {
+  const comp = new Image({
+    source: {
+      uri: "http://httpstat.us/404"
+    }
+  });
+
+  comp.setState = ({ width, height }) => {
+    expect(width).toEqual(20);
+    expect(height).toEqual(10);
+
+    return done();
+  };
+
+  comp.state = {
+    layout: {
+      width: 20,
+      height: 15
+    }
+  };
+
+  comp.calculateDimensions({
+    width: 40,
+    height: 20
+  });
+});
+
+it("calculates width and height based on image dimensions", done => {
+  const comp = new Image({
+    source: {
+      uri: "http://httpstat.us/200"
+    }
+  });
+
+  comp.setState = ({ width, height }) => {
+    expect(width).toEqual(20);
+    expect(height).toEqual(10);
+
+    return done();
+  };
+
+  comp.state = {
+    width: 40,
+    height: 20
+  };
+
+  comp.handleLayout({
+    nativeEvent: {
+      layout: {
+        width: 20,
+        height: 15
+      }
+    }
+  });
+});
+
+it("ignores layout if width and height is 100%", done => {
+  const comp = new Image({
+    source: {
+      uri: "http://httpstat.us/200"
+    }
+  });
+
+  comp.setState = ({ width, height, layout }) => {
+    expect(width).toEqual(undefined);
+    expect(height).toEqual(undefined);
+    expect(layout.width).toEqual(20);
+    expect(layout.height).toEqual(15);
+
+    return done();
+  };
+
+  comp.handleLayout({
+    nativeEvent: {
+      layout: {
+        width: 20,
+        height: 15
+      }
+    }
+  });
+});
+
+it("ignores dimension if layout is 0", done => {
+  const comp = new Image({
+    source: {
+      uri: "http://httpstat.us/200"
+    }
+  });
+
+  comp.setState = ({ width, height, layout }) => {
+    expect(width).toEqual(40);
+    expect(height).toEqual(20);
+    expect(layout).toEqual(undefined);
+
+    return done();
+  };
+
+  comp.getSize = (uri, success) => success(40, 20);
+  comp.handleLoad();
 });

--- a/packages/image/image.test.js
+++ b/packages/image/image.test.js
@@ -65,9 +65,11 @@ it("calculates width and height based on image dimensions", done => {
     }
   });
 
-  comp.setState = ({ width, height }) => {
+  comp.setState = ({ width, height, layout }) => {
     expect(width).toEqual(20);
     expect(height).toEqual(10);
+    expect(layout.width).toEqual(20);
+    expect(layout.height).toEqual(15);
 
     return done();
   };
@@ -75,32 +77,6 @@ it("calculates width and height based on image dimensions", done => {
   comp.state = {
     width: 40,
     height: 20
-  };
-
-  comp.handleLayout({
-    nativeEvent: {
-      layout: {
-        width: 20,
-        height: 15
-      }
-    }
-  });
-});
-
-it("ignores layout if width and height is 100%", done => {
-  const comp = new Image({
-    source: {
-      uri: "http://httpstat.us/200"
-    }
-  });
-
-  comp.setState = ({ width, height, layout }) => {
-    expect(width).toEqual(undefined);
-    expect(height).toEqual(undefined);
-    expect(layout.width).toEqual(20);
-    expect(layout.height).toEqual(15);
-
-    return done();
   };
 
   comp.handleLayout({

--- a/packages/image/image.test.js
+++ b/packages/image/image.test.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import { shallow } from "enzyme";
 import React from "react";
 import renderer from "react-test-renderer";
 import Image from "./image";
@@ -21,8 +20,7 @@ it("use placeholder image when image is not reachable", done => {
   const comp = new Image({
     source: {
       uri: "http://httpstat.us/404"
-    },
-    aspectRatio: 0.5
+    }
   });
 
   comp.setState = ({ source }) => {
@@ -32,39 +30,4 @@ it("use placeholder image when image is not reachable", done => {
   };
 
   comp.handleError();
-});
-
-it("lays out the image with the correct aspect ratio", done => {
-  const comp = new Image({
-    source: {
-      uri: "http://httpstat.us/404"
-    },
-    aspectRatio: 0.5
-  });
-
-  comp.setState = ({ width, height }) => {
-    expect(width).toEqual(20);
-    expect(height).toEqual(10);
-
-    return done();
-  };
-
-  comp.handleLayout({ nativeEvent: { layout: { width: 20 } } });
-});
-
-it("sets the expected dimensions for a given state", () => {
-  const props = {
-    source: {
-      uri: "http://example.com/image.jpg"
-    }
-  };
-
-  const wrapper = shallow(<Image {...props} />);
-
-  wrapper.setState({
-    height: 300,
-    width: 100
-  });
-
-  expect(wrapper).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR removes the aspect ratio property on an image and adds the resize mode.

One of the consequences of this change is that the width and height need to be specified, and there are two ways to do it. Set the dimension on the parent and the image will adapt or set the dimensions in the image.