### PR TITLE
fix: name fonts

### DIFF
--- a/.storybook/head.html
+++ b/.storybook/head.html
@@ -7,7 +7,7 @@
   }
 
   @font-face {
-    font-family: TimesDigitalW04-RegularSC;
+    font-family: TimesDigital-RegularSC;
     src: url(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"), url(/fonts/TimesDigitalW04-RegularSC.ttf) format("truetype");
     font-weight: 400;
     font-style: normal

--- a/ios/storybooknative.xcodeproj/project.pbxproj
+++ b/ios/storybooknative.xcodeproj/project.pbxproj
@@ -35,8 +35,8 @@
 		2D02E4C91E0B4AEC006451C7 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3EA31DF850E9000B6D8A /* libReact.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* storybooknativeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* storybooknativeTests.m */; };
 		515F7D171F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */; };
-		515F7D181F0E7BA000966DF3 /* TimesDigitalW04-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D141F0E7BA000966DF3 /* TimesDigitalW04-Regular.ttf */; };
-		515F7D191F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D151F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf */; };
+		515F7D181F0E7BA000966DF3 /* TimesDigital-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D141F0E7BA000966DF3 /* TimesDigital-Regular.ttf */; };
+		515F7D191F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */; };
 		515F7D1A1F0E7BA000966DF3 /* TimesModern-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D161F0E7BA000966DF3 /* TimesModern-Bold.ttf */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
@@ -268,8 +268,8 @@
 		2D02E47B1E0B4A5D006451C7 /* storybooknative-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "storybooknative-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* storybooknative-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "storybooknative-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "GillSansMTStd-Medium.ttf"; path = "../dist/public/fonts/GillSansMTStd-Medium.ttf"; sourceTree = "<group>"; };
-		515F7D141F0E7BA000966DF3 /* TimesDigitalW04-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesDigitalW04-Regular.ttf"; path = "../dist/public/fonts/TimesDigitalW04-Regular.ttf"; sourceTree = "<group>"; };
-		515F7D151F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesDigitalW04-RegularSC.ttf"; path = "../dist/public/fonts/TimesDigitalW04-RegularSC.ttf"; sourceTree = "<group>"; };
+		515F7D141F0E7BA000966DF3 /* TimesDigital-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesDigital-Regular.ttf"; path = "../dist/public/fonts/TimesDigital-Regular.ttf"; sourceTree = "<group>"; };
+		515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesDigital-RegularSC.ttf"; path = "../dist/public/fonts/TimesDigital-RegularSC.ttf"; sourceTree = "<group>"; };
 		515F7D161F0E7BA000966DF3 /* TimesModern-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesModern-Bold.ttf"; path = "../dist/public/fonts/TimesModern-Bold.ttf"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
@@ -460,8 +460,8 @@
 			isa = PBXGroup;
 			children = (
 				515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */,
-				515F7D141F0E7BA000966DF3 /* TimesDigitalW04-Regular.ttf */,
-				515F7D151F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf */,
+				515F7D141F0E7BA000966DF3 /* TimesDigital-Regular.ttf */,
+				515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */,
 				515F7D161F0E7BA000966DF3 /* TimesModern-Bold.ttf */,
 			);
 			name = Fonts;
@@ -923,8 +923,8 @@
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				87396A391EF3E9F10076CBAD /* bcovpuiiconfont.ttf in Resources */,
 				515F7D1A1F0E7BA000966DF3 /* TimesModern-Bold.ttf in Resources */,
-				515F7D181F0E7BA000966DF3 /* TimesDigitalW04-Regular.ttf in Resources */,
-				515F7D191F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf in Resources */,
+				515F7D181F0E7BA000966DF3 /* TimesDigital-Regular.ttf in Resources */,
+				515F7D191F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf in Resources */,
 				515F7D171F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
 			);

--- a/ios/storybooknative/Info.plist
+++ b/ios/storybooknative/Info.plist
@@ -5,8 +5,8 @@
 	<key>UIAppFonts</key>
 	<array>
 		<string>GillSansMTStd-Medium.ttf</string>
-		<string>TimesDigitalW04-Regular.ttf</string>
-		<string>TimesDigitalW04-RegularSC.ttf</string>
+		<string>TimesDigital-Regular.ttf</string>
+		<string>TimesDigital-RegularSC.ttf</string>
 		<string>TimesModern-Bold.ttf</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>

--- a/lib/fetch-fonts.js
+++ b/lib/fetch-fonts.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const { promisify } = require("util");
 const exec = promisify(require("child_process").exec);
 const mkdirp = promisify(require("mkdirp"));
@@ -11,69 +12,33 @@ const fonts = [
   {
     family: "TimesModern-Bold",
     sources: [
-      {
-        source: `${fontCdn}/TimesModern/TimesModern-Bold-62eb027e67.woff2`,
-        type: "woff2"
-      },
-      {
-        source: `${fontCdn}/TimesModern/TimesModern-Bold-828aec4ccd.woff`,
-        type: "woff"
-      },
-      {
-        source: `${fontCdn}/TimesModern/TimesModern-Bold-e960fb2b2c.ttf`,
-        type: "ttf"
-      }
+      `${fontCdn}/TimesModern/TimesModern-Bold-62eb027e67.woff2`,
+      `${fontCdn}/TimesModern/TimesModern-Bold-828aec4ccd.woff`,
+      `${fontCdn}/TimesModern/TimesModern-Bold-e960fb2b2c.ttf`
     ]
   },
   {
     family: "TimesDigital-RegularSC",
     sources: [
-      {
-        source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2`,
-        type: "woff2"
-      },
-      {
-        source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-a06bfa24de.woff`,
-        type: "woff"
-      },
-      {
-        source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-b3f19b6c56.ttf`,
-        type: "ttf"
-      }
+      `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2`,
+      `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-a06bfa24de.woff`,
+      `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-b3f19b6c56.ttf`
     ]
   },
   {
     family: "GillSansMTStd-Medium",
     sources: [
-      {
-        source: `${fontCdn}/GillSans/GillSansMTStd-Medium-ff809aff43.woff2`,
-        type: "woff2"
-      },
-      {
-        source: `${fontCdn}/GillSans/GillSansMTStd-Medium-f147e4bbf2.woff`,
-        type: "woff"
-      },
-      {
-        source: `${fontCdn}/GillSans/GillSansMTStd-Medium-45ad758029.ttf`,
-        type: "ttf"
-      }
+      `${fontCdn}/GillSans/GillSansMTStd-Medium-ff809aff43.woff2`,
+      `${fontCdn}/GillSans/GillSansMTStd-Medium-f147e4bbf2.woff`,
+      `${fontCdn}/GillSans/GillSansMTStd-Medium-45ad758029.ttf`
     ]
   },
   {
     family: "TimesDigital-Regular",
     sources: [
-      {
-        source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-dca82eac02.woff2`,
-        type: "woff2"
-      },
-      {
-        source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-c93f4e13dd.woff`,
-        type: "woff"
-      },
-      {
-        source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-bf4b850ffb.ttf`,
-        type: "ttf"
-      }
+      `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-dca82eac02.woff2`,
+      `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-c93f4e13dd.woff`,
+      `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-bf4b850ffb.ttf`
     ]
   }
 ];
@@ -99,12 +64,13 @@ const generate = (file, family) =>
 mkdirp(fontDir).then(() =>
   Promise.all(
     ...fonts.map(({ family, sources }) =>
-      sources.map(({ source, type }) => {
-        const dest = `${fontDir}/${family}.${type}`;
+      sources.map(source => {
+        const extension = path.extname(source);
+        const dest = `${fontDir}/${family}${extension}`;
 
         if (!fs.existsSync(dest)) {
           return download(source, dest).then(
-            () => (type === "ttf" ? generate(dest, family) : null)
+            () => (extension === ".ttf" ? generate(dest, family) : null)
           );
         }
         return Promise.resolve();

--- a/lib/fetch-fonts.js
+++ b/lib/fetch-fonts.js
@@ -9,54 +9,72 @@ const fontDir = `${__dirname}/../dist/public/fonts`;
 
 const fonts = [
   {
-    source: `${fontCdn}/TimesModern/TimesModern-Bold-62eb027e67.woff2`,
-    dest: `${fontDir}/TimesModern-Bold.woff2`
+    family: "TimesModern-Bold",
+    sources: [
+      {
+        source: `${fontCdn}/TimesModern/TimesModern-Bold-62eb027e67.woff2`,
+        type: "woff2"
+      },
+      {
+        source: `${fontCdn}/TimesModern/TimesModern-Bold-828aec4ccd.woff`,
+        type: "woff"
+      },
+      {
+        source: `${fontCdn}/TimesModern/TimesModern-Bold-e960fb2b2c.ttf`,
+        type: "ttf"
+      }
+    ]
   },
   {
-    source: `${fontCdn}/TimesModern/TimesModern-Bold-828aec4ccd.woff`,
-    dest: `${fontDir}/TimesModern-Bold.woff`
+    family: "TimesDigital-RegularSC",
+    sources: [
+      {
+        source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2`,
+        type: "woff2"
+      },
+      {
+        source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-a06bfa24de.woff`,
+        type: "woff"
+      },
+      {
+        source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-b3f19b6c56.ttf`,
+        type: "ttf"
+      }
+    ]
   },
   {
-    // hosted TimesModern-Bold.ttf isnt valid enough for ios
-    isDirty: true,
-    source: `${fontCdn}/TimesModern/TimesModern-Bold-e960fb2b2c.ttf`,
-    dest: `${fontDir}/TimesModern-Bold.ttf`
+    family: "GillSansMTStd-Medium",
+    sources: [
+      {
+        source: `${fontCdn}/GillSans/GillSansMTStd-Medium-ff809aff43.woff2`,
+        type: "woff2"
+      },
+      {
+        source: `${fontCdn}/GillSans/GillSansMTStd-Medium-f147e4bbf2.woff`,
+        type: "woff"
+      },
+      {
+        source: `${fontCdn}/GillSans/GillSansMTStd-Medium-45ad758029.ttf`,
+        type: "ttf"
+      }
+    ]
   },
   {
-    source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2`,
-    dest: `${fontDir}/TimesDigitalW04-RegularSC.woff2`
-  },
-  {
-    source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-a06bfa24de.woff`,
-    dest: `${fontDir}/TimesDigitalW04-RegularSC.woff`
-  },
-  {
-    source: `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-b3f19b6c56.ttf`,
-    dest: `${fontDir}/TimesDigitalW04-RegularSC.ttf`
-  },
-  {
-    source: `${fontCdn}/GillSans/GillSansMTStd-Medium-ff809aff43.woff2`,
-    dest: `${fontDir}/GillSansMTStd-Medium.woff2`
-  },
-  {
-    source: `${fontCdn}/GillSans/GillSansMTStd-Medium-f147e4bbf2.woff`,
-    dest: `${fontDir}/GillSansMTStd-Medium.woff`
-  },
-  {
-    source: `${fontCdn}/GillSans/GillSansMTStd-Medium-45ad758029.ttf`,
-    dest: `${fontDir}/GillSansMTStd-Medium.ttf`
-  },
-  {
-    source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-dca82eac02.woff2`,
-    dest: `${fontDir}/TimesDigitalW04-Regular.woff2`
-  },
-  {
-    source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-c93f4e13dd.woff`,
-    dest: `${fontDir}/TimesDigitalW04-Regular.woff`
-  },
-  {
-    source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-bf4b850ffb.ttf`,
-    dest: `${fontDir}/TimesDigitalW04-Regular.ttf`
+    family: "TimesDigital-Regular",
+    sources: [
+      {
+        source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-dca82eac02.woff2`,
+        type: "woff2"
+      },
+      {
+        source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-c93f4e13dd.woff`,
+        type: "woff"
+      },
+      {
+        source: `${fontCdn}/TimesDigital/TimesDigitalW04-Regular-bf4b850ffb.ttf`,
+        type: "ttf"
+      }
+    ]
   }
 ];
 
@@ -73,16 +91,24 @@ const download = (source, dest) =>
       })
   );
 
-const clean = file =>
+const generate = (file, family) =>
   exec(
-    `fontforge -lang=ff -c 'Open($1); Generate("${file}");' ${file}`
+    `fontforge -lang=ff -c 'Open($1); SetFondName("${family}"); SetFontNames("${family}", "${family}"); Generate("${file}");' ${file}`
   ).catch(e => console.error(e)); // eslint-disable-line no-console
 
-mkdirp(fontDir).then(() => {
-  const missingFonts = fonts.filter(({ dest }) => !fs.existsSync(dest));
-  return Promise.all(
-    missingFonts.map(({ isDirty, source, dest }) =>
-      download(source, dest).then(() => (isDirty ? clean(dest) : null))
+mkdirp(fontDir).then(() =>
+  Promise.all(
+    ...fonts.map(({ family, sources }) =>
+      sources.map(({ source, type }) => {
+        const dest = `${fontDir}/${family}.${type}`;
+
+        if (!fs.existsSync(dest)) {
+          return download(source, dest).then(
+            () => (type === "ttf" ? generate(dest, family) : null)
+          );
+        }
+        return Promise.resolve();
+      })
     )
-  );
-});
+  )
+);

--- a/packages/article-summary/__snapshots__/article-summary.test.js.snap
+++ b/packages/article-summary/__snapshots__/article-summary.test.js.snap
@@ -45,7 +45,7 @@ exports[`renders a snapshot 1`] = `
       Object {
         "color": "#696969",
         "flexWrap": "wrap",
-        "fontFamily": "TimesDigitalW04-Regular",
+        "fontFamily": "TimesDigital-Regular",
         "fontSize": 14,
         "lineHeight": 20,
         "marginBottom": 10,
@@ -102,7 +102,7 @@ exports[`renders a snapshot with content 1`] = `
       Object {
         "color": "#696969",
         "flexWrap": "wrap",
-        "fontFamily": "TimesDigitalW04-Regular",
+        "fontFamily": "TimesDigital-Regular",
         "fontSize": 14,
         "lineHeight": 20,
         "marginBottom": 10,

--- a/packages/article-summary/article-summary.js
+++ b/packages/article-summary/article-summary.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
   text: {
     color: "#696969",
     fontSize: 14,
-    fontFamily: "TimesDigitalW04-Regular",
+    fontFamily: "TimesDigital-Regular",
     lineHeight: 20,
     marginBottom: 10,
     flexWrap: "wrap"

--- a/packages/card/__snapshots__/card.test.js.snap
+++ b/packages/card/__snapshots__/card.test.js.snap
@@ -93,7 +93,7 @@ exports[`renders horizontal by default 1`] = `
           Object {
             "color": "#696969",
             "flexWrap": "wrap",
-            "fontFamily": "TimesDigitalW04-Regular",
+            "fontFamily": "TimesDigital-Regular",
             "fontSize": 14,
             "lineHeight": 20,
             "marginBottom": 10,


### PR DESCRIPTION
For fonts to work in `react-native`, they need to be re-named in line with the generic `font family` we use in styles, so they work across native and web