### PR TITLE
feat: expose builder

### DIFF
--- a/packages/markup/__tests__/__snapshots__/markup.native.test.js.snap
+++ b/packages/markup/__tests__/__snapshots__/markup.native.test.js.snap
@@ -73,6 +73,34 @@ exports[`Markup Native renders a single paragraph 1`] = `
 
 exports[`Markup Native renders an empty component 1`] = `<View />`;
 
+exports[`Markup Native renders multiple children 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "red",
+    }
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    This is the text for paragraph one
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    This is the text for paragraph two
+  </Text>
+</Text>
+`;
+
 exports[`Markup Native renders multiple paragraphs 1`] = `
 <View>
   <Text

--- a/packages/markup/__tests__/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/__snapshots__/markup.web.test.js.snap
@@ -39,6 +39,26 @@ exports[`Markup Web renders a single paragraph 1`] = `
 
 exports[`Markup Web renders an empty component 1`] = `<div />`;
 
+exports[`Markup Web renders multiple children 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "red",
+    }
+  }
+>
+  <p>
+    This is the text for paragraph one
+  </p>
+  <p>
+    This is the text for paragraph two
+  </p>
+</Text>
+`;
+
 exports[`Markup Web renders multiple paragraphs 1`] = `
 <div>
   <p>

--- a/packages/markup/__tests__/markup.native.test.js
+++ b/packages/markup/__tests__/markup.native.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
 import runTests from "./test-helper";
-import Markup from "../markup";
+import Markup, { builder } from "../markup";
 
-describe("Markup Native", runTests(Markup));
+describe("Markup Native", runTests(Markup, builder));

--- a/packages/markup/__tests__/markup.web.test.js
+++ b/packages/markup/__tests__/markup.web.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
 import runTests from "./test-helper";
-import Markup from "../markup.web";
+import Markup, { builder } from "../markup.web";
 
-describe("Markup Web", runTests(Markup));
+describe("Markup Web", runTests(Markup, builder));

--- a/packages/markup/__tests__/test-helper.js
+++ b/packages/markup/__tests__/test-helper.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import "react-native";
+import { Text } from "react-native";
 import React from "react";
 import renderer from "react-test-renderer";
 
@@ -16,7 +16,7 @@ const bio = require("../fixtures/bio.json").fixture;
 const script = require("../fixtures/script.json").fixture;
 const image = require("../fixtures/image.json").fixture;
 
-export default Markup => () => {
+export default (Markup, builder) => () => {
   it("renders an empty component", () => {
     const ast = [];
     const tree = renderer.create(<Markup ast={ast} />).toJSON();
@@ -74,6 +74,16 @@ export default Markup => () => {
 
   it("renders wrapped tags", () => {
     const tree = renderer.create(<Markup ast={bio} wrapIn="p" />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders multiple children", () => {
+    const tree = renderer
+      .create(
+        <Text style={{ color: "red" }}>{builder({ ast: multiParagraph })}</Text>
+      )
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/packages/markup/markup-builder.js
+++ b/packages/markup/markup-builder.js
@@ -46,13 +46,11 @@ function astToMarkup(tagMap, key, wrapTextWith, [x, ...xs]) {
   return children.concat(...astToMarkup(tagMap, bump(key), wrapTextWith, xs));
 }
 
+export const builder = tagMap => ({ ast, wrapIn }) =>
+  astToMarkup(tagMap, "0", tagMap.get(wrapIn || "div").wrapText, ast);
+
 export default function Markup({ ast, tagMap, wrapIn }) {
-  const markup = astToMarkup(
-    tagMap,
-    "0",
-    tagMap.get(wrapIn || "div").wrapText,
-    ast
-  );
+  const markup = builder(tagMap)({ ast, wrapIn });
 
   if (markup.length === 1) {
     return markup[0];

--- a/packages/markup/markup.js
+++ b/packages/markup/markup.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { View, Text, Linking, StyleSheet } from "react-native";
-import Markup from "./markup-builder";
+import Markup, { builder as mb } from "./markup-builder";
 import propTypes from "./markup-proptype";
 
 const styles = StyleSheet.create({
@@ -82,3 +82,5 @@ const MarkupNative = ({ ast, wrapIn }) =>
 MarkupNative.propTypes = propTypes;
 
 export default MarkupNative;
+
+export const builder = mb(tagMap);

--- a/packages/markup/markup.stories.js
+++ b/packages/markup/markup.stories.js
@@ -1,7 +1,9 @@
+/* eslint-disable react/no-array-index-key */
+
 import { View } from "react-native";
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
-import Markup from "./markup";
+import Markup, { builder } from "./markup";
 
 const multiParagraph = require("./fixtures/multi-paragraph.json").fixture;
 const mixture = require("./fixtures/tag-mixture.json").fixture;
@@ -12,4 +14,17 @@ const story = m => <View style={{ padding: 20 }}>{m}</View>;
 storiesOf("Markup", module)
   .add("Multiple paragraphs", () => story(<Markup ast={multiParagraph} />))
   .add("Mixture of tags", () => story(<Markup ast={mixture} />))
-  .add("Biography", () => story(<Markup ast={bio} wrapIn="p" />));
+  .add("Biography", () => story(<Markup ast={bio} wrapIn="p" />))
+  .add("Multiple children with styling", () =>
+    story(
+      <View>
+        {builder({ ast: multiParagraph }).map((el, i) =>
+          <View style={{ margin: 10 }} key={`paragraph-${i}`}>
+            {React.cloneElement(el, {
+              style: { color: "red", fontFamily: "TimesModern-Bold" }
+            })}
+          </View>
+        )}
+      </View>
+    )
+  );

--- a/packages/markup/markup.web.js
+++ b/packages/markup/markup.web.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Markup from "./markup-builder";
+import Markup, { builder as mb } from "./markup-builder";
 import propTypes from "./markup-proptype";
 
 const tagMap = new Map([
@@ -57,3 +57,5 @@ const MarkupWeb = ({ ast, wrapIn }) =>
 MarkupWeb.propTypes = propTypes;
 
 export default MarkupWeb;
+
+export const builder = mb(tagMap);


### PR DESCRIPTION
To allow `Flatlist` to use the markup output or fine grained styling of the child elements, expose builder so the consumer can act on the array of children