### PR TITLE
fix: master eslint issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,12 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
     "import/extensions": "off"
   },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".android.js", ".ios.js", ".web.js"]
+      }
+    }
+  }
   "root": true
 }


### PR DESCRIPTION
~/times-components/packages/brightcove-video/brightcove.ios.fructose.js
  4:29  error  Unable to resolve path to module './brightcove-video'
  import/no-unresolved

  ✖ 1 problem (1 error, 0 warnings)
