### PR TITLE
fix: run lint on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
   - "8"
+script:
+  - yarn lint
+  - yarn test
 after_success: yarn coverage:publish


### PR DESCRIPTION
As suggested on #89 we should run eslint for the full project on each CI job.
