### PR TITLE
fix: run lint on staged changes only

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/node_modules/*
 **/coverage/*
+dist

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "lint-staged": {
     "**/*.js": [
-      "eslint . --fix",
+      "eslint --fix",
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
Run eslint on your changes only. This will pair well with #91 since the CI will be responsible for always linting the whole project.
