### PR TITLE
Chore/add all ignores

### DIFF
--- a/lib/cli/.npmignore
+++ b/lib/cli/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -19,6 +19,10 @@ function writeStubFiles(variables) {
   fileTemplates(variables).forEach(([template, fileName]) => {
     fs.writeFileSync(path.join(packageRoot, fileName), template(variables));
   });
+
+  fs
+    .createReadStream(path.join(__dirname, ".npmignore"))
+    .pipe(fs.createWriteStream(path.join(packageRoot, ".npmignore")));
 }
 
 function addComponent() {

--- a/packages/ad/.npmignore
+++ b/packages/ad/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/article-summary/.npmignore
+++ b/packages/article-summary/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/author-head/.npmignore
+++ b/packages/author-head/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/author/.npmignore
+++ b/packages/author/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/card/.npmignore
+++ b/packages/card/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/error-view/.npmignore
+++ b/packages/error-view/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/image/.npmignore
+++ b/packages/image/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/markup/.npmignore
+++ b/packages/markup/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest


### PR DESCRIPTION
Lerna recommends having each package as standalone as possible so each one needs an `.npmignore`. Added ignores to all packages and a master one to the CLI.

Kept them generic to save overhead on remembering to update if a packages contents change