### PR TITLE
[WIP] chore: add diamond to different package (used on article flag and copy)

### DIFF
--- a/packages/diamond/.npmignore
+++ b/packages/diamond/.npmignore
@@ -1,0 +1,8 @@
+*.stories.js
+__tests__
+*.fructose.js
+*.test.js
+fixtures
+coverage
+android/**/test
+android/**/androidTest

--- a/packages/diamond/LICENSE
+++ b/packages/diamond/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, News UK & Ireland Ltd
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/diamond/diamond.js
+++ b/packages/diamond/diamond.js
@@ -1,0 +1,19 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Svg, { G, Path } from "svgs";
+
+const Diamond = ({ width, height, color }) =>
+  <Svg width={width} height={height} viewBox="0 0 20 20">
+    <G fill={color}>
+      <Path d="M 0,10 10,20 20,10 10,0 Z" />
+    </G>
+  </Svg>;
+
+Diamond.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  color: PropTypes.string.isRequired
+};
+
+export default Diamond;

--- a/packages/diamond/diamond.stories.js
+++ b/packages/diamond/diamond.stories.js
@@ -1,0 +1,8 @@
+import "react-native";
+import React from "react";
+import { storiesOf } from "@storybook/react-native";
+import Diamond from "./diamond";
+
+storiesOf("Diamond", module).add("Diamond", () =>
+  <Diamond height={7} width={7} color={"green"} />
+);

--- a/packages/diamond/diamond.test.js
+++ b/packages/diamond/diamond.test.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+
+import "react-native";
+import React from "react";
+import renderer from "react-test-renderer";
+import Diamond from "./diamond";
+
+it("renders correctly", () => {
+  const tree = renderer.create(<Diamond height={7} width={7} color={"green"} />).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/diamond/package.json
+++ b/packages/diamond/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@times-components/diamond",
+  "version": "0.0.1",
+  "description": "SVG Diamond",
+  "main": "diamond.js",
+  "scripts": {
+    "flow": "node_modules/flow-bin/cli.js",
+    "test:watch": "jest --bail --verbose --watchAll",
+    "test": "jest --bail --ci --coverage"
+  },
+  "jest": {
+    "preset": "react-native",
+    "rootDir": "../../",
+    "transformIgnorePatterns": [
+      "node_modules/(?!@times-components)/"
+    ],
+    "testMatch": [
+      "<rootDir>/packages/diamond/**.test.js"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/newsuk/times-components.git"
+  },
+  "keywords": [
+    "react-native-web",
+    "react",
+    "native",
+    "web",
+    "diamond",
+    "component"
+  ],
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/newsuk/times-components/issues"
+  },
+  "homepage": "https://github.com/newsuk/times-components#readme",
+  "devDependencies": {
+    "babel-cli": "6.24.1",
+    "babel-core": "6.24.1",
+    "babel-loader": "7.0.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.5",
+    "babel-preset-flow": "6.23.0",
+    "babel-preset-react-native": "1.9.2",
+    "flow-bin": "0.42.0",
+    "jest": "20.0.4",
+    "react-test-renderer": "15.5.4",
+    "webpack": "3.3.0"
+  },
+  "dependencies": {
+    "prop-types": "15.5.10",
+    "react": "16.0.0-alpha.6",
+    "react-dom": "15.5.4",
+    "react-native": "0.44.1",
+    "react-native-web": "0.0.97"
+  },
+  "peerDependencies": {
+    "@storybook/react-native": "3.1.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
Diamond SVG is used in article flag but we will also need it for copy (key-facts also use diamond)

Note:
- Tests will fail because snapshot is missing
