### PR TITLE
[WIP] Feat/markup extended

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -7,6 +7,13 @@
     }
 
     @font-face {
+        font-family: TimesModern-Regular;
+        src: url(/fonts/TimesModern-Regular.woff2) format("woff2"), url(/fonts/TimesModern-Regular.woff) format("woff"), url(/fonts/TimesModern-Regular.ttf) format("truetype");
+        font-weight: 400;
+        font-style:normal
+    }
+
+    @font-face {
         font-family: TimesDigital-RegularSC;
         src: url(/fonts/TimesDigital-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigital-RegularSC.woff) format("woff"), url(/fonts/TimesDigital-RegularSC.ttf) format("truetype");
         font-weight: 400;

--- a/ios/storybooknative.xcodeproj/project.pbxproj
+++ b/ios/storybooknative.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		87396A391EF3E9F10076CBAD /* bcovpuiiconfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 87396A381EF3E9F10076CBAD /* bcovpuiiconfont.ttf */; };
 		ED3A0BB01F38C8F300048867 /* RNTBrightcove.m in Sources */ = {isa = PBXBuildFile; fileRef = ED3A0BAD1F38C8F300048867 /* RNTBrightcove.m */; };
 		ED3A0BB11F38C8F300048867 /* RNTBrightcoveManager.m in Sources */ = {isa = PBXBuildFile; fileRef = ED3A0BAF1F38C8F300048867 /* RNTBrightcoveManager.m */; };
+		F013D0A81F3B560900D39179 /* TimesModern-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F013D0A71F3B539000D39179 /* TimesModern-Regular.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -296,6 +297,7 @@
 		ED3A0BAD1F38C8F300048867 /* RNTBrightcove.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNTBrightcove.m; path = "../packages/brightcove-video/ios/RNTBrightcove/RNTBrightcove.m"; sourceTree = "<group>"; };
 		ED3A0BAE1F38C8F300048867 /* RNTBrightcoveManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNTBrightcoveManager.h; path = "../packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveManager.h"; sourceTree = "<group>"; };
 		ED3A0BAF1F38C8F300048867 /* RNTBrightcoveManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNTBrightcoveManager.m; path = "../packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveManager.m"; sourceTree = "<group>"; };
+		F013D0A71F3B539000D39179 /* TimesModern-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesModern-Regular.ttf"; path = "../dist/public/fonts/TimesModern-Regular.ttf"; sourceTree = "<group>"; };
 		F99A760D4DBA4C06BAA2763C /* libRNSVG.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSVG.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -470,6 +472,7 @@
 		515F7CF91F0E7B5600966DF3 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
+				F013D0A71F3B539000D39179 /* TimesModern-Regular.ttf */,
 				515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */,
 				515F7D141F0E7BA000966DF3 /* TimesDigital-Regular.ttf */,
 				515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */,
@@ -952,6 +955,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				F013D0A81F3B560900D39179 /* TimesModern-Regular.ttf in Resources */,
 				87396A391EF3E9F10076CBAD /* bcovpuiiconfont.ttf in Resources */,
 				515F7D1A1F0E7BA000966DF3 /* TimesModern-Bold.ttf in Resources */,
 				515F7D181F0E7BA000966DF3 /* TimesDigital-Regular.ttf in Resources */,

--- a/ios/storybooknative/Info.plist
+++ b/ios/storybooknative/Info.plist
@@ -8,6 +8,7 @@
 		<string>TimesDigital-Regular.ttf</string>
 		<string>TimesDigital-RegularSC.ttf</string>
 		<string>TimesModern-Bold.ttf</string>
+		<string>TimesModern-Regular.ttf</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/lib/fetch-fonts.js
+++ b/lib/fetch-fonts.js
@@ -18,6 +18,14 @@ const fonts = [
     ]
   },
   {
+    family: "TimesModern-Regular",
+    sources: [
+      `${fontCdn}/TimesModern/TimesModern-Regular-f3419df85d.woff2`,
+      `${fontCdn}/TimesModern/TimesModern-Regular-39c619f4ef.woff`,
+      `${fontCdn}/TimesModern/TimesModern-Regular-e47b8c277b.ttf`
+    ]
+  },
+  {
     family: "TimesDigital-RegularSC",
     sources: [
       `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2`,

--- a/packages/markup/fixtures/copy-key-facts.json
+++ b/packages/markup/fixtures/copy-key-facts.json
@@ -1,0 +1,54 @@
+{
+	"fixture": [{
+			"attributes": {
+				"title": "Sex, cocaine and sport: a volatile combination"
+			},
+			"children": [{
+				"attributes": {},
+				"children": [{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "The Italian cyclist Gilberto Simoni was cleared of taking cocaine in 2002 by proving that traces of the drug came from coca leaf sweets his aunt brought back from Peru"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "Daniel Plaza, an Olympic race-walking champion from Spain, said that a positive test for nandrolone in 1996 had been caused by his performing a sex act on his pregnant wife. Ten years later, he was cleared"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "Dennis Mitchell’s high levels of testosterone in 1998 were caused by having sex with his wife “at least four times” on her birthday, according to the sprinter. USA Track and Field believed him, the IAAF did not"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "In 2010 the American sprinter LaShawn Merritt blamed a positive test on not reading the ingredients for his penis enlargement medication. A possible two-year ban was reduced by three months"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					}
+				],
+				"name": "ul"
+			}],
+			"name": "key-facts"
+		}
+	]
+}

--- a/packages/markup/fixtures/copy-multi-fields.json
+++ b/packages/markup/fixtures/copy-multi-fields.json
@@ -1,0 +1,279 @@
+{
+	"fixture": [{
+			"attributes": {
+				"title": "Sex, cocaine and sport: a volatile combination"
+			},
+			"children": [{
+				"attributes": {},
+				"children": [{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "The Italian cyclist Gilberto Simoni was cleared of taking cocaine in 2002 by proving that traces of the drug came from coca leaf sweets his aunt brought back from Peru"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "Daniel Plaza, an Olympic race-walking champion from Spain, said that a positive test for nandrolone in 1996 had been caused by his performing a sex act on his pregnant wife. Ten years later, he was cleared"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "Dennis Mitchell’s high levels of testosterone in 1998 were caused by having sex with his wife “at least four times” on her birthday, according to the sprinter. USA Track and Field believed him, the IAAF did not"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "In 2010 the American sprinter LaShawn Merritt blamed a positive test on not reading the ingredients for his penis enlargement medication. A possible two-year ban was reduced by three months"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					}
+				],
+				"name": "ul"
+			}],
+			"name": "key-facts"
+		},
+		{
+			"attributes": {
+				"title": "Sex, cocaine and sport: a volatile combination"
+			},
+			"children": [{
+				"attributes": {},
+				"children": [{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "The Italian cyclist Gilberto Simoni was cleared of taking cocaine in 2002 by proving that traces of the drug came from coca leaf sweets his aunt brought back from Peru"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "Daniel Plaza, an Olympic race-walking champion from Spain, said that a positive test for nandrolone in 1996 had been caused by his performing a sex act on his pregnant wife. Ten years later, he was cleared"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "Dennis Mitchell’s high levels of testosterone in 1998 were caused by having sex with his wife “at least four times” on her birthday, according to the sprinter. USA Track and Field believed him, the IAAF did not"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					},
+					{
+						"attributes": {},
+						"children": [{
+							"children": [{
+								"text": "In 2010 the American sprinter LaShawn Merritt blamed a positive test on not reading the ingredients for his penis enlargement medication. A possible two-year ban was reduced by three months"
+							}],
+							"name": "text"
+						}],
+						"name": "li"
+					}
+				],
+				"name": "ul"
+			}],
+			"name": "key-facts"
+		},
+		{
+			"attributes": {
+				"name": "",
+				"text": "",
+				"twitter": ""
+			},
+			"children": [{
+				"children": [{
+					"text": "He never said anything to me about suicide or self-harm. I don’t understand why he did it"
+				}],
+				"name": "text"
+			}],
+			"name": "pull-quote"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Big header"
+				}],
+				"name": "text"
+			}],
+			"name": "h2"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Stephen Evans, whose previous film credits include Henry V and The Madness of King George, wants to cast a footballer who can be taught to act, rather than an actor who can be taught to play football in the role of the young Best."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Medium header"
+				}],
+				"name": "text"
+			}],
+			"name": "h3"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Small header"
+				}],
+				"name": "text"
+			}],
+			"name": "h4"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "The search, to begin next month, is similar to that employed for Seve, a film produced by Evans about the life of the Spanish golfer Severiano Ballesteros, for which the rising young golf star Jose Luis Gutierrez, then 15, was cast in the lead role."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Smaller header"
+				}],
+				"name": "text"
+			}],
+			"name": "h5"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Like Seve, the Best film will combine archive footage with dramatic re-enactment filmed in Belfast and Manchester."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Smallest header"
+				}],
+				"name": "text"
+			}],
+			"name": "h6"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "“What we want is a good-looking, spindly, cheeky chappy,” Evans said. “The only man who could play Best in adulthood — and match his resolute intensity, wit and charisma — is George himself. Any other actor would fall woefully short, above all during any footballing sequences.”"
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Evans, who has worked on films nominated for a total of 11 Oscars, said a key aspect of the film would be Best’s relationship with Mary Fullaway, his landlady when he moved to Manchester at the age of 15."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "“She did everything. She used to answer sackloads of fan mail that came in, she built him up weight-wise by feeding him well,” said Evans, who hopes to cast someone “of [actress] Julie Walters’s calibre” to play her."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "“He was very homesick when he came to Manchester. She was the one who helped him get over it.”"
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Best, who scored 178 goals in 466 appearances for Manchester United between 1963 and 1974 and won 37 caps for Northern Ireland, remained close to Fullaway even after becoming one of the most famous and wealthy footballers of his generation."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "The biopic will also cover his hedonistic lifestyle and descent into alcoholism. He died in 2005, aged 59."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "Evans, who hopes to begin filming this summer, said there were similarities between Ballesteros, who won more than 90 tournaments including five major championships, and Best."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		},
+		{
+			"attributes": {},
+			"children": [{
+				"children": [{
+					"text": "“They lit up their generation like a comet, both on and off the pitch,” he said."
+				}],
+				"name": "text"
+			}],
+			"name": "paragraph"
+		}
+	]
+}

--- a/packages/markup/fixtures/copy-paragraph.json
+++ b/packages/markup/fixtures/copy-paragraph.json
@@ -1,0 +1,172 @@
+{
+  "fixture": [
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "THE producer of a new film about the life of George Best is to scour football academies looking for a skilful teenager to play the former Manchester United star."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "Stephen Evans, whose previous film credits include Henry V and The Madness of King George, wants to cast a footballer who can be taught to act, rather than an actor who can be taught to play football in the role of the young Best."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "The search, to begin next month, is similar to that employed for Seve, a film produced by Evans about the life of the Spanish golfer Severiano Ballesteros, for which the rising young golf star Jose Luis Gutierrez, then 15, was cast in the lead role."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "Like Seve, the Best film will combine archive footage with dramatic re-enactment filmed in Belfast and Manchester."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "“What we want is a good-looking, spindly, cheeky chappy,” Evans said. “The only man who could play Best in adulthood — and match his resolute intensity, wit and charisma — is George himself. Any other actor would fall woefully short, above all during any footballing sequences.”"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "Evans, who has worked on films nominated for a total of 11 Oscars, said a key aspect of the film would be Best’s relationship with Mary Fullaway, his landlady when he moved to Manchester at the age of 15."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "“She did everything. She used to answer sackloads of fan mail that came in, she built him up weight-wise by feeding him well,” said Evans, who hopes to cast someone “of [actress] Julie Walters’s calibre” to play her."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "“He was very homesick when he came to Manchester. She was the one who helped him get over it.”"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "Best, who scored 178 goals in 466 appearances for Manchester United between 1963 and 1974 and won 37 caps for Northern Ireland, remained close to Fullaway even after becoming one of the most famous and wealthy footballers of his generation."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "The biopic will also cover his hedonistic lifestyle and descent into alcoholism. He died in 2005, aged 59."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "Evans, who hopes to begin filming this summer, said there were similarities between Ballesteros, who won more than 90 tournaments including five major championships, and Best."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "paragraph",
+      "attributes": {},
+      "children": [
+        {
+          "name": "text",
+          "children": [
+            {
+              "text": "“They lit up their generation like a comet, both on and off the pitch,” he said."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/markup/markup-builder.js
+++ b/packages/markup/markup-builder.js
@@ -28,6 +28,11 @@ function astToMarkup(tagMap, key, wrapTextWith, [x, ...xs]) {
 
   const { tag, attrs, wrapText } = tagMap.get(x.name) || {};
 
+  console.log('--------');
+  console.log(attrs);
+  console.log(x.attributes);
+  console.log('--------');
+
   if (tag) {
     children.push(
       React.createElement(

--- a/packages/markup/markup.js
+++ b/packages/markup/markup.js
@@ -28,6 +28,11 @@ const styles = {
     lineHeight: 25,
     marginTop: 10,
     marginBottom: 10
+  },
+  keyfacts: {
+    color: "#333",
+    fontFamily: "TimesDigital-Regular",
+    fontSize: 13,
   }
 };
 
@@ -111,7 +116,20 @@ const tagMap = new Map([
         };
       }
     }
-  ]
+  ],
+  [
+    "key-facts",
+    {
+      tag: View,
+      attrs({ title }) {
+        return {
+          style: styles.keyfacts,
+          title
+        };
+      },
+      wrapText: Text
+    }
+  ],
 ]);
 
 const MarkupNative = ({ ast, wrapIn }) =>

--- a/packages/markup/markup.js
+++ b/packages/markup/markup.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { View, Text, Linking, StyleSheet } from "react-native";
+import { View, Text, Linking } from "react-native";
 import Markup, { builder as mb } from "./markup-builder";
 import propTypes from "./markup-proptype";
 
-const styles = StyleSheet.create({
+const styles = {
   italic: {
     fontStyle: "italic"
   },
@@ -12,8 +12,24 @@ const styles = StyleSheet.create({
   },
   anchor: {
     color: "blue"
+  },
+  paragraph: {
+    color: "#333",
+    fontFamily: "TimesDigital-Regular",
+    fontSize: 16,
+    lineHeight: 20,
+    marginTop: 10,
+    marginBottom: 10
+  },
+  pullquote: {
+    color: "#000",
+    fontFamily: "TimesModern-Regular",
+    fontSize: 25,
+    lineHeight: 25,
+    marginTop: 10,
+    marginBottom: 10
   }
-});
+};
 
 const tagMap = new Map([
   [
@@ -72,6 +88,28 @@ const tagMap = new Map([
       tag: View,
       attrs() {},
       wrapText: Text
+    }
+  ],
+  [
+    "paragraph",
+    {
+      tag: Text,
+      attrs() {
+        return {
+          style: styles.paragraph
+        };
+      }
+    }
+  ],
+  [
+    "pull-quote",
+    {
+      tag: Text,
+      attrs() {
+        return {
+          style: styles.pullquote
+        };
+      }
     }
   ]
 ]);

--- a/packages/markup/markup.stories.js
+++ b/packages/markup/markup.stories.js
@@ -9,6 +9,9 @@ const multiParagraph = require("./fixtures/multi-paragraph.json").fixture;
 const mixture = require("./fixtures/tag-mixture.json").fixture;
 const bio = require("./fixtures/bio.json").fixture;
 
+const copyParagraph = require("./fixtures/copy-paragraph.json").fixture;
+const copyMultiFields = require("./fixtures/copy-multi-fields.json").fixture;
+
 const story = m => <View style={{ padding: 20 }}>{m}</View>;
 
 storiesOf("Markup", module)
@@ -27,4 +30,6 @@ storiesOf("Markup", module)
         )}
       </View>
     )
-  );
+  )
+  .add("Multiple copy paragraphs", () => story(<Markup ast={copyParagraph} />))
+  .add("Multiple copy fields", () => story(<Markup ast={copyMultiFields} />));

--- a/packages/markup/markup.stories.js
+++ b/packages/markup/markup.stories.js
@@ -11,6 +11,7 @@ const bio = require("./fixtures/bio.json").fixture;
 
 const copyParagraph = require("./fixtures/copy-paragraph.json").fixture;
 const copyMultiFields = require("./fixtures/copy-multi-fields.json").fixture;
+const copyKeyFacts = require("./fixtures/copy-key-facts.json").fixture;
 
 const story = m => <View style={{ padding: 20 }}>{m}</View>;
 
@@ -32,4 +33,5 @@ storiesOf("Markup", module)
     )
   )
   .add("Multiple copy paragraphs", () => story(<Markup ast={copyParagraph} />))
+  .add("Multiple copy key-facts", () => story(<Markup ast={copyKeyFacts} />))
   .add("Multiple copy fields", () => story(<Markup ast={copyMultiFields} />));

--- a/packages/markup/markup.web.js
+++ b/packages/markup/markup.web.js
@@ -12,6 +12,11 @@ const styles = {
     fontFamily: "TimesModern-Regular",
     fontSize: 25,
     lineHeight: 1.2
+  },
+  keyfacts: {
+    color: "#333",
+    fontFamily: "TimesDigital-Regular",
+    fontSize: 13,
   }
 };
 
@@ -83,7 +88,19 @@ const tagMap = new Map([
         };
       }
     }
-  ]
+  ],
+  [
+    "key-facts",
+    {
+      tag: "div",
+      attrs({ title }) {
+        return {
+          style: styles.keyfacts,
+          title
+        };
+      }
+    }
+  ],
 ]);
 
 const MarkupWeb = ({ ast, wrapIn }) =>

--- a/packages/markup/markup.web.js
+++ b/packages/markup/markup.web.js
@@ -2,6 +2,19 @@ import React from "react";
 import Markup, { builder as mb } from "./markup-builder";
 import propTypes from "./markup-proptype";
 
+const styles = {
+  paragraph: {
+    color: "#333",
+    fontFamily: "TimesDigital-Regular"
+  },
+  pullquote: {
+    color: "#000",
+    fontFamily: "TimesModern-Regular",
+    fontSize: 25,
+    lineHeight: 1.2
+  }
+};
+
 const tagMap = new Map([
   [
     "p",
@@ -47,6 +60,28 @@ const tagMap = new Map([
     {
       tag: "div",
       attrs() {}
+    }
+  ],
+  [
+    "paragraph",
+    {
+      tag: "p",
+      attrs() {
+        return {
+          style: styles.paragraph
+        };
+      }
+    }
+  ],
+  [
+    "pull-quote",
+    {
+      tag: "p",
+      attrs() {
+        return {
+          style: styles.pullquote
+        };
+      }
     }
   ]
 ]);


### PR DESCRIPTION
Markup new UI components WIP
![image](https://user-images.githubusercontent.com/1150553/29183273-f627ef28-7df9-11e7-9915-ad318f9325f2.png)


Contains:
- [DONE] paragraphs
- [WIP] pull-quote: misses diamond as :before
- [WIP] key-facts: misses diamond as :before for every `<li>`; title is being provided but not rendered yet.

TODO:
- Above mentions for pull-quote and key-facts
- headings (h1-h5)
- handle :before as we cant have pseudo classes in RN (do it in a similar way we're doing with article-flag)