### PR TITLE
Added ability to handle fullscreen outside of the component for Android

### DIFF
--- a/packages/brightcove-video/README.md
+++ b/packages/brightcove-video/README.md
@@ -62,6 +62,8 @@ Properties types are defined in `./brightcove-video.proptypes.js`
 | `height` | number | height of the player
 | `onError` | function | Handle errors
 | `onChange` | function |
+| `onGoFullScreen` | function | Handle signal to go full screen in parent (Android)
+| `onExitFullScreen` | function | Handle signal to go out of full screen in parent (Android)
 | `autoplay` | boolean | Should the video autoplay
 
 ## Usage
@@ -79,6 +81,12 @@ import BrightcoveVideo from '@times-component/brightcove-video';
     onError={console.error}
     policyKey={BRIGHTCOVE_POLICY_KEY} // Required for native
     autoplay={true}
+    onGoFullScreen={this.doSomethingAboutIt} // Android Only, see note below
+    onExitFullScreen={this.doSomethingAboutIt} // Android Only, see note below
 />
 
 ```
+
+## Note about handling full screen on Android
+
+:warning: On Android, in the native SDK, it is the parent that handles the full screen change (`BrightCovePlayer`, that extends an Activity, and not `BrightcoveExoPlayerView`, what we use in this component), so you have to handle the full screen yourself in react-native with the `onGoFullScreen` and `onExitFullScreen` handlers.

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
@@ -26,12 +26,14 @@ public class RNTBrightcoveView extends BrightcoveExoPlayerVideoView {
     private String mAccountId;
     private String mPolicyKey;
     private String mPlayerStatus;
+    private Boolean mIsFullScreen;
     private Boolean mAutoplay;
 
     public RNTBrightcoveView(final ThemedReactContext context) {
         super(context);
         finishInitialization();
         this.setMediaController(new BrightcoveMediaController(this));
+        mIsFullScreen = false;
     }
 
     public void setVideoId(final String videoId) {
@@ -78,6 +80,23 @@ public class RNTBrightcoveView extends BrightcoveExoPlayerVideoView {
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topLoadingError", event);
     }
 
+    private void emitToggleFullScreen() {
+        WritableMap event = Arguments.createMap();
+        String nextFullScreenState = "";
+
+        if (mIsFullScreen) {
+            mIsFullScreen = false;
+            nextFullScreenState = "NORMAL_SCREEN";
+        } else {
+            mIsFullScreen = true;
+            nextFullScreenState = "FULL_SCREEN";
+        }
+
+        event.putString("fullScreenState", nextFullScreenState);
+        ReactContext reactContext = (ReactContext) getContext();
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topChange", event);
+    }
+
     private EventEmitter setupEventEmitter() {
         EventEmitter eventEmitter = getEventEmitter();
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
@@ -92,6 +111,12 @@ public class RNTBrightcoveView extends BrightcoveExoPlayerVideoView {
             @Override
             public void processEvent(Event e) {
                 emitState();
+            }
+        });
+        eventEmitter.on(EventType.ENTER_FULL_SCREEN, new EventListener() {
+            @Override
+            public void processEvent(Event e) {
+                emitToggleFullScreen();
             }
         });
         eventEmitter.on(EventType.ERROR, new EventListener() {

--- a/packages/brightcove-video/brightcove-video.defaults.js
+++ b/packages/brightcove-video/brightcove-video.defaults.js
@@ -4,5 +4,7 @@ export default {
   playerId: "default",
   onError: () => {},
   onChange: () => {},
+  onGoFullScreen: () => {},
+  onExitFullScreen: () => {},
   autoplay: false
 };

--- a/packages/brightcove-video/brightcove-video.native.js
+++ b/packages/brightcove-video/brightcove-video.native.js
@@ -27,8 +27,8 @@ class BrightcoveVideo extends Component {
 
     this.onChange = this.onChange.bind(this);
     this.onError = this.onError.bind(this);
-    this.componentWillUnmount = this.componentWillUnmount.bind(this);
     this.handleAppStateChange = this.handleAppStateChange.bind(this);
+    this.handlePlayerRef = this.handlePlayerRef.bind(this);
 
     this.publicMethods = {
       play: this.play.bind(this),
@@ -45,9 +45,14 @@ class BrightcoveVideo extends Component {
   }
 
   onChange(evt) {
-    this.props.onChange(evt.nativeEvent);
-
-    this.setState({ playing: evt.nativeEvent.playerStatus === "playing" });
+    if (evt.nativeEvent.fullScreenState === "FULL_SCREEN") {
+      this.props.onGoFullScreen();
+    } else if (evt.nativeEvent.fullScreenState === "NORMAL_SCREEN") {
+      this.props.onExitFullScreen();
+    } else {
+      this.props.onChange(evt.nativeEvent);
+      this.setState({ playing: evt.nativeEvent.playerStatus === "playing" });
+    }
   }
 
   onError(evt) {
@@ -87,14 +92,16 @@ class BrightcoveVideo extends Component {
     this.props.runNativeCommand("pause", []);
   }
 
+  handlePlayerRef(ref) {
+    this.bcPlayer = ref;
+  }
+
   render() {
     const NativeBrightcove = BrightcoveVideo.getNativeBrightcoveComponent();
 
     return (
       <NativeBrightcove
-        ref={ref => {
-          this.bcPlayer = ref;
-        }}
+        ref={this.handlePlayerRef}
         style={{ height: this.props.height, width: this.props.width }}
         policyKey={this.props.policyKey}
         accountId={this.props.accountId}


### PR DESCRIPTION
I did not manage to have a `topGoFullScreen` or `topExitFullScreen` native event to work so I go through the `onChange` method instead. I hope that's ok.

Also, there is one problem left that I didn't manage to solve, it is that the internal state of the component does not seem to see that it goes fullscreen, so the button does not change state (=the icon stays the same) and only the `EventType.ENTER_FULL_SCREEN` event is emitted, so I had to add an internal state variable (`mIsFullScreen`) to handle that problem on our level.

About the `ref` handling in `brightcove-video.native.js`, React docs recommend to avoid binding functions in the render
```
We generally recommend binding in the constructor or using the property
initializer syntax, to avoid this sort of performance problem.
```
https://facebook.github.io/react/docs/handling-events.html

As always, feedback is welcome 😄 

Should solve #121 

What do you think @trevorah ?