### PR TITLE
fix: allow image caption to have credits only

### DIFF
--- a/packages/caption/__snapshots__/caption.test.js.snap
+++ b/packages/caption/__snapshots__/caption.test.js.snap
@@ -140,6 +140,47 @@ exports[`renders correctly with credits 1`] = `
 </View>
 `;
 
+exports[`renders correctly with credits only 1`] = `
+<View>
+  <View
+    style={
+      Array [
+        Object {
+          "paddingTop": 10,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#696969",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 13,
+            "lineHeight": 15,
+          },
+          Object {
+            "color": "#333",
+            "fontSize": 9,
+            "fontWeight": "400",
+            "letterSpacing": 1,
+            "marginTop": 2,
+          },
+          undefined,
+        ]
+      }
+    >
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`renders correctly with specific styles 1`] = `
 <View>
   <View

--- a/packages/caption/caption.js
+++ b/packages/caption/caption.js
@@ -25,7 +25,7 @@ const Caption = ({ text, credits, style, children }) =>
   <View>
     {children}
     <View style={[defaultStyle.container, style.container]}>
-      <Text style={[defaultStyle.text, style.text]}>{text}</Text>
+      {text && <Text style={[defaultStyle.text, style.text]}>{text}</Text>}
       {credits &&
         <Text style={[defaultStyle.text, defaultStyle.credits, style.text]}>
           {credits.toUpperCase()}
@@ -34,13 +34,14 @@ const Caption = ({ text, credits, style, children }) =>
   </View>;
 
 Caption.defaultProps = {
+  text: null,
   credits: null,
   style: {},
   children: null
 };
 
 Caption.propTypes = {
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   credits: PropTypes.string,
   style: PropTypes.shape({
     text: Text.propTypes.style,

--- a/packages/caption/caption.stories.js
+++ b/packages/caption/caption.stories.js
@@ -22,6 +22,7 @@ const style = {
 storiesOf("Caption", module)
   .add("Without credits", () => <Caption text={captionText} />)
   .add("With credits", () => <Caption text={captionText} credits={credits} />)
+  .add("Credits only", () => <Caption credits={credits} />)
   .add("With specific styles", () =>
     <Caption text={captionText} credits={credits} style={style} />
   )

--- a/packages/caption/caption.test.js
+++ b/packages/caption/caption.test.js
@@ -35,6 +35,12 @@ it("renders correctly with credits", () => {
   expect(tree).toMatchSnapshot();
 });
 
+it("renders correctly with credits only", () => {
+  const tree = renderer.create(<Caption credits={credits} />).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
 it("renders correctly with specific styles", () => {
   const tree = renderer
     .create(<Caption text={captionText} credits={credits} style={style} />)


### PR DESCRIPTION
This PR is just to allow the already existent caption component to render credits only.

![image](https://user-images.githubusercontent.com/5799039/29421145-08bfe024-836c-11e7-91fa-d62c374fed43.png)

