### PR TITLE
fix: link package main entry point should be link

### DIFF
--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -2,7 +2,7 @@
   "name": "@times-components/link",
   "version": "0.1.1",
   "description": "component to handle links and navigation",
-  "main": "link.js",
+  "main": "link",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
     "test:watch": "jest --bail --verbose --watchAll",


### PR DESCRIPTION
Change the entry point for the `link` package from `link.js` to `link` in order to support proper multi platform import.
