### PR TITLE
fix: remove extension from main entry point in cli tool

### DIFF
--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -2,7 +2,7 @@ module.exports = variables => ({
   name: `@times-components/${variables.packageName}`,
   version: variables.version || "0.0.1",
   description: variables.packageDescription,
-  main: `${variables.packageName}.js`,
+  main: `${variables.packageName}`,
   scripts: {
     flow: "node_modules/flow-bin/cli.js",
     "test:watch": "jest --bail --verbose --watchAll",


### PR DESCRIPTION
Remove the `.js` extension from the main entry point in the cli tool. To avoid issues like #166
