### PR TITLE
chore: remove storybook reference from peerDependencies

### DIFF
--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -51,7 +51,6 @@ module.exports = variables => ({
     "react-native-web": "0.0.119"
   },
   peerDependencies: {
-    "@storybook/react-native": ">=3",
     react: ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/lib/cli/templates.js
+++ b/lib/cli/templates.js
@@ -12,6 +12,7 @@ export default function {{{component}}}() {
 
 const storyFile = handlebars.compile(`import "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import {{{component}}} from "./{{{packageName}}}";
 

--- a/packages/ad/ad.stories.native.js
+++ b/packages/ad/ad.stories.native.js
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import { Text, ScrollView } from "react-native";
 

--- a/packages/ad/ad.stories.web.js
+++ b/packages/ad/ad.stories.web.js
@@ -1,5 +1,6 @@
 /* eslint-env browser */
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 
 import Ad, { AdComposer } from "./ad.web";

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -60,7 +60,6 @@
     "svgs": "2.3.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/article-byline/article-byline.stories.js
+++ b/packages/article-byline/article-byline.stories.js
@@ -1,5 +1,6 @@
 import { View } from "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import ArticleByline from "./article-byline";
 

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -57,7 +57,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/article-flag/article-flag.stories.js
+++ b/packages/article-flag/article-flag.stories.js
@@ -1,5 +1,6 @@
 import "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import {
   NewArticleFlag,

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -57,7 +57,6 @@
     "svgs": "2.3.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42",

--- a/packages/article-headline/article-headline.stories.js
+++ b/packages/article-headline/article-headline.stories.js
@@ -1,5 +1,6 @@
 import "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import ArticleHeadline from "./article-headline";
 

--- a/packages/article-headline/package.json
+++ b/packages/article-headline/package.json
@@ -56,7 +56,6 @@
     "react-style-proptype": "3.0.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/article-label/article-label.stories.js
+++ b/packages/article-label/article-label.stories.js
@@ -1,5 +1,6 @@
 import "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import ArticleLabel from "./article-label";
 

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -55,7 +55,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/article-summary/article-summary.stories.js
+++ b/packages/article-summary/article-summary.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { View } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import ArticleSummary from "./article-summary";
 import props from "./fixtures/article.json";

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -58,7 +58,6 @@
     "react-style-proptype": "3.0.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/article/article.stories.js
+++ b/packages/article/article.stories.js
@@ -2,8 +2,9 @@
 
 import { View, Platform } from "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
-import Article from "./article";
+import Article from "../article";
 
 const renderIframe = () => {
   if (Platform.OS !== "web") {

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -58,7 +58,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/author-head/author-head.stories.js
+++ b/packages/author-head/author-head.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { View } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import AuthorHead from "./author-head";
 

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -56,7 +56,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/author-profile/author-profile.stories.js
+++ b/packages/author-profile/author-profile.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import AuthorProfile from "./author-profile";
 import example from "./example.json";

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -67,7 +67,6 @@
     "react-style-proptype": "3.0.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/brightcove-video/brightcove-video.stories.js
+++ b/packages/brightcove-video/brightcove-video.stories.js
@@ -2,7 +2,9 @@
 
 import React from "react";
 import { View } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { decorateAction } from "@storybook/addon-actions";
 
 import BrightcoveVideo from "./brightcove-video";

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -57,8 +57,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/addon-actions": ">=3",
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/caption/caption.stories.js
+++ b/packages/caption/caption.stories.js
@@ -1,5 +1,6 @@
 import "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import Image from "@times-components/image";
 import Caption from "./caption";

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -56,7 +56,6 @@
     "react-style-proptype": "3.0.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/card/card.stories.js
+++ b/packages/card/card.stories.js
@@ -1,5 +1,6 @@
 import { View } from "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import Card from "./card";
 import props from "./fixtures/card-props.json";

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -60,7 +60,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/date-publication/date-publication.stories.js
+++ b/packages/date-publication/date-publication.stories.js
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import DatePublication from "./date-publication";
 

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -56,7 +56,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/error-view/error-view.stories.js
+++ b/packages/error-view/error-view.stories.js
@@ -2,7 +2,9 @@
 
 import React from "react";
 import { TouchableWithoutFeedback, View, Text } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { decorateAction } from "@storybook/addon-actions";
 import PropTypes from "prop-types";
 import StylePropTypes from "react-style-proptype";

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -57,8 +57,6 @@
     "react-style-proptype": "3.0.0"
   },
   "peerDependencies": {
-    "@storybook/addon-actions": ">=3",
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import Image from "./image";
 

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -60,7 +60,6 @@
     "react-style-proptype": "3.0.0"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/link/link.stories.js
+++ b/packages/link/link.stories.js
@@ -1,5 +1,6 @@
 import "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import Link from "./link";
 

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -62,7 +62,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/markup/markup.stories.js
+++ b/packages/markup/markup.stories.js
@@ -2,6 +2,7 @@
 
 import { View } from "react-native";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import Markup, { builder } from "./markup";
 

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -48,7 +48,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -62,8 +62,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/addon-actions": ">=3",
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/pagination/pagination.stories.js
+++ b/packages/pagination/pagination.stories.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { View } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { action } from "@storybook/addon-actions";
 import Pagination, { withPageState } from "./pagination";
 

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -62,7 +62,6 @@
     "react-native-web": "0.0.119"
   },
   "peerDependencies": {
-    "@storybook/react-native": ">=3",
     "react": ">=15",
     "react-dom": ">=15",
     "react-native": ">=0.42"

--- a/packages/provider/provider.stories.js
+++ b/packages/provider/provider.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import { withPageState } from "@times-components/pagination";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,9 +189,9 @@
     react-treebeard "^2.0.3"
     redux "^3.6.0"
 
-"@times-components/fructose@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@times-components/fructose/-/fructose-1.0.0.tgz#4acd4590ccfcae8815321d643d29b2b87300a498"
+"@times-components/fructose@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@times-components/fructose/-/fructose-1.1.0.tgz#6d2e1e8126850e260316e65d83d2d5814fc58eb2"
   dependencies:
     babel-polyfill "^6.23.0"
     babel-preset-es2015 "^6.24.1"


### PR DESCRIPTION
When using the components for production builds we don't need storybook packages.