### PR TITLE
twitter username link proposal

### DIFF
--- a/packages/author-head/author-head.js
+++ b/packages/author-head/author-head.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, StyleSheet, Text } from "react-native";
+import { View, StyleSheet, Text, TouchableHighlight } from "react-native";
 import PropTypes from "prop-types";
 
 import Image from "@times-components/image";
@@ -42,6 +42,8 @@ const styles = StyleSheet.create({
     padding: 8,
     fontSize: 15,
     fontFamily: "GillSansMTStd-Medium",
+    // backgroundColor required for TouchableHighlight to look correct on press
+    backgroundColor: "#F9F8F3",
     color: "#069"
   },
   bio: {
@@ -60,7 +62,7 @@ const styles = StyleSheet.create({
 });
 
 const AuthorHead = props => {
-  const { name, title, twitter, bio, uri } = props;
+  const { name, title, twitter, bio, uri, onLinkPress } = props;
 
   return (
     <View style={styles.wrapper} pointerEvents="box-none">
@@ -71,9 +73,13 @@ const AuthorHead = props => {
         <Text accessibilityRole="heading" aria-level="2" style={styles.title}>
           {title.toLowerCase()}
         </Text>
-        <Text style={styles.twitter}>
-          {twitter}
-        </Text>
+        <TouchableHighlight
+          onPress={() => onLinkPress(`https://twitter.com/${twitter}`)}
+        >
+          <Text style={styles.twitter}>
+            {"@" + twitter}
+          </Text>
+        </TouchableHighlight>
         <Text style={styles.bio}>
           <Markup ast={bio} wrapIn="p" />
         </Text>
@@ -98,7 +104,8 @@ AuthorHead.propTypes = {
   title: PropTypes.string,
   uri: PropTypes.string,
   bio: Markup.propTypes.ast,
-  twitter: PropTypes.string
+  twitter: PropTypes.string,
+  onLinkPress: PropTypes.function
 };
 
 export default AuthorHead;

--- a/packages/author-head/author-head.stories.js
+++ b/packages/author-head/author-head.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { storiesOf } from "@storybook/react-native";
+import { action } from "@storybook/addon-actions";
 import AuthorHead from "./author-head";
 
 const data = require("./fixtures/profile.json");
@@ -11,5 +12,5 @@ const story = m =>
   </View>;
 
 storiesOf("AuthorHead", module).add("Full Header", () =>
-  story(<AuthorHead {...data} />)
+  story(<AuthorHead onLinkPress={action("onLinkPress")} {...data} />)
 );

--- a/packages/author-profile/author-profile-header.js
+++ b/packages/author-profile/author-profile-header.js
@@ -29,6 +29,7 @@ const AuthorProfileHeader = ({
   name,
   onNext,
   onPrev,
+  onLinkPress,
   pageSize,
   twitter
 }) => {
@@ -37,7 +38,8 @@ const AuthorProfileHeader = ({
     name,
     uri,
     title,
-    twitter
+    twitter,
+    onLinkPress
   };
 
   const paginationProps = {
@@ -70,6 +72,7 @@ AuthorProfileHeader.propTypes = {
   name: AuthorHead.propTypes.name,
   onNext: PropTypes.func,
   onPrev: PropTypes.func,
+  onLinkPress: PropTypes.func,
   page: Pagination.propTypes.page,
   pageSize: Pagination.propTypes.pageSize,
   twitter: AuthorHead.propTypes.twitter

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -18,6 +18,7 @@ const AuthorProfile = props => {
     const extra = {
       onNext: props.onNext,
       onPrev: props.onPrev,
+      onLinkPress: props.onLinkPress,
       page: props.page,
       pageSize: props.pageSize
     };
@@ -34,7 +35,8 @@ AuthorProfile.propTypes = {
   onNext: AuthorProfileContent.propTypes.onNext,
   onPrev: AuthorProfileContent.propTypes.onPrev,
   page: AuthorProfileContent.propTypes.page,
-  pageSize: AuthorProfileContent.propTypes.pageSize
+  pageSize: AuthorProfileContent.propTypes.pageSize,
+  onLinkPress: PropTypes.function
 };
 
 AuthorProfile.defaultProps = {

--- a/packages/author-profile/author-profile.stories.js
+++ b/packages/author-profile/author-profile.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import { storiesOf } from "@storybook/react-native";
+import { action } from "@storybook/addon-actions";
 import AuthorProfile from "./author-profile";
 import example from "./example.json";
 
@@ -30,6 +31,7 @@ storiesOf("AuthorProfile", module)
         pageSize: 10,
         page: 1
       }),
+      onLinkPress: action("onLinkPress"),
       isLoading: false
     };
 


### PR DESCRIPTION
DO NOT MERGE

I've done this as a bit of a discussion piece. Web, Android and iOS all have their different navigation styles, so I figured it would be up to something outside of the component to figure out how to navigate to a given uri.

Here's a proposal in the form of an example for author profile twitter username links. Check out and try the storybook.

talking points:
- **buttons vs links:** on web, these "links" feel like buttons. this may help us feel more appy, but it means that people cant open the twitter profiles in new tabs. 👎 
- **prop passing:** It may just be the author profile components, but passing a function through 3 components seems a bit much. fix the nesting or use context hackery?
- **required functions:** buttons that look enabled but are unresponsive are poo poo. I say make them required.
- **fancy links:** article link navigation would be so much easier if ids (not just urls) get passed around. Should we have a catchall function or specialist ones (e.g `onLinkPress` vs `onArticleLinkPress` and`onAuthorLinkPress` etc)

@craigbilner @fampinheiro @nehasri89 @JGAntunes thoughts?