### PR TITLE
BREAKING CHANGE: conform markup component to new server side api

### DIFF
--- a/packages/article-byline/__snapshots__/article-byline.test.js.snap
+++ b/packages/article-byline/__snapshots__/article-byline.test.js.snap
@@ -75,14 +75,6 @@ exports[`renders correctly with multiple authors, titles and texts 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    style={Object {}}
-  >
-    , Social Affairs Correspondent | Mark Bridge, Technology Correspondent | 
-  </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     onPress={[Function]}
     style={
       Array [

--- a/packages/article-byline/__snapshots__/article-byline.test.js.snap
+++ b/packages/article-byline/__snapshots__/article-byline.test.js.snap
@@ -75,6 +75,14 @@ exports[`renders correctly with multiple authors, titles and texts 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
+    style={Object {}}
+  >
+    , Social Affairs Correspondent | Mark Bridge, Technology Correspondent | 
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
     onPress={[Function]}
     style={
       Array [

--- a/packages/article-byline/fixtures/authors.json
+++ b/packages/article-byline/fixtures/authors.json
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "name": "span",
+      "name": "inline",
       "attributes": {},
       "children": [
         {

--- a/packages/article-summary/__tests__/__snapshots__/article-summary.test.js.snap
+++ b/packages/article-summary/__tests__/__snapshots__/article-summary.test.js.snap
@@ -124,7 +124,49 @@ exports[`renders an article-summary component with content 1`] = `
         "marginBottom": 10,
       }
     }
-  />
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "fontStyle": "italic",
+          }
+        }
+      >
+        The Times
+      </Text>
+       has learnt.
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      Quick action by the parents of the younger boys, when the pair did not return home after Friday prayers, thwarted the latest alleged attempt by young Britons to join the terrorist group, sources said.
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      It came two days after Britain’s most senior police officer reassured the families of three runaway schoolgirls from east London that they would not be prosecuted if they returned
+    </Text>
+  </Text>
   <Text
     accessible={true}
     allowFontScaling={true}

--- a/packages/article-summary/__tests__/__snapshots__/article-summary.test.js.snap
+++ b/packages/article-summary/__tests__/__snapshots__/article-summary.test.js.snap
@@ -124,37 +124,7 @@ exports[`renders an article-summary component with content 1`] = `
         "marginBottom": 10,
       }
     }
-  >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
-      A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-       has learnt.
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
-      Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
-      Quick action by the parents of the younger boys, when the pair did not return home after Friday prayers, thwarted the latest alleged attempt by young Britons to join the terrorist group, sources said.
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
-      It came two days after Britain’s most senior police officer reassured the families of three runaway schoolgirls from east London that they would not be prosecuted if they returned
-    </Text>
-  </Text>
+  />
   <Text
     accessible={true}
     allowFontScaling={true}

--- a/packages/article-summary/fixtures/article.json
+++ b/packages/article-summary/fixtures/article.json
@@ -5,7 +5,7 @@
   "publication": "SUNDAYTIMES",
   "text": [
     {
-      "name": "p",
+      "name": "paragraph",
       "children": [
         {
           "name": "text",
@@ -16,7 +16,7 @@
           ]
         },
         {
-          "name": "em",
+          "name": "italic",
           "children": [
             {
               "name": "text",
@@ -41,7 +41,7 @@
       "attributes": {}
     },
     {
-      "name": "p",
+      "name": "paragraph",
       "children": [
         {
           "name": "text",
@@ -55,7 +55,7 @@
       "attributes": {}
     },
     {
-      "name": "p",
+      "name": "paragraph",
       "children": [
         {
           "name": "text",
@@ -69,7 +69,7 @@
       "attributes": {}
     },
     {
-      "name": "p",
+      "name": "paragraph",
       "children": [
         {
           "name": "text",

--- a/packages/author-head/author-head.js
+++ b/packages/author-head/author-head.js
@@ -75,7 +75,7 @@ const AuthorHead = props => {
           {twitter}
         </Text>
         <Text style={styles.bio}>
-          <Markup ast={bio} wrapIn="p" />
+          <Markup ast={bio} wrapIn="paragraph" />
         </Text>
       </View>
       <View style={styles.photoContainer}>

--- a/packages/author-head/fixtures/profile.json
+++ b/packages/author-head/fixtures/profile.json
@@ -3,8 +3,7 @@
   "name": "Carol Midgley",
   "title": "columnist",
   "twitter": "carolmidgley",
-  "bio":
-  [
+  "bio": [
     {
       "name": "text",
       "children": [
@@ -14,10 +13,8 @@
       ]
     },
     {
-      "name": "i",
-      "attributes": {
-
-      },
+      "name": "italic",
+      "attributes": {},
       "children": [
         {
           "name": "text",
@@ -38,10 +35,8 @@
       ]
     },
     {
-      "name": "i",
-      "attributes": {
-
-      },
+      "name": "italic",
+      "attributes": {},
       "children": [
         {
           "name": "text",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -967,7 +967,7 @@ exports[`renders profile 1`] = `
             "name": "text",
           },
         ],
-        "name": "b",
+        "name": "bold",
       },
       Object {
         "children": Array [
@@ -979,7 +979,7 @@ exports[`renders profile 1`] = `
       },
       Object {
         "attributes": Object {},
-        "name": "br",
+        "name": "break",
       },
       Object {
         "children": Array [
@@ -1001,7 +1001,7 @@ exports[`renders profile 1`] = `
             "name": "text",
           },
         ],
-        "name": "i",
+        "name": "italic",
       },
     ]
   }
@@ -1113,8 +1113,32 @@ exports[`renders profile content 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                ipsum
+              </Text>
                testbr 
               More text 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontStyle": "italic",
+                  }
+                }
+              >
+                 last 
+              </Text>
             </Text>
           </Text>
         </View>
@@ -4461,8 +4485,32 @@ exports[`renders profile content component 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                ipsum
+              </Text>
                testbr 
               More text 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontStyle": "italic",
+                  }
+                }
+              >
+                 last 
+              </Text>
             </Text>
           </Text>
         </View>
@@ -7838,8 +7886,32 @@ exports[`renders profile header 1`] = `
           ellipsizeMode="tail"
         >
           Lorem 
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            ipsum
+          </Text>
            testbr 
           More text 
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+             last 
+          </Text>
         </Text>
       </Text>
     </View>

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -1113,32 +1113,8 @@ exports[`renders profile content 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
-                }
-              >
-                ipsum
-              </Text>
                testbr 
               More text 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
-                }
-              >
-                 last 
-              </Text>
             </Text>
           </Text>
         </View>
@@ -1410,23 +1386,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1578,23 +1538,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1746,23 +1690,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1914,23 +1842,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2082,22 +1994,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2249,23 +2146,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2417,22 +2298,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2584,22 +2450,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2751,22 +2602,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2918,22 +2754,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3085,22 +2906,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3252,22 +3058,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3419,22 +3210,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3586,22 +3362,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3753,23 +3514,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3921,22 +3666,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4088,16 +3818,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Terry Pratchett, who died last week, began his career on the 
-                   in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4249,23 +3970,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
-                   to recite it by heart?
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4389,32 +4094,8 @@ exports[`renders profile content component 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
-                }
-              >
-                ipsum
-              </Text>
                testbr 
               More text 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
-                }
-              >
-                 last 
-              </Text>
             </Text>
           </Text>
         </View>
@@ -4686,23 +4367,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4854,23 +4519,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5022,23 +4671,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5190,23 +4823,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5358,22 +4975,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5525,23 +5127,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5693,22 +5279,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5860,22 +5431,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6027,22 +5583,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6194,22 +5735,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6361,22 +5887,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6528,22 +6039,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6695,22 +6191,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6862,22 +6343,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -7029,23 +6495,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -7197,22 +6647,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -7364,16 +6799,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Terry Pratchett, who died last week, began his career on the 
-                   in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -7525,23 +6951,7 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
-                   to recite it by heart?
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -7694,32 +7104,8 @@ exports[`renders profile header 1`] = `
           ellipsizeMode="tail"
         >
           Lorem 
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            ipsum
-          </Text>
            testbr 
           More text 
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-             last 
-          </Text>
         </Text>
       </Text>
     </View>

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -41,7 +41,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -52,7 +52,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -66,7 +66,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -106,7 +106,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -117,7 +117,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -131,7 +131,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -171,7 +171,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -182,7 +182,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -196,7 +196,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -236,7 +236,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -247,7 +247,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -261,7 +261,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -290,7 +290,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -304,7 +304,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Gay and IVF couples ‘better at raising children’",
@@ -344,7 +344,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -355,7 +355,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -369,7 +369,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -398,7 +398,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -412,7 +412,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -441,7 +441,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -455,7 +455,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -484,7 +484,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -498,7 +498,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -527,7 +527,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -541,7 +541,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -570,7 +570,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -584,7 +584,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -613,7 +613,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -627,7 +627,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -656,7 +656,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -670,7 +670,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Clash of interests tarnished the project",
@@ -699,7 +699,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -713,7 +713,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Giant brings out the stars for one last time",
@@ -753,7 +753,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -764,7 +764,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -778,7 +778,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Inquiry at sect schools that banned books",
@@ -807,7 +807,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -821,7 +821,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Top graduates drawn to jobs in social work",
@@ -861,7 +861,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -872,7 +872,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "TMS: Pratchett’s law of the jungle",
@@ -912,7 +912,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -923,7 +923,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -937,7 +937,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Learning by rote ‘will put pupils off poetry’",
@@ -1386,7 +1386,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1538,7 +1566,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1690,7 +1746,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1842,7 +1926,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1994,7 +2106,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2146,7 +2273,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2298,7 +2453,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2450,7 +2620,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2602,7 +2787,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2754,7 +2954,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2906,7 +3121,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3058,7 +3288,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3210,7 +3455,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3362,7 +3622,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3514,7 +3789,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3666,7 +3969,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3818,7 +4136,28 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Terry Pratchett, who died last week, began his career on the 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    Bucks Free Press
+                  </Text>
+                   in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3970,7 +4309,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    dulce et decorum
+                  </Text>
+                   to recite it by heart?
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4367,7 +4734,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4519,7 +4914,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4671,7 +5094,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4823,7 +5274,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4975,7 +5454,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5127,7 +5621,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5279,7 +5801,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5431,7 +5968,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5583,7 +6135,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5735,7 +6302,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -5887,7 +6469,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6039,7 +6636,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6191,7 +6803,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6343,7 +6970,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6495,7 +7137,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6647,7 +7317,22 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6799,7 +7484,28 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Terry Pratchett, who died last week, began his career on the 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    Bucks Free Press
+                  </Text>
+                   in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -6951,7 +7657,35 @@ exports[`renders profile content component 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    dulce et decorum
+                  </Text>
+                   to recite it by heart?
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -41,7 +41,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -52,7 +52,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -66,7 +66,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -106,7 +106,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -117,7 +117,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -131,7 +131,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -171,7 +171,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -182,7 +182,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -196,7 +196,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -236,7 +236,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -247,7 +247,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -261,7 +261,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -290,7 +290,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -304,7 +304,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Gay and IVF couples ‘better at raising children’",
@@ -344,7 +344,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -355,7 +355,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -369,7 +369,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "British trio stopped on the way to join Isis",
@@ -398,7 +398,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -412,7 +412,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -441,7 +441,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -455,7 +455,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -484,7 +484,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -498,7 +498,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -527,7 +527,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -541,7 +541,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -570,7 +570,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -584,7 +584,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -613,7 +613,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -627,7 +627,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Fourth Briton is seized trying to join Isis",
@@ -656,7 +656,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -670,7 +670,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Clash of interests tarnished the project",
@@ -699,7 +699,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -713,7 +713,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Giant brings out the stars for one last time",
@@ -753,7 +753,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -764,7 +764,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -778,7 +778,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Inquiry at sect schools that banned books",
@@ -807,7 +807,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -821,7 +821,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Top graduates drawn to jobs in social work",
@@ -861,7 +861,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -872,7 +872,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "TMS: Pratchett’s law of the jungle",
@@ -912,7 +912,7 @@ exports[`renders profile 1`] = `
                       "name": "text",
                     },
                   ],
-                  "name": "em",
+                  "name": "italic",
                 },
                 Object {
                   "children": Array [
@@ -923,7 +923,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
             Object {
               "attributes": Object {},
@@ -937,7 +937,7 @@ exports[`renders profile 1`] = `
                   "name": "text",
                 },
               ],
-              "name": "p",
+              "name": "paragraph",
             },
           ],
           "title": "Learning by rote ‘will put pupils off poetry’",
@@ -1386,7 +1386,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1538,7 +1566,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1690,7 +1746,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1842,7 +1926,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1994,7 +2106,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2146,7 +2273,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2298,7 +2453,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2450,7 +2620,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2602,7 +2787,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2754,7 +2954,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2906,7 +3121,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3058,7 +3288,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3210,7 +3455,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3362,7 +3622,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3514,7 +3789,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                   has learnt.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3666,7 +3969,22 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3818,7 +4136,28 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Terry Pratchett, who died last week, began his career on the 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    Bucks Free Press
+                  </Text>
+                   in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3970,7 +4309,35 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              />
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    dulce et decorum
+                  </Text>
+                   to recite it by heart?
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
+                </Text>
+              </Text>
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4373,7 +4740,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                 has learnt.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4532,7 +4927,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                 has learnt.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4691,7 +5114,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                 has learnt.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4850,7 +5301,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                 has learnt.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5009,7 +5488,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5168,7 +5662,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                 has learnt.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5327,7 +5849,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5486,7 +6023,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5645,7 +6197,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5804,7 +6371,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5963,7 +6545,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6122,7 +6719,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6281,7 +6893,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6440,7 +7067,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6599,7 +7241,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The Times
+                </Text>
+                 has learnt.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6758,7 +7428,22 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6917,7 +7602,28 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Terry Pratchett, who died last week, began his career on the 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  Bucks Free Press
+                </Text>
+                 in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -7076,7 +7782,35 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            />
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  dulce et decorum
+                </Text>
+                 to recite it by heart?
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
+              </Text>
+            </Text>
             <Text
               accessible={true}
               allowFontScaling={true}

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -1113,32 +1113,8 @@ exports[`renders profile content 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
-                }
-              >
-                ipsum
-              </Text>
                testbr 
               More text 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
-                }
-              >
-                 last 
-              </Text>
             </Text>
           </Text>
         </View>
@@ -1410,23 +1386,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1578,23 +1538,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1746,23 +1690,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -1914,23 +1842,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2082,22 +1994,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2249,23 +2146,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2417,22 +2298,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2584,22 +2450,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2751,22 +2602,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -2918,22 +2754,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3085,22 +2906,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3252,22 +3058,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3419,22 +3210,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3586,22 +3362,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3753,23 +3514,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
-                   has learnt.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -3921,22 +3666,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4088,16 +3818,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Terry Pratchett, who died last week, began his career on the 
-                   in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4249,23 +3970,7 @@ exports[`renders profile content 1`] = `
                     "marginBottom": 10,
                   }
                 }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
-                   to recite it by heart?
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
-                </Text>
-              </Text>
+              />
               <Text
                 accessible={true}
                 allowFontScaling={true}
@@ -4388,32 +4093,8 @@ exports[`renders profile content component 1`] = `
             ellipsizeMode="tail"
           >
             Lorem 
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "fontWeight": "bold",
-                }
-              }
-            >
-              ipsum
-            </Text>
              testbr 
             More text 
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "fontStyle": "italic",
-                }
-              }
-            >
-               last 
-            </Text>
           </Text>
         </Text>
       </View>
@@ -4692,23 +4373,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                 has learnt.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4867,23 +4532,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                 has learnt.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5042,23 +4691,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                 has learnt.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5217,23 +4850,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                 has learnt.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5392,22 +5009,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according to the author of a new book.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Susan Golombok, director of the Centre for Family Research at Cambridge University, believes that, in general, these so-called “new” families face so many obstacles to reach parenthood that they perform better when they arrive there.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5566,23 +5168,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                 has learnt.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5741,22 +5327,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -5915,22 +5486,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6089,22 +5645,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6263,22 +5804,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6437,22 +5963,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6611,22 +6122,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to reach Syria and join Islamic State.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The woman, identified as JNH, was detained at a bus terminal in Ankara by specialist police units that identify any would-be jihadists, according to Turkish officials. The Foreign Office confirmed that a British national had been detained. It is understood that she will be deported in the next few days.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6785,22 +6281,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories would help. It was never much more than an idea.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                His own prosperity as a result of his broad web of post prime ministerial business interests — including in the Middle East — is not in doubt.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -6959,22 +6440,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Dames, lords, actors, politicians and footballers were among 2,000 well-wishers at a memorial service in Westminster Abbey yesterday for Richard Attenborough, who died last August aged 90.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -7133,23 +6599,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid claims, 
-                 has learnt.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The Exclusive Brethren operates 34 schools under a restrictive regime that segregates boys and girls during break times at secondary school, has banned books, including JD Salinger’s 
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -7308,22 +6758,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The Think Ahead programme, funded by a £1.6 million grant from the Department of Health, is an attempt to help the NHS and local councils to cope with increasing demand for mental health services. A quarter of the population will encounter mental health issues in any one year.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -7482,16 +6917,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Terry Pratchett, who died last week, began his career on the 
-                 in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like the cut of your jib, young man.” As Pratchett, above, noted, he was “possibly the last person ever to say that without being arrested”. The author once told the paper that he learnt nothing more than to “spit and fight” at school but owed
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -7650,23 +7076,7 @@ exports[`renders profile content component 1`] = `
                   "marginBottom": 10,
                 }
               }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
-                 to recite it by heart?
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Leading poets have been drawn into a row over the new requirement for students to memorise up to 15 poems for their GCSE English literature exams.
-              </Text>
-            </Text>
+            />
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -7818,32 +7228,8 @@ exports[`renders profile header 1`] = `
           ellipsizeMode="tail"
         >
           Lorem 
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            ipsum
-          </Text>
            testbr 
           More text 
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-             last 
-          </Text>
         </Text>
       </Text>
     </View>

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -967,7 +967,7 @@ exports[`renders profile 1`] = `
             "name": "text",
           },
         ],
-        "name": "b",
+        "name": "bold",
       },
       Object {
         "children": Array [
@@ -979,7 +979,7 @@ exports[`renders profile 1`] = `
       },
       Object {
         "attributes": Object {},
-        "name": "br",
+        "name": "break",
       },
       Object {
         "children": Array [
@@ -1001,7 +1001,7 @@ exports[`renders profile 1`] = `
             "name": "text",
           },
         ],
-        "name": "i",
+        "name": "italic",
       },
     ]
   }
@@ -1113,8 +1113,32 @@ exports[`renders profile content 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                ipsum
+              </Text>
                testbr 
               More text 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontStyle": "italic",
+                  }
+                }
+              >
+                 last 
+              </Text>
             </Text>
           </Text>
         </View>
@@ -4460,8 +4484,32 @@ exports[`renders profile content component 1`] = `
             ellipsizeMode="tail"
           >
             Lorem 
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "fontWeight": "bold",
+                }
+              }
+            >
+              ipsum
+            </Text>
              testbr 
             More text 
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "fontStyle": "italic",
+                }
+              }
+            >
+               last 
+            </Text>
           </Text>
         </Text>
       </View>
@@ -7962,8 +8010,32 @@ exports[`renders profile header 1`] = `
           ellipsizeMode="tail"
         >
           Lorem 
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            ipsum
+          </Text>
            testbr 
           More text 
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+             last 
+          </Text>
         </Text>
       </Text>
     </View>

--- a/packages/author-profile/example.json
+++ b/packages/author-profile/example.json
@@ -11,7 +11,7 @@
       ]
     },
     {
-      "name": "b",
+      "name": "bold",
       "attributes": {},
       "children": [
         {
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "name": "br",
+      "name": "break",
       "attributes": {}
     },
     {
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "name": "i",
+      "name": "italic",
       "attributes": {},
       "children": [
         {

--- a/packages/author-profile/example.json
+++ b/packages/author-profile/example.json
@@ -78,7 +78,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -89,7 +89,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -114,7 +114,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -143,7 +143,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -154,7 +154,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -179,7 +179,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -208,7 +208,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -219,7 +219,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -244,7 +244,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -273,7 +273,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -284,7 +284,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -309,7 +309,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -338,7 +338,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -352,7 +352,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -381,7 +381,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -392,7 +392,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -417,7 +417,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -446,7 +446,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -460,7 +460,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -489,7 +489,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -503,7 +503,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -532,7 +532,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -546,7 +546,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -575,7 +575,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -589,7 +589,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -618,7 +618,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -632,7 +632,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -661,7 +661,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -675,7 +675,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -704,7 +704,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -718,7 +718,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -747,7 +747,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -761,7 +761,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -790,7 +790,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -801,7 +801,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -826,7 +826,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -855,7 +855,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -869,7 +869,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -898,7 +898,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -909,7 +909,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -949,7 +949,7 @@
         },
         "teaser": [
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",
@@ -960,7 +960,7 @@
                 ]
               },
               {
-                "name": "em",
+                "name": "italic",
                 "children": [
                   {
                     "name": "text",
@@ -985,7 +985,7 @@
             "attributes": {}
           },
           {
-            "name": "p",
+            "name": "paragraph",
             "children": [
               {
                 "name": "text",

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -195,15 +195,7 @@ exports[`renders vertical by default 1`] = `
             "marginBottom": 10,
           }
         }
-      >
-        <Text
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-        >
-          A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-        </Text>
-      </Text>
+      />
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -75,7 +75,7 @@ exports[`renders horizontal above breakpoint 1`] = `
                 "name": "text",
               },
             ],
-            "name": "p",
+            "name": "paragraph",
           },
         ]
       }
@@ -195,7 +195,15 @@ exports[`renders vertical by default 1`] = `
             "marginBottom": 10,
           }
         }
-      />
+      >
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+        </Text>
+      </Text>
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/packages/card/fixtures/card-props.json
+++ b/packages/card/fixtures/card-props.json
@@ -5,7 +5,7 @@
   "publication": "SUNDAYTIMES",
   "text": [
     {
-      "name": "p",
+      "name": "paragraph",
       "children": [
         {
           "name": "text",

--- a/packages/markup/__tests__/test-helper.js
+++ b/packages/markup/__tests__/test-helper.js
@@ -73,7 +73,9 @@ export default (Markup, builder) => () => {
   });
 
   it("renders wrapped tags", () => {
-    const tree = renderer.create(<Markup ast={bio} wrapIn="p" />).toJSON();
+    const tree = renderer
+      .create(<Markup ast={bio} wrapIn="paragraph" />)
+      .toJSON();
 
     expect(tree).toMatchSnapshot();
   });
@@ -81,7 +83,9 @@ export default (Markup, builder) => () => {
   it("renders multiple children", () => {
     const tree = renderer
       .create(
-        <Text style={{ color: "red" }}>{builder({ ast: multiParagraph })}</Text>
+        <Text style={{ color: "red" }}>
+          {builder({ ast: multiParagraph })}
+        </Text>
       )
       .toJSON();
 

--- a/packages/markup/fixtures/anchor.json
+++ b/packages/markup/fixtures/anchor.json
@@ -1,7 +1,7 @@
 {
   "fixture": [
     {
-      "name": "a",
+      "name": "link",
       "attributes": {
         "href": "www.google.com"
       },

--- a/packages/markup/fixtures/bio.json
+++ b/packages/markup/fixtures/bio.json
@@ -9,10 +9,8 @@
       ]
     },
     {
-      "name": "i",
-      "attributes": {
-
-      },
+      "name": "italic",
+      "attributes": {},
       "children": [
         {
           "name": "text",
@@ -33,7 +31,7 @@
       ]
     },
     {
-      "name": "b",
+      "name": "bold",
       "children": [
         {
           "name": "text",

--- a/packages/markup/fixtures/bold.json
+++ b/packages/markup/fixtures/bold.json
@@ -1,10 +1,8 @@
 {
   "fixture": [
     {
-      "name": "b",
-      "attributes": {
-
-      },
+      "name": "bold",
+      "attributes": {},
       "children": [
         {
           "name": "text",

--- a/packages/markup/fixtures/image.json
+++ b/packages/markup/fixtures/image.json
@@ -1,14 +1,12 @@
 {
   "fixture": [
     {
-      "name": "img",
+      "name": "image",
       "attributes": {
         "onerror": "eval(console.log('evil');)",
         "src": "http://example.com/image.jpg"
       },
-      "children": [
-
-      ]
+      "children": []
     }
   ]
 }

--- a/packages/markup/fixtures/italic.json
+++ b/packages/markup/fixtures/italic.json
@@ -1,10 +1,8 @@
 {
   "fixture": [
     {
-      "name": "i",
-      "attributes": {
-
-      },
+      "name": "italic",
+      "attributes": {},
       "children": [
         {
           "name": "text",

--- a/packages/markup/fixtures/multi-paragraph.json
+++ b/packages/markup/fixtures/multi-paragraph.json
@@ -1,10 +1,8 @@
 {
   "fixture": [
     {
-      "name": "p",
-      "attributes": {
-
-      },
+      "name": "paragraph",
+      "attributes": {},
       "children": [
         {
           "name": "text",
@@ -17,10 +15,8 @@
       ]
     },
     {
-      "name": "p",
-      "attributes": {
-
-      },
+      "name": "paragraph",
+      "attributes": {},
       "children": [
         {
           "name": "text",

--- a/packages/markup/fixtures/nested.json
+++ b/packages/markup/fixtures/nested.json
@@ -1,10 +1,8 @@
 {
   "fixture": [
     {
-      "name": "div",
-      "attributes": {
-
-      },
+      "name": "block",
+      "attributes": {},
       "children": [
         {
           "name": "text",
@@ -15,10 +13,8 @@
           ]
         },
         {
-          "name": "div",
-          "attributes": {
-
-          },
+          "name": "block",
+          "attributes": {},
           "children": [
             {
               "name": "text",
@@ -29,10 +25,8 @@
               ]
             },
             {
-              "name": "div",
-              "attributes": {
-
-              },
+              "name": "block",
+              "attributes": {},
               "children": [
                 {
                   "name": "text",
@@ -43,10 +37,8 @@
                   ]
                 },
                 {
-                  "name": "span",
-                  "attributes": {
-
-                  },
+                  "name": "inline",
+                  "attributes": {},
                   "children": [
                     {
                       "name": "text",

--- a/packages/markup/fixtures/script.json
+++ b/packages/markup/fixtures/script.json
@@ -1,19 +1,15 @@
 {
   "fixture": [
     {
-      "name": "div",
-      "attributes": {
-
-      },
+      "name": "block",
+      "attributes": {},
       "children": [
         {
           "name": "script",
           "attributes": {
             "src": "http://www.evil.com"
           },
-          "children": [
-
-          ]
+          "children": []
         }
       ]
     }

--- a/packages/markup/fixtures/script.json
+++ b/packages/markup/fixtures/script.json
@@ -1,7 +1,7 @@
 {
   "fixture": [
     {
-      "name": "block",
+      "name": "script",
       "attributes": {},
       "children": [
         {

--- a/packages/markup/fixtures/single-paragraph.json
+++ b/packages/markup/fixtures/single-paragraph.json
@@ -1,10 +1,8 @@
 {
   "fixture": [
     {
-      "name": "p",
-      "attributes": {
-
-      },
+      "name": "paragraph",
+      "attributes": {},
       "children": [
         {
           "name": "text",

--- a/packages/markup/fixtures/span.json
+++ b/packages/markup/fixtures/span.json
@@ -1,10 +1,8 @@
 {
   "fixture": [
     {
-      "name": "span",
-      "attributes": {
-
-      },
+      "name": "inline",
+      "attributes": {},
       "children": [
         {
           "name": "text",

--- a/packages/markup/fixtures/tag-mixture.json
+++ b/packages/markup/fixtures/tag-mixture.json
@@ -1,19 +1,15 @@
 {
   "fixture": [
     {
-      "name": "div",
-      "attributes": {
-
-      },
+      "name": "block",
+      "attributes": {},
       "children": [
         {
-          "name": "div",
-          "attributes": {
-
-          },
+          "name": "block",
+          "attributes": {},
           "children": [
             {
-              "name": "a",
+              "name": "link",
               "attributes": {
                 "href": "http://www.google.com"
               },
@@ -31,13 +27,12 @@
           ]
         },
         {
-          "name": "div",
+          "name": "block",
           "attributes": {},
           "children": [
             {
-              "name": "b",
-              "attributes": {
-              },
+              "name": "bold",
+              "attributes": {},
               "children": [
                 {
                   "name": "text",
@@ -52,13 +47,12 @@
           ]
         },
         {
-          "name": "div",
+          "name": "block",
           "attributes": {},
           "children": [
             {
-              "name": "i",
-              "attributes": {
-              },
+              "name": "italic",
+              "attributes": {},
               "children": [
                 {
                   "name": "text",
@@ -73,13 +67,12 @@
           ]
         },
         {
-          "name": "div",
+          "name": "block",
           "attributes": {},
           "children": [
             {
-              "name": "span",
-              "attributes": {
-              },
+              "name": "inline",
+              "attributes": {},
               "children": [
                 {
                   "name": "text",

--- a/packages/markup/markup-builder.js
+++ b/packages/markup/markup-builder.js
@@ -47,7 +47,7 @@ function astToMarkup(tagMap, key, wrapTextWith, [x, ...xs]) {
 }
 
 export const builder = tagMap => ({ ast, wrapIn }) =>
-  astToMarkup(tagMap, "0", tagMap.get(wrapIn || "div").wrapText, ast);
+  astToMarkup(tagMap, "0", tagMap.get(wrapIn || "block").wrapText, ast);
 
 export default function Markup({ ast, tagMap, wrapIn }) {
   const markup = builder(tagMap)({ ast, wrapIn });
@@ -56,7 +56,7 @@ export default function Markup({ ast, tagMap, wrapIn }) {
     return markup[0];
   }
 
-  return React.createElement(tagMap.get(wrapIn || "div").tag, {}, markup);
+  return React.createElement(tagMap.get(wrapIn || "block").tag, {}, markup);
 }
 
 Markup.propTypes = Object.assign({}, propTypes, {

--- a/packages/markup/markup.js
+++ b/packages/markup/markup.js
@@ -15,14 +15,14 @@ const styles = {
 
 const tagMap = new Map([
   [
-    "p",
+    "paragraph",
     {
       tag: Text,
       attrs() {}
     }
   ],
   [
-    "a",
+    "link",
     {
       tag: Link,
       attrs({ href }) {
@@ -33,7 +33,7 @@ const tagMap = new Map([
     }
   ],
   [
-    "b",
+    "bold",
     {
       tag: Text,
       attrs() {
@@ -44,7 +44,7 @@ const tagMap = new Map([
     }
   ],
   [
-    "i",
+    "italic",
     {
       tag: Text,
       attrs() {
@@ -55,7 +55,7 @@ const tagMap = new Map([
     }
   ],
   [
-    "span",
+    "inline",
     {
       tag: Text,
       attrs() {}
@@ -73,7 +73,7 @@ const tagMap = new Map([
     }
   ],
   [
-    "div",
+    "block",
     {
       tag: View,
       attrs() {},

--- a/packages/markup/markup.stories.js
+++ b/packages/markup/markup.stories.js
@@ -18,7 +18,7 @@ const story = m =>
 storiesOf("Markup", module)
   .add("Multiple paragraphs", () => story(<Markup ast={multiParagraph} />))
   .add("Mixture of tags", () => story(<Markup ast={mixture} />))
-  .add("Biography", () => story(<Markup ast={bio} wrapIn="p" />))
+  .add("Biography", () => story(<Markup ast={bio} wrapIn="paragraph" />))
   .add("Multiple children with styling", () =>
     story(
       <View>

--- a/packages/markup/markup.web.js
+++ b/packages/markup/markup.web.js
@@ -5,14 +5,14 @@ import propTypes from "./markup-proptype";
 
 const tagMap = new Map([
   [
-    "p",
+    "paragraph",
     {
       tag: "p",
       attrs() {}
     }
   ],
   [
-    "a",
+    "link",
     {
       tag: Link,
       attrs({ href }) {
@@ -23,21 +23,21 @@ const tagMap = new Map([
     }
   ],
   [
-    "b",
+    "bold",
     {
       tag: "strong",
       attrs() {}
     }
   ],
   [
-    "i",
+    "italic",
     {
       tag: "em",
       attrs() {}
     }
   ],
   [
-    "span",
+    "inline",
     {
       tag: "span",
       attrs() {}
@@ -55,7 +55,7 @@ const tagMap = new Map([
     }
   ],
   [
-    "div",
+    "block",
     {
       tag: "div",
       attrs() {}

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -96,8 +96,32 @@ exports[`renders data 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                ipsum
+              </Text>
                testbr 
               More text 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontStyle": "italic",
+                  }
+                }
+              >
+                 last 
+              </Text>
             </Text>
           </Text>
         </View>
@@ -329,8 +353,32 @@ exports[`renders data from graphql 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontWeight": "bold",
+                  }
+                }
+              >
+                ipsum
+              </Text>
                testbr 
               More text 
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "fontStyle": "italic",
+                  }
+                }
+              >
+                 last 
+              </Text>
             </Text>
           </Text>
         </View>

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -96,32 +96,8 @@ exports[`renders data 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
-                }
-              >
-                ipsum
-              </Text>
                testbr 
               More text 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
-                }
-              >
-                 last 
-              </Text>
             </Text>
           </Text>
         </View>
@@ -353,32 +329,8 @@ exports[`renders data from graphql 1`] = `
               ellipsizeMode="tail"
             >
               Lorem 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontWeight": "bold",
-                  }
-                }
-              >
-                ipsum
-              </Text>
                testbr 
               More text 
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "fontStyle": "italic",
-                  }
-                }
-              >
-                 last 
-              </Text>
             </Text>
           </Text>
         </View>

--- a/packages/provider/example.json
+++ b/packages/provider/example.json
@@ -11,7 +11,7 @@
       ]
     },
     {
-      "name": "b",
+      "name": "bold",
       "attributes": {},
       "children": [
         {
@@ -33,7 +33,7 @@
       ]
     },
     {
-      "name": "br",
+      "name": "break",
       "attributes": {}
     },
     {
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "name": "i",
+      "name": "italic",
       "attributes": {},
       "children": [
         {


### PR DESCRIPTION
updated the markup tags and all the tests to reflect the changes on times-public-api.