### PR TITLE
Article Flag support for styles

### DIFF
--- a/packages/article-flag/__snapshots__/article-flag.test.js.snap
+++ b/packages/article-flag/__snapshots__/article-flag.test.js.snap
@@ -12,31 +12,22 @@ exports[`Article Flag renders Exclusive flag correctly 1`] = `
     ]
   }
 >
-  <View
-    style={
-      Object {
-        "marginBottom": 1,
-        "marginRight": 5,
-      }
-    }
+  <svg
+    height={7}
+    style={Object {}}
+    viewBox="0 0 20 20"
+    width={7}
   >
-    <svg
-      height={7}
+    <g
+      fill="#C51D24"
       style={Object {}}
-      viewBox="0 0 20 20"
-      width={7}
     >
-      <g
-        fill="#C51D24"
+      <path
+        d="M 0,10 10,20 20,10 10,0 Z"
         style={Object {}}
-      >
-        <path
-          d="M 0,10 10,20 20,10 10,0 Z"
-          style={Object {}}
-        />
-      </g>
-    </svg>
-  </View>
+      />
+    </g>
+  </svg>
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -47,6 +38,8 @@ exports[`Article Flag renders Exclusive flag correctly 1`] = `
           "fontFamily": "TimesDigital-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
+          "marginLeft": 5,
+          "marginTop": 1,
         },
         Object {
           "color": "#C51D24",
@@ -71,31 +64,22 @@ exports[`Article Flag renders New flag correctly 1`] = `
     ]
   }
 >
-  <View
-    style={
-      Object {
-        "marginBottom": 1,
-        "marginRight": 5,
-      }
-    }
+  <svg
+    height={7}
+    style={Object {}}
+    viewBox="0 0 20 20"
+    width={7}
   >
-    <svg
-      height={7}
+    <g
+      fill="#E34605"
       style={Object {}}
-      viewBox="0 0 20 20"
-      width={7}
     >
-      <g
-        fill="#E34605"
+      <path
+        d="M 0,10 10,20 20,10 10,0 Z"
         style={Object {}}
-      >
-        <path
-          d="M 0,10 10,20 20,10 10,0 Z"
-          style={Object {}}
-        />
-      </g>
-    </svg>
-  </View>
+      />
+    </g>
+  </svg>
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -106,6 +90,8 @@ exports[`Article Flag renders New flag correctly 1`] = `
           "fontFamily": "TimesDigital-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
+          "marginLeft": 5,
+          "marginTop": 1,
         },
         Object {
           "color": "#E34605",
@@ -130,31 +116,22 @@ exports[`Article Flag renders Sponsored flag correctly 1`] = `
     ]
   }
 >
-  <View
-    style={
-      Object {
-        "marginBottom": 1,
-        "marginRight": 5,
-      }
-    }
+  <svg
+    height={7}
+    style={Object {}}
+    viewBox="0 0 20 20"
+    width={7}
   >
-    <svg
-      height={7}
+    <g
+      fill="#4D4D4D"
       style={Object {}}
-      viewBox="0 0 20 20"
-      width={7}
     >
-      <g
-        fill="#4D4D4D"
+      <path
+        d="M 0,10 10,20 20,10 10,0 Z"
         style={Object {}}
-      >
-        <path
-          d="M 0,10 10,20 20,10 10,0 Z"
-          style={Object {}}
-        />
-      </g>
-    </svg>
-  </View>
+      />
+    </g>
+  </svg>
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -165,6 +142,8 @@ exports[`Article Flag renders Sponsored flag correctly 1`] = `
           "fontFamily": "TimesDigital-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
+          "marginLeft": 5,
+          "marginTop": 1,
         },
         Object {
           "color": "#4D4D4D",
@@ -189,31 +168,22 @@ exports[`Article Flag renders Updated flag correctly 1`] = `
     ]
   }
 >
-  <View
-    style={
-      Object {
-        "marginBottom": 1,
-        "marginRight": 5,
-      }
-    }
+  <svg
+    height={7}
+    style={Object {}}
+    viewBox="0 0 20 20"
+    width={7}
   >
-    <svg
-      height={7}
+    <g
+      fill="#3C81BE"
       style={Object {}}
-      viewBox="0 0 20 20"
-      width={7}
     >
-      <g
-        fill="#3C81BE"
+      <path
+        d="M 0,10 10,20 20,10 10,0 Z"
         style={Object {}}
-      >
-        <path
-          d="M 0,10 10,20 20,10 10,0 Z"
-          style={Object {}}
-        />
-      </g>
-    </svg>
-  </View>
+      />
+    </g>
+  </svg>
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -224,6 +194,8 @@ exports[`Article Flag renders Updated flag correctly 1`] = `
           "fontFamily": "TimesDigital-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
+          "marginLeft": 5,
+          "marginTop": 1,
         },
         Object {
           "color": "#3C81BE",
@@ -248,31 +220,22 @@ exports[`Article Flag renders correctly 1`] = `
     ]
   }
 >
-  <View
-    style={
-      Object {
-        "marginBottom": 1,
-        "marginRight": 5,
-      }
-    }
+  <svg
+    height={7}
+    style={Object {}}
+    viewBox="0 0 20 20"
+    width={7}
   >
-    <svg
-      height={7}
+    <g
+      fill="black"
       style={Object {}}
-      viewBox="0 0 20 20"
-      width={7}
     >
-      <g
-        fill="black"
+      <path
+        d="M 0,10 10,20 20,10 10,0 Z"
         style={Object {}}
-      >
-        <path
-          d="M 0,10 10,20 20,10 10,0 Z"
-          style={Object {}}
-        />
-      </g>
-    </svg>
-  </View>
+      />
+    </g>
+  </svg>
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -283,6 +246,8 @@ exports[`Article Flag renders correctly 1`] = `
           "fontFamily": "TimesDigital-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
+          "marginLeft": 5,
+          "marginTop": 1,
         },
         Object {
           "color": "black",

--- a/packages/article-flag/__snapshots__/article-flag.test.js.snap
+++ b/packages/article-flag/__snapshots__/article-flag.test.js.snap
@@ -45,13 +45,12 @@ exports[`Article Flag renders Exclusive flag correctly 1`] = `
       Array [
         Object {
           "fontFamily": "TimesDigital-RegularSC",
-          "fontSize": 10,
+          "fontSize": 12,
           "fontWeight": "400",
         },
         Object {
           "color": "#C51D24",
         },
-        undefined,
       ]
     }
   >
@@ -105,13 +104,12 @@ exports[`Article Flag renders New flag correctly 1`] = `
       Array [
         Object {
           "fontFamily": "TimesDigital-RegularSC",
-          "fontSize": 10,
+          "fontSize": 12,
           "fontWeight": "400",
         },
         Object {
           "color": "#E34605",
         },
-        undefined,
       ]
     }
   >
@@ -165,13 +163,12 @@ exports[`Article Flag renders Sponsored flag correctly 1`] = `
       Array [
         Object {
           "fontFamily": "TimesDigital-RegularSC",
-          "fontSize": 10,
+          "fontSize": 12,
           "fontWeight": "400",
         },
         Object {
           "color": "#4D4D4D",
         },
-        undefined,
       ]
     }
   >
@@ -225,13 +222,12 @@ exports[`Article Flag renders Updated flag correctly 1`] = `
       Array [
         Object {
           "fontFamily": "TimesDigital-RegularSC",
-          "fontSize": 10,
+          "fontSize": 12,
           "fontWeight": "400",
         },
         Object {
           "color": "#3C81BE",
         },
-        undefined,
       ]
     }
   >
@@ -285,13 +281,12 @@ exports[`Article Flag renders correctly 1`] = `
       Array [
         Object {
           "fontFamily": "TimesDigital-RegularSC",
-          "fontSize": 10,
+          "fontSize": 12,
           "fontWeight": "400",
         },
         Object {
           "color": "black",
         },
-        undefined,
       ]
     }
   >

--- a/packages/article-flag/__snapshots__/article-flag.test.js.snap
+++ b/packages/article-flag/__snapshots__/article-flag.test.js.snap
@@ -3,10 +3,13 @@
 exports[`Article Flag renders Exclusive flag correctly 1`] = `
 <View
   style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-    }
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
   }
 >
   <View
@@ -48,6 +51,7 @@ exports[`Article Flag renders Exclusive flag correctly 1`] = `
         Object {
           "color": "#C51D24",
         },
+        undefined,
       ]
     }
   >
@@ -59,10 +63,13 @@ exports[`Article Flag renders Exclusive flag correctly 1`] = `
 exports[`Article Flag renders New flag correctly 1`] = `
 <View
   style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-    }
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
   }
 >
   <View
@@ -104,6 +111,7 @@ exports[`Article Flag renders New flag correctly 1`] = `
         Object {
           "color": "#E34605",
         },
+        undefined,
       ]
     }
   >
@@ -115,10 +123,13 @@ exports[`Article Flag renders New flag correctly 1`] = `
 exports[`Article Flag renders Sponsored flag correctly 1`] = `
 <View
   style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-    }
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
   }
 >
   <View
@@ -160,6 +171,7 @@ exports[`Article Flag renders Sponsored flag correctly 1`] = `
         Object {
           "color": "#4D4D4D",
         },
+        undefined,
       ]
     }
   >
@@ -171,10 +183,13 @@ exports[`Article Flag renders Sponsored flag correctly 1`] = `
 exports[`Article Flag renders Updated flag correctly 1`] = `
 <View
   style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-    }
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
   }
 >
   <View
@@ -216,6 +231,7 @@ exports[`Article Flag renders Updated flag correctly 1`] = `
         Object {
           "color": "#3C81BE",
         },
+        undefined,
       ]
     }
   >
@@ -224,4 +240,62 @@ exports[`Article Flag renders Updated flag correctly 1`] = `
 </View>
 `;
 
-exports[`Article Flag renders correctly 1`] = `null`;
+exports[`Article Flag renders correctly 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "marginBottom": 1,
+        "marginRight": 5,
+      }
+    }
+  >
+    <svg
+      height={7}
+      style={Object {}}
+      viewBox="0 0 20 20"
+      width={7}
+    >
+      <g
+        fill="black"
+        style={Object {}}
+      >
+        <path
+          d="M 0,10 10,20 20,10 10,0 Z"
+          style={Object {}}
+        />
+      </g>
+    </svg>
+  </View>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontFamily": "TimesDigital-RegularSC",
+          "fontSize": 10,
+          "fontWeight": "400",
+        },
+        Object {
+          "color": "black",
+        },
+        undefined,
+      ]
+    }
+  >
+    A R T I C L E F L A G
+  </Text>
+</View>
+`;

--- a/packages/article-flag/__snapshots__/article-flag.test.js.snap
+++ b/packages/article-flag/__snapshots__/article-flag.test.js.snap
@@ -8,7 +8,7 @@ exports[`Article Flag renders Exclusive flag correctly 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
       },
-      undefined,
+      Object {},
     ]
   }
 >
@@ -60,7 +60,7 @@ exports[`Article Flag renders New flag correctly 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
       },
-      undefined,
+      Object {},
     ]
   }
 >
@@ -112,7 +112,7 @@ exports[`Article Flag renders Sponsored flag correctly 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
       },
-      undefined,
+      Object {},
     ]
   }
 >
@@ -164,7 +164,7 @@ exports[`Article Flag renders Updated flag correctly 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
       },
-      undefined,
+      Object {},
     ]
   }
 >
@@ -216,7 +216,7 @@ exports[`Article Flag renders correctly 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
       },
-      undefined,
+      Object {},
     ]
   }
 >

--- a/packages/article-flag/article-flag.js
+++ b/packages/article-flag/article-flag.js
@@ -43,52 +43,52 @@ const ArticleFlag = ({ title, color, style }) => {
 ArticleFlag.propTypes = {
   title: PropTypes.string.isRequired,
   color: PropTypes.string,
-  style: PropTypes.number
+  style: View.propTypes.style
 };
 
 ArticleFlag.defaultProps = {
   color: "black",
-  style: undefined
+  style: {}
 };
 
 export const NewArticleFlag = props =>
   <ArticleFlag title="new" color="#E34605" style={props.style} />;
 
 NewArticleFlag.propTypes = {
-  style: PropTypes.string
+  style: View.propTypes.style
 };
 NewArticleFlag.defaultProps = {
-  style: undefined
+  style: {}
 };
 
 export const UpdatedArticleFlag = props =>
   <ArticleFlag title="updated" color="#3C81BE" style={props.style} />;
 
 UpdatedArticleFlag.propTypes = {
-  style: PropTypes.string
+  style: View.propTypes.style
 };
 UpdatedArticleFlag.defaultProps = {
-  style: undefined
+  style: {}
 };
 
 export const ExclusiveArticleFlag = props =>
   <ArticleFlag title="exclusive" color="#C51D24" style={props.style} />;
 
 ExclusiveArticleFlag.propTypes = {
-  style: PropTypes.string
+  style: View.propTypes.style
 };
 ExclusiveArticleFlag.defaultProps = {
-  style: undefined
+  style: {}
 };
 
 export const SponsoredArticleFlag = props =>
   <ArticleFlag title="sponsored" color="#4D4D4D" style={props.style} />;
 
 SponsoredArticleFlag.propTypes = {
-  style: PropTypes.string
+  style: View.propTypes.style
 };
 SponsoredArticleFlag.defaultProps = {
-  style: undefined
+  style: {}
 };
 
 export default ArticleFlag;

--- a/packages/article-flag/article-flag.js
+++ b/packages/article-flag/article-flag.js
@@ -1,12 +1,12 @@
 import React from "react";
-import { View, Text } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
 import PropTypes from "prop-types";
 
 import Diamond from "./diamond";
 
 // When changing styles please debug both web, android and ios because
 // some styles are not working correctly on all platforms (namely, android)
-const styles = {
+const styles = StyleSheet.create({
   view: {
     flexDirection: "row",
     alignItems: "center"
@@ -20,24 +20,24 @@ const styles = {
     fontSize: 10,
     fontWeight: "400"
   }
-};
+});
 
 // apply transformations to add uppercase and letter spacing.
 // letterSpacing CSS prop does not work on android:
 // https://github.com/facebook/react-native/pull/13199
 const beautifyTitle = title => title.toUpperCase().split("").join(" ");
 
-const ArticleFlag = ({ title, color }) => {
+const ArticleFlag = ({ title, color, containerStyle, textStyle }) => {
   if (!title) {
     return null;
   }
 
   return (
-    <View style={styles.view}>
+    <View style={[styles.view, containerStyle]}>
       <View style={styles.diamond}>
         <Diamond height={7} width={7} color={color} />
       </View>
-      <Text style={[styles.title, { color }]}>
+      <Text style={[styles.title, { color }, textStyle]}>
         {beautifyTitle(title)}
       </Text>
     </View>
@@ -46,20 +46,25 @@ const ArticleFlag = ({ title, color }) => {
 
 ArticleFlag.propTypes = {
   title: PropTypes.string.isRequired,
-  color: PropTypes.string
+  color: PropTypes.string,
+  containerStyle: PropTypes.number,
+  textStyle: PropTypes.number
 };
 
 ArticleFlag.defaultProps = {
-  color: "black"
+  color: "black",
+  containerStyle: undefined,
+  textStyle: undefined
 };
 
-const NewArticleFlag = () => <ArticleFlag title="new" color="#E34605" />;
-const UpdatedArticleFlag = () =>
-  <ArticleFlag title="updated" color="#3C81BE" />;
-const ExclusiveArticleFlag = () =>
-  <ArticleFlag title="exclusive" color="#C51D24" />;
-const SponsoredArticleFlag = () =>
-  <ArticleFlag title="sponsored" color="#4D4D4D" />;
+const NewArticleFlag = props =>
+  <ArticleFlag title="new" color="#E34605" {...props} />;
+const UpdatedArticleFlag = props =>
+  <ArticleFlag title="updated" color="#3C81BE" {...props} />;
+const ExclusiveArticleFlag = props =>
+  <ArticleFlag title="exclusive" color="#C51D24" {...props} />;
+const SponsoredArticleFlag = props =>
+  <ArticleFlag title="sponsored" color="#4D4D4D" {...props} />;
 
 export default ArticleFlag;
 

--- a/packages/article-flag/article-flag.js
+++ b/packages/article-flag/article-flag.js
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
   },
   title: {
     fontFamily: "TimesDigital-RegularSC",
-    fontSize: 10,
+    fontSize: 12,
     fontWeight: "400"
   }
 });
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
 // https://github.com/facebook/react-native/pull/13199
 const beautifyTitle = title => title.toUpperCase().split("").join(" ");
 
-const ArticleFlag = ({ title, color, containerStyle, textStyle }) => {
+const ArticleFlag = ({ title, color, containerStyle }) => {
   if (!title) {
     return null;
   }
@@ -37,7 +37,7 @@ const ArticleFlag = ({ title, color, containerStyle, textStyle }) => {
       <View style={styles.diamond}>
         <Diamond height={7} width={7} color={color} />
       </View>
-      <Text style={[styles.title, { color }, textStyle]}>
+      <Text style={[styles.title, { color }]}>
         {beautifyTitle(title)}
       </Text>
     </View>
@@ -47,14 +47,12 @@ const ArticleFlag = ({ title, color, containerStyle, textStyle }) => {
 ArticleFlag.propTypes = {
   title: PropTypes.string.isRequired,
   color: PropTypes.string,
-  containerStyle: PropTypes.number,
-  textStyle: PropTypes.number
+  containerStyle: PropTypes.number
 };
 
 ArticleFlag.defaultProps = {
   color: "black",
-  containerStyle: undefined,
-  textStyle: undefined
+  containerStyle: undefined
 };
 
 const NewArticleFlag = props =>

--- a/packages/article-flag/article-flag.js
+++ b/packages/article-flag/article-flag.js
@@ -11,11 +11,9 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center"
   },
-  diamond: {
-    marginRight: 5,
-    marginBottom: 1
-  },
   title: {
+    marginTop: 1,
+    marginLeft: 5,
     fontFamily: "TimesDigital-RegularSC",
     fontSize: 12,
     fontWeight: "400"
@@ -27,16 +25,14 @@ const styles = StyleSheet.create({
 // https://github.com/facebook/react-native/pull/13199
 const beautifyTitle = title => title.toUpperCase().split("").join(" ");
 
-const ArticleFlag = ({ title, color, containerStyle }) => {
+const ArticleFlag = ({ title, color, style }) => {
   if (!title) {
     return null;
   }
 
   return (
-    <View style={[styles.view, containerStyle]}>
-      <View style={styles.diamond}>
-        <Diamond height={7} width={7} color={color} />
-      </View>
+    <View style={[styles.view, style]}>
+      <Diamond height={7} width={7} color={color} />
       <Text style={[styles.title, { color }]}>
         {beautifyTitle(title)}
       </Text>
@@ -47,28 +43,52 @@ const ArticleFlag = ({ title, color, containerStyle }) => {
 ArticleFlag.propTypes = {
   title: PropTypes.string.isRequired,
   color: PropTypes.string,
-  containerStyle: PropTypes.number
+  style: PropTypes.number
 };
 
 ArticleFlag.defaultProps = {
   color: "black",
-  containerStyle: undefined
+  style: undefined
 };
 
-const NewArticleFlag = props =>
-  <ArticleFlag title="new" color="#E34605" {...props} />;
-const UpdatedArticleFlag = props =>
-  <ArticleFlag title="updated" color="#3C81BE" {...props} />;
-const ExclusiveArticleFlag = props =>
-  <ArticleFlag title="exclusive" color="#C51D24" {...props} />;
-const SponsoredArticleFlag = props =>
-  <ArticleFlag title="sponsored" color="#4D4D4D" {...props} />;
+export const NewArticleFlag = props =>
+  <ArticleFlag title="new" color="#E34605" style={props.style} />;
+
+NewArticleFlag.propTypes = {
+  style: PropTypes.string
+};
+NewArticleFlag.defaultProps = {
+  style: undefined
+};
+
+export const UpdatedArticleFlag = props =>
+  <ArticleFlag title="updated" color="#3C81BE" style={props.style} />;
+
+UpdatedArticleFlag.propTypes = {
+  style: PropTypes.string
+};
+UpdatedArticleFlag.defaultProps = {
+  style: undefined
+};
+
+export const ExclusiveArticleFlag = props =>
+  <ArticleFlag title="exclusive" color="#C51D24" style={props.style} />;
+
+ExclusiveArticleFlag.propTypes = {
+  style: PropTypes.string
+};
+ExclusiveArticleFlag.defaultProps = {
+  style: undefined
+};
+
+export const SponsoredArticleFlag = props =>
+  <ArticleFlag title="sponsored" color="#4D4D4D" style={props.style} />;
+
+SponsoredArticleFlag.propTypes = {
+  style: PropTypes.string
+};
+SponsoredArticleFlag.defaultProps = {
+  style: undefined
+};
 
 export default ArticleFlag;
-
-export {
-  NewArticleFlag,
-  UpdatedArticleFlag,
-  ExclusiveArticleFlag,
-  SponsoredArticleFlag
-};

--- a/packages/article-flag/article-flag.stories.js
+++ b/packages/article-flag/article-flag.stories.js
@@ -19,14 +19,8 @@ const styles = StyleSheet.create({
 });
 
 storiesOf("ArticleFlag", module)
-  .add("ArticleFlag (New) with extra text style", () =>
-    <NewArticleFlag textStyle={styles.text} />
-  )
-  .add("ArticleFlag (New) with extra container style", () =>
+  .add("ArticleFlag (New) with extra styles", () =>
     <NewArticleFlag containerStyle={styles.container} />
-  )
-  .add("ArticleFlag (New) with extra style", () =>
-    <NewArticleFlag containerStyle={styles.container} textStyle={styles.text} />
   )
   .add("ArticleFlag (New)", () => <NewArticleFlag />)
   .add("ArticleFlag (Updated)", () => <UpdatedArticleFlag />)

--- a/packages/article-flag/article-flag.stories.js
+++ b/packages/article-flag/article-flag.stories.js
@@ -12,15 +12,12 @@ import {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: "#EAFF00"
-  },
-  text: {
-    fontSize: 12
   }
 });
 
 storiesOf("ArticleFlag", module)
-  .add("ArticleFlag (New) with extra styles", () =>
-    <NewArticleFlag containerStyle={styles.container} />
+  .add("ArticleFlag (New) extra styles", () =>
+    <NewArticleFlag style={styles.container} />
   )
   .add("ArticleFlag (New)", () => <NewArticleFlag />)
   .add("ArticleFlag (Updated)", () => <UpdatedArticleFlag />)

--- a/packages/article-flag/article-flag.stories.js
+++ b/packages/article-flag/article-flag.stories.js
@@ -1,5 +1,5 @@
-import "react-native";
 import React from "react";
+import { StyleSheet } from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 import {
@@ -9,7 +9,25 @@ import {
   SponsoredArticleFlag
 } from "./article-flag";
 
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "#EAFF00"
+  },
+  text: {
+    fontSize: 12
+  }
+});
+
 storiesOf("ArticleFlag", module)
+  .add("ArticleFlag (New) with extra text style", () =>
+    <NewArticleFlag textStyle={styles.text} />
+  )
+  .add("ArticleFlag (New) with extra container style", () =>
+    <NewArticleFlag containerStyle={styles.container} />
+  )
+  .add("ArticleFlag (New) with extra style", () =>
+    <NewArticleFlag containerStyle={styles.container} textStyle={styles.text} />
+  )
   .add("ArticleFlag (New)", () => <NewArticleFlag />)
   .add("ArticleFlag (Updated)", () => <UpdatedArticleFlag />)
   .add("ArticleFlag (Exclusive)", () => <ExclusiveArticleFlag />)

--- a/packages/article-flag/article-flag.test.js
+++ b/packages/article-flag/article-flag.test.js
@@ -12,7 +12,7 @@ import ArticleFlag, {
 
 describe("Article Flag", () => {
   it("renders correctly", () => {
-    const tree = renderer.create(<ArticleFlag />).toJSON();
+    const tree = renderer.create(<ArticleFlag title="articleFlag" />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/packages/article/__snapshots__/article.test.js.snap
+++ b/packages/article/__snapshots__/article.test.js.snap
@@ -32,10 +32,13 @@ exports[`Article test renders native correctly 1`] = `
       </Text>
       <View
         style={
-          Object {
-            "alignItems": "center",
-            "flexDirection": "row",
-          }
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+            },
+            undefined,
+          ]
         }
       >
         <View
@@ -77,6 +80,7 @@ exports[`Article test renders native correctly 1`] = `
               Object {
                 "color": "#E34605",
               },
+              undefined,
             ]
           }
         >

--- a/packages/article/__snapshots__/article.test.js.snap
+++ b/packages/article/__snapshots__/article.test.js.snap
@@ -74,13 +74,12 @@ exports[`Article test renders native correctly 1`] = `
             Array [
               Object {
                 "fontFamily": "TimesDigital-RegularSC",
-                "fontSize": 10,
+                "fontSize": 12,
                 "fontWeight": "400",
               },
               Object {
                 "color": "#E34605",
               },
-              undefined,
             ]
           }
         >

--- a/packages/article/__snapshots__/article.test.js.snap
+++ b/packages/article/__snapshots__/article.test.js.snap
@@ -41,31 +41,22 @@ exports[`Article test renders native correctly 1`] = `
           ]
         }
       >
-        <View
-          style={
-            Object {
-              "marginBottom": 1,
-              "marginRight": 5,
-            }
-          }
+        <svg
+          height={7}
+          style={Object {}}
+          viewBox="0 0 20 20"
+          width={7}
         >
-          <svg
-            height={7}
+          <g
+            fill="#E34605"
             style={Object {}}
-            viewBox="0 0 20 20"
-            width={7}
           >
-            <g
-              fill="#E34605"
+            <path
+              d="M 0,10 10,20 20,10 10,0 Z"
               style={Object {}}
-            >
-              <path
-                d="M 0,10 10,20 20,10 10,0 Z"
-                style={Object {}}
-              />
-            </g>
-          </svg>
-        </View>
+            />
+          </g>
+        </svg>
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -76,6 +67,8 @@ exports[`Article test renders native correctly 1`] = `
                 "fontFamily": "TimesDigital-RegularSC",
                 "fontSize": 12,
                 "fontWeight": "400",
+                "marginLeft": 5,
+                "marginTop": 1,
               },
               Object {
                 "color": "#E34605",

--- a/packages/article/__snapshots__/article.test.js.snap
+++ b/packages/article/__snapshots__/article.test.js.snap
@@ -37,7 +37,7 @@ exports[`Article test renders native correctly 1`] = `
               "alignItems": "center",
               "flexDirection": "row",
             },
-            undefined,
+            Object {},
           ]
         }
       >


### PR DESCRIPTION
<!--
Thank you for your PR!

If you changed any code, please provide clear instructions on how you verified your changes work.

Screenshots are most welcome!

:-)
-->
ref #172 

- updated design
- fixed a warning on a missing title prop for the base ArticleFlag (inside the tests)
- use `Stylesheet` for internal component styling instead of plain object to avoid duplication on style attribute
- support external styling on the container and on the text element to avoid extra `<View>` to style the component on the `Article` component

```jsx
<View style={styles.ArticleFlagContainer}>
    <NewArticleFlag />
</View>
```
```jsx
const styles = StyleSheet.create({
  container: {
    backgroundColor: "#EAFF00"
  },
  text: {
    fontSize: 12
  }
});
<NewArticleFlag containerStyle={styles.container} textStyle={styles.text}/>
```