### PR TITLE
fix: fetch https images on native

### DIFF
--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`prepends https schema 1`] = `
+<View
+  onLayout={[Function]}
+>
+  <Image
+    onError={[Function]}
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://example.com/image.jpg",
+      }
+    }
+    style={
+      Array [
+        Object {
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
+</View>
+`;
+
 exports[`renders correctly with no dimensions and given URI 1`] = `
 <View
   onLayout={[Function]}

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, Image, View } from "react-native";
+import { Platform, Dimensions, Image, View } from "react-native";
 import placeholder from "./placeholder";
 
 const window = Dimensions.get("window");
@@ -8,8 +8,15 @@ class ImageComponent extends React.Component {
   constructor(props) {
     super(props);
 
+    const uri = props.source && props.source.uri;
+
     this.state = {
-      source: props.source,
+      source: {
+        uri:
+          Platform.OS !== "web" && uri && uri.indexOf("//") === 0
+            ? `https:${uri}`
+            : uri
+      },
       width: window.width,
       height: 1
     };

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -43,6 +43,17 @@ storiesOf("Image", module)
       <Image style={{ resizeMode: "center" }} source={exampleNonImage} />
     </View>
   )
+  .add("No schema url", () =>
+    <View style={{ width: 100, height: 100 }}>
+      <Image
+        resizeMode={"cover"}
+        source={{
+          uri:
+            "//www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320"
+        }}
+      />
+    </View>
+  )
   .add("Apply style to image", () =>
     <View style={{ width: 100, height: 100 }}>
       <Image

--- a/packages/image/image.test.js
+++ b/packages/image/image.test.js
@@ -107,3 +107,14 @@ it("ignores dimension if layout is 0", done => {
   comp.getSize = (uri, success) => success(40, 20);
   comp.handleLoad();
 });
+
+it("prepends https schema", () => {
+  const props = {
+    source: {
+      uri: "//example.com/image.jpg"
+    }
+  };
+
+  const tree = renderer.create(<Image {...props} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -226,7 +226,7 @@ exports[`renders data 1`] = `
                   ]
                 }
               >
-                Showing 1 - 0 of 0 results
+                Showing 1 - 2 of 2 results
               </Text>
             </View>
             <View
@@ -250,6 +250,147 @@ exports[`renders data 1`] = `
             >
               <View />
               <View />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              />
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigital-Regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              />
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Monday March 23 2015
+                , The Times
+              </Text>
             </View>
           </View>
         </View>
@@ -485,7 +626,7 @@ exports[`renders data from graphql 1`] = `
                   ]
                 }
               >
-                Showing 1 - 0 of 0 results
+                Showing 1 - 2 of 2 results
               </Text>
             </View>
             <View
@@ -509,6 +650,147 @@ exports[`renders data from graphql 1`] = `
             >
               <View />
               <View />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              />
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigital-Regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              />
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Monday March 23 2015
+                , The Times
+              </Text>
             </View>
           </View>
         </View>

--- a/packages/provider/author-profile-provider.js
+++ b/packages/provider/author-profile-provider.js
@@ -1,6 +1,5 @@
 import get from "lodash.get";
 import gql from "graphql-tag";
-import { Platform } from "react-native";
 import AuthorProfile from "@times-components/author-profile";
 import connectGraphql from "./connect";
 
@@ -57,18 +56,6 @@ const propsToVariables = ({ slug, pageSize, page, imageRatio }) => ({
 });
 
 const transformResponse = response => {
-  const resolve = url => {
-    if (Platform.OS === "web") {
-      return url;
-    }
-
-    if (url.indexOf("//") !== 0) {
-      return url;
-    }
-
-    return `https:${url}`;
-  };
-
   const author = get(response, "data.author");
   if (author) {
     return {
@@ -77,43 +64,10 @@ const transformResponse = response => {
         Object.assign({}, author, {
           articles: {
             count: author.articles.count,
-            list: author.articles.list.map(article => {
-              if (get(article, "leadAsset.crop.url", null)) {
-                return {
-                  ...article,
-                  publishedTime: new Date(article.publishedTime),
-                  leadAsset: {
-                    ...article.leadAsset,
-                    crop: {
-                      ...article.leadAsset.crop,
-                      url: resolve(article.leadAsset.crop.url)
-                    }
-                  }
-                };
-              }
-
-              if (get(article, "leadAsset.posterImage.crop.url", null)) {
-                return {
-                  ...article,
-                  publishedTime: new Date(article.publishedTime),
-                  leadAsset: {
-                    ...article.leadAsset,
-                    posterImage: {
-                      ...article.leadAsset.posterImage,
-                      crop: {
-                        ...article.leadAsset.posterImage.crop,
-                        url: resolve(article.leadAsset.posterImage.crop.url)
-                      }
-                    }
-                  }
-                };
-              }
-
-              return {
-                ...article,
-                publishedTime: new Date(article.publishedTime)
-              };
-            })
+            list: author.articles.list.map(article => ({
+              ...article,
+              publishedTime: new Date(article.publishedTime)
+            }))
           }
         }),
         {

--- a/packages/provider/author-profile-provider.js
+++ b/packages/provider/author-profile-provider.js
@@ -1,5 +1,6 @@
 import get from "lodash.get";
 import gql from "graphql-tag";
+import { Platform } from "react-native";
 import AuthorProfile from "@times-components/author-profile";
 import connectGraphql from "./connect";
 
@@ -56,6 +57,18 @@ const propsToVariables = ({ slug, pageSize, page, imageRatio }) => ({
 });
 
 const transformResponse = response => {
+  const resolve = url => {
+    if (Platform.OS === "web") {
+      return url;
+    }
+
+    if (url.indexOf("//") !== 0) {
+      return url;
+    }
+
+    return `https:${url}`;
+  };
+
   const author = get(response, "data.author");
   if (author) {
     return {
@@ -64,10 +77,43 @@ const transformResponse = response => {
         Object.assign({}, author, {
           articles: {
             count: author.articles.count,
-            list: author.articles.list.map(article => ({
-              ...article,
-              publishedTime: new Date(article.publishedTime)
-            }))
+            list: author.articles.list.map(article => {
+              if (get(article, "leadAsset.crop.url", null)) {
+                return {
+                  ...article,
+                  publishedTime: new Date(article.publishedTime),
+                  leadAsset: {
+                    ...article.leadAsset,
+                    crop: {
+                      ...article.leadAsset.crop,
+                      url: resolve(article.leadAsset.crop.url)
+                    }
+                  }
+                };
+              }
+
+              if (get(article, "leadAsset.posterImage.crop.url", null)) {
+                return {
+                  ...article,
+                  publishedTime: new Date(article.publishedTime),
+                  leadAsset: {
+                    ...article.leadAsset,
+                    posterImage: {
+                      ...article.leadAsset.posterImage,
+                      crop: {
+                        ...article.leadAsset.posterImage.crop,
+                        url: resolve(article.leadAsset.posterImage.crop.url)
+                      }
+                    }
+                  }
+                };
+              }
+
+              return {
+                ...article,
+                publishedTime: new Date(article.publishedTime)
+              };
+            })
           }
         }),
         {

--- a/packages/provider/example.json
+++ b/packages/provider/example.json
@@ -62,7 +62,35 @@
   "image": "",
   "twitter": "jdoe",
   "articles": {
-    "count": 0,
-    "list": []
+    "count": 2,
+    "list": [{
+      "id": "97c64f20-cb67-11e4-a202-50ac5def393a",
+      "title": "British trio stopped on the way to join Isis",
+      "label": null,
+      "publicationName": "TIMES",
+      "publishedTime": "2015-03-23T23:06:34.000Z",
+      "leadAsset": {
+        "title": "British trio stopped on the way to join Isis",
+        "crop": {
+          "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+          "ratio": "3:2"
+        }
+      }
+    }, {
+      "id": "97c64f20-cb67-11e4-a202-50ac5def393a",
+      "title": "British trio stopped on the way to join Isis",
+      "label": null,
+      "publicationName": "TIMES",
+      "publishedTime": "2015-03-23T23:06:34.000Z",
+      "leadAsset": {
+        "posterImage": {
+          "title": "British trio stopped on the way to join Isis",
+          "crop": {
+            "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+            "ratio": "3:2"
+          }
+        }
+      }
+    }]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3291,9 +3291,16 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1, domutils@^1.5.1:
+domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -3427,7 +3434,7 @@ engine.io@~3.1.0:
   optionalDependencies:
     uws "~0.14.4"
 
-enhanced-resolve@^3.3.0:
+enhanced-resolve@^3.3.0, enhanced-resolve@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
   dependencies:
@@ -5383,14 +5390,14 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.6.1, js-yaml@^3.4.3, js-yaml@^3.5.1:
+js-yaml@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
   dependencies:
@@ -6133,21 +6140,25 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.29.0 < 2", mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
+"mime-db@>= 1.29.0 < 2":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
 mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
-mime-types@2.1.11, mime-types@~2.1.7:
+mime-db@~1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
+
+mime-types@2.1.11:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.6, mime-types@~2.1.9:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.6, mime-types@~2.1.7, mime-types@~2.1.9:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
   dependencies:
@@ -6189,7 +6200,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8, minimist@~0.0.1:
+minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
@@ -6200,6 +6211,10 @@ minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2
 minimist@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -6307,9 +6322,16 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@1.7.1, node-fetch@^1.0.1, node-fetch@^1.3.3:
+node-fetch@1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
+node-fetch@^1.0.1, node-fetch@^1.3.3:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.2.tgz#c54e9aac57e432875233525f3c891c4159ffefd7"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -7256,11 +7278,11 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
-punycode@1.3.2, punycode@^1.2.4:
+punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@^1.4.1:
+punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
@@ -9203,7 +9225,7 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@3.3.0, "webpack@^2.5.1 || ^3.0.0":
+webpack@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.3.0.tgz#ce2f9e076566aba91f74887133a883fd7da187bc"
   dependencies:
@@ -9230,19 +9252,46 @@ webpack@3.3.0, "webpack@^2.5.1 || ^3.0.0":
     webpack-sources "^1.0.1"
     yargs "^6.0.0"
 
+"webpack@^2.5.1 || ^3.0.0":
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
+  dependencies:
+    acorn "^5.0.0"
+    acorn-dynamic-import "^2.0.0"
+    ajv "^5.1.5"
+    ajv-keywords "^2.0.0"
+    async "^2.1.2"
+    enhanced-resolve "^3.4.0"
+    escope "^3.6.0"
+    interpret "^1.0.0"
+    json-loader "^0.5.4"
+    json5 "^0.5.1"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    mkdirp "~0.5.0"
+    node-libs-browser "^2.0.0"
+    source-map "^0.5.3"
+    supports-color "^4.2.1"
+    tapable "^0.2.7"
+    uglifyjs-webpack-plugin "^0.4.6"
+    watchpack "^1.4.0"
+    webpack-sources "^1.0.1"
+    yargs "^8.0.2"
+
 whatwg-encoding@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
-
-whatwg-fetch@^2.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
+whatwg-fetch@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 
 whatwg-url@^4.3.0:
   version "4.8.0"
@@ -9271,9 +9320,15 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1.2.x, which@^1.2.10, which@^1.2.12, which@^1.2.9:
+which@1.2.x:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.10, which@^1.2.12, which@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
On native, the URL resolver prepends the images path with `file`.
This PR ensures we fetch images from the image server using the https scheme.

<img src="https://user-images.githubusercontent.com/763528/29922248-af5ee32c-8e4c-11e7-892c-e598c9c08662.gif" width="256" />

