### PR TITLE
fix: show images on web

### DIFF
--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -97,8 +97,8 @@ exports[`renders a snapshot 1`] = `
         style={
           Array [
             Object {
-              "height": undefined,
-              "width": undefined,
+              "height": 1,
+              "width": 750,
             },
             Object {
               "borderColor": "#FFF",
@@ -265,8 +265,8 @@ exports[`renders a snapshot with data 1`] = `
         style={
           Array [
             Object {
-              "height": undefined,
-              "width": undefined,
+              "height": 1,
+              "width": 750,
             },
             Object {
               "borderColor": "#FFF",

--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -83,34 +83,31 @@ exports[`renders a snapshot 1`] = `
       }
     }
   >
-    <View
+    <Image
+      onError={[Function]}
       onLayout={[Function]}
-    >
-      <Image
-        onError={[Function]}
-        onLoad={[Function]}
-        source={
+      onLoad={[Function]}
+      source={
+        Object {
+          "uri": "",
+        }
+      }
+      style={
+        Array [
           Object {
-            "uri": "",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "height": 1,
-              "width": 750,
-            },
-            Object {
-              "borderColor": "#FFF",
-              "borderRadius": 50,
-              "borderWidth": 5,
-              "height": 100,
-              "width": 100,
-            },
-          ]
-        }
-      />
-    </View>
+            "height": 1,
+            "width": 750,
+          },
+          Object {
+            "borderColor": "#FFF",
+            "borderRadius": 50,
+            "borderWidth": 5,
+            "height": 100,
+            "width": 100,
+          },
+        ]
+      }
+    />
   </View>
 </View>
 `;
@@ -251,34 +248,31 @@ exports[`renders a snapshot with data 1`] = `
       }
     }
   >
-    <View
+    <Image
+      onError={[Function]}
       onLayout={[Function]}
-    >
-      <Image
-        onError={[Function]}
-        onLoad={[Function]}
-        source={
+      onLoad={[Function]}
+      source={
+        Object {
+          "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+        }
+      }
+      style={
+        Array [
           Object {
-            "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "height": 1,
-              "width": 750,
-            },
-            Object {
-              "borderColor": "#FFF",
-              "borderRadius": 50,
-              "borderWidth": 5,
-              "height": 100,
-              "width": 100,
-            },
-          ]
-        }
-      />
-    </View>
+            "height": 1,
+            "width": 750,
+          },
+          Object {
+            "borderColor": "#FFF",
+            "borderRadius": 50,
+            "borderWidth": 5,
+            "height": 100,
+            "width": 100,
+          },
+        ]
+      }
+    />
   </View>
 </View>
 `;

--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -97,8 +97,8 @@ exports[`renders a snapshot 1`] = `
         style={
           Array [
             Object {
-              "height": 1,
-              "width": 750,
+              "height": undefined,
+              "width": undefined,
             },
             Object {
               "borderColor": "#FFF",
@@ -265,8 +265,8 @@ exports[`renders a snapshot with data 1`] = `
         style={
           Array [
             Object {
-              "height": 1,
-              "width": 750,
+              "height": undefined,
+              "width": undefined,
             },
             Object {
               "borderColor": "#FFF",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -913,34 +913,31 @@ exports[`renders profile content 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -1089,28 +1086,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1260,28 +1254,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1433,28 +1424,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1606,28 +1594,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1779,28 +1764,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1940,28 +1922,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2113,28 +2092,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2274,28 +2250,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2435,28 +2408,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2596,28 +2566,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2757,28 +2724,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2918,28 +2882,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3079,28 +3040,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3240,28 +3198,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3408,28 +3363,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3569,28 +3521,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3737,28 +3686,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3911,28 +3857,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4186,34 +4129,31 @@ exports[`renders profile content component 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -4362,28 +4302,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4533,28 +4470,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4706,28 +4640,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4879,28 +4810,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5052,28 +4980,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5213,28 +5138,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5386,28 +5308,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5547,28 +5466,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5708,28 +5624,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5869,28 +5782,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -6030,28 +5940,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -6191,28 +6098,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -6352,28 +6256,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -6513,28 +6414,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -6681,28 +6579,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -6842,28 +6737,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -7010,28 +6902,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -7184,28 +7073,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -7486,34 +7372,31 @@ exports[`renders profile header 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              Object {
-                "borderColor": "#FFF",
-                "borderRadius": 50,
-                "borderWidth": 5,
-                "height": 100,
-                "width": 100,
-              },
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            Object {
+              "borderColor": "#FFF",
+              "borderRadius": 50,
+              "borderWidth": 5,
+              "height": 100,
+              "width": 100,
+            },
+          ]
+        }
+      />
     </View>
   </View>
   <View

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -927,8 +927,8 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -1103,8 +1103,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1274,8 +1274,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1447,8 +1447,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1620,8 +1620,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1793,8 +1793,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1954,8 +1954,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2127,8 +2127,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2288,8 +2288,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2449,8 +2449,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2610,8 +2610,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2771,8 +2771,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2932,8 +2932,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3093,8 +3093,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3254,8 +3254,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3422,8 +3422,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3583,8 +3583,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3751,8 +3751,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3925,8 +3925,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -4200,8 +4200,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -4376,8 +4376,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -4547,8 +4547,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -4720,8 +4720,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -4893,8 +4893,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -5066,8 +5066,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -5227,8 +5227,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -5400,8 +5400,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -5561,8 +5561,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -5722,8 +5722,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -5883,8 +5883,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -6044,8 +6044,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -6205,8 +6205,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -6366,8 +6366,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -6527,8 +6527,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -6695,8 +6695,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -6856,8 +6856,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -7024,8 +7024,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -7198,8 +7198,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -7500,8 +7500,8 @@ exports[`renders profile header 1`] = `
           style={
             Array [
               Object {
-                "height": 1,
-                "width": 750,
+                "height": undefined,
+                "width": undefined,
               },
               Object {
                 "borderColor": "#FFF",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -927,8 +927,8 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -1103,8 +1103,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1274,8 +1274,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1447,8 +1447,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1620,8 +1620,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1793,8 +1793,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1954,8 +1954,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2127,8 +2127,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2288,8 +2288,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2449,8 +2449,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2610,8 +2610,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2771,8 +2771,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2932,8 +2932,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3093,8 +3093,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3254,8 +3254,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3422,8 +3422,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3583,8 +3583,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3751,8 +3751,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3925,8 +3925,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4200,8 +4200,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -4376,8 +4376,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4547,8 +4547,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4720,8 +4720,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4893,8 +4893,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5066,8 +5066,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5227,8 +5227,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5400,8 +5400,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5561,8 +5561,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5722,8 +5722,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5883,8 +5883,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -6044,8 +6044,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -6205,8 +6205,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -6366,8 +6366,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -6527,8 +6527,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -6695,8 +6695,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -6856,8 +6856,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -7024,8 +7024,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -7198,8 +7198,8 @@ exports[`renders profile content component 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -7500,8 +7500,8 @@ exports[`renders profile header 1`] = `
           style={
             Array [
               Object {
-                "height": undefined,
-                "width": undefined,
+                "height": 1,
+                "width": 750,
               },
               Object {
                 "borderColor": "#FFF",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -927,8 +927,8 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -1103,8 +1103,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1274,8 +1274,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1447,8 +1447,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1620,8 +1620,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1793,8 +1793,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -1954,8 +1954,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2127,8 +2127,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2288,8 +2288,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2449,8 +2449,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2610,8 +2610,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2771,8 +2771,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2932,8 +2932,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3093,8 +3093,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3254,8 +3254,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3422,8 +3422,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3583,8 +3583,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3751,8 +3751,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3925,8 +3925,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4197,8 +4197,8 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
-                  "height": undefined,
-                  "width": undefined,
+                  "height": 1,
+                  "width": 750,
                 },
                 Object {
                   "borderColor": "#FFF",
@@ -4380,8 +4380,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -4558,8 +4558,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -4738,8 +4738,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -4918,8 +4918,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5098,8 +5098,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5266,8 +5266,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5446,8 +5446,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5614,8 +5614,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5782,8 +5782,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5950,8 +5950,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -6118,8 +6118,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -6286,8 +6286,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -6454,8 +6454,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -6622,8 +6622,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -6797,8 +6797,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -6965,8 +6965,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -7140,8 +7140,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -7321,8 +7321,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -7622,8 +7622,8 @@ exports[`renders profile header 1`] = `
           style={
             Array [
               Object {
-                "height": undefined,
-                "width": undefined,
+                "height": 1,
+                "width": 750,
               },
               Object {
                 "borderColor": "#FFF",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -913,34 +913,31 @@ exports[`renders profile content 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -1089,28 +1086,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1260,28 +1254,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1433,28 +1424,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1606,28 +1594,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1779,28 +1764,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -1940,28 +1922,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2113,28 +2092,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2274,28 +2250,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2435,28 +2408,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2596,28 +2566,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2757,28 +2724,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2918,28 +2882,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3079,28 +3040,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3240,28 +3198,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3408,28 +3363,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3569,28 +3521,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3737,28 +3686,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3911,28 +3857,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4183,34 +4126,31 @@ exports[`renders profile content component 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                Object {
-                  "borderColor": "#FFF",
-                  "borderRadius": 50,
-                  "borderWidth": 5,
-                  "height": 100,
-                  "width": 100,
-                },
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              Object {
+                "borderColor": "#FFF",
+                "borderRadius": 50,
+                "borderWidth": 5,
+                "height": 100,
+                "width": 100,
+              },
+            ]
+          }
+        />
       </View>
     </View>
     <View
@@ -4366,28 +4306,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -4544,28 +4481,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -4724,28 +4658,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -4904,28 +4835,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5084,28 +5012,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5252,28 +5177,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5432,28 +5354,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5600,28 +5519,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5768,28 +5684,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5936,28 +5849,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -6104,28 +6014,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -6272,28 +6179,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -6440,28 +6344,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -6608,28 +6509,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -6783,28 +6681,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -6951,28 +6846,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -7126,28 +7018,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -7307,28 +7196,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -7608,34 +7494,31 @@ exports[`renders profile header 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              Object {
-                "borderColor": "#FFF",
-                "borderRadius": 50,
-                "borderWidth": 5,
-                "height": 100,
-                "width": 100,
-              },
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            Object {
+              "borderColor": "#FFF",
+              "borderRadius": 50,
+              "borderWidth": 5,
+              "height": 100,
+              "width": 100,
+            },
+          ]
+        }
+      />
     </View>
   </View>
   <View

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -927,8 +927,8 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -1103,8 +1103,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1274,8 +1274,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1447,8 +1447,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1620,8 +1620,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1793,8 +1793,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -1954,8 +1954,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2127,8 +2127,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2288,8 +2288,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2449,8 +2449,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2610,8 +2610,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2771,8 +2771,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -2932,8 +2932,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3093,8 +3093,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3254,8 +3254,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3422,8 +3422,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3583,8 +3583,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3751,8 +3751,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -3925,8 +3925,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -4197,8 +4197,8 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
-                  "height": 1,
-                  "width": 750,
+                  "height": undefined,
+                  "width": undefined,
                 },
                 Object {
                   "borderColor": "#FFF",
@@ -4380,8 +4380,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -4558,8 +4558,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -4738,8 +4738,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -4918,8 +4918,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -5098,8 +5098,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -5266,8 +5266,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -5446,8 +5446,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -5614,8 +5614,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -5782,8 +5782,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -5950,8 +5950,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -6118,8 +6118,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -6286,8 +6286,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -6454,8 +6454,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -6622,8 +6622,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -6797,8 +6797,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -6965,8 +6965,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -7140,8 +7140,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -7321,8 +7321,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   undefined,
                 ]
@@ -7622,8 +7622,8 @@ exports[`renders profile header 1`] = `
           style={
             Array [
               Object {
-                "height": 1,
-                "width": 750,
+                "height": undefined,
+                "width": undefined,
               },
               Object {
                 "borderColor": "#FFF",

--- a/packages/caption/__tests__/__snapshots__/caption.android.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.android.native.test.js.snap
@@ -2,28 +2,25 @@
 
 exports[`renders an image with a caption 1`] = `
 <View>
-  <View
+  <Image
+    onError={[Function]}
     onLayout={[Function]}
-  >
-    <Image
-      onError={[Function]}
-      onLoad={[Function]}
-      source={
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+      }
+    }
+    style={
+      Array [
         Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Array [
-          Object {
-            "height": 1,
-            "width": 750,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
   <View
     style={
       Array [

--- a/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
@@ -16,8 +16,8 @@ exports[`renders an image with a caption 1`] = `
       style={
         Array [
           Object {
-            "height": 1,
-            "width": 750,
+            "height": undefined,
+            "width": undefined,
           },
           undefined,
         ]

--- a/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
@@ -16,8 +16,8 @@ exports[`renders an image with a caption 1`] = `
       style={
         Array [
           Object {
-            "height": undefined,
-            "width": undefined,
+            "height": 1,
+            "width": 750,
           },
           undefined,
         ]

--- a/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
@@ -2,28 +2,25 @@
 
 exports[`renders an image with a caption 1`] = `
 <View>
-  <View
+  <Image
+    onError={[Function]}
     onLayout={[Function]}
-  >
-    <Image
-      onError={[Function]}
-      onLoad={[Function]}
-      source={
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+      }
+    }
+    style={
+      Array [
         Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Array [
-          Object {
-            "height": 1,
-            "width": 750,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
   <View
     style={
       Array [

--- a/packages/caption/__tests__/__snapshots__/caption.web.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.web.test.js.snap
@@ -2,28 +2,25 @@
 
 exports[`renders an image with a caption 1`] = `
 <View>
-  <View
+  <Image
+    onError={[Function]}
     onLayout={[Function]}
-  >
-    <Image
-      onError={[Function]}
-      onLoad={[Function]}
-      source={
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+      }
+    }
+    style={
+      Array [
         Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Array [
-          Object {
-            "height": 1,
-            "width": 750,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
   <View
     style={
       Array [

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -111,28 +111,25 @@ exports[`renders vertical by default 1`] = `
       ]
     }
   >
-    <View
+    <Image
+      onError={[Function]}
       onLayout={[Function]}
-    >
-      <Image
-        onError={[Function]}
-        onLoad={[Function]}
-        source={
+      onLoad={[Function]}
+      source={
+        Object {
+          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+        }
+      }
+      style={
+        Array [
           Object {
-            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "height": 1,
-              "width": 750,
-            },
-            undefined,
-          ]
-        }
-      />
-    </View>
+            "height": 1,
+            "width": 750,
+          },
+          undefined,
+        ]
+      }
+    />
   </View>
   <View
     style={

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -125,8 +125,8 @@ exports[`renders vertical by default 1`] = `
         style={
           Array [
             Object {
-              "height": 1,
-              "width": 750,
+              "height": undefined,
+              "width": undefined,
             },
             undefined,
           ]

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -125,8 +125,8 @@ exports[`renders vertical by default 1`] = `
         style={
           Array [
             Object {
-              "height": undefined,
-              "width": undefined,
+              "height": 1,
+              "width": 750,
             },
             undefined,
           ]

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -9,14 +9,14 @@ exports[`prepends https schema 1`] = `
     onLoad={[Function]}
     source={
       Object {
-        "uri": "https://example.com/image.jpg",
+        "uri": "//example.com/image.jpg",
       }
     }
     style={
       Array [
         Object {
-          "height": 1,
-          "width": 750,
+          "height": undefined,
+          "width": undefined,
         },
         undefined,
       ]
@@ -40,8 +40,8 @@ exports[`renders correctly with no dimensions and given URI 1`] = `
     style={
       Array [
         Object {
-          "height": 1,
-          "width": 750,
+          "height": undefined,
+          "width": undefined,
         },
         undefined,
       ]

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -1,51 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prepends https schema 1`] = `
-<View
+<Image
+  onError={[Function]}
   onLayout={[Function]}
->
-  <Image
-    onError={[Function]}
-    onLoad={[Function]}
-    source={
+  onLoad={[Function]}
+  source={
+    Object {
+      "uri": "https://example.com/image.jpg",
+    }
+  }
+  style={
+    Array [
       Object {
-        "uri": "https://example.com/image.jpg",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "height": 1,
-          "width": 750,
-        },
-        undefined,
-      ]
-    }
-  />
-</View>
+        "height": 1,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+/>
 `;
 
 exports[`renders correctly with no dimensions and given URI 1`] = `
-<View
+<Image
+  onError={[Function]}
   onLayout={[Function]}
->
-  <Image
-    onError={[Function]}
-    onLoad={[Function]}
-    source={
+  onLoad={[Function]}
+  source={
+    Object {
+      "uri": "http://example.com/image.jpg",
+    }
+  }
+  style={
+    Array [
       Object {
-        "uri": "http://example.com/image.jpg",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "height": 1,
-          "width": 750,
-        },
-        undefined,
-      ]
-    }
-  />
-</View>
+        "height": 1,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+/>
 `;

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -9,14 +9,14 @@ exports[`prepends https schema 1`] = `
     onLoad={[Function]}
     source={
       Object {
-        "uri": "//example.com/image.jpg",
+        "uri": "https://example.com/image.jpg",
       }
     }
     style={
       Array [
         Object {
-          "height": undefined,
-          "width": undefined,
+          "height": 1,
+          "width": 750,
         },
         undefined,
       ]
@@ -40,8 +40,8 @@ exports[`renders correctly with no dimensions and given URI 1`] = `
     style={
       Array [
         Object {
-          "height": undefined,
-          "width": undefined,
+          "height": 1,
+          "width": 750,
         },
         undefined,
       ]

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Image, View } from "react-native";
+import { Image } from "react-native";
 import placeholder from "./placeholder";
 import mapPropsToState from "./props-to-state";
 
@@ -63,17 +63,20 @@ class ImageComponent extends React.Component {
       source: this.state.source,
       style: [
         {
-          height: this.state.height,
-          width: this.state.width
+          height: this.state.height || "inherit",
+          width: this.state.width || "inherit"
         },
         this.props.style
       ]
     });
 
     return (
-      <View onLayout={this.handleLayout}>
-        <Image {...props} onError={this.handleError} onLoad={this.handleLoad} />
-      </View>
+      <Image
+        {...props}
+        onLayout={this.handleLayout}
+        onError={this.handleError}
+        onLoad={this.handleLoad}
+      />
     );
   }
 }

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,32 +1,13 @@
 import React from "react";
-import { Platform, Dimensions, Image, View } from "react-native";
+import { Image, View } from "react-native";
 import placeholder from "./placeholder";
-
-const window = Dimensions.get("window");
+import mapPropsToState from "./props-to-state";
 
 class ImageComponent extends React.Component {
   constructor(props) {
     super(props);
 
-    const uri = props.source && props.source.uri;
-
-    this.state = {
-      height: 1,
-      source: {
-        uri:
-          Platform.OS !== "web" && uri && uri.indexOf("//") === 0
-            ? `https:${uri}`
-            : uri
-      },
-      width: window.width,
-      ...Platform.select({
-        web: {
-          height: null,
-          width: null
-        }
-      })
-    };
-
+    this.state = mapPropsToState(props);
     this.getSize = Image.getSize;
     this.handleError = this.handleError.bind(this);
     this.handleLayout = this.handleLayout.bind(this);

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -11,6 +11,7 @@ class ImageComponent extends React.Component {
     const uri = props.source && props.source.uri;
 
     this.state = {
+      height: 1,
       source: {
         uri:
           Platform.OS !== "web" && uri && uri.indexOf("//") === 0
@@ -18,7 +19,12 @@ class ImageComponent extends React.Component {
             : uri
       },
       width: window.width,
-      height: 1
+      ...Platform.select({
+        web: {
+          height: null,
+          width: null
+        }
+      })
     };
 
     this.getSize = Image.getSize;

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -17,7 +17,7 @@ const exampleNonImage = {
 
 const styles = StyleSheet.create({
   container: {
-    height: 256
+    width: 320
   },
   halfWidthView: {
     width: "50%"
@@ -32,7 +32,7 @@ storiesOf("Image", module)
   ))
   .add("Resized to half of full width, keeping aspect ratio", () => (
     <View style={[styles.container, styles.halfWidthView]}>
-      <Image source={exampleImage} />
+      <Image style={{ resizeMode: "center" }} source={exampleImage} />
     </View>
   ))
   .add("Show default image on error", () => (
@@ -46,9 +46,9 @@ storiesOf("Image", module)
     </View>
   ))
   .add("No schema url", () => (
-    <View style={{ width: 100, height: 100 }}>
+    <View style={[styles.container]}>
       <Image
-        resizeMode={"cover"}
+        style={{ resizeMode: "cover" }}
         source={{
           uri:
             "//www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320"
@@ -59,7 +59,6 @@ storiesOf("Image", module)
   .add("Apply style to image", () => (
     <View style={{ width: 100, height: 100 }}>
       <Image
-        resizeMode={"cover"}
         style={{ borderRadius: 50, width: 100, height: 100 }}
         source={exampleImage}
       />

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -1,4 +1,6 @@
+/* eslint-disable react/no-danger */
 import React from "react";
+import ReactDOMServer from "react-dom/server";
 import { StyleSheet, View } from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
@@ -62,4 +64,14 @@ storiesOf("Image", module)
         source={exampleImage}
       />
     </View>
-  ));
+  ))
+  .add("Server side rendered Image", () => {
+    const comp = (
+      <View style={[styles.container, styles.halfWidthView]}>
+        <Image style={{ resizeMode: "center" }} source={exampleImage} />
+      </View>
+    );
+    const markup = { __html: ReactDOMServer.renderToStaticMarkup(comp) };
+
+    return <div dangerouslySetInnerHTML={markup} />;
+  });

--- a/packages/image/image.web.js
+++ b/packages/image/image.web.js
@@ -1,0 +1,70 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import placeholder from "./placeholder";
+
+class Image extends Component {
+  constructor(props) {
+    super(props);
+
+    const { resizeMode, source, height, width, style } = this.props;
+
+    this.style = style;
+    this.defaults = {
+      height,
+      width
+    };
+    this.important = {
+      backgroundSize: resizeMode,
+      backgroundPosition: "center center",
+      backgroundRepeat: "no-repeat"
+    };
+
+    this.state = {
+      source
+    };
+
+    this.handleError = this.handleError.bind(this);
+  }
+
+  handleError() {
+    this.setState({
+      source: {
+        uri: placeholder
+      }
+    });
+  }
+
+  render() {
+    return (
+      <img
+        {...this.props}
+        alt=""
+        onError={this.handleError}
+        src={this.state.source.uri}
+        style={{ ...this.defaults, ...this.style, ...this.important }}
+      />
+    );
+  }
+}
+
+Image.propTypes = {
+  source: PropTypes.shape({
+    uri: PropTypes.string.isRequired
+  }),
+  resizeMode: PropTypes.string,
+  height: PropTypes.string,
+  width: PropTypes.string,
+  style: PropTypes.shape()
+};
+
+Image.defaultProps = {
+  source: {
+    uri: ""
+  },
+  resizeMode: "contain",
+  height: "inherit",
+  width: "inherit",
+  style: {}
+};
+
+export default Image;

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@times-components/image",
   "version": "1.2.1",
-  "main": "image.js",
+  "main": "image",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
     "test:watch": "jest --bail --verbose --watchAll",

--- a/packages/image/props-to-state.js
+++ b/packages/image/props-to-state.js
@@ -1,0 +1,5 @@
+export default ({ source }) => ({
+  source: {
+    uri: source && source.uri
+  }
+});

--- a/packages/image/props-to-state.js
+++ b/packages/image/props-to-state.js
@@ -1,5 +1,14 @@
-export default ({ source }) => ({
-  source: {
-    uri: source && source.uri
-  }
-});
+import { Dimensions } from "react-native";
+
+const window = Dimensions.get("window");
+export default ({ source }) => {
+  const uri = source.uri;
+
+  return {
+    height: 1,
+    source: {
+      uri: uri && uri.indexOf("//") === 0 ? `https:${uri}` : uri
+    },
+    width: window.width
+  };
+};

--- a/packages/image/props-to-state.web.js
+++ b/packages/image/props-to-state.web.js
@@ -1,0 +1,14 @@
+import { Dimensions } from "react-native";
+
+const window = Dimensions.get("window");
+export default ({ source }) => {
+  const uri = source.uri;
+
+  return {
+    height: 1,
+    source: {
+      uri: uri && uri.indexOf("//") === 0 ? `https:${uri}` : uri
+    },
+    width: window.width
+  };
+};

--- a/packages/image/props-to-state.web.js
+++ b/packages/image/props-to-state.web.js
@@ -1,14 +1,5 @@
-import { Dimensions } from "react-native";
-
-const window = Dimensions.get("window");
-export default ({ source }) => {
-  const uri = source.uri;
-
-  return {
-    height: 1,
-    source: {
-      uri: uri && uri.indexOf("//") === 0 ? `https:${uri}` : uri
-    },
-    width: window.width
-  };
-};
+export default ({ source }) => ({
+  source: {
+    uri: source && source.uri
+  }
+});

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -155,8 +155,8 @@ exports[`renders data 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -302,14 +302,14 @@ exports[`renders data 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
-                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -560,8 +560,8 @@ exports[`renders data from graphql 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -707,14 +707,14 @@ exports[`renders data from graphql 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
-                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -141,34 +141,31 @@ exports[`renders data 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -294,28 +291,25 @@ exports[`renders data 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -546,34 +540,31 @@ exports[`renders data from graphql 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -699,28 +690,25 @@ exports[`renders data from graphql 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -155,8 +155,8 @@ exports[`renders data 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -302,14 +302,14 @@ exports[`renders data 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
-                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]
@@ -560,8 +560,8 @@ exports[`renders data from graphql 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -707,14 +707,14 @@ exports[`renders data from graphql 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
-                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
                 style={
                   Array [
                     Object {
-                      "height": 1,
-                      "width": 750,
+                      "height": undefined,
+                      "width": undefined,
                     },
                     undefined,
                   ]


### PR DESCRIPTION
On native, the `Image.onLoad` is only called when the image has dimensions so we have a minimum height (1). 

On the web, the image doesn't need to have dimensions and in order for the image to appear to the user, we let the browser decide on the dimensions of the image.