### PR TITLE
export the main entry point without the ext

### DIFF
--- a/packages/article-headline/package.json
+++ b/packages/article-headline/package.json
@@ -2,7 +2,7 @@
   "name": "@times-components/article-headline",
   "version": "0.4.0",
   "description": "The article headline",
-  "main": "article-headline.js",
+  "main": "article-headline",
   "scripts": {
     "flow": "node_modules/flow-bin/cli.js",
     "test:watch": "jest --bail --verbose --watchAll",


### PR DESCRIPTION
<!--
Thank you for your PR!

If you changed any code, please provide clear instructions on how you verified your changes work.

Screenshots are most welcome!

:-)
-->
export the main entry point without the ext otherwise we can't use the specific android component