### PR TITLE
Author profile links

### DIFF
--- a/packages/author-head/__tests__/author-head.test.js
+++ b/packages/author-head/__tests__/author-head.test.js
@@ -7,12 +7,14 @@ import AuthorHead from "../author-head";
 
 const data = require("../fixtures/profile.json");
 
+const extra = { onTwitterLinkPress: () => {} };
+
 it("renders a snapshot", () => {
-  const tree = renderer.create(<AuthorHead />).toJSON();
+  const tree = renderer.create(<AuthorHead {...extra} />).toJSON();
   expect(tree).toMatchSnapshot();
 });
 
 it("renders a snapshot with data", () => {
-  const tree = renderer.create(<AuthorHead {...data} />).toJSON();
+  const tree = renderer.create(<AuthorHead {...data} {...extra} />).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/packages/author-head/author-head.js
+++ b/packages/author-head/author-head.js
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
 });
 
 const AuthorHead = props => {
-  const { name, title, twitter, bio, uri } = props;
+  const { name, title, twitter, bio, uri, onTwitterLinkPress } = props;
 
   return (
     <View style={styles.wrapper} pointerEvents="box-none">
@@ -73,7 +73,7 @@ const AuthorHead = props => {
         <Text accessibilityRole="heading" aria-level="2" style={styles.title}>
           {title.toLowerCase()}
         </Text>
-        <TwitterLink handle={twitter} />
+        <TwitterLink handle={twitter} onPress={onTwitterLinkPress} />
         <Text style={styles.bio}>{renderTrees(bio)}</Text>
       </View>
       <View style={styles.photoContainer}>
@@ -96,24 +96,30 @@ AuthorHead.propTypes = {
   title: PropTypes.string,
   uri: PropTypes.string,
   bio: PropTypes.arrayOf(treePropType),
-  twitter: PropTypes.string
+  twitter: PropTypes.string,
+  onTwitterLinkPress: PropTypes.func.isRequired
 };
 
-const TwitterLink = ({ handle }) => {
+const TwitterLink = ({ handle, onPress }) => {
   if (!handle) {
     return null;
   }
-  const target = `https://twitter.com/${handle}`;
+  const url = `https://twitter.com/${handle}`;
 
   return (
-    <TextLink style={styles.twitter} url={target} onPress={() => {}}>
+    <TextLink
+      style={styles.twitter}
+      url={url}
+      onPress={e => onPress(e, { handle, url })}
+    >
       @{handle}
     </TextLink>
   );
 };
 
 TwitterLink.propTypes = {
-  handle: AuthorHead.propTypes.twitter
+  handle: AuthorHead.propTypes.twitter,
+  onPress: PropTypes.func.isRequired
 };
 
 TwitterLink.defaultProps = {

--- a/packages/author-head/author-head.stories.js
+++ b/packages/author-head/author-head.stories.js
@@ -2,12 +2,25 @@ import React from "react";
 import { View } from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { decorateAction } from "@storybook/addon-actions";
 import AuthorHead from "./author-head";
 
 const data = require("./fixtures/profile.json");
 
 const story = m => <View style={{ padding: 20 }}>{m}</View>;
 
+const preventDefaultedAction = decorateAction([
+  ([e, ...args]) => {
+    e.preventDefault();
+    return ["[SyntheticEvent (storybook prevented default)]", ...args];
+  }
+]);
+
+const extras = {
+  onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
+};
+
 storiesOf("AuthorHead", module).add("Full Header", () =>
-  story(<AuthorHead {...data} />)
+  story(<AuthorHead {...data} {...extras} />)
 );

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -12,6 +12,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -55,6 +56,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -98,6 +100,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -141,6 +144,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -184,6 +188,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according",
@@ -213,6 +218,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -256,6 +262,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -285,6 +292,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -314,6 +322,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -343,6 +352,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -372,6 +382,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -401,6 +412,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -430,6 +442,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories",
@@ -459,6 +472,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.",
@@ -473,6 +487,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Dames, lords, actors",
@@ -502,6 +517,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid",
@@ -531,6 +547,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.",
@@ -545,6 +562,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "The Think",
@@ -574,6 +592,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Terry Pratchett, who died last week, began his career on the ",
@@ -596,6 +615,7 @@ exports[`renders profile 1`] = `
                   "name": "italic",
                 },
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
@@ -625,6 +645,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it ",
@@ -647,6 +668,7 @@ exports[`renders profile 1`] = `
                   "name": "italic",
                 },
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": " to",
@@ -676,6 +698,7 @@ exports[`renders profile 1`] = `
   biography={
     Array [
       Object {
+        "attributes": Object {},
         "children": Array [
           Object {
             "text": "Lorem ",
@@ -698,6 +721,7 @@ exports[`renders profile 1`] = `
         "name": "bold",
       },
       Object {
+        "attributes": Object {},
         "children": Array [
           Object {
             "text": " testbr ",
@@ -707,9 +731,11 @@ exports[`renders profile 1`] = `
       },
       Object {
         "attributes": Object {},
+        "children": Array [],
         "name": "break",
       },
       Object {
+        "attributes": Object {},
         "children": Array [
           Object {
             "text": "More text ",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -765,6 +765,7 @@ exports[`renders profile 1`] = `
   name="Fiona Hamilton"
   onNext={[Function]}
   onPrev={[Function]}
+  onTwitterLinkPress={[Function]}
   page={1}
   pageSize={10}
   twitter="jdoe"

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -12,6 +12,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -55,6 +56,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -98,6 +100,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -141,6 +144,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -184,6 +188,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according",
@@ -213,6 +218,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
@@ -256,6 +262,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -285,6 +292,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -314,6 +322,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -343,6 +352,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -372,6 +382,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -401,6 +412,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
@@ -430,6 +442,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories",
@@ -459,6 +472,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.",
@@ -473,6 +487,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Dames, lords, actors",
@@ -502,6 +517,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid",
@@ -531,6 +547,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.",
@@ -545,6 +562,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "The Think",
@@ -574,6 +592,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Terry Pratchett, who died last week, began his career on the ",
@@ -596,6 +615,7 @@ exports[`renders profile 1`] = `
                   "name": "italic",
                 },
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
@@ -625,6 +645,7 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it ",
@@ -647,6 +668,7 @@ exports[`renders profile 1`] = `
                   "name": "italic",
                 },
                 Object {
+                  "attributes": Object {},
                   "children": Array [
                     Object {
                       "text": " to",
@@ -676,6 +698,7 @@ exports[`renders profile 1`] = `
   biography={
     Array [
       Object {
+        "attributes": Object {},
         "children": Array [
           Object {
             "text": "Lorem ",
@@ -698,6 +721,7 @@ exports[`renders profile 1`] = `
         "name": "bold",
       },
       Object {
+        "attributes": Object {},
         "children": Array [
           Object {
             "text": " testbr ",
@@ -707,9 +731,11 @@ exports[`renders profile 1`] = `
       },
       Object {
         "attributes": Object {},
+        "children": Array [],
         "name": "break",
       },
       Object {
+        "attributes": Object {},
         "children": Array [
           Object {
             "text": "More text ",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -765,6 +765,7 @@ exports[`renders profile 1`] = `
   name="Fiona Hamilton"
   onNext={[Function]}
   onPrev={[Function]}
+  onTwitterLinkPress={[Function]}
   page={1}
   pageSize={10}
   twitter="jdoe"

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -21,7 +21,8 @@ const props = {
     page: 1,
     pageSize: 10
   }),
-  isLoading: false
+  isLoading: false,
+  onTwitterLinkPress: () => {}
 };
 
 export default AuthorProfileContent => {
@@ -72,7 +73,9 @@ export default AuthorProfileContent => {
   });
 
   it("renders profile header", () => {
-    const component = renderer.create(<AuthorProfileHeader {...props.data} />);
+    const component = renderer.create(
+      <AuthorProfileHeader onTwitterLinkPress={() => {}} {...props.data} />
+    );
 
     expect(component).toMatchSnapshot();
   });
@@ -84,7 +87,9 @@ export default AuthorProfileContent => {
   });
 
   it("renders profile content component", () => {
-    const component = renderer.create(<AuthorProfileContent {...props.data} />);
+    const component = renderer.create(
+      <AuthorProfileContent onTwitterLinkPress={() => {}} {...props.data} />
+    );
 
     expect(component).toMatchSnapshot();
   });

--- a/packages/author-profile/author-profile-header.js
+++ b/packages/author-profile/author-profile-header.js
@@ -30,14 +30,16 @@ const AuthorProfileHeader = ({
   onNext,
   onPrev,
   pageSize,
-  twitter
+  twitter,
+  onTwitterLinkPress
 }) => {
   const authorProps = {
     bio,
     name,
     uri,
     title,
-    twitter
+    twitter,
+    onTwitterLinkPress
   };
 
   const paginationProps = {
@@ -72,7 +74,8 @@ AuthorProfileHeader.propTypes = {
   onPrev: PropTypes.func,
   page: Pagination.propTypes.page,
   pageSize: Pagination.propTypes.pageSize,
-  twitter: AuthorHead.propTypes.twitter
+  twitter: AuthorHead.propTypes.twitter,
+  onTwitterLinkPress: PropTypes.func.isRequired
 };
 
 AuthorProfileHeader.defaultProps = {

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -19,7 +19,8 @@ const AuthorProfile = props => {
       onNext: props.onNext,
       onPrev: props.onPrev,
       page: props.page,
-      pageSize: props.pageSize
+      pageSize: props.pageSize,
+      onTwitterLinkPress: props.onTwitterLinkPress
     };
     return <AuthorProfileContent {...props.data} {...extra} />;
   }
@@ -27,14 +28,26 @@ const AuthorProfile = props => {
   return <AuthorProfileEmpty />;
 };
 
+const {
+  onNext,
+  onPrev,
+  page,
+  pageSize,
+  onTwitterLinkPress,
+  ...data
+} = AuthorProfileContent.propTypes;
+
 AuthorProfile.propTypes = {
-  data: PropTypes.shape(AuthorProfileContent.propTypes),
+  data: PropTypes.shape(data),
   error: PropTypes.shape(),
   isLoading: PropTypes.bool,
-  onNext: AuthorProfileContent.propTypes.onNext,
-  onPrev: AuthorProfileContent.propTypes.onPrev,
-  page: AuthorProfileContent.propTypes.page,
-  pageSize: AuthorProfileContent.propTypes.pageSize
+  onNext,
+  onPrev,
+  page,
+  pageSize,
+  // eslint doesnt follow the reference. AuthorProfileContent.propTypes.onTwitterLinkPress is actually marked as required.
+  // eslint-disable-next-line react/require-default-props
+  onTwitterLinkPress
 };
 
 AuthorProfile.defaultProps = {

--- a/packages/author-profile/author-profile.stories.js
+++ b/packages/author-profile/author-profile.stories.js
@@ -2,6 +2,8 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { decorateAction } from "@storybook/addon-actions";
 import AuthorProfile from "./author-profile";
 import example from "./example.json";
 
@@ -22,6 +24,13 @@ const story = m => (
   </View>
 );
 
+const preventDefaultedAction = decorateAction([
+  ([e, ...args]) => {
+    e.preventDefault();
+    return ["[SyntheticEvent (storybook prevented default)]", ...args];
+  }
+]);
+
 storiesOf("AuthorProfile", module)
   .add("AuthorProfile", () => {
     const props = {
@@ -30,7 +39,8 @@ storiesOf("AuthorProfile", module)
         pageSize: 10,
         page: 1
       }),
-      isLoading: false
+      isLoading: false,
+      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
     };
 
     props.data.articles.list.forEach(article => {
@@ -42,14 +52,16 @@ storiesOf("AuthorProfile", module)
   })
   .add("AuthorProfile Loading", () => {
     const props = {
-      isLoading: true
+      isLoading: true,
+      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
     };
 
     return story(<AuthorProfile {...props} />);
   })
   .add("AuthorProfile Empty State", () => {
     const props = {
-      isLoading: false
+      isLoading: false,
+      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
     };
 
     return story(<AuthorProfile {...props} />);

--- a/packages/author-profile/example.json
+++ b/packages/author-profile/example.json
@@ -4,6 +4,7 @@
   "biography": [
     {
       "name": "text",
+      "attributes": {},
       "children": [
         {
           "text": "Lorem "
@@ -26,6 +27,7 @@
     },
     {
       "name": "text",
+      "attributes": {},
       "children": [
         {
           "text": " testbr "
@@ -34,10 +36,12 @@
     },
     {
       "name": "break",
-      "attributes": {}
+      "attributes": {},
+      "children": []
     },
     {
       "name": "text",
+      "attributes": {},
       "children": [
         {
           "text": "More text "
@@ -79,9 +83,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
@@ -90,6 +96,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -122,9 +129,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
@@ -133,6 +142,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -165,9 +175,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
@@ -176,6 +188,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -208,9 +221,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
@@ -219,6 +234,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -251,9 +267,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according"
@@ -280,9 +298,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
@@ -291,6 +311,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -323,9 +344,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
@@ -352,9 +375,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
@@ -381,9 +406,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
@@ -410,9 +437,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
@@ -439,9 +468,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
@@ -468,9 +499,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
@@ -497,9 +530,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories"
@@ -526,9 +561,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved."
@@ -540,9 +577,11 @@
           },
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "Dames, lords, actors"
@@ -569,9 +608,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid"
@@ -598,9 +639,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today."
@@ -612,9 +655,11 @@
           },
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "The Think"
@@ -641,9 +686,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "Terry Pratchett, who died last week, began his career on the "
@@ -652,6 +699,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -666,6 +714,7 @@
               },
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": " in 1965, aged 17, and the paper recalls in a tribute that he wore"
@@ -692,9 +741,11 @@
         "content": [
           {
             "name": "paragraph",
+            "attributes": {},
             "children": [
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it "
@@ -703,6 +754,7 @@
               },
               {
                 "name": "italic",
+                "attributes": {},
                 "children": [
                   {
                     "name": "text",
@@ -717,6 +769,7 @@
               },
               {
                 "name": "text",
+                "attributes": {},
                 "children": [
                   {
                     "text": " to"


### PR DESCRIPTION
Adds a `onTwitterLinkPress` to author head and author profile.

It calls back with `(event, { url, handle })` so that native can handle the navigation.

![screen shot 2017-09-19 at 17 28 19](https://user-images.githubusercontent.com/298742/30603664-1ef087d2-9d60-11e7-8a7c-a36f13ea248b.png)

PS
There's a bit of noise on the diff as I had to update the snapshots and fix all "missing proptype" warnings.