### PR TITLE
chore: add yarn to engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of presentational components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.0.0",
+    "yarn": "1.0.2"
   },
   "bin": {
     "times-components": "times-components"


### PR DESCRIPTION
Rather than slacking devs to upgrade...yarn is supported in the `package.json` engines field