### PR TITLE
fix: use the correct version of ad on markup

### DIFF
--- a/packages/markup/__tests__/__snapshots__/markup.native.test.js.snap
+++ b/packages/markup/__tests__/__snapshots__/markup.native.test.js.snap
@@ -343,7 +343,7 @@ exports[`Markup Native renders multiple paragraphs with ads 1`] = `
               "borderStyle": "solid",
               "borderWidth": 1,
               "color": "#696969",
-              "fontFamily": "TimesDigital-Regular",
+              "fontFamily": "TimesDigitalW04",
               "fontSize": 12,
               "letterSpacing": 1.5,
               "paddingBottom": 5,

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -52,7 +52,7 @@
     "webpack": "3.3.0"
   },
   "dependencies": {
-    "@times-components/ad": "0.1.2",
+    "@times-components/ad": "0.3.1",
     "prop-types": "15.5.10",
     "react-native-web": "0.0.119"
   },


### PR DESCRIPTION
Fix a bug introduced by #232. Bumping the `Ad` component to the correct version on the markup.
