### PR TITLE
Author profile article links

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -49,6 +49,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-23T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -93,6 +94,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-20T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -137,6 +139,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-19T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -181,6 +184,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-18T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -211,6 +215,7 @@ exports[`renders profile 1`] = `
           "publicationName": "SUNDAYTIMES",
           "publishedTime": 2015-03-17T23:37:49.000Z,
           "title": "Gay and IVF couples ‘better at raising children’",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -255,6 +260,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -285,6 +291,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -315,6 +322,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -345,6 +353,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -375,6 +384,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -405,6 +415,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -435,6 +446,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -465,6 +477,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T22:11:25.000Z,
           "title": "Clash of interests tarnished the project",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -510,6 +523,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T21:49:11.000Z,
           "title": "Giant brings out the stars for one last time",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -540,6 +554,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T21:25:02.000Z,
           "title": "Inquiry at sect schools that banned books",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -585,6 +600,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T20:51:44.000Z,
           "title": "Top graduates drawn to jobs in social work",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -638,6 +654,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T19:39:39.000Z,
           "title": "TMS: Pratchett’s law of the jungle",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -691,6 +708,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T19:36:43.000Z,
           "title": "Learning by rote ‘will put pupils off poetry’",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
       ],
     }
@@ -763,6 +781,7 @@ exports[`renders profile 1`] = `
   image="https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg"
   jobTitle="Legal Editor"
   name="Fiona Hamilton"
+  onArticlePress={[Function]}
   onNext={[Function]}
   onPrev={[Function]}
   onTwitterLinkPress={[Function]}
@@ -1056,161 +1075,184 @@ exports[`renders profile content 1`] = `
     </View>
     <View>
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
+              <View
+                onLayout={[Function]}
               >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
                   }
-                }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Monday March 23 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Monday March 23 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1227,163 +1269,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                POLITICS
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  POLITICS
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Friday March 20 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Friday March 20 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1400,163 +1465,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Thursday March 19 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Thursday March 19 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1573,324 +1661,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Wednesday March 18 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Gay and IVF couples ‘better at raising children’
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
                 >
-                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
+                  Wednesday March 18 2015
+                  , The Times
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Sunday Times
-              </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1907,163 +1857,174 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Gay and IVF couples ‘better at raising children’
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Sunday Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -2080,1788 +2041,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  SCIENCE
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
                   }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                POLITICS
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
                 >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Clash of interests tarnished the project
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Giant brings out the stars for one last time
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Dames, lords, actors
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Inquiry at sect schools that banned books
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Top graduates drawn to jobs in social work
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Think
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                TMS: Pratchett’s law of the jungle
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Terry Pratchett, who died last week, began his career on the 
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    Bucks Free Press
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
-                   in 1965, aged 17, and the paper recalls in a tribute that he wore
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -3878,164 +2237,2238 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Learning by rote ‘will put pupils off poetry’
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    dulce et decorum
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
                   </Text>
-                   to
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  POLITICS
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
               >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Clash of interests tarnished the project
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Giant brings out the stars for one last time
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Dames, lords, actors
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Inquiry at sect schools that banned books
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Top graduates drawn to jobs in social work
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    The Think
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  TMS: Pratchett’s law of the jungle
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Terry Pratchett, who died last week, began his career on the 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      Bucks Free Press
+                    </Text>
+                     in 1965, aged 17, and the paper recalls in a tribute that he wore
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Learning by rote ‘will put pupils off poetry’
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      dulce et decorum
+                    </Text>
+                     to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -4329,161 +4762,184 @@ exports[`renders profile content component 1`] = `
     </View>
     <View>
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
+              <View
+                onLayout={[Function]}
               >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
                   }
-                }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Monday March 23 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Monday March 23 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -4500,163 +4956,186 @@ exports[`renders profile content component 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                POLITICS
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  POLITICS
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Friday March 20 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Friday March 20 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -4673,163 +5152,186 @@ exports[`renders profile content component 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Thursday March 19 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Thursday March 19 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -4846,324 +5348,186 @@ exports[`renders profile content component 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Wednesday March 18 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Gay and IVF couples ‘better at raising children’
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
                 >
-                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
+                  Wednesday March 18 2015
+                  , The Times
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Sunday Times
-              </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -5180,163 +5544,174 @@ exports[`renders profile content component 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Gay and IVF couples ‘better at raising children’
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Sunday Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -5353,1788 +5728,186 @@ exports[`renders profile content component 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  SCIENCE
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
                   }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                POLITICS
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
                 >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Clash of interests tarnished the project
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Giant brings out the stars for one last time
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Dames, lords, actors
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Inquiry at sect schools that banned books
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Top graduates drawn to jobs in social work
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Think
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                TMS: Pratchett’s law of the jungle
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Terry Pratchett, who died last week, began his career on the 
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    Bucks Free Press
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
-                   in 1965, aged 17, and the paper recalls in a tribute that he wore
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -7151,164 +5924,2238 @@ exports[`renders profile content component 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Learning by rote ‘will put pupils off poetry’
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    dulce et decorum
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
                   </Text>
-                   to
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  POLITICS
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
               >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Clash of interests tarnished the project
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Giant brings out the stars for one last time
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Dames, lords, actors
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Inquiry at sect schools that banned books
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Top graduates drawn to jobs in social work
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    The Think
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  TMS: Pratchett’s law of the jungle
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Terry Pratchett, who died last week, began his career on the 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      Bucks Free Press
+                    </Text>
+                     in 1965, aged 17, and the paper recalls in a tribute that he wore
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Learning by rote ‘will put pupils off poetry’
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      dulce et decorum
+                    </Text>
+                     to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -49,6 +49,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-23T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -93,6 +94,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-20T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -137,6 +139,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-19T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -181,6 +184,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-18T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -211,6 +215,7 @@ exports[`renders profile 1`] = `
           "publicationName": "SUNDAYTIMES",
           "publishedTime": 2015-03-17T23:37:49.000Z,
           "title": "Gay and IVF couples ‘better at raising children’",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -255,6 +260,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:06:34.000Z,
           "title": "British trio stopped on the way to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -285,6 +291,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -315,6 +322,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -345,6 +353,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -375,6 +384,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -405,6 +415,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -435,6 +446,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T23:01:44.000Z,
           "title": "Fourth Briton is seized trying to join Isis",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -465,6 +477,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T22:11:25.000Z,
           "title": "Clash of interests tarnished the project",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -510,6 +523,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T21:49:11.000Z,
           "title": "Giant brings out the stars for one last time",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -540,6 +554,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T21:25:02.000Z,
           "title": "Inquiry at sect schools that banned books",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -585,6 +600,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T20:51:44.000Z,
           "title": "Top graduates drawn to jobs in social work",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -638,6 +654,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T19:39:39.000Z,
           "title": "TMS: Pratchett’s law of the jungle",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
         Object {
           "content": Array [
@@ -691,6 +708,7 @@ exports[`renders profile 1`] = `
           "publicationName": "TIMES",
           "publishedTime": 2015-03-17T19:36:43.000Z,
           "title": "Learning by rote ‘will put pupils off poetry’",
+          "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         },
       ],
     }
@@ -763,6 +781,7 @@ exports[`renders profile 1`] = `
   image="https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg"
   jobTitle="Legal Editor"
   name="Fiona Hamilton"
+  onArticlePress={[Function]}
   onNext={[Function]}
   onPrev={[Function]}
   onTwitterLinkPress={[Function]}
@@ -1056,161 +1075,184 @@ exports[`renders profile content 1`] = `
     </View>
     <View>
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
+              <View
+                onLayout={[Function]}
               >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
                   }
-                }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Monday March 23 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Monday March 23 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1227,163 +1269,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                POLITICS
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  POLITICS
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Friday March 20 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Friday March 20 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1400,163 +1465,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Thursday March 19 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Thursday March 19 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1573,324 +1661,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Wednesday March 18 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Gay and IVF couples ‘better at raising children’
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
                 >
-                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
+                  Wednesday March 18 2015
+                  , The Times
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Sunday Times
-              </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -1907,163 +1857,174 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Gay and IVF couples ‘better at raising children’
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    The
+                    GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
                   </Text>
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Sunday Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -2080,1788 +2041,186 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  SCIENCE
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
                   }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                POLITICS
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
                 >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Clash of interests tarnished the project
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Giant brings out the stars for one last time
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Dames, lords, actors
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Inquiry at sect schools that banned books
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Top graduates drawn to jobs in social work
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-                </Text>
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  The Think
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                TMS: Pratchett’s law of the jungle
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  Terry Pratchett, who died last week, began his career on the 
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    Bucks Free Press
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      The
+                    </Text>
                   </Text>
-                   in 1965, aged 17, and the paper recalls in a tribute that he wore
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -3878,164 +2237,2238 @@ exports[`renders profile content 1`] = `
         }
       />
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
                     Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
             </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
             <View
-              style={Object {}}
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                ENVIRONMENT
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Learning by rote ‘will put pupils off poetry’
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
+              <View
+                style={Object {}}
               >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
                 >
-                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
                   <Text
                     accessible={true}
                     allowFontScaling={true}
                     ellipsizeMode="tail"
-                    style={
-                      Object {
-                        "fontStyle": "italic",
-                      }
-                    }
                   >
-                    dulce et decorum
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
                   </Text>
-                   to
                 </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  POLITICS
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
               >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Fourth Briton is seized trying to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Clash of interests tarnished the project
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Giant brings out the stars for one last time
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Dames, lords, actors
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  SCIENCE
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Inquiry at sect schools that banned books
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Top graduates drawn to jobs in social work
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    The Think
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  HEALTH
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  TMS: Pratchett’s law of the jungle
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Terry Pratchett, who died last week, began his career on the 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      Bucks Free Press
+                    </Text>
+                     in 1965, aged 17, and the paper recalls in a tribute that he wore
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <View
+          style={
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flexDirection": "column",
+                },
+                null,
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                onLayout={[Function]}
+              >
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                >
+                  ENVIRONMENT
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  Learning by rote ‘will put pupils off poetry’
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#696969",
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                  >
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "fontStyle": "italic",
+                        }
+                      }
+                    >
+                      dulce et decorum
+                    </Text>
+                     to
+                  </Text>
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Tuesday March 17 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -4333,161 +4766,184 @@ exports[`renders profile content component 1`] = `
     }
   >
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            />
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
+            <View
+              onLayout={[Function]}
             >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
                 }
-              }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              />
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
               >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  The
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The
+                  </Text>
                 </Text>
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Monday March 23 2015
-              , The Times
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Monday March 23 2015
+                , The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -4511,163 +4967,186 @@ exports[`renders profile content component 1`] = `
       }
     />
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
                   Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
           </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
           <View
-            style={Object {}}
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              POLITICS
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
               >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                POLITICS
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  The
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The
+                  </Text>
                 </Text>
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Friday March 20 2015
-              , The Times
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Friday March 20 2015
+                , The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -4691,163 +5170,186 @@ exports[`renders profile content component 1`] = `
       }
     />
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
                   Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
           </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
           <View
-            style={Object {}}
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
               >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  The
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The
+                  </Text>
                 </Text>
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Thursday March 19 2015
-              , The Times
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Thursday March 19 2015
+                , The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -4871,331 +5373,186 @@ exports[`renders profile content component 1`] = `
       }
     />
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
                   Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
           </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
           <View
-            style={Object {}}
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
               >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  The
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The
+                  </Text>
                 </Text>
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Wednesday March 18 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              HEALTH
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Gay and IVF couples ‘better at raising children’
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
               >
-                GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
+                Wednesday March 18 2015
+                , The Times
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Sunday Times
-            </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -5219,163 +5576,174 @@ exports[`renders profile content component 1`] = `
       }
     />
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
                   Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
           </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
           <View
-            style={Object {}}
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
               >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                HEALTH
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Gay and IVF couples ‘better at raising children’
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  The
+                  GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according
                 </Text>
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Sunday Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -5399,1858 +5767,186 @@ exports[`renders profile content component 1`] = `
       }
     />
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
                   Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
           </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
           <View
-            style={Object {}}
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              ENVIRONMENT
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Fourth Briton is seized trying to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
               >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                SCIENCE
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                British trio stopped on the way to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
                   Object {
                     "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
                 }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              POLITICS
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Fourth Briton is seized trying to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
               >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              HEALTH
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Fourth Briton is seized trying to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Fourth Briton is seized trying to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              HEALTH
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Fourth Briton is seized trying to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              ENVIRONMENT
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Fourth Briton is seized trying to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Clash of interests tarnished the project
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Giant brings out the stars for one last time
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Dames, lords, actors
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              SCIENCE
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Inquiry at sect schools that banned books
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              HEALTH
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Top graduates drawn to jobs in social work
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                The Think
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "backgroundColor": "#dbdbdb",
-          "height": 1,
-          "margin": 10,
-        }
-      }
-    />
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              HEALTH
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              TMS: Pratchett’s law of the jungle
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                Terry Pratchett, who died last week, began his career on the 
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  Bucks Free Press
+                  A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The
+                  </Text>
                 </Text>
-                 in 1965, aged 17, and the paper recalls in a tribute that he wore
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -7274,164 +5970,2315 @@ exports[`renders profile content component 1`] = `
       }
     />
     <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
+          "opacity": 1,
         }
       }
+      testID={undefined}
+      tvParallaxProperties={undefined}
     >
       <View
-        onLayout={[Function]}
         style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
         }
       >
         <View
+          onLayout={[Function]}
           style={
             Array [
               Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
+                "flexDirection": "column",
               },
               null,
+              undefined,
             ]
           }
         >
           <View
-            onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
                   Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
           </View>
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
           <View
-            style={Object {}}
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            >
-              ENVIRONMENT
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              Learning by rote ‘will put pupils off poetry’
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
+            <View
+              style={Object {}}
             >
               <Text
                 accessible={true}
                 allowFontScaling={true}
                 ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
               >
-                Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                ENVIRONMENT
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
                 <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
                 >
-                  dulce et decorum
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
                 </Text>
-                 to
               </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                POLITICS
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
                   Object {
                     "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
             >
-              Tuesday March 17 2015
-              , The Times
-            </Text>
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                HEALTH
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                HEALTH
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                ENVIRONMENT
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Clash of interests tarnished the project
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Giant brings out the stars for one last time
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Dames, lords, actors
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Inquiry at sect schools that banned books
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                HEALTH
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Top graduates drawn to jobs in social work
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  The Think
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                HEALTH
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                TMS: Pratchett’s law of the jungle
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Terry Pratchett, who died last week, began his career on the 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    Bucks Free Press
+                  </Text>
+                   in 1965, aged 17, and the paper recalls in a tribute that he wore
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#dbdbdb",
+          "height": 1,
+          "margin": 10,
+        }
+      }
+    />
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                ENVIRONMENT
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Learning by rote ‘will put pupils off poetry’
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    dulce et decorum
+                  </Text>
+                   to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -22,7 +22,8 @@ const props = {
     pageSize: 10
   }),
   isLoading: false,
-  onTwitterLinkPress: () => {}
+  onTwitterLinkPress: () => {},
+  onArticlePress: () => {}
 };
 
 export default AuthorProfileContent => {
@@ -74,7 +75,11 @@ export default AuthorProfileContent => {
 
   it("renders profile header", () => {
     const component = renderer.create(
-      <AuthorProfileHeader onTwitterLinkPress={() => {}} {...props.data} />
+      <AuthorProfileHeader
+        onTwitterLinkPress={() => {}}
+        onArticlePress={() => {}}
+        {...props.data}
+      />
     );
 
     expect(component).toMatchSnapshot();
@@ -88,7 +93,11 @@ export default AuthorProfileContent => {
 
   it("renders profile content component", () => {
     const component = renderer.create(
-      <AuthorProfileContent onTwitterLinkPress={() => {}} {...props.data} />
+      <AuthorProfileContent
+        onTwitterLinkPress={() => {}}
+        onArticlePress={() => {}}
+        {...props.data}
+      />
     );
 
     expect(component).toMatchSnapshot();

--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -8,14 +8,18 @@ import AuthorProfileItemSeparator from "./author-profile-item-separator";
 const AuthorProfile = props => (
   <ScrollView testID="scroll-view">
     <AuthorProfileHeader {...props} />
-    {props.articles.list.map((item, key) => {
+    {props.articles.list.map((article, key) => {
+      const { id, url } = article;
       const separatorComponent =
         key > 0 ? <AuthorProfileItemSeparator /> : null;
 
       return (
-        <View key={item.id}>
+        <View key={id}>
           {separatorComponent}
-          <AuthorProfileItem {...item} />
+          <AuthorProfileItem
+            {...article}
+            onPress={e => props.onArticlePress(e, { id, url })}
+          />
         </View>
       );
     })}
@@ -23,6 +27,7 @@ const AuthorProfile = props => (
 );
 
 AuthorProfile.propTypes = Object.assign(
+  { onArticlePress: PropTypes.func.isRequired },
   {
     articles: PropTypes.shape({
       list: PropTypes.arrayOf(PropTypes.shape(AuthorProfileItem.propTypes))

--- a/packages/author-profile/author-profile-content.web.js
+++ b/packages/author-profile/author-profile-content.web.js
@@ -15,14 +15,18 @@ const styles = StyleSheet.create({
 const AuthorProfile = props => (
   <View>
     <AuthorProfileHeader {...props} />
-    {props.articles.list.map((item, key) => {
+    {props.articles.list.map((article, key) => {
+      const { id, url } = article;
       const separatorComponent =
         key > 0 ? <AuthorProfileItemSeparator /> : null;
 
       return (
-        <View key={item.id} style={styles.container}>
+        <View key={id} style={styles.container}>
           {separatorComponent}
-          <AuthorProfileItem {...item} />
+          <AuthorProfileItem
+            {...article}
+            onPress={e => props.onArticlePress(e, { id, url })}
+          />
         </View>
       );
     })}
@@ -30,6 +34,7 @@ const AuthorProfile = props => (
 );
 
 AuthorProfile.propTypes = Object.assign(
+  { onArticlePress: PropTypes.func.isRequired },
   {
     articles: PropTypes.shape({
       list: PropTypes.arrayOf(PropTypes.shape(AuthorProfileItem.propTypes))

--- a/packages/author-profile/author-profile-item.js
+++ b/packages/author-profile/author-profile-item.js
@@ -2,6 +2,7 @@ import React from "react";
 import get from "lodash.get";
 import { StyleSheet, View } from "react-native";
 import Card from "@times-components/card";
+import Link from "@times-components/link";
 
 const styles = StyleSheet.create({
   container: {
@@ -11,25 +12,34 @@ const styles = StyleSheet.create({
 });
 
 const AuthorProfileItem = item => {
-  const props = {
-    date: item.publishedTime,
-    headline: item.title,
-    image: {
-      uri: get(
-        item,
-        "leadAsset.crop.url",
-        get(item, "leadAsset.posterImage.crop.url", null)
-      )
-    },
-    text: item.content,
-    label: item.label,
-    publication: item.publicationName
-  };
+  const {
+    title,
+    content,
+    publishedTime,
+    label,
+    publicationName,
+    url,
+    onPress
+  } = item;
+  const imageUri = get(
+    item,
+    "leadAsset.crop.url",
+    get(item, "leadAsset.posterImage.crop.url", null)
+  );
 
   return (
-    <View style={styles.container}>
-      <Card {...props} />
-    </View>
+    <Link url={url} onPress={onPress}>
+      <View style={styles.container}>
+        <Card
+          headline={title}
+          text={content}
+          image={{ uri: imageUri }}
+          date={publishedTime}
+          label={label}
+          publication={publicationName}
+        />
+      </View>
+    </Link>
   );
 };
 

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -20,7 +20,8 @@ const AuthorProfile = props => {
       onPrev: props.onPrev,
       page: props.page,
       pageSize: props.pageSize,
-      onTwitterLinkPress: props.onTwitterLinkPress
+      onTwitterLinkPress: props.onTwitterLinkPress,
+      onArticlePress: props.onArticlePress
     };
     return <AuthorProfileContent {...props.data} {...extra} />;
   }
@@ -34,6 +35,7 @@ const {
   page,
   pageSize,
   onTwitterLinkPress,
+  onArticlePress,
   ...data
 } = AuthorProfileContent.propTypes;
 
@@ -47,7 +49,9 @@ AuthorProfile.propTypes = {
   pageSize,
   // eslint doesnt follow the reference. AuthorProfileContent.propTypes.onTwitterLinkPress is actually marked as required.
   // eslint-disable-next-line react/require-default-props
-  onTwitterLinkPress
+  onTwitterLinkPress,
+  // eslint-disable-next-line react/require-default-props
+  onArticlePress
 };
 
 AuthorProfile.defaultProps = {

--- a/packages/author-profile/author-profile.stories.js
+++ b/packages/author-profile/author-profile.stories.js
@@ -40,7 +40,8 @@ storiesOf("AuthorProfile", module)
         page: 1
       }),
       isLoading: false,
-      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
+      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress"),
+      onArticlePress: preventDefaultedAction("onArticlePress")
     };
 
     props.data.articles.list.forEach(article => {
@@ -53,7 +54,8 @@ storiesOf("AuthorProfile", module)
   .add("AuthorProfile Loading", () => {
     const props = {
       isLoading: true,
-      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
+      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress"),
+      onArticlePress: preventDefaultedAction("onArticlePress")
     };
 
     return story(<AuthorProfile {...props} />);
@@ -61,7 +63,8 @@ storiesOf("AuthorProfile", module)
   .add("AuthorProfile Empty State", () => {
     const props = {
       isLoading: false,
-      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress")
+      onTwitterLinkPress: preventDefaultedAction("onTwitterLinkPress"),
+      onArticlePress: preventDefaultedAction("onArticlePress")
     };
 
     return story(<AuthorProfile {...props} />);

--- a/packages/author-profile/example.json
+++ b/packages/author-profile/example.json
@@ -72,6 +72,7 @@
         "id": "97c64f20-cb67-11e4-a202-50ac5def393a",
         "title": "British trio stopped on the way to join Isis",
         "label": null,
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-23T23:06:34.000Z",
         "leadAsset": {
@@ -118,6 +119,7 @@
         "id": "61143932-6f49-4720-9506-10f32f2eca0d",
         "title": "British trio stopped on the way to join Isis",
         "label": "Politics",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-20T23:06:34.000Z",
         "leadAsset": {
@@ -164,6 +166,7 @@
         "id": "08fc89f8-bbe1-4ba1-9fd3-39607ea9bc49",
         "title": "British trio stopped on the way to join Isis",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-19T23:06:34.000Z",
         "leadAsset": {
@@ -210,6 +213,7 @@
         "id": "d9851f3a-a67f-4249-b16a-1b0cb5bec915",
         "title": "British trio stopped on the way to join Isis",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-18T23:06:34.000Z",
         "leadAsset": {
@@ -256,6 +260,7 @@
         "id": "be9dfdb0-a21e-45d5-93a5-76fa6d748b7b",
         "title": "Gay and IVF couples ‘better at raising children’",
         "label": "Health",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "SUNDAYTIMES",
         "publishedTime": "2015-03-17T23:37:49.000Z",
         "leadAsset": {
@@ -287,6 +292,7 @@
         "id": "6674e762-f171-4885-820d-ea067ec66a74",
         "title": "British trio stopped on the way to join Isis",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:06:34.000Z",
         "leadAsset": {
@@ -333,6 +339,7 @@
         "id": "89bd6c18-ccf9-11e4-81dd-064fe933cd40",
         "title": "Fourth Briton is seized trying to join Isis",
         "label": "Environment",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:01:44.000Z",
         "leadAsset": {
@@ -364,6 +371,7 @@
         "id": "88152206-eaaa-4c19-940e-a1a2a9b80b62",
         "title": "Fourth Briton is seized trying to join Isis",
         "label": "Politics",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:01:44.000Z",
         "leadAsset": {
@@ -395,6 +403,7 @@
         "id": "89bd6c18-ccf9-11e4-81dd-064fe933cd41",
         "title": "Fourth Briton is seized trying to join Isis",
         "label": "Health",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:01:44.000Z",
         "leadAsset": {
@@ -426,6 +435,7 @@
         "id": "aaa93b19-e26e-4ee5-81de-3e8090b5a1a1",
         "title": "Fourth Briton is seized trying to join Isis",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:01:44.000Z",
         "leadAsset": {
@@ -457,6 +467,7 @@
         "id": "9b16fbe5-958d-4874-9d2e-b6d29dbcbe9f",
         "title": "Fourth Briton is seized trying to join Isis",
         "label": "Health",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:01:44.000Z",
         "leadAsset": {
@@ -488,6 +499,7 @@
         "id": "0407b30e-0751-403a-a39c-f30ff6c3f5bb",
         "title": "Fourth Briton is seized trying to join Isis",
         "label": "Environment",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T23:01:44.000Z",
         "leadAsset": {
@@ -519,6 +531,7 @@
         "id": "7966deb9-b1f7-447c-81c5-51fa88b935ee",
         "title": "Clash of interests tarnished the project",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T22:11:25.000Z",
         "leadAsset": {
@@ -550,6 +563,7 @@
         "id": "7b3e8143-d446-4cd8-b330-0dacc5f818c4",
         "title": "Giant brings out the stars for one last time",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T21:49:11.000Z",
         "leadAsset": {
@@ -597,6 +611,7 @@
         "id": "aa3ccb09-2407-4151-b1d8-a9ec55487d05",
         "title": "Inquiry at sect schools that banned books",
         "label": "Science",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T21:25:02.000Z",
         "leadAsset": {
@@ -628,6 +643,7 @@
         "id": "5a33a77b-c24e-41b6-9876-32b83a336da9",
         "title": "Top graduates drawn to jobs in social work",
         "label": "Health",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T20:51:44.000Z",
         "leadAsset": {
@@ -675,6 +691,7 @@
         "id": "fcc85270-54c9-4938-a0fc-5de8e3628885",
         "title": "TMS: Pratchett’s law of the jungle",
         "label": "Health",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T19:39:39.000Z",
         "leadAsset": {
@@ -730,6 +747,7 @@
         "id": "be725c01-dd7e-4c46-85b5-16ffc30c0b98",
         "title": "Learning by rote ‘will put pupils off poetry’",
         "label": "Environment",
+        "url": "https://www.thetimes.co.uk/article/carol-midgley-my-labrador-isnt-fat-from-eating-chocolates-its-scientifically-proven-zw0380pp2",
         "publicationName": "TIMES",
         "publishedTime": "2015-03-17T19:36:43.000Z",
         "leadAsset": {

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@times-components/author-head": "0.6.3",
     "@times-components/card": "0.6.2",
+    "@times-components/link": "0.6.0",
     "@times-components/pagination": "0.6.0",
     "jest-cli": "20.0.4",
     "lodash.get": "4.4.2",

--- a/packages/link/__tests__/__snapshots__/link.native.test.js.snap
+++ b/packages/link/__tests__/__snapshots__/link.native.test.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Link doesnt change inner text styles 1`] = `
+<View
+  accessibilityComponentType={undefined}
+  accessibilityLabel={undefined}
+  accessibilityTraits={undefined}
+  accessible={true}
+  hitSlop={undefined}
+  isTVSelectable={true}
+  onLayout={undefined}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "opacity": 1,
+    }
+  }
+  testID={undefined}
+  tvParallaxProperties={undefined}
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    Hello
+  </Text>
+</View>
+`;
+
 exports[`Link renders correctly 1`] = `
 <View
   accessibilityComponentType={undefined}

--- a/packages/link/__tests__/__snapshots__/link.web.test.js.snap
+++ b/packages/link/__tests__/__snapshots__/link.web.test.js.snap
@@ -1,9 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Link doesnt change inner text styles 1`] = `
+<a
+  href="http://thetimes.co.uk"
+  onClick={[Function]}
+  style={
+    Object {
+      "textDecoration": "none",
+    }
+  }
+>
+  <p>
+    Hello
+  </p>
+</a>
+`;
+
 exports[`Link renders correctly 1`] = `
 <a
   href="http://thetimes.co.uk"
   onClick={[Function]}
+  style={
+    Object {
+      "textDecoration": "none",
+    }
+  }
 />
 `;
 

--- a/packages/link/__tests__/link-helper.js
+++ b/packages/link/__tests__/link-helper.js
@@ -3,11 +3,22 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-export default (Link, TextLink) => {
+export default (Link, TextLink, Text) => {
   describe("Link", () => {
     it("renders correctly", () => {
       const tree = renderer
         .create(<Link url="http://thetimes.co.uk" onPress={() => {}} />)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+    it("doesnt change inner text styles", () => {
+      const tree = renderer
+        .create(
+          <Link url="http://thetimes.co.uk" onPress={() => {}}>
+            <Text>Hello</Text>
+          </Link>
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();

--- a/packages/link/__tests__/link.native.test.js
+++ b/packages/link/__tests__/link.native.test.js
@@ -1,4 +1,5 @@
+import { Text } from "react-native";
 import test from "./link-helper";
 import Link, { TextLink } from "../link.js";
 
-test(Link, TextLink);
+test(Link, TextLink, Text);

--- a/packages/link/__tests__/link.web.test.js
+++ b/packages/link/__tests__/link.web.test.js
@@ -1,4 +1,4 @@
 import test from "./link-helper";
 import Link, { TextLink } from "../link.web.js";
 
-test(Link, TextLink);
+test(Link, TextLink, "p");

--- a/packages/link/link.web.js
+++ b/packages/link/link.web.js
@@ -2,7 +2,7 @@ import React from "react";
 import propTypes from "./link.proptypes";
 
 const Link = ({ url, onPress, children }) => (
-  <a href={url} onClick={onPress}>
+  <a href={url} onClick={onPress} style={{ textDecoration: "none" }}>
     {children}
   </a>
 );

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -222,141 +222,164 @@ exports[`renders data 1`] = `
     </View>
     <View>
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
+              <View
+                onLayout={[Function]}
               >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
                   }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Monday March 23 2015
-                , The Times
-              </Text>
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Monday March 23 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>
@@ -588,141 +611,164 @@ exports[`renders data from graphql 1`] = `
     </View>
     <View>
       <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
+            "opacity": 1,
           }
         }
+        testID={undefined}
+        tvParallaxProperties={undefined}
       >
         <View
-          onLayout={[Function]}
           style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
+            Object {
+              "paddingLeft": 10,
+              "paddingRight": 10,
+            }
           }
         >
           <View
+            onLayout={[Function]}
             style={
               Array [
                 Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
+                  "flexDirection": "column",
                 },
                 null,
+                undefined,
               ]
             }
           >
             <View
-              onLayout={[Function]}
+              style={
+                Array [
+                  Object {
+                    "paddingBottom": 15,
+                  },
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
             >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
+              <View
+                onLayout={[Function]}
               >
-                British trio stopped on the way to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
+                <Image
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  source={
+                    Object {
+                      "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                    }
                   }
-                }
-              />
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
+                  style={
+                    Array [
+                      Object {
+                        "height": 1,
+                        "width": 750,
+                      },
+                      undefined,
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={Object {}}
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "letterSpacing": 1,
+                      "marginBottom": 2,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesModern-Bold",
+                      "fontSize": 22,
+                      "fontWeight": "400",
+                      "lineHeight": 22,
+                      "marginBottom": 8,
+                    }
+                  }
+                >
+                  British trio stopped on the way to join Isis
+                </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
                     Object {
                       "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Monday March 23 2015
-                , The Times
-              </Text>
+                      "flexWrap": "wrap",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                      "marginBottom": 10,
+                    }
+                  }
+                />
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Monday March 23 2015
+                  , The Times
+                </Text>
+              </View>
             </View>
           </View>
         </View>


### PR DESCRIPTION
Oooh, article links!

Now when you tap on a link, you get the `event` (duh) and an object with the `id` and `url` of the article.

![screen shot 2017-09-25 at 12 19 16](https://user-images.githubusercontent.com/298742/30811243-844b9894-a1ff-11e7-8b0b-5e8a7af39ad1.png)

<img width="1172" alt="screen shot 2017-09-25 at 12 17 29" src="https://user-images.githubusercontent.com/298742/30811216-749839a2-a1ff-11e7-90d3-775ea727c3da.png">

## Weirdness
1. Block links were adding underlines to text content, so I stopped that.
2. The article list now needs each articles `url`. Turns out that the provider was providing it anyway.

I hope you like snapshot diffs.