### PR TITLE
fix: add missing dependency for ads

### DIFF
--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "prop-types": "15.5.10",
     "react-broadcast": "0.1.2",
+    "react-native-svg": "5.1.7",
     "react-native-web": "0.0.119",
     "svgs": "2.3.0"
   },

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -56,20 +56,19 @@
     "react": "15.4.2",
     "react-dom": "15.4.2",
     "react-native": "0.42.3",
-    "react-native-svg": "5.1.7",
     "react-test-renderer": "15.4.2",
     "webpack": "3.3.0"
   },
   "dependencies": {
     "prop-types": "15.5.10",
+    "react-native-svg": "5.1.7",
     "react-native-web": "0.0.119",
     "svgs": "2.3.0"
   },
   "peerDependencies": {
     "react": ">=15",
     "react-dom": ">=15",
-    "react-native": ">=0.42",
-    "react-native-svg": "5.1.7"
+    "react-native": ">=0.42"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
(`svgs` requires `react-native-svg` as a peer)

This was breaking on the native apps. The storybook didnt catch this as some other package was pulling it in as a dev dependency.