### PR TITLE
Drop old text node support

### DIFF
--- a/packages/article-byline/fixtures/authors.json
+++ b/packages/article-byline/fixtures/authors.json
@@ -8,11 +8,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Alexandra Frean"
-            }
-          ]
+          "attributes": {
+            "value": "Alexandra Frean"
+          },
+          "children": []
         }
       ]
     }
@@ -24,11 +23,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Lindsay McIntosh Scottish Political Editor"
-            }
-          ]
+          "attributes": {
+            "value": "Lindsay McIntosh Scottish Political Editor"
+          },
+          "children": []
         }
       ]
     }
@@ -42,11 +40,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Camilla Long"
-            }
-          ]
+          "attributes": {
+            "value": "Camilla Long"
+          },
+          "children": []
         }
       ]
     },
@@ -56,11 +53,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": ", Environment Editor"
-            }
-          ]
+          "attributes": {
+            "value": ", Environment Editor"
+          },
+          "children": []
         }
       ]
     }
@@ -72,11 +68,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "RBS Six Nations "
-            }
-          ]
+          "attributes": {
+            "value": "RBS Six Nations "
+          },
+          "children": []
         }
       ]
     },
@@ -88,11 +83,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Mike Atherton"
-            }
-          ]
+          "attributes": {
+            "value": "Mike Atherton"
+          },
+          "children": []
         }
       ]
     }
@@ -106,11 +100,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Camilla Long"
-            }
-          ]
+          "attributes": {
+            "value": "Camilla Long"
+          },
+          "children": []
         }
       ]
     },
@@ -120,11 +113,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": ", "
-            }
-          ]
+          "attributes": {
+            "value": ", "
+          },
+          "children": []
         }
       ]
     },
@@ -136,11 +128,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Mike Atherton"
-            }
-          ]
+          "attributes": {
+            "value": "Mike Atherton"
+          },
+          "children": []
         }
       ]
     },
@@ -150,11 +141,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": ", "
-            }
-          ]
+          "attributes": {
+            "value": ", "
+          },
+          "children": []
         }
       ]
     },
@@ -166,11 +156,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Alexandra Frean"
-            }
-          ]
+          "attributes": {
+            "value": "Alexandra Frean"
+          },
+          "children": []
         }
       ]
     }
@@ -184,11 +173,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Camilla Long"
-            }
-          ]
+          "attributes": {
+            "value": "Camilla Long"
+          },
+          "children": []
         }
       ]
     },
@@ -198,11 +186,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": " "
-            }
-          ]
+          "attributes": {
+            "value": " "
+          },
+          "children": []
         }
       ]
     },
@@ -214,11 +201,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Mike Atherton"
-            }
-          ]
+          "attributes": {
+            "value": "Mike Atherton"
+          },
+          "children": []
         }
       ]
     },
@@ -228,11 +214,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": " "
-            }
-          ]
+          "attributes": {
+            "value": " "
+          },
+          "children": []
         }
       ]
     },
@@ -244,11 +229,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Alexandra Frean"
-            }
-          ]
+          "attributes": {
+            "value": "Alexandra Frean"
+          },
+          "children": []
         }
       ]
     }

--- a/packages/article-summary/fixtures/article.json
+++ b/packages/article-summary/fixtures/article.json
@@ -9,33 +9,30 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-            }
-          ]
+          "attributes": {
+            "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+          },
+          "children": []
         },
         {
           "name": "italic",
           "children": [
             {
               "name": "text",
-              "children": [
-                {
-                  "text": "The Times"
-                }
-              ]
+              "attributes": {
+                "value": "The Times"
+              },
+              "children": []
             }
           ],
           "attributes": {}
         },
         {
           "name": "text",
-          "children": [
-            {
-              "text": " has learnt."
-            }
-          ]
+          "attributes": {
+            "value": " has learnt."
+          },
+          "children": []
         }
       ],
       "attributes": {}
@@ -45,11 +42,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night."
-            }
-          ]
+          "attributes": {
+            "value": "Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night."
+          },
+          "children": []
         }
       ],
       "attributes": {}
@@ -59,11 +55,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Quick action by the parents of the younger boys, when the pair did not return home after Friday prayers, thwarted the latest alleged attempt by young Britons to join the terrorist group, sources said."
-            }
-          ]
+          "attributes": {
+            "value": "Quick action by the parents of the younger boys, when the pair did not return home after Friday prayers, thwarted the latest alleged attempt by young Britons to join the terrorist group, sources said."
+          },
+          "children": []
         }
       ],
       "attributes": {}
@@ -73,11 +68,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "It came two days after Britain’s most senior police officer reassured the families of three runaway schoolgirls from east London that they would not be prosecuted if they returned"
-            }
-          ]
+          "attributes": {
+            "value": "It came two days after Britain’s most senior police officer reassured the families of three runaway schoolgirls from east London that they would not be prosecuted if they returned"
+          },
+          "children": []
         }
       ],
       "attributes": {}

--- a/packages/article/fixtures/article-no-flags-no-standfirst.json
+++ b/packages/article/fixtures/article-no-flags-no-standfirst.json
@@ -13,11 +13,10 @@
             "children": [
               {
                 "name": "text",
-                "children": [
-                  {
-                    "text": "Rick Broadbent"
-                  }
-                ]
+                "attributes": {
+                  "value": "Rick Broadbent"
+                },
+                "children": []
               }
             ]
           }
@@ -31,11 +30,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-                      }
-                    ]
+                    "attributes": {
+                      "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+                    },
+                    "children": []
                   },
                   {
                     "name": "italic",
@@ -43,21 +41,19 @@
                     "children": [
                       {
                         "name": "text",
-                        "children": [
-                          {
-                            "text": "Telegraph "
-                          }
-                        ]
+                        "attributes": {
+                          "value": "Telegraph "
+                        },
+                        "children": []
                       }
                     ]
                   },
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+                    },
+                    "children": []
                   },
                   {
                     "name": "break",
@@ -69,11 +65,10 @@
                         "children": [
                           {
                             "name": "text",
-                            "children": [
-                              {
-                                "text": "See leading article"
-                              }
-                            ]
+                            "attributes": {
+                              "value": "See leading article"
+                            },
+                            "children": []
                           }
                         ]
                       }

--- a/packages/article/fixtures/article-no-flags.json
+++ b/packages/article/fixtures/article-no-flags.json
@@ -13,11 +13,10 @@
             "children": [
               {
                 "name": "text",
-                "children": [
-                  {
-                    "text": "Rick Broadbent"
-                  }
-                ]
+                "attributes": {
+                  "value": "Rick Broadbent"
+                },
+                "children": []
               }
             ]
           }
@@ -31,11 +30,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-                      }
-                    ]
+                    "attributes": {
+                      "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+                    },
+                    "children": []
                   },
                   {
                     "name": "italic",
@@ -43,21 +41,19 @@
                     "children": [
                       {
                         "name": "text",
-                        "children": [
-                          {
-                            "text": "Telegraph "
-                          }
-                        ]
+                        "attributes": {
+                          "value": "Telegraph "
+                        },
+                        "children": []
                       }
                     ]
                   },
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+                    },
+                    "children": []
                   },
                   {
                     "name": "break",
@@ -69,11 +65,10 @@
                         "children": [
                           {
                             "name": "text",
-                            "children": [
-                              {
-                                "text": "See leading article"
-                              }
-                            ]
+                            "attributes": {
+                              "value": "See leading article"
+                            },
+                            "children": []
                           }
                         ]
                       }

--- a/packages/article/fixtures/full-article.json
+++ b/packages/article/fixtures/full-article.json
@@ -11,9 +11,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
@@ -36,34 +37,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -76,9 +81,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -87,9 +93,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -97,9 +104,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -107,9 +115,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -117,9 +126,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -127,9 +137,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -137,9 +148,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -147,9 +159,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -157,9 +170,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -167,9 +181,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -177,9 +192,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -187,9 +203,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-flags.json
+++ b/packages/article/fixtures/no-flags.json
@@ -11,9 +11,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
@@ -33,34 +34,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -73,9 +78,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -84,9 +90,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -94,9 +101,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -104,9 +112,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -114,9 +123,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -124,9 +134,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -134,9 +145,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -144,9 +156,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -154,9 +167,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -164,9 +178,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -174,9 +189,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -184,9 +200,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-label-no-flags-no-standfirst.json
+++ b/packages/article/fixtures/no-label-no-flags-no-standfirst.json
@@ -10,9 +10,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "label": null,
@@ -33,34 +34,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -73,9 +78,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -84,9 +90,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -94,9 +101,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -104,9 +112,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -114,9 +123,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -124,9 +134,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -134,9 +145,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -144,9 +156,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -154,9 +167,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -164,9 +178,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -174,9 +189,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -184,9 +200,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-label-no-flags.json
+++ b/packages/article/fixtures/no-label-no-flags.json
@@ -10,9 +10,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "label": null,
@@ -34,34 +35,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -74,9 +79,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -85,9 +91,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -95,9 +102,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -105,9 +113,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -115,9 +124,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -125,9 +135,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -135,9 +146,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -145,9 +157,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -155,9 +168,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -165,9 +179,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -175,9 +190,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -185,9 +201,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-label.json
+++ b/packages/article/fixtures/no-label.json
@@ -10,9 +10,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "label": null,
@@ -36,34 +37,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -76,9 +81,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -87,9 +93,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -97,9 +104,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -107,9 +115,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -117,9 +126,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -127,9 +137,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -137,9 +148,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -147,9 +159,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -157,9 +170,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -167,9 +181,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -177,9 +192,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -187,9 +203,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-standfirst-no-flags.json
+++ b/packages/article/fixtures/no-standfirst-no-flags.json
@@ -11,9 +11,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "flags": [
@@ -34,34 +35,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -74,9 +79,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -85,9 +91,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -95,9 +102,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -105,9 +113,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -115,9 +124,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -125,9 +135,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -135,9 +146,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -145,9 +157,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -155,9 +168,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -165,9 +179,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -175,9 +190,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -185,9 +201,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-standfirst-no-label.json
+++ b/packages/article/fixtures/no-standfirst-no-label.json
@@ -10,9 +10,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "flags": [
@@ -36,34 +37,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -76,9 +81,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -87,9 +93,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -97,9 +104,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -107,9 +115,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -117,9 +126,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -127,9 +137,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -137,9 +148,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -147,9 +159,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -157,9 +170,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -167,9 +181,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -177,9 +192,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -187,9 +203,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/article/fixtures/no-standfirst.json
+++ b/packages/article/fixtures/no-standfirst.json
@@ -11,9 +11,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "flags": [
@@ -36,34 +37,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -76,9 +81,10 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
           }]
         },
@@ -87,9 +93,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -97,9 +104,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
           }]
         },
         {
@@ -107,9 +115,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -117,9 +126,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
           }]
         },
         {
@@ -127,9 +137,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
           }]
         },
         {
@@ -137,9 +148,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -147,9 +159,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -157,9 +170,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -167,9 +181,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -177,9 +192,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -187,9 +203,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]

--- a/packages/author-head/fixtures/profile.json
+++ b/packages/author-head/fixtures/profile.json
@@ -6,12 +6,10 @@
   "bio": [
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": "Carol Midgley joined "
-        }
-      ]
+      "attributes": {
+        "value": "Carol Midgley joined "
+      },
+      "children": []
     },
     {
       "name": "italic",
@@ -19,22 +17,19 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "The Times"
-            }
-          ]
+          "attributes": {
+            "value": "The Times"
+          },
+          "children": []
         }
       ]
     },
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": " in 1996, and won feature writer of the year in 2004. Find her Wednesday column in "
-        }
-      ]
+      "attributes": {
+        "value": " in 1996, and won feature writer of the year in 2004. Find her Wednesday column in "
+      },
+      "children": []
     },
     {
       "name": "italic",
@@ -42,22 +37,19 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Times2"
-            }
-          ]
+          "attributes": {
+            "value": "Times2"
+          },
+          "children": []
         }
       ]
     },
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": " each week and a weekly comment piece on Fridays."
-        }
-      ]
+      "attributes": {
+        "value": " each week and a weekly comment piece on Fridays."
+      },
+      "children": []
     }
   ]
 }

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -12,23 +12,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -57,23 +54,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -102,23 +96,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -147,23 +138,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -192,12 +180,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -223,23 +209,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -268,12 +251,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -299,12 +280,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -330,12 +309,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -361,12 +338,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -392,12 +367,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -423,12 +396,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -454,12 +425,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -485,12 +454,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -500,12 +467,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Dames, lords, actors",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Dames, lords, actors",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -531,12 +496,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -562,12 +525,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -577,12 +538,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "The Think",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "The Think",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -608,35 +567,30 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Terry Pratchett, who died last week, began his career on the ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "Bucks Free Press",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
                   "name": "italic",
                 },
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -662,35 +616,30 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "dulce et decorum",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "dulce et decorum",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
                   "name": "italic",
                 },
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": " to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": " to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -716,35 +665,30 @@ exports[`renders profile 1`] = `
   biography={
     Array [
       Object {
-        "attributes": Object {},
-        "children": Array [
-          Object {
-            "text": "Lorem ",
-          },
-        ],
+        "attributes": Object {
+          "value": "Lorem ",
+        },
+        "children": Array [],
         "name": "text",
       },
       Object {
         "attributes": Object {},
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "text": "ipsum",
-              },
-            ],
+            "attributes": Object {
+              "value": "ipsum",
+            },
+            "children": Array [],
             "name": "text",
           },
         ],
         "name": "bold",
       },
       Object {
-        "attributes": Object {},
-        "children": Array [
-          Object {
-            "text": " testbr ",
-          },
-        ],
+        "attributes": Object {
+          "value": " testbr ",
+        },
+        "children": Array [],
         "name": "text",
       },
       Object {
@@ -753,23 +697,20 @@ exports[`renders profile 1`] = `
         "name": "break",
       },
       Object {
-        "attributes": Object {},
-        "children": Array [
-          Object {
-            "text": "More text ",
-          },
-        ],
+        "attributes": Object {
+          "value": "More text ",
+        },
+        "children": Array [],
         "name": "text",
       },
       Object {
         "attributes": Object {},
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "text": " last ",
-              },
-            ],
+            "attributes": Object {
+              "value": " last ",
+            },
+            "children": Array [],
             "name": "text",
           },
         ],

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -12,23 +12,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -57,23 +54,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -102,23 +96,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -147,23 +138,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -192,12 +180,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -223,23 +209,20 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "The",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "The",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
@@ -268,12 +251,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -299,12 +280,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -330,12 +309,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -361,12 +338,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -392,12 +367,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -423,12 +396,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -454,12 +425,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -485,12 +454,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved.",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -500,12 +467,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Dames, lords, actors",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Dames, lords, actors",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -531,12 +496,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -562,12 +525,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today.",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -577,12 +538,10 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "The Think",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "The Think",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -608,35 +567,30 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Terry Pratchett, who died last week, began his career on the ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "Bucks Free Press",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
                   "name": "italic",
                 },
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -662,35 +616,30 @@ exports[`renders profile 1`] = `
               "attributes": Object {},
               "children": Array [
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it ",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it ",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
                 Object {
                   "attributes": Object {},
                   "children": Array [
                     Object {
-                      "children": Array [
-                        Object {
-                          "text": "dulce et decorum",
-                        },
-                      ],
+                      "attributes": Object {
+                        "value": "dulce et decorum",
+                      },
+                      "children": Array [],
                       "name": "text",
                     },
                   ],
                   "name": "italic",
                 },
                 Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "text": " to",
-                    },
-                  ],
+                  "attributes": Object {
+                    "value": " to",
+                  },
+                  "children": Array [],
                   "name": "text",
                 },
               ],
@@ -716,35 +665,30 @@ exports[`renders profile 1`] = `
   biography={
     Array [
       Object {
-        "attributes": Object {},
-        "children": Array [
-          Object {
-            "text": "Lorem ",
-          },
-        ],
+        "attributes": Object {
+          "value": "Lorem ",
+        },
+        "children": Array [],
         "name": "text",
       },
       Object {
         "attributes": Object {},
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "text": "ipsum",
-              },
-            ],
+            "attributes": Object {
+              "value": "ipsum",
+            },
+            "children": Array [],
             "name": "text",
           },
         ],
         "name": "bold",
       },
       Object {
-        "attributes": Object {},
-        "children": Array [
-          Object {
-            "text": " testbr ",
-          },
-        ],
+        "attributes": Object {
+          "value": " testbr ",
+        },
+        "children": Array [],
         "name": "text",
       },
       Object {
@@ -753,23 +697,20 @@ exports[`renders profile 1`] = `
         "name": "break",
       },
       Object {
-        "attributes": Object {},
-        "children": Array [
-          Object {
-            "text": "More text ",
-          },
-        ],
+        "attributes": Object {
+          "value": "More text ",
+        },
+        "children": Array [],
         "name": "text",
       },
       Object {
         "attributes": Object {},
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "text": " last ",
-              },
-            ],
+            "attributes": Object {
+              "value": " last ",
+            },
+            "children": Array [],
             "name": "text",
           },
         ],

--- a/packages/author-profile/example.json
+++ b/packages/author-profile/example.json
@@ -4,12 +4,10 @@
   "biography": [
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": "Lorem "
-        }
-      ]
+      "attributes": {
+        "value": "Lorem "
+      },
+      "children": []
     },
     {
       "name": "bold",
@@ -17,22 +15,19 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "ipsum"
-            }
-          ]
+          "attributes": {
+            "value": "ipsum"
+          },
+          "children": []
         }
       ]
     },
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": " testbr "
-        }
-      ]
+      "attributes": {
+        "value": " testbr "
+      },
+      "children": []
     },
     {
       "name": "break",
@@ -41,12 +36,10 @@
     },
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": "More text "
-        }
-      ]
+      "attributes": {
+        "value": "More text "
+      },
+      "children": []
     },
     {
       "name": "italic",
@@ -54,11 +47,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": " last "
-            }
-          ]
+          "attributes": {
+            "value": " last "
+          },
+          "children": []
         }
       ]
     }
@@ -88,12 +80,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-                  }
-                ]
+                "attributes": {
+                  "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -101,11 +91,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "The"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "The"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
@@ -135,12 +124,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-                  }
-                ]
+                "attributes": {
+                  "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -148,11 +135,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "The"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "The"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
@@ -182,12 +168,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-                  }
-                ]
+                "attributes": {
+                  "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -195,11 +179,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "The"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "The"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
@@ -229,12 +212,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-                  }
-                ]
+                "attributes": {
+                  "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -242,11 +223,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "The"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "The"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
@@ -276,12 +256,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according"
-                  }
-                ]
+                "attributes": {
+                  "value": "GAY and lesbian couples and those who have children using IVF treatment or a surrogate make better parents than heterosexual couples, according"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -308,12 +286,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-                  }
-                ]
+                "attributes": {
+                  "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -321,11 +297,10 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "The"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "The"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
@@ -355,12 +330,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
-                  }
-                ]
+                "attributes": {
+                  "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -387,12 +360,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
-                  }
-                ]
+                "attributes": {
+                  "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -419,12 +390,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
-                  }
-                ]
+                "attributes": {
+                  "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -451,12 +420,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
-                  }
-                ]
+                "attributes": {
+                  "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -483,12 +450,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
-                  }
-                ]
+                "attributes": {
+                  "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -515,12 +480,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
-                  }
-                ]
+                "attributes": {
+                  "value": "A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -547,12 +510,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories"
-                  }
-                ]
+                "attributes": {
+                  "value": "Tony Blair’s main contribution to Middle East peace as the Quartet’s special envoy was the idea that prosperity in the Palestinian territories"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -579,12 +540,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved."
-                  }
-                ]
+                "attributes": {
+                  "value": "It was a celebration of the life of one of the greatest champions of the arts, a luvvie who was universally loved."
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -595,12 +554,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "Dames, lords, actors"
-                  }
-                ]
+                "attributes": {
+                  "value": "Dames, lords, actors"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -627,12 +584,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid"
-                  }
-                ]
+                "attributes": {
+                  "value": "The funding of British faith schools run by an extreme religious sect is under investigation by the taxman over multi-million pound gift aid"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -659,12 +614,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today."
-                  }
-                ]
+                "attributes": {
+                  "value": "A Teach First-style scheme for mental health social workers aimed at recruiting top graduates to the profession is to be launched today."
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -675,12 +628,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "The Think"
-                  }
-                ]
+                "attributes": {
+                  "value": "The Think"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -707,12 +658,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "Terry Pratchett, who died last week, began his career on the "
-                  }
-                ]
+                "attributes": {
+                  "value": "Terry Pratchett, who died last week, began his career on the "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -720,23 +669,20 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "Bucks Free Press"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "Bucks Free Press"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
               },
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": " in 1965, aged 17, and the paper recalls in a tribute that he wore"
-                  }
-                ]
+                "attributes": {
+                  "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore"
+                },
+                "children": []
               }
             ],
             "attributes": {}
@@ -763,12 +709,10 @@
             "children": [
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it "
-                  }
-                ]
+                "attributes": {
+                  "value": "Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it "
+                },
+                "children": []
               },
               {
                 "name": "italic",
@@ -776,23 +720,20 @@
                 "children": [
                   {
                     "name": "text",
-                    "children": [
-                      {
-                        "text": "dulce et decorum"
-                      }
-                    ]
+                    "attributes": {
+                      "value": "dulce et decorum"
+                    },
+                    "children": []
                   }
                 ],
                 "attributes": {}
               },
               {
                 "name": "text",
-                "attributes": {},
-                "children": [
-                  {
-                    "text": " to"
-                  }
-                ]
+                "attributes": {
+                  "value": " to"
+                },
+                "children": []
               }
             ],
             "attributes": {}

--- a/packages/author-profile/fixture-generator.js
+++ b/packages/author-profile/fixture-generator.js
@@ -28,34 +28,31 @@ const article = () => ({
       children: [
         {
           name: "text",
-          children: [
-            {
-              text:
-                "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-            }
-          ]
+          attributes: {
+            value:
+              "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+          },
+          children: []
         },
         {
           name: "em",
           children: [
             {
               name: "text",
-              children: [
-                {
-                  text: "The Times"
-                }
-              ]
+              attributes: {
+                value: "The Times"
+              },
+              children: []
             }
           ],
           attributes: {}
         },
         {
           name: "text",
-          children: [
-            {
-              text: " has learnt."
-            }
-          ]
+          attributes: {
+            value: " has learnt."
+          },
+          children: []
         }
       ],
       attributes: {}
@@ -65,12 +62,11 @@ const article = () => ({
       children: [
         {
           name: "text",
-          children: [
-            {
-              text:
-                "Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night."
-            }
-          ]
+          attributes: {
+            value:
+              "Two 17-year-old Muslim schoolboys from the Pakistani community in Brent, northwest London, and a 19-year-old man were intercepted in Istanbul at the weekend and swiftly returned to England. They were questioned by counterterrorism officials last night."
+          },
+          children: []
         }
       ],
       attributes: {}
@@ -81,11 +77,10 @@ const article = () => ({
 const biography = [
   {
     name: "text",
-    children: [
-      {
-        text: "Lorem "
-      }
-    ]
+    attributes: {
+      value: "Lorem "
+    },
+    children: []
   },
   {
     name: "b",
@@ -93,33 +88,31 @@ const biography = [
     children: [
       {
         name: "text",
-        children: [
-          {
-            text: "ipsum"
-          }
-        ]
+        attributes: {
+          value: "ipsum"
+        },
+        children: []
       }
     ]
   },
   {
     name: "text",
-    children: [
-      {
-        text: " testbr "
-      }
-    ]
+    attributes: {
+      value: " testbr "
+    },
+    children: []
   },
   {
     name: "br",
-    attributes: {}
+    attributes: {},
+    children: []
   },
   {
     name: "text",
-    children: [
-      {
-        text: "More text "
-      }
-    ]
+    attributes: {
+      value: "More text "
+    },
+    children: []
   },
   {
     name: "i",
@@ -127,11 +120,10 @@ const biography = [
     children: [
       {
         name: "text",
-        children: [
-          {
-            text: " last "
-          }
-        ]
+        attributes: {
+          value: " last "
+        },
+        children: []
       }
     ]
   }

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -67,11 +67,10 @@ exports[`renders horizontal above breakpoint 1`] = `
             "attributes": Object {},
             "children": Array [
               Object {
-                "children": Array [
-                  Object {
-                    "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
-                  },
-                ],
+                "attributes": Object {
+                  "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, ",
+                },
+                "children": Array [],
                 "name": "text",
               },
             ],

--- a/packages/card/fixtures/card-props.json
+++ b/packages/card/fixtures/card-props.json
@@ -9,11 +9,10 @@
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
-            }
-          ]
+          "attributes": {
+            "value": "A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, "
+          },
+          "children": []
         }
       ],
       "attributes": {}

--- a/packages/markup/__tests__/test-helper.js
+++ b/packages/markup/__tests__/test-helper.js
@@ -3,19 +3,18 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-const singleParagraph = require("../fixtures/single-paragraph.json").fixture;
-const multiParagraph = require("../fixtures/multi-paragraph.json").fixture;
-const multiParagraphWithAds = require("../fixtures/multi-paragraph-with-ads.json")
-  .fixture;
-const anchor = require("../fixtures/anchor.json").fixture;
-const bold = require("../fixtures/bold.json").fixture;
-const italic = require("../fixtures/italic.json").fixture;
-const span = require("../fixtures/span.json").fixture;
-const mixture = require("../fixtures/tag-mixture.json").fixture;
-const nested = require("../fixtures/nested.json").fixture;
-const bio = require("../fixtures/bio.json").fixture;
-const script = require("../fixtures/script.json").fixture;
-const image = require("../fixtures/image.json").fixture;
+const singleParagraph = require("../fixtures/single-paragraph.json");
+const multiParagraph = require("../fixtures/multi-paragraph.json");
+const multiParagraphWithAds = require("../fixtures/multi-paragraph-with-ads.json");
+const anchor = require("../fixtures/anchor.json");
+const bold = require("../fixtures/bold.json");
+const italic = require("../fixtures/italic.json");
+const span = require("../fixtures/span.json");
+const mixture = require("../fixtures/tag-mixture.json");
+const nested = require("../fixtures/nested.json");
+const bio = require("../fixtures/bio.json");
+const script = require("../fixtures/script.json");
+const image = require("../fixtures/image.json");
 
 export default (
   renderTree,
@@ -24,7 +23,7 @@ export default (
   BlockComponent
 ) => () => {
   it("renders a single paragraph", () => {
-    const output = renderer.create(renderTree(singleParagraph[0])).toJSON();
+    const output = renderer.create(renderTree(singleParagraph)).toJSON();
 
     expect(output).toMatchSnapshot();
   });
@@ -50,7 +49,7 @@ export default (
   it("renders the anchor tag", () => {
     const output = renderer
       .create(
-        renderTree(anchor[0], {
+        renderTree(anchor, {
           link(key, { href }, children) {
             return (
               <TextComponent key={key} href={href}>
@@ -66,19 +65,19 @@ export default (
   });
 
   it("renders the bold tag", () => {
-    const output = renderer.create(renderTree(bold[0])).toJSON();
+    const output = renderer.create(renderTree(bold)).toJSON();
 
     expect(output).toMatchSnapshot();
   });
 
   it("renders the italic tag", () => {
-    const output = renderer.create(renderTree(italic[0])).toJSON();
+    const output = renderer.create(renderTree(italic)).toJSON();
 
     expect(output).toMatchSnapshot();
   });
 
   it("renders the span tag", () => {
-    const output = renderer.create(renderTree(span[0])).toJSON();
+    const output = renderer.create(renderTree(span)).toJSON();
 
     expect(output).toMatchSnapshot();
   });
@@ -86,7 +85,7 @@ export default (
   it("renders a mixture of tags", () => {
     const output = renderer
       .create(
-        renderTree(mixture[0], {
+        renderTree(mixture, {
           block(key, attributes, renderedChildren) {
             return (
               <BlockComponent key={key}>{renderedChildren}</BlockComponent>
@@ -109,7 +108,7 @@ export default (
   it("renders tags nested within blocks", () => {
     const output = renderer
       .create(
-        renderTree(nested[0], {
+        renderTree(nested, {
           block(key, attributes, renderedChildren) {
             return (
               <BlockComponent key={key}>{renderedChildren}</BlockComponent>

--- a/packages/markup/fixtures/anchor.json
+++ b/packages/markup/fixtures/anchor.json
@@ -1,20 +1,15 @@
 {
-  "fixture": [
-    {
-      "name": "link",
-      "attributes": {
-        "href": "www.google.com"
-      },
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "some link here"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+   "name": "link",
+   "attributes": {
+     "href": "www.google.com"
+   },
+   "children": [
+     {
+       "name": "text",
+       "attributes": {
+         "value": "some link here"
+       },
+       "children": []
+     }
+   ]
+ }

--- a/packages/markup/fixtures/bio.json
+++ b/packages/markup/fixtures/bio.json
@@ -1,55 +1,48 @@
-{
-  "fixture": [
-    {
-      "name": "text",
-      "children": [
-        {
-          "text": "Camilla Long is "
-        }
-      ]
+[
+  {
+    "name": "text",
+    "attributes": {
+      "value": "Camilla Long is "
     },
-    {
-      "name": "italic",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "the Sunday Times"
-            }
-          ]
-        }
-      ]
+    "children": []
+  },
+  {
+    "name": "italic",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "the Sunday Times"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "text",
+    "attributes": {
+      "value": " film critic. She also writes interviews and a column, and was named "
     },
-    {
-      "name": "text",
-      "children": [
-        {
-          "text": " film critic. She also writes interviews and a column, and was named "
-        }
-      ]
+    "children": []
+  },
+  {
+    "name": "bold",
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "interviewer of the year"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "text",
+    "attributes": {
+      "value": " at the British Press Awards in 2010 and 2016."
     },
-    {
-      "name": "bold",
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "interviewer of the year"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "text",
-      "children": [
-        {
-          "text": " at the British Press Awards in 2010 and 2016."
-        }
-      ]
-    }
-  ]
-}
+    "children": []
+  }
+]

--- a/packages/markup/fixtures/bold.json
+++ b/packages/markup/fixtures/bold.json
@@ -1,18 +1,13 @@
 {
-  "fixture": [
+  "name": "bold",
+  "attributes": {},
+  "children": [
     {
-      "name": "bold",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "some text here"
-            }
-          ]
-        }
-      ]
+      "name": "text",
+      "attributes": {
+        "value": "some text here"
+      },
+      "children": []
     }
   ]
 }

--- a/packages/markup/fixtures/image.json
+++ b/packages/markup/fixtures/image.json
@@ -1,12 +1,10 @@
-{
-  "fixture": [
-    {
-      "name": "image",
-      "attributes": {
-        "onerror": "eval(console.log('evil');)",
-        "src": "http://example.com/image.jpg"
-      },
-      "children": []
-    }
-  ]
-}
+[
+  {
+    "name": "image",
+    "attributes": {
+      "onerror": "eval(console.log('evil');)",
+      "src": "http://example.com/image.jpg"
+    },
+    "children": []
+  }
+]

--- a/packages/markup/fixtures/italic.json
+++ b/packages/markup/fixtures/italic.json
@@ -1,18 +1,13 @@
 {
-  "fixture": [
+  "name": "italic",
+  "attributes": {},
+  "children": [
     {
-      "name": "italic",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": " some more text here"
-            }
-          ]
-        }
-      ]
+      "name": "text",
+      "attributes": {
+        "value": " some more text here"
+      },
+      "children": []
     }
   ]
 }

--- a/packages/markup/fixtures/multi-paragraph-with-ads.json
+++ b/packages/markup/fixtures/multi-paragraph-with-ads.json
@@ -1,135 +1,124 @@
-{
-  "fixture": [
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph one"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "ad",
-      "attributes": {},
-      "children": []
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+[
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph one"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "ad",
+    "attributes": {},
+    "children": []
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  }
+]

--- a/packages/markup/fixtures/multi-paragraph.json
+++ b/packages/markup/fixtures/multi-paragraph.json
@@ -1,32 +1,28 @@
-{
-  "fixture": [
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph one"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph two"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+[
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph one"
+        },
+        "children": []
+      }
+    ]
+  },
+  {
+    "name": "paragraph",
+    "attributes": {},
+    "children": [
+      {
+        "name": "text",
+        "attributes": {
+          "value": "This is the text for paragraph two"
+        },
+        "children": []
+      }
+    ]
+  }
+]

--- a/packages/markup/fixtures/nested.json
+++ b/packages/markup/fixtures/nested.json
@@ -1,16 +1,24 @@
 {
-  "fixture": [
+  "name": "block",
+  "attributes": {},
+  "children": [
+    {
+      "name": "text",
+      "attributes": {
+        "value": "Some text is here "
+      },
+      "children": []
+    },
     {
       "name": "block",
       "attributes": {},
       "children": [
         {
           "name": "text",
-          "children": [
-            {
-              "text": "Some text is here "
-            }
-          ]
+          "attributes": {
+            "value": "and there is some "
+          },
+          "children": []
         },
         {
           "name": "block",
@@ -18,45 +26,21 @@
           "children": [
             {
               "name": "text",
-              "children": [
-                {
-                  "text": "and there is some "
-                }
-              ]
+              "attributes": {
+                "value": "more text "
+              },
+              "children": []
             },
             {
-              "name": "block",
+              "name": "inline",
               "attributes": {},
               "children": [
                 {
                   "name": "text",
-                  "children": [
-                    {
-                      "text": "more text "
-                    }
-                  ]
-                },
-                {
-                  "name": "inline",
-                  "attributes": {},
-                  "children": [
-                    {
-                      "name": "text",
-                      "children": [
-                        {
-                          "text": "and in here"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "name": "text",
-              "children": [
-                {
-                  "text": " after it too"
+                  "attributes": {
+                    "value": "and in here"
+                  },
+                  "children": []
                 }
               ]
             }
@@ -64,13 +48,19 @@
         },
         {
           "name": "text",
-          "children": [
-            {
-              "text": " and here"
-            }
-          ]
+          "attributes": {
+            "value": " after it too"
+          },
+          "children": []
         }
       ]
+    },
+    {
+      "name": "text",
+      "attributes": {
+        "value": " and here"
+      },
+      "children": []
     }
   ]
 }

--- a/packages/markup/fixtures/script.json
+++ b/packages/markup/fixtures/script.json
@@ -1,17 +1,15 @@
-{
-  "fixture": [
-    {
-      "name": "script",
-      "attributes": {},
-      "children": [
-        {
-          "name": "script",
-          "attributes": {
-            "src": "http://www.evil.com"
-          },
-          "children": []
-        }
-      ]
-    }
-  ]
-}
+[
+  {
+    "name": "script",
+    "attributes": {},
+    "children": [
+      {
+        "name": "script",
+        "attributes": {
+          "src": "http://www.evil.com"
+        },
+        "children": []
+      }
+    ]
+  }
+]

--- a/packages/markup/fixtures/single-paragraph.json
+++ b/packages/markup/fixtures/single-paragraph.json
@@ -1,18 +1,13 @@
 {
-  "fixture": [
+  "name": "paragraph",
+  "attributes": {},
+  "children": [
     {
-      "name": "paragraph",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "This is the text for paragraph one"
-            }
-          ]
-        }
-      ]
+      "name": "text",
+      "attributes": {
+        "value": "This is the text for paragraph one"
+      },
+      "children": []
     }
   ]
 }

--- a/packages/markup/fixtures/span.json
+++ b/packages/markup/fixtures/span.json
@@ -1,18 +1,13 @@
 {
-  "fixture": [
+  "name": "inline",
+  "attributes": {},
+  "children": [
     {
-      "name": "inline",
-      "attributes": {},
-      "children": [
-        {
-          "name": "text",
-          "children": [
-            {
-              "text": "some other text here"
-            }
-          ]
-        }
-      ]
+      "name": "text",
+      "attributes": {
+        "value": "some other text here"
+      },
+      "children": []
     }
   ]
 }

--- a/packages/markup/fixtures/tag-mixture.json
+++ b/packages/markup/fixtures/tag-mixture.json
@@ -1,88 +1,80 @@
 {
-  "fixture": [
+  "name": "block",
+  "attributes": {},
+  "children": [
     {
       "name": "block",
       "attributes": {},
       "children": [
         {
-          "name": "block",
-          "attributes": {},
+          "name": "link",
+          "attributes": {
+            "href": "http://www.google.com"
+          },
           "children": [
             {
-              "name": "link",
+              "name": "text",
               "attributes": {
-                "href": "http://www.google.com"
+                "value": "some link here"
               },
-              "children": [
-                {
-                  "name": "text",
-                  "children": [
-                    {
-                      "text": "some link here"
-                    }
-                  ]
-                }
-              ]
+              "children": []
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "name": "block",
+      "attributes": {},
+      "children": [
         {
-          "name": "block",
+          "name": "bold",
           "attributes": {},
           "children": [
             {
-              "name": "bold",
-              "attributes": {},
-              "children": [
-                {
-                  "name": "text",
-                  "children": [
-                    {
-                      "text": "some text here"
-                    }
-                  ]
-                }
-              ]
+              "name": "text",
+              "attributes": {
+                "value": "some text here"
+              },
+              "children": []
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "name": "block",
+      "attributes": {},
+      "children": [
         {
-          "name": "block",
+          "name": "italic",
           "attributes": {},
           "children": [
             {
-              "name": "italic",
-              "attributes": {},
-              "children": [
-                {
-                  "name": "text",
-                  "children": [
-                    {
-                      "text": " some more text here"
-                    }
-                  ]
-                }
-              ]
+              "name": "text",
+              "attributes": {
+                "value": " some more text here"
+              },
+              "children": []
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "name": "block",
+      "attributes": {},
+      "children": [
         {
-          "name": "block",
+          "name": "inline",
           "attributes": {},
           "children": [
             {
-              "name": "inline",
-              "attributes": {},
-              "children": [
-                {
-                  "name": "text",
-                  "children": [
-                    {
-                      "text": "some other text here"
-                    }
-                  ]
-                }
-              ]
+              "name": "text",
+              "attributes": {
+                "value": "some other text here"
+              },
+              "children": []
             }
           ]
         }

--- a/packages/markup/render-tree-without-defaults.js
+++ b/packages/markup/render-tree-without-defaults.js
@@ -1,20 +1,5 @@
-// text nodes have a single child that isnt a node (it's { text: "something"}),
-// so we turn the child text into an attribute
-// needed until https://github.com/newsuk/times-public-api/pull/104 is live
-const fixIfTextNode = ({ name, attributes, children }) => {
-  if (name === "text" && children.length === 1) {
-    const value = children[0].text;
-    return {
-      name,
-      attributes: Object.assign({}, attributes, { value }),
-      children: []
-    };
-  }
-  return { name, attributes, children };
-};
-
 const renderTree = (tree, renderers, key) => {
-  const { name, attributes, children } = fixIfTextNode(tree);
+  const { name, attributes, children } = tree;
 
   const renderer = renderers[name];
   if (!renderer) return null;

--- a/packages/markup/tree-proptype.js
+++ b/packages/markup/tree-proptype.js
@@ -1,15 +1,11 @@
 import PropTypes from "prop-types";
 
-const TextNode = PropTypes.shape({ text: PropTypes.string });
-
 const nodeShape = {
   name: PropTypes.string.isRequired,
   attributes: PropTypes.object.isRequired
 };
 
-nodeShape.children = PropTypes.arrayOf(
-  PropTypes.oneOfType([PropTypes.shape(nodeShape), TextNode])
-).isRequired;
+nodeShape.children = PropTypes.arrayOf(PropTypes.shape(nodeShape)).isRequired;
 
 const Node = PropTypes.shape(nodeShape);
 

--- a/packages/provider/example.json
+++ b/packages/provider/example.json
@@ -4,12 +4,10 @@
   "biography": [
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": "Lorem "
-        }
-      ]
+      "attributes": {
+        "value": "Lorem "
+      },
+      "children": []
     },
     {
       "name": "bold",
@@ -17,23 +15,19 @@
       "children": [
         {
           "name": "text",
-          "attributes": {},
-          "children": [
-            {
-              "text": "ipsum"
-            }
-          ]
+          "attributes": {
+            "value": "ipsum"
+          },
+          "children": []
         }
       ]
     },
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": " testbr "
-        }
-      ]
+      "attributes": {
+        "value": " testbr "
+      },
+      "children": []
     },
     {
       "name": "break",
@@ -41,12 +35,10 @@
     },
     {
       "name": "text",
-      "attributes": {},
-      "children": [
-        {
-          "text": "More text "
-        }
-      ]
+      "attributes": {
+        "value": "More text "
+      },
+      "children": []
     },
     {
       "name": "italic",
@@ -54,12 +46,10 @@
       "children": [
         {
           "name": "text",
-          "attributes": {},
-          "children": [
-            {
-              "text": " last "
-            }
-          ]
+          "attributes": {
+            "value": " last "
+          },
+          "children": []
         }
       ]
     }


### PR DESCRIPTION
Easier to do this sooner rather than later. This also means that the markup component (and anything that uses it) will be easier to type in the future...

Odd bits:
- i've simplified the markup fixtures whilst I was in there. The json structure for those fixtures no longer exports a "fixture" object.
- The only snapshot change is for some props in a subcomponent that passes the tree onto the markup component.
