### PR TITLE
fix: web font smoothing

### DIFF
--- a/packages/author-head/author-head.js
+++ b/packages/author-head/author-head.js
@@ -39,7 +39,13 @@ const styles = StyleSheet.create({
   title: {
     fontFamily: "TimesDigital-RegularSC",
     fontSize: 15,
-    color: "#696969"
+    color: "#696969",
+    ...Platform.select({
+      web: {
+        WebkitFontSmoothing: "antialiased",
+        MozOsxFontSmoothing: "grayscale"
+      }
+    })
   },
   twitter: {
     fontSize: 18,
@@ -56,7 +62,13 @@ const styles = StyleSheet.create({
     lineHeight: 26,
     color: "#333",
     maxWidth: "88%",
-    paddingBottom: 32
+    paddingBottom: 32,
+    ...Platform.select({
+      web: {
+        WebkitFontSmoothing: "antialiased",
+        MozOsxFontSmoothing: "grayscale"
+      }
+    })
   },
   wrapper: {
     alignItems: "center",

--- a/packages/pagination/pagination.js
+++ b/packages/pagination/pagination.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View, Platform } from "react-native";
 import PropTypes from "prop-types";
 import { TextLink } from "@times-components/link";
 import withPageState from "./pagination-wrapper";
@@ -35,7 +35,13 @@ const styles = StyleSheet.create({
   label: {
     color: "#696969",
     fontFamily: "GillSansMTStd-Medium",
-    fontSize: 15
+    fontSize: 15,
+    ...Platform.select({
+      web: {
+        WebkitFontSmoothing: "antialiased",
+        MozOsxFontSmoothing: "grayscale"
+      }
+    })
   },
   message: {
     justifyContent: "center"


### PR DESCRIPTION
Adds font smoothing to correct the wrong shade of grey.

Job title:
<img width="372" alt="screen shot 2017-09-28 at 10 36 13" src="https://user-images.githubusercontent.com/1024116/30959736-f7cffac2-a438-11e7-85e7-ac1c9d070756.png">
Pagination:
<img width="364" alt="screen shot 2017-09-28 at 10 36 19" src="https://user-images.githubusercontent.com/1024116/30959737-f7d012b4-a438-11e7-9179-c122be20db19.png">

IOS
![screen shot 2017-09-28 at 12 49 50](https://user-images.githubusercontent.com/1024116/31010841-265b2ec2-a504-11e7-821c-2d41db65f5ab.png)