### PR TITLE
fix: Image component for web

### DIFF
--- a/packages/article-image/__tests__/__snapshots__/article-image.test.js.snap
+++ b/packages/article-image/__tests__/__snapshots__/article-image.test.js.snap
@@ -13,28 +13,25 @@ exports[`does not render Article Image display is not received 1`] = `
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -120,28 +117,25 @@ exports[`does not render Article Image if url is not received 1`] = `
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": null,
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": null,
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -227,28 +221,25 @@ exports[`does not render Caption on Article Image if both caption and credits ar
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -281,28 +272,25 @@ exports[`renders inline image (landscape) correctly 1`] = `
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=300%2C200%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=300%2C200%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -403,28 +391,25 @@ exports[`renders inline image (portrait) correctly 1`] = `
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=100%2C150%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=100%2C150%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -518,28 +503,25 @@ exports[`renders primary image correctly 1`] = `
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -632,28 +614,25 @@ exports[`renders secondary image correctly 1`] = `
       <View
         style={undefined}
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>

--- a/packages/article-image/__tests__/__snapshots__/article-image.web.test.js.snap
+++ b/packages/article-image/__tests__/__snapshots__/article-image.web.test.js.snap
@@ -28,28 +28,25 @@ exports[`does not render Article Image display is not received 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -150,28 +147,25 @@ exports[`does not render Article Image if url is not received 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": null,
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": null,
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -272,28 +266,25 @@ exports[`does not render Caption on Article Image if both caption and credits ar
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -341,28 +332,25 @@ exports[`renders inline image (landscape) correctly 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=300%2C200%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=300%2C200%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -478,28 +466,25 @@ exports[`renders inline image (portrait) correctly 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=100%2C150%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=100%2C150%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -608,28 +593,25 @@ exports[`renders primary image correctly 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>
@@ -737,28 +719,25 @@ exports[`renders secondary image correctly 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              undefined,
+            ]
+          }
+        />
       </View>
     </View>
   </View>

--- a/packages/article/__tests__/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.android.test.js.snap
@@ -42,28 +42,25 @@ exports[`Article test on android renders article no flags 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -708,28 +705,25 @@ exports[`Article test on android renders article no label 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -1479,28 +1473,25 @@ exports[`Article test on android renders article no label no flags 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -2115,28 +2106,25 @@ exports[`Article test on android renders article no label no flags no standfirst
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -2733,28 +2721,25 @@ exports[`Article test on android renders article no standfirst 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -3516,28 +3501,25 @@ exports[`Article test on android renders article no standfirst no flags 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -4164,28 +4146,25 @@ exports[`Article test on android renders article no standfirst no label 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -4917,28 +4896,25 @@ exports[`Article test on android renders full article 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -5381,28 +5357,25 @@ exports[`Article test on android renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>
@@ -5554,28 +5527,25 @@ exports[`Article test on android renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>
@@ -5735,28 +5705,25 @@ exports[`Article test on android renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=800%2C1200%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=800%2C1200%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>
@@ -5886,28 +5853,25 @@ exports[`Article test on android renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>

--- a/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
@@ -42,28 +42,25 @@ exports[`Article test on ios renders article no flags 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -708,28 +705,25 @@ exports[`Article test on ios renders article no label 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -1479,28 +1473,25 @@ exports[`Article test on ios renders article no label no flags 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -2115,28 +2106,25 @@ exports[`Article test on ios renders article no label no flags no standfirst 1`]
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -2733,28 +2721,25 @@ exports[`Article test on ios renders article no standfirst 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -3516,28 +3501,25 @@ exports[`Article test on ios renders article no standfirst no flags 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -4164,28 +4146,25 @@ exports[`Article test on ios renders article no standfirst no label 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -4917,28 +4896,25 @@ exports[`Article test on ios renders full article 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              undefined,
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            undefined,
+          ]
+        }
+      />
     </View>
     <View
       style={
@@ -5381,28 +5357,25 @@ exports[`Article test on ios renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>
@@ -5554,28 +5527,25 @@ exports[`Article test on ios renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>
@@ -5735,28 +5705,25 @@ exports[`Article test on ios renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=800%2C1200%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=800%2C1200%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>
@@ -5886,28 +5853,25 @@ exports[`Article test on ios renders full article 1`] = `
             <View
               style={undefined}
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
           </View>
         </View>

--- a/packages/article/__tests__/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.web.test.js.snap
@@ -74,26 +74,28 @@ exports[`Article test on web renders article no flags 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -308,26 +310,28 @@ exports[`Article test on web renders article no label 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -624,26 +628,28 @@ exports[`Article test on web renders article no label no flags 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -840,26 +846,28 @@ exports[`Article test on web renders article no label no flags no standfirst 1`]
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -1050,26 +1058,28 @@ exports[`Article test on web renders article no standfirst 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -1378,26 +1388,28 @@ exports[`Article test on web renders article no standfirst no flags 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -1606,26 +1618,28 @@ exports[`Article test on web renders article no standfirst no label 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -1916,26 +1930,28 @@ exports[`Article test on web renders full article 1`] = `
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
     >
-      <div
-        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-      >
-        <div
-          className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-          style={
-            Object {
-              "backgroundImage": "url(\\"//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200\\")",
-              "height": "1px",
-            }
+      <img
+        alt=""
+        height="inherit"
+        onError={[Function]}
+        resizeMode="contain"
+        source={
+          Object {
+            "uri": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200",
           }
-        >
-          <img
-            alt=""
-            className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-            draggable={undefined}
-            src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
-          />
-        </div>
-      </div>
+        }
+        src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1200"
+        style={
+          Object {
+            "backgroundPosition": "center center",
+            "backgroundRepeat": "no-repeat",
+            "backgroundSize": "contain",
+            "height": "inherit",
+            "width": "inherit",
+          }
+        }
+        width="inherit"
+      />
     </div>
     <div
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingBottom-1mdbw0j rn-paddingLeft-1hfyk0a rn-paddingRight-1qfoi16 rn-position-bnwqim"
@@ -2168,26 +2184,28 @@ exports[`Article test on web renders full article 1`] = `
             <div
               className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-height-1pi2tsx rn-left-1d2f490 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-u8s1d rn-top-ipm5af rn-width-13qz1uu"
             >
-              <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-              >
-                <div
-                  className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                  style={
-                    Object {
-                      "backgroundImage": "url(\\"https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0\\")",
-                      "height": "1px",
-                    }
+              <img
+                alt=""
+                height="inherit"
+                onError={[Function]}
+                resizeMode="contain"
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0",
                   }
-                >
-                  <img
-                    alt=""
-                    className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-                    draggable={undefined}
-                    src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0"
-                  />
-                </div>
-              </div>
+                }
+                src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0"
+                style={
+                  Object {
+                    "backgroundPosition": "center center",
+                    "backgroundRepeat": "no-repeat",
+                    "backgroundSize": "contain",
+                    "height": "inherit",
+                    "width": "inherit",
+                  }
+                }
+                width="inherit"
+              />
             </div>
           </div>
         </div>
@@ -2260,26 +2278,28 @@ exports[`Article test on web renders full article 1`] = `
             <div
               className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-height-1pi2tsx rn-left-1d2f490 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-u8s1d rn-top-ipm5af rn-width-13qz1uu"
             >
-              <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
-              >
-                <div
-                  className="rn-alignItems-1oszu61 rn-backgroundColor-wib322 rn-backgroundPosition-vvn4in rn-backgroundRepeat-u6sd8q rn-backgroundSize-4gszlv rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                  style={
-                    Object {
-                      "backgroundImage": "url(\\"https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0\\")",
-                      "height": "1px",
-                    }
+              <img
+                alt=""
+                height="inherit"
+                onError={[Function]}
+                resizeMode="contain"
+                source={
+                  Object {
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0",
                   }
-                >
-                  <img
-                    alt=""
-                    className="rn-bottom-1p0dtai rn-height-1pi2tsx rn-left-1d2f490 rn-opacity-1272l3b rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-width-13qz1uu rn-zIndex-1wyyakw"
-                    draggable={undefined}
-                    src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0"
-                  />
-                </div>
-              </div>
+                }
+                src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0"
+                style={
+                  Object {
+                    "backgroundPosition": "center center",
+                    "backgroundRepeat": "no-repeat",
+                    "backgroundSize": "contain",
+                    "height": "inherit",
+                    "width": "inherit",
+                  }
+                }
+                width="inherit"
+              />
             </div>
           </div>
         </div>

--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -212,34 +212,31 @@ exports[`renders with data 1`] = `
       }
     }
   >
-    <View
+    <Image
+      onError={[Function]}
       onLayout={[Function]}
-    >
-      <Image
-        onError={[Function]}
-        onLoad={[Function]}
-        source={
+      onLoad={[Function]}
+      source={
+        Object {
+          "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+        }
+      }
+      style={
+        Array [
           Object {
-            "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "height": 1,
-              "width": 750,
-            },
-            Object {
-              "borderColor": "#FFF",
-              "borderRadius": 50,
-              "borderWidth": 5,
-              "height": 100,
-              "width": 100,
-            },
-          ]
-        }
-      />
-    </View>
+            "height": 1,
+            "width": 750,
+          },
+          Object {
+            "borderColor": "#FFF",
+            "borderRadius": 50,
+            "borderWidth": 5,
+            "height": 100,
+            "width": 100,
+          },
+        ]
+      }
+    />
   </View>
 </View>
 `;

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -893,7 +893,7 @@ exports[`renders profile content 1`] = `
               }
             }
           >
-            Lorem
+            Lorem 
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -906,8 +906,8 @@ exports[`renders profile content 1`] = `
             >
               ipsum
             </Text>
-             testbr
-            More text
+             testbr 
+            More text 
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -918,7 +918,7 @@ exports[`renders profile content 1`] = `
                 }
               }
             >
-               last
+               last 
             </Text>
           </Text>
         </View>
@@ -932,34 +932,31 @@ exports[`renders profile content 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -1130,28 +1127,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -1218,7 +1212,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1324,28 +1318,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -1414,7 +1405,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1520,28 +1511,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -1610,7 +1598,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1716,28 +1704,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -1806,7 +1791,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1912,28 +1897,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -2096,28 +2078,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -2186,7 +2165,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -2292,28 +2271,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -2476,28 +2452,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -2660,28 +2633,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -2844,28 +2814,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3028,28 +2995,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3212,28 +3176,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3396,28 +3357,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3580,28 +3538,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3771,28 +3726,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3955,28 +3907,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -4146,28 +4095,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -4236,7 +4182,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Terry Pratchett, who died last week, began his career on the
+                    Terry Pratchett, who died last week, began his career on the 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -4343,28 +4289,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -4433,7 +4376,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -4580,7 +4523,7 @@ exports[`renders profile content component 1`] = `
               }
             }
           >
-            Lorem
+            Lorem 
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4593,8 +4536,8 @@ exports[`renders profile content component 1`] = `
             >
               ipsum
             </Text>
-             testbr
-            More text
+             testbr 
+            More text 
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4605,7 +4548,7 @@ exports[`renders profile content component 1`] = `
                 }
               }
             >
-               last
+               last 
             </Text>
           </Text>
         </View>
@@ -4619,34 +4562,31 @@ exports[`renders profile content component 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -4817,28 +4757,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -4905,7 +4842,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5011,28 +4948,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -5101,7 +5035,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5207,28 +5141,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -5297,7 +5228,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5403,28 +5334,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -5493,7 +5421,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5599,28 +5527,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -5783,28 +5708,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -5873,7 +5795,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5979,28 +5901,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -6163,28 +6082,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -6347,28 +6263,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -6531,28 +6444,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -6715,28 +6625,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -6899,28 +6806,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -7083,28 +6987,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -7267,28 +7168,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -7458,28 +7356,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -7642,28 +7537,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -7833,28 +7725,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -7923,7 +7812,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Terry Pratchett, who died last week, began his career on the
+                    Terry Pratchett, who died last week, began his career on the 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -8030,28 +7919,25 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -8120,7 +8006,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -8294,7 +8180,7 @@ exports[`renders profile header 1`] = `
           }
         }
       >
-        Lorem
+        Lorem 
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -8307,8 +8193,8 @@ exports[`renders profile header 1`] = `
         >
           ipsum
         </Text>
-         testbr
-        More text
+         testbr 
+        More text 
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -8319,7 +8205,7 @@ exports[`renders profile header 1`] = `
             }
           }
         >
-           last
+           last 
         </Text>
       </Text>
     </View>
@@ -8333,34 +8219,31 @@ exports[`renders profile header 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              Object {
-                "borderColor": "#FFF",
-                "borderRadius": 50,
-                "borderWidth": 5,
-                "height": 100,
-                "width": 100,
-              },
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            Object {
+              "borderColor": "#FFF",
+              "borderRadius": 50,
+              "borderWidth": 5,
+              "height": 100,
+              "width": 100,
+            },
+          ]
+        }
+      />
     </View>
   </View>
   <View

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -893,7 +893,7 @@ exports[`renders profile content 1`] = `
               }
             }
           >
-            Lorem 
+            Lorem
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -906,8 +906,8 @@ exports[`renders profile content 1`] = `
             >
               ipsum
             </Text>
-             testbr 
-            More text 
+             testbr
+            More text
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -918,7 +918,7 @@ exports[`renders profile content 1`] = `
                 }
               }
             >
-               last 
+               last
             </Text>
           </Text>
         </View>
@@ -1218,7 +1218,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1414,7 +1414,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1610,7 +1610,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -1806,7 +1806,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -2186,7 +2186,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -4236,7 +4236,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Terry Pratchett, who died last week, began his career on the 
+                    Terry Pratchett, who died last week, began his career on the
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -4433,7 +4433,7 @@ exports[`renders profile content 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -4580,7 +4580,7 @@ exports[`renders profile content component 1`] = `
               }
             }
           >
-            Lorem 
+            Lorem
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4593,8 +4593,8 @@ exports[`renders profile content component 1`] = `
             >
               ipsum
             </Text>
-             testbr 
-            More text 
+             testbr
+            More text
             <Text
               accessible={true}
               allowFontScaling={true}
@@ -4605,7 +4605,7 @@ exports[`renders profile content component 1`] = `
                 }
               }
             >
-               last 
+               last
             </Text>
           </Text>
         </View>
@@ -4905,7 +4905,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5101,7 +5101,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5297,7 +5297,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5493,7 +5493,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -5873,7 +5873,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                    A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State,
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -7923,7 +7923,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Terry Pratchett, who died last week, began his career on the 
+                    Terry Pratchett, who died last week, began his career on the
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -8120,7 +8120,7 @@ exports[`renders profile content component 1`] = `
                     allowFontScaling={true}
                     ellipsizeMode="tail"
                   >
-                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it 
+                    Is poetry best when written down or is it nobler in the mind? Is it enough to read a great verse off the page, or is it
                     <Text
                       accessible={true}
                       allowFontScaling={true}
@@ -8294,7 +8294,7 @@ exports[`renders profile header 1`] = `
           }
         }
       >
-        Lorem 
+        Lorem
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -8307,8 +8307,8 @@ exports[`renders profile header 1`] = `
         >
           ipsum
         </Text>
-         testbr 
-        More text 
+         testbr
+        More text
         <Text
           accessible={true}
           allowFontScaling={true}
@@ -8319,7 +8319,7 @@ exports[`renders profile header 1`] = `
             }
           }
         >
-           last 
+           last
         </Text>
       </Text>
     </View>

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -932,34 +932,31 @@ exports[`renders profile content 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
       </View>
       <View
@@ -1116,6 +1113,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1168,6 +1166,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1325,6 +1356,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1377,6 +1409,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1536,6 +1601,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1588,6 +1654,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1747,6 +1846,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1799,6 +1899,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1958,6 +2091,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2010,6 +2144,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2157,6 +2324,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2209,6 +2377,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2368,6 +2569,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2415,6 +2617,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 5e388c3... feat: map props depending on platform
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2756,6 +2991,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2766,18 +3002,27 @@ exports[`renders profile content 1`] = `
 =======
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -2923,28 +3168,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3091,28 +3333,25 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3295,6 +3534,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -3342,6 +3582,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 5e388c3... feat: map props depending on platform
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -3499,6 +3772,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -3518,9 +3792,27 @@ exports[`renders profile content 1`] = `
                     },
                     undefined,
                   ]
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-              />
-            </View>
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -3720,6 +4012,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -3772,6 +4065,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -3919,6 +4245,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -3971,6 +4298,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -4124,8 +4484,10 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
+<<<<<<< HEAD
             >
               <Image
                 onError={[Function]}
@@ -4143,9 +4505,24 @@ exports[`renders profile content 1`] = `
                     },
                     undefined,
                   ]
+=======
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-              />
-            </View>
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4351,6 +4728,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -4403,6 +4781,39 @@ exports[`renders profile content 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -4550,6 +4961,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -4569,9 +4981,27 @@ exports[`renders profile content 1`] = `
                     },
                     undefined,
                   ]
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-              />
-            </View>
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -4778,6 +5208,7 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -5010,9 +5441,27 @@ exports[`renders profile content 1`] = `
                     },
                     undefined,
                   ]
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-              />
-            </View>
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -5314,34 +5763,31 @@ exports[`renders profile content component 1`] = `
           }
         }
       >
-        <View
+        <Image
+          onError={[Function]}
           onLayout={[Function]}
-        >
-          <Image
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+            }
+          }
+          style={
+            Array [
               Object {
-                "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                Object {
-                  "borderColor": "#FFF",
-                  "borderRadius": 50,
-                  "borderWidth": 5,
-                  "height": 100,
-                  "width": 100,
-                },
-              ]
-            }
-          />
-        </View>
+                "height": 1,
+                "width": 750,
+              },
+              Object {
+                "borderColor": "#FFF",
+                "borderRadius": 50,
+                "borderWidth": 5,
+                "height": 100,
+                "width": 100,
+              },
+            ]
+          }
+        />
       </View>
     </View>
     <View
@@ -5448,6 +5894,156 @@ exports[`renders profile content component 1`] = `
                 }
               >
                 Next page &gt;
+<<<<<<< HEAD
+=======
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        }
+      }
+    >
+      <View
+        onLayout={[Function]}
+        style={
+          Array [
+            Object {
+              "flexDirection": "column",
+            },
+            null,
+            undefined,
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "paddingBottom": 15,
+              },
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#333333",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 12,
+                  "letterSpacing": 1,
+                  "marginBottom": 2,
+                }
+              }
+            />
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#333333",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "400",
+                  "lineHeight": 22,
+                  "marginBottom": 8,
+                }
+              }
+            >
+              British trio stopped on the way to join Isis
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#696969",
+                  "flexWrap": "wrap",
+                  "fontFamily": "TimesDigitalW04",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                  "marginBottom": 10,
+                }
+              }
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The
+                </Text>
+>>>>>>> 1d7173d... fix: fixes image size with ssr
               </Text>
             </View>
 <<<<<<< HEAD
@@ -5499,28 +6095,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5683,28 +6276,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -5930,6 +6520,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -6085,6 +6676,27 @@ exports[`renders profile content component 1`] = `
               </Text>
             </View>
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+>>>>>>> 1d7173d... fix: fixes image size with ssr
         </View>
       </View>
     </View>
@@ -6366,12 +6978,54 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
                 Object {
                   "paddingBottom": 15,
                 },
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+>>>>>>> 1d7173d... fix: fixes image size with ssr
                 Object {
                   "flexGrow": 1,
                   "flexShrink": 1,
@@ -6584,6 +7238,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -6636,6 +7291,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 67b993e... chore: create state conversion for web
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -6790,6 +7478,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -6842,6 +7531,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 67b993e... chore: create state conversion for web
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -7025,28 +7747,25 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
 >>>>>>> 67b993e... chore: create state conversion for web
         <View
@@ -7252,6 +7971,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -7390,6 +8110,27 @@ exports[`renders profile content component 1`] = `
               </Text>
             </View>
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+>>>>>>> 1d7173d... fix: fixes image size with ssr
         </View>
       </View>
     </View>
@@ -7659,6 +8400,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -7711,6 +8453,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 67b993e... chore: create state conversion for web
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -7856,28 +8631,25 @@ exports[`renders profile content component 1`] = `
       >
 =======
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
 >>>>>>> 67b993e... chore: create state conversion for web
         <View
@@ -8083,6 +8855,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -8102,9 +8875,27 @@ exports[`renders profile content component 1`] = `
                   },
                   undefined,
                 ]
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
               }
-            />
-          </View>
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -8311,6 +9102,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -8330,9 +9122,27 @@ exports[`renders profile content component 1`] = `
                   },
                   undefined,
                 ]
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
               }
-            />
-          </View>
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -8549,6 +9359,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -8568,9 +9379,27 @@ exports[`renders profile content component 1`] = `
                   },
                   undefined,
                 ]
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+>>>>>>> 1d7173d... fix: fixes image size with ssr
               }
-            />
-          </View>
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
         </View>
         <View
           style={
@@ -8794,6 +9623,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -8841,6 +9671,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 5e388c3... feat: map props depending on platform
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -9005,6 +9868,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -9052,6 +9916,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 5e388c3... feat: map props depending on platform
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -9213,6 +10110,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -9265,6 +10163,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 67b993e... chore: create state conversion for web
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -9432,6 +10363,7 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
+<<<<<<< HEAD
           <View
             style={
               Array [
@@ -9484,6 +10416,39 @@ exports[`renders profile content component 1`] = `
             />
 >>>>>>> 67b993e... chore: create state conversion for web
           </View>
+=======
+          <Image
+            onError={[Function]}
+            onLayout={[Function]}
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "height": 1,
+                  "width": 750,
+                },
+                undefined,
+              ]
+            }
+          />
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -9763,34 +10728,31 @@ exports[`renders profile header 1`] = `
         }
       }
     >
-      <View
+      <Image
+        onError={[Function]}
         onLayout={[Function]}
-      >
-        <Image
-          onError={[Function]}
-          onLoad={[Function]}
-          source={
+        onLoad={[Function]}
+        source={
+          Object {
+            "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
+          }
+        }
+        style={
+          Array [
             Object {
-              "uri": "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg",
-            }
-          }
-          style={
-            Array [
-              Object {
-                "height": 1,
-                "width": 750,
-              },
-              Object {
-                "borderColor": "#FFF",
-                "borderRadius": 50,
-                "borderWidth": 5,
-                "height": 100,
-                "width": 100,
-              },
-            ]
-          }
-        />
-      </View>
+              "height": 1,
+              "width": 750,
+            },
+            Object {
+              "borderColor": "#FFF",
+              "borderRadius": 50,
+              "borderWidth": 5,
+              "height": 100,
+              "width": 100,
+            },
+          ]
+        }
+      />
     </View>
   </View>
   <View

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -1113,7 +1113,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1128,77 +1127,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1356,7 +1304,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1371,77 +1318,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1601,7 +1497,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1616,77 +1511,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -1846,7 +1690,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -1861,77 +1704,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2091,7 +1883,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2106,77 +1897,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2324,7 +2064,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2339,77 +2078,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2569,7 +2257,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -2584,30 +2271,18 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
                       "height": 1,
                       "width": 750,
                     },
@@ -2615,41 +2290,7 @@ exports[`renders profile content 1`] = `
                   ]
                 }
               />
->>>>>>> 5e388c3... feat: map props depending on platform
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -2686,7 +2327,6 @@ exports[`renders profile content 1`] = `
                   ellipsizeMode="tail"
                   style={
                     Object {
-<<<<<<< HEAD
                       "color": "#333333",
                       "fontFamily": "TimesModern-Bold",
                       "fontSize": 22,
@@ -2741,15 +2381,6 @@ exports[`renders profile content 1`] = `
                   , The Times
                 </Text>
               </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-                    },
-                    undefined,
-                  ]
-                }
-              />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
           </View>
         </View>
@@ -2821,28 +2452,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -2991,59 +2619,12 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
                   Object {
-<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
-=======
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
->>>>>>> 1d7173d... fix: fixes image size with ssr
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
->>>>>>> 67b993e... chore: create state conversion for web
                   Object {
                     "flexGrow": 1,
                     "flexShrink": 1,
@@ -3052,28 +2633,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -3093,326 +2671,14 @@ exports[`renders profile content 1`] = `
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
-<<<<<<< HEAD
                   style={
-=======
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
-                    Object {
-                      "color": "#696969",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                HEALTH
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
-                  }
-                }
-              >
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                >
-                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
-                </Text>
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Array [
->>>>>>> 67b993e... chore: create state conversion for web
                     Object {
                       "color": "#333333",
                       "fontFamily": "GillSansMTStd-Medium",
-<<<<<<< HEAD
                       "fontSize": 12,
                       "letterSpacing": 1,
                       "marginBottom": 2,
                     }
-=======
-                      "fontSize": 13,
-                      "lineHeight": 15,
-                    },
-                    Object {},
-                  ]
-                }
-              >
-                Tuesday March 17 2015
-                , The Times
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "backgroundColor": "#dbdbdb",
-            "height": 1,
-            "margin": 10,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          onLayout={[Function]}
-          style={
-            Array [
-              Object {
-                "flexDirection": "column",
-              },
-              null,
-              undefined,
-            ]
-          }
-        >
-          <View
-            style={
-              Array [
-                Object {
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 12,
-                    "letterSpacing": 1,
-                    "marginBottom": 2,
-                  }
-                }
-              >
-                SCIENCE
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#333333",
-                    "fontFamily": "TimesModern-Bold",
-                    "fontSize": 22,
-                    "fontWeight": "400",
-                    "lineHeight": 22,
-                    "marginBottom": 8,
-                  }
-                }
-              >
-                Fourth Briton is seized trying to join Isis
-              </Text>
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "color": "#696969",
-                    "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
-                    "fontSize": 14,
-                    "lineHeight": 20,
-                    "marginBottom": 10,
->>>>>>> 67b993e... chore: create state conversion for web
                   }
                 >
                   HEALTH
@@ -3534,7 +2800,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -3549,30 +2814,18 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
                       "height": 1,
                       "width": 750,
                     },
@@ -3580,41 +2833,7 @@ exports[`renders profile content 1`] = `
                   ]
                 }
               />
->>>>>>> 5e388c3... feat: map props depending on platform
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -3651,7 +2870,6 @@ exports[`renders profile content 1`] = `
                   ellipsizeMode="tail"
                   style={
                     Object {
-<<<<<<< HEAD
                       "color": "#333333",
                       "fontFamily": "TimesModern-Bold",
                       "fontSize": 22,
@@ -3706,15 +2924,6 @@ exports[`renders profile content 1`] = `
                   , The Times
                 </Text>
               </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-                    },
-                    undefined,
-                  ]
-                }
-              />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
           </View>
         </View>
@@ -3772,15 +2981,26 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
                   Object {
-<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
-=======
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <Image
+                onError={[Function]}
+                onLayout={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
                 }
@@ -3792,78 +3012,8 @@ exports[`renders profile content 1`] = `
                     },
                     undefined,
                   ]
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
->>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
->>>>>>> 5e388c3... feat: map props depending on platform
-                  Object {
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                  },
-                  null,
-                ]
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+              />
             </View>
             <View
               style={
@@ -4012,7 +3162,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -4027,77 +3176,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -4245,7 +3343,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -4260,77 +3357,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -4471,66 +3517,7 @@ exports[`renders profile content 1`] = `
             style={
               Array [
                 Object {
-<<<<<<< HEAD
                   "flexDirection": "column",
-=======
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-<<<<<<< HEAD
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-=======
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
->>>>>>> 1d7173d... fix: fixes image size with ssr
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
->>>>>>> 67b993e... chore: create state conversion for web
                 },
                 null,
                 undefined,
@@ -4551,28 +3538,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -4728,7 +3712,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -4743,77 +3726,26 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
-=======
                       "height": 1,
                       "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -4961,15 +3893,26 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
                   Object {
-<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
-=======
+                  Object {
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <Image
+                onError={[Function]}
+                onLayout={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -4981,78 +3924,8 @@ exports[`renders profile content 1`] = `
                     },
                     undefined,
                   ]
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
->>>>>>> 1d7173d... fix: fixes image size with ssr
                 }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              style={Object {}}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
->>>>>>> 67b993e... chore: create state conversion for web
-                  Object {
-                    "flexGrow": 1,
-                    "flexShrink": 1,
-                  },
-                  null,
-                ]
-              }
-            >
-              <View
-                onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+              />
             </View>
             <View
               style={
@@ -5208,7 +4081,6 @@ exports[`renders profile content 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -5223,38 +4095,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-<<<<<<< HEAD
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -5409,67 +4268,7 @@ exports[`renders profile content 1`] = `
             style={
               Array [
                 Object {
-<<<<<<< HEAD
                   "flexDirection": "column",
-=======
-                  "paddingBottom": 15,
-                },
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
->>>>>>> 1d7173d... fix: fixes image size with ssr
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
->>>>>>> 67b993e... chore: create state conversion for web
                 },
                 null,
                 undefined,
@@ -5490,28 +4289,25 @@ exports[`renders profile content 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
                     Object {
-                      "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
             </View>
             <View
               style={
@@ -5894,327 +4690,8 @@ exports[`renders profile content component 1`] = `
                 }
               >
                 Next page &gt;
-<<<<<<< HEAD
-=======
               </Text>
             </View>
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            />
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
-                >
-                  The
-                </Text>
->>>>>>> 1d7173d... fix: fixes image size with ssr
-              </Text>
-            </View>
-<<<<<<< HEAD
-=======
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-  <View
-    style={
-      Object {
-        "alignSelf": "center",
-        "maxWidth": 820,
-      }
-    }
-  >
-    <View
-      style={
-        Object {
-          "paddingLeft": 10,
-          "paddingRight": 10,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 12,
-                  "letterSpacing": 1,
-                  "marginBottom": 2,
-                }
-              }
-            />
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "TimesModern-Bold",
-                  "fontSize": 22,
-                  "fontWeight": "400",
-                  "lineHeight": 22,
-                  "marginBottom": 8,
-                }
-              }
-            >
-              British trio stopped on the way to join Isis
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "color": "#696969",
-                  "flexWrap": "wrap",
-                  "fontFamily": "TimesDigitalW04",
-                  "fontSize": 14,
-                  "lineHeight": 20,
-                  "marginBottom": 10,
-                }
-              }
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-              >
-                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
-                <Text
-                  accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  style={
-                    Object {
-                      "fontStyle": "italic",
-                    }
-                  }
-                >
-                  The
-                </Text>
-              </Text>
-            </Text>
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Array [
-                  Object {
-                    "color": "#696969",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 13,
-                    "lineHeight": 15,
-                  },
-                  Object {},
-                ]
-              }
-            >
-              Monday March 23 2015
-              , The Times
-            </Text>
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
         </View>
       </View>
@@ -6263,46 +4740,7 @@ exports[`renders profile content component 1`] = `
           style={
             Array [
               Object {
-<<<<<<< HEAD
                 "flexDirection": "column",
-=======
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
->>>>>>> 5e388c3... feat: map props depending on platform
               },
               null,
               undefined,
@@ -6323,38 +4761,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -6520,7 +4945,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -6535,43 +4959,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -6676,27 +5082,6 @@ exports[`renders profile content component 1`] = `
               </Text>
             </View>
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
->>>>>>> 1d7173d... fix: fixes image size with ssr
         </View>
       </View>
     </View>
@@ -6774,43 +5159,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -6978,54 +5345,12 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
                 Object {
                   "paddingBottom": 15,
                 },
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
->>>>>>> 1d7173d... fix: fixes image size with ssr
                 Object {
                   "flexGrow": 1,
                   "flexShrink": 1,
@@ -7034,43 +5359,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -7238,7 +5545,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -7253,77 +5559,26 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -7478,7 +5733,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -7493,77 +5747,26 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -7707,7 +5910,6 @@ exports[`renders profile content component 1`] = `
           "opacity": 1,
         }
       }
-<<<<<<< HEAD
       testID={undefined}
       tvParallaxProperties={undefined}
     >
@@ -7719,55 +5921,6 @@ exports[`renders profile content component 1`] = `
           }
         }
       >
-=======
-    >
-      <View
-        onLayout={[Function]}
-        style={
-          Array [
-            Object {
-              "flexDirection": "column",
-            },
-            null,
-            undefined,
-          ]
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "paddingBottom": 15,
-              },
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
->>>>>>> 67b993e... chore: create state conversion for web
         <View
           onLayout={[Function]}
           style={
@@ -7794,28 +5947,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -7971,7 +6121,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -7986,38 +6135,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -8110,27 +6246,6 @@ exports[`renders profile content component 1`] = `
               </Text>
             </View>
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
->>>>>>> 1d7173d... fix: fixes image size with ssr
         </View>
       </View>
     </View>
@@ -8208,43 +6323,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -8400,7 +6497,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -8415,77 +6511,26 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -8626,32 +6671,8 @@ exports[`renders profile content component 1`] = `
             "paddingLeft": 10,
             "paddingRight": 10,
           }
-<<<<<<< HEAD
         }
       >
-=======
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
->>>>>>> 67b993e... chore: create state conversion for web
         <View
           onLayout={[Function]}
           style={
@@ -8678,28 +6699,25 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
                   Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
           </View>
           <View
             style={
@@ -8855,16 +6873,27 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
                 Object {
-<<<<<<< HEAD
                   "paddingBottom": 15,
                 },
-=======
-                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                 }
               }
               style={
@@ -8875,78 +6904,8 @@ exports[`renders profile content component 1`] = `
                   },
                   undefined,
                 ]
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
->>>>>>> 1d7173d... fix: fixes image size with ssr
               }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
->>>>>>> 67b993e... chore: create state conversion for web
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
+            />
           </View>
           <View
             style={
@@ -9102,15 +7061,26 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
                 Object {
-<<<<<<< HEAD
                   "paddingBottom": 15,
                 },
-=======
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
                   "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
                 }
               }
@@ -9122,88 +7092,8 @@ exports[`renders profile content component 1`] = `
                   },
                   undefined,
                 ]
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
->>>>>>> 1d7173d... fix: fixes image size with ssr
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
->>>>>>> 5e388c3... feat: map props depending on platform
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-                  },
-                  undefined,
-                ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -9359,15 +7249,26 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
                 Object {
-<<<<<<< HEAD
                   "paddingBottom": 15,
                 },
-=======
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
                   "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
                 }
               }
@@ -9379,88 +7280,8 @@ exports[`renders profile content component 1`] = `
                   },
                   undefined,
                 ]
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
->>>>>>> 1d7173d... fix: fixes image size with ssr
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
-          <View
-            style={Object {}}
-          >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
->>>>>>> 5e388c3... feat: map props depending on platform
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
-            <View
-              onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
-                  Object {
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-                  },
-                  undefined,
-                ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -9623,7 +7444,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -9638,30 +7458,18 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
                     "height": 1,
                     "width": 750,
                   },
@@ -9669,41 +7477,7 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             />
->>>>>>> 5e388c3... feat: map props depending on platform
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -9740,7 +7514,6 @@ exports[`renders profile content component 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
-<<<<<<< HEAD
                     "color": "#333333",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 22,
@@ -9795,15 +7568,6 @@ exports[`renders profile content component 1`] = `
                 , The Times
               </Text>
             </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-                  },
-                  undefined,
-                ]
-              }
-            />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
         </View>
       </View>
@@ -9868,7 +7632,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -9883,30 +7646,18 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
                     "height": 1,
                     "width": 750,
                   },
@@ -9914,41 +7665,7 @@ exports[`renders profile content component 1`] = `
                 ]
               }
             />
->>>>>>> 5e388c3... feat: map props depending on platform
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -10110,7 +7827,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -10125,77 +7841,26 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [
@@ -10363,7 +8028,6 @@ exports[`renders profile content component 1`] = `
             ]
           }
         >
-<<<<<<< HEAD
           <View
             style={
               Array [
@@ -10378,77 +8042,26 @@ exports[`renders profile content component 1`] = `
               ]
             }
           >
-            <View
+            <Image
+              onError={[Function]}
               onLayout={[Function]}
-            >
-              <Image
-                onError={[Function]}
-                onLoad={[Function]}
-                source={
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-                  }
-                }
-                style={
-                  Array [
-                    Object {
-                      "height": 1,
-                      "width": 750,
-                    },
-                    undefined,
-                  ]
-                }
-              />
-            </View>
-=======
-                    "height": undefined,
-                    "width": undefined,
-=======
                     "height": 1,
                     "width": 750,
->>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
               }
             />
->>>>>>> 67b993e... chore: create state conversion for web
           </View>
-=======
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                undefined,
-              ]
-            }
-          />
-        </View>
-        <View
-          style={
-            Array [
-              Object {
-                "flexGrow": 1,
-                "flexShrink": 1,
-              },
-              null,
-            ]
-          }
-        >
->>>>>>> 1d7173d... fix: fixes image size with ssr
           <View
             style={
               Array [

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -946,8 +946,8 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
-                    "height": 1,
-                    "width": 750,
+                    "height": undefined,
+                    "width": undefined,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -1138,6 +1138,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1152,6 +1153,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -1332,6 +1342,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1346,6 +1357,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -1528,6 +1548,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1542,6 +1563,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -1724,6 +1754,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1738,6 +1769,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -1920,6 +1960,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
                     }
                   }
@@ -1934,6 +1975,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -2104,6 +2154,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -2118,6 +2169,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -2351,6 +2411,7 @@ exports[`renders profile content 1`] = `
                   ellipsizeMode="tail"
                   style={
                     Object {
+<<<<<<< HEAD
                       "color": "#333333",
                       "fontFamily": "TimesModern-Bold",
                       "fontSize": 22,
@@ -2405,6 +2466,15 @@ exports[`renders profile content 1`] = `
                   , The Times
                 </Text>
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
           </View>
         </View>
@@ -2650,8 +2720,45 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
+=======
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+>>>>>>> 67b993e... chore: create state conversion for web
                   Object {
                     "flexGrow": 1,
                     "flexShrink": 1,
@@ -2701,14 +2808,332 @@ exports[`renders profile content 1`] = `
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
+<<<<<<< HEAD
                   style={
+=======
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                HEALTH
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                >
+                  A 21-year-old woman became the fourth Briton in less than a week last night to be detained by the Turkish authorities on suspicion of trying to
+                </Text>
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+>>>>>>> 67b993e... chore: create state conversion for web
                     Object {
                       "color": "#333333",
                       "fontFamily": "GillSansMTStd-Medium",
+<<<<<<< HEAD
                       "fontSize": 12,
                       "letterSpacing": 1,
                       "marginBottom": 2,
                     }
+=======
+                      "fontSize": 13,
+                      "lineHeight": 15,
+                    },
+                    Object {},
+                  ]
+                }
+              >
+                Tuesday March 17 2015
+                , The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "#dbdbdb",
+            "height": 1,
+            "margin": 10,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              null,
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "letterSpacing": 1,
+                    "marginBottom": 2,
+                  }
+                }
+              >
+                SCIENCE
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#333333",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Fourth Briton is seized trying to join Isis
+              </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+>>>>>>> 67b993e... chore: create state conversion for web
                   }
                 >
                   HEALTH
@@ -2903,6 +3328,7 @@ exports[`renders profile content 1`] = `
                   ellipsizeMode="tail"
                   style={
                     Object {
+<<<<<<< HEAD
                       "color": "#333333",
                       "fontFamily": "TimesModern-Bold",
                       "fontSize": 22,
@@ -2957,6 +3383,15 @@ exports[`renders profile content 1`] = `
                   , The Times
                 </Text>
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
           </View>
         </View>
@@ -3220,6 +3655,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                     }
                   }
@@ -3234,6 +3670,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -3404,6 +3849,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
                     }
                   }
@@ -3418,6 +3864,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -3559,7 +4014,49 @@ exports[`renders profile content 1`] = `
             style={
               Array [
                 Object {
+<<<<<<< HEAD
                   "flexDirection": "column",
+=======
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+>>>>>>> 67b993e... chore: create state conversion for web
                 },
                 null,
                 undefined,
@@ -3779,6 +4276,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -3793,6 +4291,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -3945,8 +4452,45 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
+=======
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+>>>>>>> 67b993e... chore: create state conversion for web
                   Object {
                     "flexGrow": 1,
                     "flexShrink": 1,
@@ -4154,6 +4698,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
                     }
                   }
@@ -4168,6 +4713,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -4322,7 +4876,49 @@ exports[`renders profile content 1`] = `
             style={
               Array [
                 Object {
+<<<<<<< HEAD
                   "flexDirection": "column",
+=======
+                  "paddingBottom": 15,
+                },
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <Image
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+>>>>>>> 67b993e... chore: create state conversion for web
                 },
                 null,
                 undefined,
@@ -4630,8 +5226,8 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
-                  "height": 1,
-                  "width": 750,
+                  "height": undefined,
+                  "width": undefined,
                 },
                 Object {
                   "borderColor": "#FFF",
@@ -4752,6 +5348,178 @@ exports[`renders profile content component 1`] = `
                 Next page &gt;
               </Text>
             </View>
+<<<<<<< HEAD
+=======
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "alignSelf": "center",
+        "maxWidth": 820,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "paddingLeft": 10,
+          "paddingRight": 10,
+        }
+      }
+    >
+      <View
+        onLayout={[Function]}
+        style={
+          Array [
+            Object {
+              "flexDirection": "column",
+            },
+            null,
+            undefined,
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "paddingBottom": 15,
+              },
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            onLayout={[Function]}
+          >
+            <Image
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#333333",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 12,
+                  "letterSpacing": 1,
+                  "marginBottom": 2,
+                }
+              }
+            />
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#333333",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "400",
+                  "lineHeight": 22,
+                  "marginBottom": 8,
+                }
+              }
+            >
+              British trio stopped on the way to join Isis
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#696969",
+                  "flexWrap": "wrap",
+                  "fontFamily": "TimesDigitalW04",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                  "marginBottom": 10,
+                }
+              }
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                A tip-off from desperate parents led Turkish police to swoop on three British teenagers as they allegedly travelled to join Islamic State, 
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "fontStyle": "italic",
+                    }
+                  }
+                >
+                  The
+                </Text>
+              </Text>
+            </Text>
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+                Array [
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                  },
+                  Object {},
+                ]
+              }
+            >
+              Monday March 23 2015
+              , The Times
+            </Text>
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
         </View>
       </View>
@@ -4829,6 +5597,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -4843,6 +5612,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -5030,6 +5808,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -5044,6 +5823,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -5233,6 +6021,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -5247,6 +6036,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -5436,6 +6234,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -5450,6 +6249,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -5639,6 +6447,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
                   }
                 }
@@ -5653,6 +6462,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -5830,6 +6648,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -5844,6 +6663,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -5988,6 +6816,7 @@ exports[`renders profile content component 1`] = `
           "opacity": 1,
         }
       }
+<<<<<<< HEAD
       testID={undefined}
       tvParallaxProperties={undefined}
     >
@@ -5999,6 +6828,58 @@ exports[`renders profile content component 1`] = `
           }
         }
       >
+=======
+    >
+      <View
+        onLayout={[Function]}
+        style={
+          Array [
+            Object {
+              "flexDirection": "column",
+            },
+            null,
+            undefined,
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "paddingBottom": 15,
+              },
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            onLayout={[Function]}
+          >
+            <Image
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+>>>>>>> 67b993e... chore: create state conversion for web
         <View
           onLayout={[Function]}
           style={
@@ -6224,6 +7105,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
                 }
@@ -6238,6 +7120,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -6415,6 +7306,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
                 }
@@ -6429,6 +7321,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -6606,6 +7507,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
                 }
@@ -6620,6 +7522,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -6761,8 +7672,35 @@ exports[`renders profile content component 1`] = `
             "paddingLeft": 10,
             "paddingRight": 10,
           }
+<<<<<<< HEAD
         }
       >
+=======
+        >
+          <View
+            onLayout={[Function]}
+          >
+            <Image
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+>>>>>>> 67b993e... chore: create state conversion for web
         <View
           onLayout={[Function]}
           style={
@@ -6970,8 +7908,45 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
+<<<<<<< HEAD
                   "paddingBottom": 15,
                 },
+=======
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+>>>>>>> 67b993e... chore: create state conversion for web
                 Object {
                   "flexGrow": 1,
                   "flexShrink": 1,
@@ -7179,6 +8154,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -7193,6 +8169,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -7370,6 +8355,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -7384,6 +8370,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -7619,6 +8614,7 @@ exports[`renders profile content component 1`] = `
                 ellipsizeMode="tail"
                 style={
                   Object {
+<<<<<<< HEAD
                     "color": "#333333",
                     "fontFamily": "TimesModern-Bold",
                     "fontSize": 22,
@@ -7673,6 +8669,15 @@ exports[`renders profile content component 1`] = `
                 , The Times
               </Text>
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
         </View>
       </View>
@@ -7957,6 +8962,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -7971,6 +8977,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -8161,6 +9176,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -8175,6 +9191,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 67b993e... chore: create state conversion for web
           </View>
           <View
             style={
@@ -8469,8 +9494,8 @@ exports[`renders profile header 1`] = `
           style={
             Array [
               Object {
-                "height": 1,
-                "width": 750,
+                "height": undefined,
+                "width": undefined,
               },
               Object {
                 "borderColor": "#FFF",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -946,8 +946,8 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -1139,6 +1139,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1156,6 +1157,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -1343,6 +1348,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1360,6 +1366,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -1549,6 +1559,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1566,6 +1577,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -1755,6 +1770,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -1772,6 +1788,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -1961,6 +1981,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
                     }
                   }
@@ -1978,6 +1999,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -2155,6 +2180,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -2172,6 +2198,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -2360,6 +2390,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                     }
                   }
@@ -2374,6 +2405,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 5e388c3... feat: map props depending on platform
             </View>
             <View
               style={
@@ -2730,8 +2770,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -2897,8 +2937,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3065,8 +3105,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -3277,6 +3317,7 @@ exports[`renders profile content 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                     }
                   }
@@ -3291,6 +3332,15 @@ exports[`renders profile content 1`] = `
                   }
                 />
               </View>
+=======
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 5e388c3... feat: map props depending on platform
             </View>
             <View
               style={
@@ -3453,8 +3503,45 @@ exports[`renders profile content 1`] = `
               style={
                 Array [
                   Object {
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
+=======
+                    "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": 1,
+                      "width": 750,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+            </View>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={Object {}}
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+>>>>>>> 5e388c3... feat: map props depending on platform
                   Object {
                     "flexGrow": 1,
                     "flexShrink": 1,
@@ -3656,6 +3743,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                     }
                   }
@@ -3673,6 +3761,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -3850,6 +3942,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
                     }
                   }
@@ -3867,6 +3960,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -4041,8 +4138,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4277,6 +4374,7 @@ exports[`renders profile content 1`] = `
                   source={
                     Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                       "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
                     }
                   }
@@ -4294,6 +4392,10 @@ exports[`renders profile content 1`] = `
 =======
                       "height": undefined,
                       "width": undefined,
+=======
+                      "height": 1,
+                      "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                     },
                     undefined,
                   ]
@@ -4462,8 +4564,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -4903,8 +5005,8 @@ exports[`renders profile content 1`] = `
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -5226,8 +5328,8 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
-                  "height": undefined,
-                  "width": undefined,
+                  "height": 1,
+                  "width": 750,
                 },
                 Object {
                   "borderColor": "#FFF",
@@ -5411,8 +5513,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -5568,7 +5670,49 @@ exports[`renders profile content component 1`] = `
           style={
             Array [
               Object {
+<<<<<<< HEAD
                 "flexDirection": "column",
+=======
+                "paddingBottom": 15,
+              },
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            onLayout={[Function]}
+          >
+            <Image
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+>>>>>>> 5e388c3... feat: map props depending on platform
               },
               null,
               undefined,
@@ -5809,6 +5953,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -5826,6 +5971,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -6022,6 +6171,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -6039,6 +6189,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -6235,6 +6389,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -6252,6 +6407,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -6448,6 +6607,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/10a7a0fb2847e9187b442e405f648f6f3e0602e8?crop=520%2C347%2C0%2C173",
                   }
                 }
@@ -6465,6 +6625,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -6649,6 +6813,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -6666,6 +6831,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -6870,8 +7039,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -7307,6 +7476,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
                 }
@@ -7324,6 +7494,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -7508,6 +7682,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/32c8f8856543fac1733907189c9ada3457b1baa3.jpg?crop=520%2C347%2C0%2C216",
                   }
                 }
@@ -7525,6 +7700,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -7691,8 +7870,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -7918,8 +8097,8 @@ exports[`renders profile content component 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   undefined,
                 ]
@@ -8136,8 +8315,45 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
+<<<<<<< HEAD
                   "paddingBottom": 15,
                 },
+=======
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/adb4a48fc124b9cd4cf98c3a793ddae80d870e2e.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+>>>>>>> 5e388c3... feat: map props depending on platform
                 Object {
                   "flexGrow": 1,
                   "flexShrink": 1,
@@ -8337,8 +8553,45 @@ exports[`renders profile content component 1`] = `
             style={
               Array [
                 Object {
+<<<<<<< HEAD
                   "paddingBottom": 15,
                 },
+=======
+                  "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0a36e5e3aa3fa281979258f23ec7d9bb0b1316b7.jpg?crop=780%2C520%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={
+            Array [
+              Object {
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={Object {}}
+          >
+            <Text
+              accessible={true}
+              allowFontScaling={true}
+              ellipsizeMode="tail"
+              style={
+>>>>>>> 5e388c3... feat: map props depending on platform
                 Object {
                   "flexGrow": 1,
                   "flexShrink": 1,
@@ -8563,6 +8816,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/e1099c348c8c727584842b53d5e708a0377770a2.jpg?crop=620%2C413%2C0%2C0",
                   }
                 }
@@ -8577,6 +8831,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 5e388c3... feat: map props depending on platform
           </View>
           <View
             style={
@@ -8764,6 +9027,7 @@ exports[`renders profile content component 1`] = `
                 onLoad={[Function]}
                 source={
                   Object {
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/eee1c7f320c3690dce7ee275ceb77e915c61c4f3.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -8778,6 +9042,15 @@ exports[`renders profile content component 1`] = `
                 }
               />
             </View>
+=======
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+>>>>>>> 5e388c3... feat: map props depending on platform
           </View>
           <View
             style={
@@ -8963,6 +9236,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -8980,6 +9254,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -9177,6 +9455,7 @@ exports[`renders profile content component 1`] = `
                 source={
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "uri": "http://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/0d5fa06d6b10cfbbc2dade5f0d7b0271fccd994b.jpg?crop=780%2C520%2C0%2C0",
                   }
                 }
@@ -9194,6 +9473,10 @@ exports[`renders profile content component 1`] = `
 =======
                     "height": undefined,
                     "width": undefined,
+=======
+                    "height": 1,
+                    "width": 750,
+>>>>>>> 5e388c3... feat: map props depending on platform
                   },
                   undefined,
                 ]
@@ -9494,8 +9777,8 @@ exports[`renders profile header 1`] = `
           style={
             Array [
               Object {
-                "height": undefined,
-                "width": undefined,
+                "height": 1,
+                "width": 750,
               },
               Object {
                 "borderColor": "#FFF",

--- a/packages/caption/__tests__/__snapshots__/caption.android.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.android.native.test.js.snap
@@ -2,28 +2,25 @@
 
 exports[`renders an image with a caption 1`] = `
 <View>
-  <View
+  <Image
+    onError={[Function]}
     onLayout={[Function]}
-  >
-    <Image
-      onError={[Function]}
-      onLoad={[Function]}
-      source={
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+      }
+    }
+    style={
+      Array [
         Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Array [
-          Object {
-            "height": 1,
-            "width": 750,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
   <View
     style={
       Array [

--- a/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
@@ -16,8 +16,8 @@ exports[`renders an image with a caption 1`] = `
       style={
         Array [
           Object {
-            "height": 1,
-            "width": 750,
+            "height": undefined,
+            "width": undefined,
           },
           undefined,
         ]

--- a/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
@@ -16,8 +16,8 @@ exports[`renders an image with a caption 1`] = `
       style={
         Array [
           Object {
-            "height": undefined,
-            "width": undefined,
+            "height": 1,
+            "width": 750,
           },
           undefined,
         ]

--- a/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.ios.native.test.js.snap
@@ -2,28 +2,25 @@
 
 exports[`renders an image with a caption 1`] = `
 <View>
-  <View
+  <Image
+    onError={[Function]}
     onLayout={[Function]}
-  >
-    <Image
-      onError={[Function]}
-      onLoad={[Function]}
-      source={
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+      }
+    }
+    style={
+      Array [
         Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Array [
-          Object {
-            "height": 1,
-            "width": 750,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
   <View
     style={
       Array [

--- a/packages/caption/__tests__/__snapshots__/caption.web.test.js.snap
+++ b/packages/caption/__tests__/__snapshots__/caption.web.test.js.snap
@@ -2,28 +2,25 @@
 
 exports[`renders an image with a caption 1`] = `
 <View>
-  <View
+  <Image
+    onError={[Function]}
     onLayout={[Function]}
-  >
-    <Image
-      onError={[Function]}
-      onLoad={[Function]}
-      source={
+    onLoad={[Function]}
+    source={
+      Object {
+        "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+      }
+    }
+    style={
+      Array [
         Object {
-          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-        }
-      }
-      style={
-        Array [
-          Object {
-            "height": 1,
-            "width": 750,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
+          "height": 1,
+          "width": 750,
+        },
+        undefined,
+      ]
+    }
+  />
   <View
     style={
       Array [

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -111,28 +111,25 @@ exports[`renders vertical by default 1`] = `
       ]
     }
   >
-    <View
+    <Image
+      onError={[Function]}
       onLayout={[Function]}
-    >
-      <Image
-        onError={[Function]}
-        onLoad={[Function]}
-        source={
+      onLoad={[Function]}
+      source={
+        Object {
+          "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
+        }
+      }
+      style={
+        Array [
           Object {
-            "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320",
-          }
-        }
-        style={
-          Array [
-            Object {
-              "height": 1,
-              "width": 750,
-            },
-            undefined,
-          ]
-        }
-      />
-    </View>
+            "height": 1,
+            "width": 750,
+          },
+          undefined,
+        ]
+      }
+    />
   </View>
   <View
     style={

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -125,8 +125,8 @@ exports[`renders vertical by default 1`] = `
         style={
           Array [
             Object {
-              "height": 1,
-              "width": 750,
+              "height": undefined,
+              "width": undefined,
             },
             undefined,
           ]

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -125,8 +125,8 @@ exports[`renders vertical by default 1`] = `
         style={
           Array [
             Object {
-              "height": undefined,
-              "width": undefined,
+              "height": 1,
+              "width": 750,
             },
             undefined,
           ]

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -9,14 +9,14 @@ exports[`prepends https schema 1`] = `
     onLoad={[Function]}
     source={
       Object {
-        "uri": "https://example.com/image.jpg",
+        "uri": "//example.com/image.jpg",
       }
     }
     style={
       Array [
         Object {
-          "height": 1,
-          "width": 750,
+          "height": undefined,
+          "width": undefined,
         },
         undefined,
       ]
@@ -40,8 +40,8 @@ exports[`renders correctly with no dimensions and given URI 1`] = `
     style={
       Array [
         Object {
-          "height": 1,
-          "width": 750,
+          "height": undefined,
+          "width": undefined,
         },
         undefined,
       ]

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -1,51 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prepends https schema 1`] = `
-<View
+<Image
+  onError={[Function]}
   onLayout={[Function]}
->
-  <Image
-    onError={[Function]}
-    onLoad={[Function]}
-    source={
+  onLoad={[Function]}
+  source={
+    Object {
+      "uri": "https://example.com/image.jpg",
+    }
+  }
+  style={
+    Array [
       Object {
-        "uri": "https://example.com/image.jpg",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "height": 1,
-          "width": 750,
-        },
-        undefined,
-      ]
-    }
-  />
-</View>
+        "height": 1,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+/>
 `;
 
 exports[`renders correctly with no dimensions and given URI 1`] = `
-<View
+<Image
+  onError={[Function]}
   onLayout={[Function]}
->
-  <Image
-    onError={[Function]}
-    onLoad={[Function]}
-    source={
+  onLoad={[Function]}
+  source={
+    Object {
+      "uri": "http://example.com/image.jpg",
+    }
+  }
+  style={
+    Array [
       Object {
-        "uri": "http://example.com/image.jpg",
-      }
-    }
-    style={
-      Array [
-        Object {
-          "height": 1,
-          "width": 750,
-        },
-        undefined,
-      ]
-    }
-  />
-</View>
+        "height": 1,
+        "width": 750,
+      },
+      undefined,
+    ]
+  }
+/>
 `;

--- a/packages/image/__snapshots__/image.test.js.snap
+++ b/packages/image/__snapshots__/image.test.js.snap
@@ -9,14 +9,14 @@ exports[`prepends https schema 1`] = `
     onLoad={[Function]}
     source={
       Object {
-        "uri": "//example.com/image.jpg",
+        "uri": "https://example.com/image.jpg",
       }
     }
     style={
       Array [
         Object {
-          "height": undefined,
-          "width": undefined,
+          "height": 1,
+          "width": 750,
         },
         undefined,
       ]
@@ -40,8 +40,8 @@ exports[`renders correctly with no dimensions and given URI 1`] = `
     style={
       Array [
         Object {
-          "height": undefined,
-          "width": undefined,
+          "height": 1,
+          "width": 750,
         },
         undefined,
       ]

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Image, View } from "react-native";
+import { Image } from "react-native";
 import placeholder from "./placeholder";
 import mapPropsToState from "./props-to-state";
 
@@ -63,17 +63,20 @@ class ImageComponent extends React.Component {
       source: this.state.source,
       style: [
         {
-          height: this.state.height,
-          width: this.state.width
+          height: this.state.height || "inherit",
+          width: this.state.width || "inherit"
         },
         this.props.style
       ]
     });
 
     return (
-      <View onLayout={this.handleLayout}>
-        <Image {...props} onError={this.handleError} onLoad={this.handleLoad} />
-      </View>
+      <Image
+        {...props}
+        onLayout={this.handleLayout}
+        onError={this.handleError}
+        onLoad={this.handleLoad}
+      />
     );
   }
 }

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -1,32 +1,13 @@
 import React from "react";
-import { Platform, Dimensions, Image, View } from "react-native";
+import { Image, View } from "react-native";
 import placeholder from "./placeholder";
-
-const window = Dimensions.get("window");
+import mapPropsToState from "./props-to-state";
 
 class ImageComponent extends React.Component {
   constructor(props) {
     super(props);
 
-    const uri = props.source && props.source.uri;
-
-    this.state = {
-      height: 1,
-      source: {
-        uri:
-          Platform.OS !== "web" && uri && uri.indexOf("//") === 0
-            ? `https:${uri}`
-            : uri
-      },
-      width: window.width,
-      ...Platform.select({
-        web: {
-          height: null,
-          width: null
-        }
-      })
-    };
-
+    this.state = mapPropsToState(props);
     this.getSize = Image.getSize;
     this.handleError = this.handleError.bind(this);
     this.handleLayout = this.handleLayout.bind(this);

--- a/packages/image/image.js
+++ b/packages/image/image.js
@@ -11,6 +11,7 @@ class ImageComponent extends React.Component {
     const uri = props.source && props.source.uri;
 
     this.state = {
+      height: 1,
       source: {
         uri:
           Platform.OS !== "web" && uri && uri.indexOf("//") === 0
@@ -18,7 +19,12 @@ class ImageComponent extends React.Component {
             : uri
       },
       width: window.width,
-      height: 1
+      ...Platform.select({
+        web: {
+          height: null,
+          width: null
+        }
+      })
     };
 
     this.getSize = Image.getSize;

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -17,7 +17,7 @@ const exampleNonImage = {
 
 const styles = StyleSheet.create({
   container: {
-    height: 256
+    width: 320
   },
   halfWidthView: {
     width: "50%"
@@ -32,7 +32,7 @@ storiesOf("Image", module)
   ))
   .add("Resized to half of full width, keeping aspect ratio", () => (
     <View style={[styles.container, styles.halfWidthView]}>
-      <Image source={exampleImage} />
+      <Image style={{ resizeMode: "center" }} source={exampleImage} />
     </View>
   ))
   .add("Show default image on error", () => (
@@ -46,9 +46,9 @@ storiesOf("Image", module)
     </View>
   ))
   .add("No schema url", () => (
-    <View style={{ width: 100, height: 100 }}>
+    <View style={[styles.container]}>
       <Image
-        resizeMode={"cover"}
+        style={{ resizeMode: "cover" }}
         source={{
           uri:
             "//www.thetimes.co.uk/imageserver/image/methode%2Fsundaytimes%2Fprod%2Fweb%2Fbin%2F9242e576-4dfc-11e7-a20e-a11097d3353d.jpg?crop=1463%2C975%2C293%2C12&resize=320"
@@ -59,7 +59,6 @@ storiesOf("Image", module)
   .add("Apply style to image", () => (
     <View style={{ width: 100, height: 100 }}>
       <Image
-        resizeMode={"cover"}
         style={{ borderRadius: 50, width: 100, height: 100 }}
         source={exampleImage}
       />

--- a/packages/image/image.stories.js
+++ b/packages/image/image.stories.js
@@ -1,4 +1,6 @@
+/* eslint-disable react/no-danger */
 import React from "react";
+import ReactDOMServer from "react-dom/server";
 import { StyleSheet, View } from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
@@ -62,4 +64,14 @@ storiesOf("Image", module)
         source={exampleImage}
       />
     </View>
-  ));
+  ))
+  .add("Server side rendered Image", () => {
+    const comp = (
+      <View style={[styles.container, styles.halfWidthView]}>
+        <Image style={{ resizeMode: "center" }} source={exampleImage} />
+      </View>
+    );
+    const markup = { __html: ReactDOMServer.renderToStaticMarkup(comp) };
+
+    return <div dangerouslySetInnerHTML={markup} />;
+  });

--- a/packages/image/image.web.js
+++ b/packages/image/image.web.js
@@ -1,0 +1,70 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import placeholder from "./placeholder";
+
+class Image extends Component {
+  constructor(props) {
+    super(props);
+
+    const { resizeMode, source, height, width, style } = this.props;
+
+    this.style = style;
+    this.defaults = {
+      height,
+      width
+    };
+    this.important = {
+      backgroundSize: resizeMode,
+      backgroundPosition: "center center",
+      backgroundRepeat: "no-repeat"
+    };
+
+    this.state = {
+      source
+    };
+
+    this.handleError = this.handleError.bind(this);
+  }
+
+  handleError() {
+    this.setState({
+      source: {
+        uri: placeholder
+      }
+    });
+  }
+
+  render() {
+    return (
+      <img
+        {...this.props}
+        alt=""
+        onError={this.handleError}
+        src={this.state.source.uri}
+        style={{ ...this.defaults, ...this.style, ...this.important }}
+      />
+    );
+  }
+}
+
+Image.propTypes = {
+  source: PropTypes.shape({
+    uri: PropTypes.string.isRequired
+  }),
+  resizeMode: PropTypes.string,
+  height: PropTypes.string,
+  width: PropTypes.string,
+  style: PropTypes.shape()
+};
+
+Image.defaultProps = {
+  source: {
+    uri: ""
+  },
+  resizeMode: "contain",
+  height: "inherit",
+  width: "inherit",
+  style: {}
+};
+
+export default Image;

--- a/packages/image/props-to-state.js
+++ b/packages/image/props-to-state.js
@@ -1,0 +1,5 @@
+export default ({ source }) => ({
+  source: {
+    uri: source && source.uri
+  }
+});

--- a/packages/image/props-to-state.js
+++ b/packages/image/props-to-state.js
@@ -1,5 +1,14 @@
-export default ({ source }) => ({
-  source: {
-    uri: source && source.uri
-  }
-});
+import { Dimensions } from "react-native";
+
+const window = Dimensions.get("window");
+export default ({ source }) => {
+  const uri = source.uri;
+
+  return {
+    height: 1,
+    source: {
+      uri: uri && uri.indexOf("//") === 0 ? `https:${uri}` : uri
+    },
+    width: window.width
+  };
+};

--- a/packages/image/props-to-state.web.js
+++ b/packages/image/props-to-state.web.js
@@ -1,0 +1,14 @@
+import { Dimensions } from "react-native";
+
+const window = Dimensions.get("window");
+export default ({ source }) => {
+  const uri = source.uri;
+
+  return {
+    height: 1,
+    source: {
+      uri: uri && uri.indexOf("//") === 0 ? `https:${uri}` : uri
+    },
+    width: window.width
+  };
+};

--- a/packages/image/props-to-state.web.js
+++ b/packages/image/props-to-state.web.js
@@ -1,14 +1,5 @@
-import { Dimensions } from "react-native";
-
-const window = Dimensions.get("window");
-export default ({ source }) => {
-  const uri = source.uri;
-
-  return {
-    height: 1,
-    source: {
-      uri: uri && uri.indexOf("//") === 0 ? `https:${uri}` : uri
-    },
-    width: window.width
-  };
-};
+export default ({ source }) => ({
+  source: {
+    uri: source && source.uri
+  }
+});

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -143,34 +143,31 @@ exports[`renders data 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
 >>>>>>> 67b993e... chore: create state conversion for web
       </View>
@@ -305,6 +302,7 @@ exports[`renders data 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -362,6 +360,39 @@ exports[`renders data 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -594,34 +625,31 @@ exports[`renders data from graphql 1`] = `
             }
           }
         >
-          <View
+          <Image
+            onError={[Function]}
             onLayout={[Function]}
-          >
-            <Image
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "",
+              }
+            }
+            style={
+              Array [
                 Object {
-                  "uri": "",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  Object {
-                    "borderColor": "#FFF",
-                    "borderRadius": 50,
-                    "borderWidth": 5,
-                    "height": 100,
-                    "width": 100,
-                  },
-                ]
-              }
-            />
-          </View>
+                  "height": 1,
+                  "width": 750,
+                },
+                Object {
+                  "borderColor": "#FFF",
+                  "borderRadius": 50,
+                  "borderWidth": 5,
+                  "height": 100,
+                  "width": 100,
+                },
+              ]
+            }
+          />
         </View>
 >>>>>>> 67b993e... chore: create state conversion for web
       </View>
@@ -756,6 +784,7 @@ exports[`renders data from graphql 1`] = `
               ]
             }
           >
+<<<<<<< HEAD
             <View
               style={
                 Array [
@@ -813,6 +842,39 @@ exports[`renders data from graphql 1`] = `
               />
 >>>>>>> 67b993e... chore: create state conversion for web
             </View>
+=======
+            <Image
+              onError={[Function]}
+              onLayout={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": 1,
+                    "width": 750,
+                  },
+                  undefined,
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                },
+                null,
+              ]
+            }
+          >
+>>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -131,45 +131,6 @@ exports[`renders data 1`] = `
             </Text>
           </Text>
         </View>
-<<<<<<< HEAD
-=======
-        <View
-          style={
-            Object {
-              "bottom": 0,
-              "height": 100,
-              "position": "absolute",
-              "width": 100,
-            }
-          }
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                Object {
-                  "borderColor": "#FFF",
-                  "borderRadius": 50,
-                  "borderWidth": 5,
-                  "height": 100,
-                  "width": 100,
-                },
-              ]
-            }
-          />
-        </View>
->>>>>>> 67b993e... chore: create state conversion for web
       </View>
       <View
         style={
@@ -302,13 +263,10 @@ exports[`renders data 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
                   Object {
@@ -319,33 +277,13 @@ exports[`renders data 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-=======
+                onLoad={[Function]}
+                source={
+                  Object {
                     "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
->>>>>>> 5e388c3... feat: map props depending on platform
                   }
                 }
                 style={
@@ -358,41 +296,7 @@ exports[`renders data 1`] = `
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [
@@ -613,45 +517,6 @@ exports[`renders data from graphql 1`] = `
             </Text>
           </Text>
         </View>
-<<<<<<< HEAD
-=======
-        <View
-          style={
-            Object {
-              "bottom": 0,
-              "height": 100,
-              "position": "absolute",
-              "width": 100,
-            }
-          }
-        >
-          <Image
-            onError={[Function]}
-            onLayout={[Function]}
-            onLoad={[Function]}
-            source={
-              Object {
-                "uri": "",
-              }
-            }
-            style={
-              Array [
-                Object {
-                  "height": 1,
-                  "width": 750,
-                },
-                Object {
-                  "borderColor": "#FFF",
-                  "borderRadius": 50,
-                  "borderWidth": 5,
-                  "height": 100,
-                  "width": 100,
-                },
-              ]
-            }
-          />
-        </View>
->>>>>>> 67b993e... chore: create state conversion for web
       </View>
       <View
         style={
@@ -784,13 +649,10 @@ exports[`renders data from graphql 1`] = `
               ]
             }
           >
-<<<<<<< HEAD
             <View
               style={
                 Array [
                   Object {
-<<<<<<< HEAD
-<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
                   Object {
@@ -801,33 +663,13 @@ exports[`renders data from graphql 1`] = `
                 ]
               }
             >
-              <View
+              <Image
+                onError={[Function]}
                 onLayout={[Function]}
-              >
-                <Image
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                    }
-                  }
-                  style={
-                    Array [
-                      Object {
-                        "height": 1,
-                        "width": 750,
-                      },
-                      undefined,
-                    ]
-                  }
-                />
-              </View>
-=======
-                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-=======
+                onLoad={[Function]}
+                source={
+                  Object {
                     "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
->>>>>>> 5e388c3... feat: map props depending on platform
                   }
                 }
                 style={
@@ -840,41 +682,7 @@ exports[`renders data from graphql 1`] = `
                   ]
                 }
               />
->>>>>>> 67b993e... chore: create state conversion for web
             </View>
-=======
-            <Image
-              onError={[Function]}
-              onLayout={[Function]}
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
-                }
-              }
-              style={
-                Array [
-                  Object {
-                    "height": 1,
-                    "width": 750,
-                  },
-                  undefined,
-                ]
-              }
-            />
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                },
-                null,
-              ]
-            }
-          >
->>>>>>> 1d7173d... fix: fixes image size with ssr
             <View
               style={
                 Array [

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -131,6 +131,48 @@ exports[`renders data 1`] = `
             </Text>
           </Text>
         </View>
+<<<<<<< HEAD
+=======
+        <View
+          style={
+            Object {
+              "bottom": 0,
+              "height": 100,
+              "position": "absolute",
+              "width": 100,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+          >
+            <Image
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  Object {
+                    "borderColor": "#FFF",
+                    "borderRadius": 50,
+                    "borderWidth": 5,
+                    "height": 100,
+                    "width": 100,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+>>>>>>> 67b993e... chore: create state conversion for web
       </View>
       <View
         style={
@@ -267,6 +309,7 @@ exports[`renders data 1`] = `
               style={
                 Array [
                   Object {
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
                   Object {
@@ -299,6 +342,21 @@ exports[`renders data 1`] = `
                   }
                 />
               </View>
+=======
+                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={
@@ -520,6 +578,48 @@ exports[`renders data from graphql 1`] = `
             </Text>
           </Text>
         </View>
+<<<<<<< HEAD
+=======
+        <View
+          style={
+            Object {
+              "bottom": 0,
+              "height": 100,
+              "position": "absolute",
+              "width": 100,
+            }
+          }
+        >
+          <View
+            onLayout={[Function]}
+          >
+            <Image
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
+                  },
+                  Object {
+                    "borderColor": "#FFF",
+                    "borderRadius": 50,
+                    "borderWidth": 5,
+                    "height": 100,
+                    "width": 100,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+>>>>>>> 67b993e... chore: create state conversion for web
       </View>
       <View
         style={
@@ -656,6 +756,7 @@ exports[`renders data from graphql 1`] = `
               style={
                 Array [
                   Object {
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
                   Object {
@@ -688,6 +789,21 @@ exports[`renders data from graphql 1`] = `
                   }
                 />
               </View>
+=======
+                    "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "height": undefined,
+                      "width": undefined,
+                    },
+                    undefined,
+                  ]
+                }
+              />
+>>>>>>> 67b993e... chore: create state conversion for web
             </View>
             <View
               style={

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -157,8 +157,8 @@ exports[`renders data 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -310,6 +310,7 @@ exports[`renders data 1`] = `
                 Array [
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
                   Object {
@@ -344,13 +345,16 @@ exports[`renders data 1`] = `
               </View>
 =======
                     "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+=======
+                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+>>>>>>> 5e388c3... feat: map props depending on platform
                   }
                 }
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]
@@ -604,8 +608,8 @@ exports[`renders data from graphql 1`] = `
               style={
                 Array [
                   Object {
-                    "height": undefined,
-                    "width": undefined,
+                    "height": 1,
+                    "width": 750,
                   },
                   Object {
                     "borderColor": "#FFF",
@@ -757,6 +761,7 @@ exports[`renders data from graphql 1`] = `
                 Array [
                   Object {
 <<<<<<< HEAD
+<<<<<<< HEAD
                     "paddingBottom": 15,
                   },
                   Object {
@@ -791,13 +796,16 @@ exports[`renders data from graphql 1`] = `
               </View>
 =======
                     "uri": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+=======
+                    "uri": "https://nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/90cfa89f4ebe003ab967e64b9c79c9afa520c273.jpg?crop=620%2C413%2C0%2C0",
+>>>>>>> 5e388c3... feat: map props depending on platform
                   }
                 }
                 style={
                   Array [
                     Object {
-                      "height": undefined,
-                      "width": undefined,
+                      "height": 1,
+                      "width": 750,
                     },
                     undefined,
                   ]


### PR DESCRIPTION
This PR supersedes of #206 

Web image component with fixed stories to work both on Native and Web.

_Right now the best approach would be to wrap `Image`s in a `View` and then size them directly instead of doing so on the `View`._