### PR TITLE
fix: update no-ads article fixture

### DIFF
--- a/packages/article/fixtures/no-ads.json
+++ b/packages/article/fixtures/no-ads.json
@@ -11,9 +11,10 @@
         "attributes": {},
         "children": [{
           "name": "text",
-          "children": [{
-            "text": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
-          }]
+          "attributes": {
+            "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent"
+          },
+          "children": []
         }]
       }],
       "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
@@ -36,34 +37,38 @@
           "attributes": {},
           "children": [{
               "name": "text",
-              "children": [{
-                "text": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
-              }]
+              "attributes": {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the "
+              },
+              "children": []
             },
             {
               "name": "italic",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "Telegraph "
-                }]
+                "attributes": {
+                  "value": "Telegraph "
+                },
+                "children": []
               }]
             },
             {
               "name": "text",
-              "children": [{
-                "text": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
-              }]
+              "attributes": {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”"
+              },
+              "children": []
             },
             {
               "name": "bold",
               "attributes": {},
               "children": [{
                 "name": "text",
-                "children": [{
-                  "text": "When Thatcher joined the campaign trail for the 2001 general election..."
-                }]
+                "attributes": {
+                  "value": "When Thatcher joined the campaign trail for the 2001 general election..."
+                },
+                "children": []
               }]
             }
           ]
@@ -76,10 +81,33 @@
             "attributes": {},
             "children": [{
               "name": "text",
-              "children": [{
-                "text": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
-              }]
+              "attributes": {
+                "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87."
+              },
+              "children": []
             }]
+          }]
+        },
+        {
+          "name": "image",
+          "attributes": {
+            "display": "primary",
+            "ratio": "16:9",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1600%2C900%2C-0%2C-0",
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits"
+          },
+          "children": []
+        },
+        {
+          "name": "paragraph",
+          "attributes": {},
+          "children": [{
+            "name": "text",
+            "attributes": {
+              "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
+            },
+            "children": []
           }]
         },
         {
@@ -87,9 +115,32 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. "
-            }]
+            "attributes": {
+              "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
+            },
+            "children": []
+          }]
+        },
+        {
+          "name": "image",
+          "attributes": {
+            "display": "secondary",
+            "ratio": "3:2",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=1200%2C800%2C-0%2C-0",
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits"
+          },
+          "children": []
+        },
+        {
+          "name": "paragraph",
+          "attributes": {},
+          "children": [{
+            "name": "text",
+            "attributes": {
+              "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
+            },
+            "children": []
           }]
         },
         {
@@ -97,9 +148,54 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. "
-            }]
+            "attributes": {
+              "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
+            },
+            "children": []
+          }]
+        },
+        {
+          "name": "image",
+          "attributes": {
+            "display": "inline",
+            "ratio": "1:1.50",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=800%2C1200%2C-0%2C-0",
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits"
+          },
+          "children": []
+        },
+        {
+          "name": "paragraph",
+          "attributes": {},
+          "children": [{
+            "name": "text",
+            "attributes": {
+              "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
+            },
+            "children": []
+          }]
+        },
+        {
+          "name": "image",
+          "attributes": {
+            "display": "inline",
+            "ratio": "3:2",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=600%2C400%2C-0%2C-0",
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits"
+          },
+          "children": []
+        },
+        {
+          "name": "paragraph",
+          "attributes": {},
+          "children": [{
+            "name": "text",
+            "attributes": {
+              "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
+            },
+            "children": []
           }]
         },
         {
@@ -107,9 +203,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. "
-            }]
+            "attributes": {
+              "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
+            },
+            "children": []
           }]
         },
         {
@@ -117,9 +214,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. "
-            }]
+            "attributes": {
+              "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
+            },
+            "children": []
           }]
         },
         {
@@ -127,9 +225,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. "
-            }]
+            "attributes": {
+              "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
+            },
+            "children": []
           }]
         },
         {
@@ -137,9 +236,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. "
-            }]
+            "attributes": {
+              "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
+            },
+            "children": []
           }]
         },
         {
@@ -147,49 +247,10 @@
           "attributes": {},
           "children": [{
             "name": "text",
-            "children": [{
-              "text": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. "
-            }]
-          }]
-        },
-        {
-          "name": "paragraph",
-          "attributes": {},
-          "children": [{
-            "name": "text",
-            "children": [{
-              "text": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. "
-            }]
-          }]
-        },
-        {
-          "name": "paragraph",
-          "attributes": {},
-          "children": [{
-            "name": "text",
-            "children": [{
-              "text": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. "
-            }]
-          }]
-        },
-        {
-          "name": "paragraph",
-          "attributes": {},
-          "children": [{
-            "name": "text",
-            "children": [{
-              "text": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. "
-            }]
-          }]
-        },
-        {
-          "name": "paragraph",
-          "attributes": {},
-          "children": [{
-            "name": "text",
-            "children": [{
-              "text": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
-            }]
+            "attributes": {
+              "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. "
+            },
+            "children": []
           }]
         }
       ]


### PR DESCRIPTION
Updating the fixture for the article without ads. Fixing this issue:

<img width="821" alt="screen shot 2017-10-02 at 16 30 22" src="https://user-images.githubusercontent.com/5799039/31088979-6e21f536-a79a-11e7-8f7a-bd13e3438e77.png">
