### PR TITLE
fix: the next/previous page styling

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -987,28 +987,73 @@ exports[`renders profile content 1`] = `
             >
               <View />
               <View>
-                <Text
-                  accessibilityRole="link"
+                <View
+                  accessibilityComponentType={undefined}
+                  accessibilityLabel={undefined}
+                  accessibilityTraits={undefined}
                   accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  href="?page=2"
-                  onPress={[Function]}
+                  hitSlop={undefined}
+                  isTVSelectable={true}
+                  onLayout={undefined}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    Array [
-                      Object {
-                        "textDecorationLine": "underline",
-                      },
-                      Object {
-                        "color": "#006699",
-                        "fontFamily": "GillSansMTStd-Medium",
-                        "fontSize": 14,
-                      },
-                    ]
+                    Object {
+                      "opacity": 1,
+                    }
                   }
+                  testID={undefined}
+                  tvParallaxProperties={undefined}
                 >
-                  Next &gt;
-                </Text>
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "flex-start",
+                        "flexDirection": "row",
+                        "paddingLeft": 10,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "color": "#006699",
+                          "fontFamily": "GillSansMTStd-Medium",
+                          "fontSize": 15,
+                          "height": 15,
+                          "paddingRight": 10,
+                          "textAlign": "right",
+                        }
+                      }
+                    >
+                      Next
+                    </Text>
+                    <svg
+                      height={12}
+                      style={Object {}}
+                      viewBox="0 0 144 144"
+                      width={12}
+                    >
+                      <g
+                        fill="#006699"
+                        style={Object {}}
+                      >
+                        <path
+                          d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                          style={Object {}}
+                        />
+                      </g>
+                    </svg>
+                  </View>
+                </View>
               </View>
             </View>
           </View>
@@ -4412,28 +4457,73 @@ exports[`renders profile content 1`] = `
           >
             <View />
             <View>
-              <Text
-                accessibilityRole="link"
+              <View
+                accessibilityComponentType={undefined}
+                accessibilityLabel={undefined}
+                accessibilityTraits={undefined}
                 accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                href="?page=2"
-                onPress={[Function]}
+                hitSlop={undefined}
+                isTVSelectable={true}
+                onLayout={undefined}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "textDecorationLine": "underline",
-                    },
-                    Object {
-                      "color": "#006699",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 14,
-                    },
-                  ]
+                  Object {
+                    "opacity": 1,
+                  }
                 }
+                testID={undefined}
+                tvParallaxProperties={undefined}
               >
-                Next &gt;
-              </Text>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "flex-start",
+                      "flexDirection": "row",
+                      "paddingLeft": 10,
+                      "paddingRight": 12,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 15,
+                        "height": 15,
+                        "paddingRight": 10,
+                        "textAlign": "right",
+                      }
+                    }
+                  >
+                    Next
+                  </Text>
+                  <svg
+                    height={12}
+                    style={Object {}}
+                    viewBox="0 0 144 144"
+                    width={12}
+                  >
+                    <g
+                      fill="#006699"
+                      style={Object {}}
+                    >
+                      <path
+                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                        style={Object {}}
+                      />
+                    </g>
+                  </svg>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -4698,28 +4788,73 @@ exports[`renders profile content component 1`] = `
             >
               <View />
               <View>
-                <Text
-                  accessibilityRole="link"
+                <View
+                  accessibilityComponentType={undefined}
+                  accessibilityLabel={undefined}
+                  accessibilityTraits={undefined}
                   accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  href="?page=2"
-                  onPress={[Function]}
+                  hitSlop={undefined}
+                  isTVSelectable={true}
+                  onLayout={undefined}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    Array [
-                      Object {
-                        "textDecorationLine": "underline",
-                      },
-                      Object {
-                        "color": "#006699",
-                        "fontFamily": "GillSansMTStd-Medium",
-                        "fontSize": 14,
-                      },
-                    ]
+                    Object {
+                      "opacity": 1,
+                    }
                   }
+                  testID={undefined}
+                  tvParallaxProperties={undefined}
                 >
-                  Next &gt;
-                </Text>
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "flex-start",
+                        "flexDirection": "row",
+                        "paddingLeft": 10,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "color": "#006699",
+                          "fontFamily": "GillSansMTStd-Medium",
+                          "fontSize": 15,
+                          "height": 15,
+                          "paddingRight": 10,
+                          "textAlign": "right",
+                        }
+                      }
+                    >
+                      Next
+                    </Text>
+                    <svg
+                      height={12}
+                      style={Object {}}
+                      viewBox="0 0 144 144"
+                      width={12}
+                    >
+                      <g
+                        fill="#006699"
+                        style={Object {}}
+                      >
+                        <path
+                          d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                          style={Object {}}
+                        />
+                      </g>
+                    </svg>
+                  </View>
+                </View>
               </View>
             </View>
           </View>
@@ -8123,28 +8258,73 @@ exports[`renders profile content component 1`] = `
           >
             <View />
             <View>
-              <Text
-                accessibilityRole="link"
+              <View
+                accessibilityComponentType={undefined}
+                accessibilityLabel={undefined}
+                accessibilityTraits={undefined}
                 accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                href="?page=2"
-                onPress={[Function]}
+                hitSlop={undefined}
+                isTVSelectable={true}
+                onLayout={undefined}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "textDecorationLine": "underline",
-                    },
-                    Object {
-                      "color": "#006699",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 14,
-                    },
-                  ]
+                  Object {
+                    "opacity": 1,
+                  }
                 }
+                testID={undefined}
+                tvParallaxProperties={undefined}
               >
-                Next &gt;
-              </Text>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "flex-start",
+                      "flexDirection": "row",
+                      "paddingLeft": 10,
+                      "paddingRight": 12,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 15,
+                        "height": 15,
+                        "paddingRight": 10,
+                        "textAlign": "right",
+                      }
+                    }
+                  >
+                    Next
+                  </Text>
+                  <svg
+                    height={12}
+                    style={Object {}}
+                    viewBox="0 0 144 144"
+                    width={12}
+                  >
+                    <g
+                      fill="#006699"
+                      style={Object {}}
+                    >
+                      <path
+                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                        style={Object {}}
+                      />
+                    </g>
+                  </svg>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -8436,28 +8616,73 @@ exports[`renders profile header 1`] = `
         >
           <View />
           <View>
-            <Text
-              accessibilityRole="link"
+            <View
+              accessibilityComponentType={undefined}
+              accessibilityLabel={undefined}
+              accessibilityTraits={undefined}
               accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              href="?page=2"
-              onPress={[Function]}
+              hitSlop={undefined}
+              isTVSelectable={true}
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
-                Array [
-                  Object {
-                    "textDecorationLine": "underline",
-                  },
-                  Object {
-                    "color": "#006699",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 14,
-                  },
-                ]
+                Object {
+                  "opacity": 1,
+                }
               }
+              testID={undefined}
+              tvParallaxProperties={undefined}
             >
-              Next &gt;
-            </Text>
+              <View
+                style={
+                  Object {
+                    "alignItems": "flex-start",
+                    "flexDirection": "row",
+                    "paddingLeft": 10,
+                    "paddingRight": 12,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "height": 15,
+                      "paddingRight": 10,
+                      "textAlign": "right",
+                    }
+                  }
+                >
+                  Next
+                </Text>
+                <svg
+                  height={12}
+                  style={Object {}}
+                  viewBox="0 0 144 144"
+                  width={12}
+                >
+                  <g
+                    fill="#006699"
+                    style={Object {}}
+                  >
+                    <path
+                      d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                      style={Object {}}
+                    />
+                  </g>
+                </svg>
+              </View>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -987,28 +987,73 @@ exports[`renders profile content 1`] = `
             >
               <View />
               <View>
-                <Text
-                  accessibilityRole="link"
+                <View
+                  accessibilityComponentType={undefined}
+                  accessibilityLabel={undefined}
+                  accessibilityTraits={undefined}
                   accessible={true}
-                  allowFontScaling={true}
-                  ellipsizeMode="tail"
-                  href="?page=2"
-                  onPress={[Function]}
+                  hitSlop={undefined}
+                  isTVSelectable={true}
+                  onLayout={undefined}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
-                    Array [
-                      Object {
-                        "textDecorationLine": "underline",
-                      },
-                      Object {
-                        "color": "#006699",
-                        "fontFamily": "GillSansMTStd-Medium",
-                        "fontSize": 14,
-                      },
-                    ]
+                    Object {
+                      "opacity": 1,
+                    }
                   }
+                  testID={undefined}
+                  tvParallaxProperties={undefined}
                 >
-                  Next &gt;
-                </Text>
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "flex-start",
+                        "flexDirection": "row",
+                        "paddingLeft": 10,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "color": "#006699",
+                          "fontFamily": "GillSansMTStd-Medium",
+                          "fontSize": 15,
+                          "height": 15,
+                          "paddingRight": 10,
+                          "textAlign": "right",
+                        }
+                      }
+                    >
+                      Next
+                    </Text>
+                    <svg
+                      height={12}
+                      style={Object {}}
+                      viewBox="0 0 144 144"
+                      width={12}
+                    >
+                      <g
+                        fill="#006699"
+                        style={Object {}}
+                      >
+                        <path
+                          d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                          style={Object {}}
+                        />
+                      </g>
+                    </svg>
+                  </View>
+                </View>
               </View>
             </View>
           </View>
@@ -4412,28 +4457,73 @@ exports[`renders profile content 1`] = `
           >
             <View />
             <View>
-              <Text
-                accessibilityRole="link"
+              <View
+                accessibilityComponentType={undefined}
+                accessibilityLabel={undefined}
+                accessibilityTraits={undefined}
                 accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                href="?page=2"
-                onPress={[Function]}
+                hitSlop={undefined}
+                isTVSelectable={true}
+                onLayout={undefined}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "textDecorationLine": "underline",
-                    },
-                    Object {
-                      "color": "#006699",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 14,
-                    },
-                  ]
+                  Object {
+                    "opacity": 1,
+                  }
                 }
+                testID={undefined}
+                tvParallaxProperties={undefined}
               >
-                Next &gt;
-              </Text>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "flex-start",
+                      "flexDirection": "row",
+                      "paddingLeft": 10,
+                      "paddingRight": 12,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 15,
+                        "height": 15,
+                        "paddingRight": 10,
+                        "textAlign": "right",
+                      }
+                    }
+                  >
+                    Next
+                  </Text>
+                  <svg
+                    height={12}
+                    style={Object {}}
+                    viewBox="0 0 144 144"
+                    width={12}
+                  >
+                    <g
+                      fill="#006699"
+                      style={Object {}}
+                    >
+                      <path
+                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                        style={Object {}}
+                      />
+                    </g>
+                  </svg>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -4695,28 +4785,73 @@ exports[`renders profile content component 1`] = `
           >
             <View />
             <View>
-              <Text
-                accessibilityRole="link"
+              <View
+                accessibilityComponentType={undefined}
+                accessibilityLabel={undefined}
+                accessibilityTraits={undefined}
                 accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                href="?page=2"
-                onPress={[Function]}
+                hitSlop={undefined}
+                isTVSelectable={true}
+                onLayout={undefined}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
-                  Array [
-                    Object {
-                      "textDecorationLine": "underline",
-                    },
-                    Object {
-                      "color": "#006699",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 14,
-                    },
-                  ]
+                  Object {
+                    "opacity": 1,
+                  }
                 }
+                testID={undefined}
+                tvParallaxProperties={undefined}
               >
-                Next &gt;
-              </Text>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "flex-start",
+                      "flexDirection": "row",
+                      "paddingLeft": 10,
+                      "paddingRight": 12,
+                    }
+                  }
+                >
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#006699",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 15,
+                        "height": 15,
+                        "paddingRight": 10,
+                        "textAlign": "right",
+                      }
+                    }
+                  >
+                    Next
+                  </Text>
+                  <svg
+                    height={12}
+                    style={Object {}}
+                    viewBox="0 0 144 144"
+                    width={12}
+                  >
+                    <g
+                      fill="#006699"
+                      style={Object {}}
+                    >
+                      <path
+                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                        style={Object {}}
+                      />
+                    </g>
+                  </svg>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -8264,28 +8399,73 @@ exports[`renders profile content component 1`] = `
         >
           <View />
           <View>
-            <Text
-              accessibilityRole="link"
+            <View
+              accessibilityComponentType={undefined}
+              accessibilityLabel={undefined}
+              accessibilityTraits={undefined}
               accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              href="?page=2"
-              onPress={[Function]}
+              hitSlop={undefined}
+              isTVSelectable={true}
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
-                Array [
-                  Object {
-                    "textDecorationLine": "underline",
-                  },
-                  Object {
-                    "color": "#006699",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 14,
-                  },
-                ]
+                Object {
+                  "opacity": 1,
+                }
               }
+              testID={undefined}
+              tvParallaxProperties={undefined}
             >
-              Next &gt;
-            </Text>
+              <View
+                style={
+                  Object {
+                    "alignItems": "flex-start",
+                    "flexDirection": "row",
+                    "paddingLeft": 10,
+                    "paddingRight": 12,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "height": 15,
+                      "paddingRight": 10,
+                      "textAlign": "right",
+                    }
+                  }
+                >
+                  Next
+                </Text>
+                <svg
+                  height={12}
+                  style={Object {}}
+                  viewBox="0 0 144 144"
+                  width={12}
+                >
+                  <g
+                    fill="#006699"
+                    style={Object {}}
+                  >
+                    <path
+                      d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                      style={Object {}}
+                    />
+                  </g>
+                </svg>
+              </View>
+            </View>
           </View>
         </View>
       </View>
@@ -8576,28 +8756,73 @@ exports[`renders profile header 1`] = `
         >
           <View />
           <View>
-            <Text
-              accessibilityRole="link"
+            <View
+              accessibilityComponentType={undefined}
+              accessibilityLabel={undefined}
+              accessibilityTraits={undefined}
               accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              href="?page=2"
-              onPress={[Function]}
+              hitSlop={undefined}
+              isTVSelectable={true}
+              onLayout={undefined}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
-                Array [
-                  Object {
-                    "textDecorationLine": "underline",
-                  },
-                  Object {
-                    "color": "#006699",
-                    "fontFamily": "GillSansMTStd-Medium",
-                    "fontSize": 14,
-                  },
-                ]
+                Object {
+                  "opacity": 1,
+                }
               }
+              testID={undefined}
+              tvParallaxProperties={undefined}
             >
-              Next &gt;
-            </Text>
+              <View
+                style={
+                  Object {
+                    "alignItems": "flex-start",
+                    "flexDirection": "row",
+                    "paddingLeft": 10,
+                    "paddingRight": 12,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "height": 15,
+                      "paddingRight": 10,
+                      "textAlign": "right",
+                    }
+                  }
+                >
+                  Next
+                </Text>
+                <svg
+                  height={12}
+                  style={Object {}}
+                  viewBox="0 0 144 144"
+                  width={12}
+                >
+                  <g
+                    fill="#006699"
+                    style={Object {}}
+                  >
+                    <path
+                      d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                      style={Object {}}
+                    />
+                  </g>
+                </svg>
+              </View>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/pagination/__tests__/__snapshots__/pagination-icons.native.test.js.snap
+++ b/packages/pagination/__tests__/__snapshots__/pagination-icons.native.test.js.snap
@@ -1,0 +1,457 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationIcons Native Next page icon renders out an svg and the passed in label 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <View
+    style={
+        Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 10,
+            "paddingRight": 12,
+          }
+    }
+>
+    <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+            Object {
+                "color": "#006699",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 15,
+                "height": 15,
+                "paddingRight": 10,
+                "textAlign": "right",
+              }
+        }
+    >
+        a label
+    </Text>
+    <Svg
+        height={12}
+        viewBox="0 0 144 144"
+        width={12}
+    >
+        <G
+            fill="#006699"
+        >
+            <Path
+                d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+            />
+        </G>
+    </Svg>
+</View>,
+  "nodes": Array [
+    <View
+      style={
+            Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingLeft": 10,
+                  "paddingRight": 12,
+                }
+      }
+>
+      <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+                  Object {
+                        "color": "#006699",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 15,
+                        "height": 15,
+                        "paddingRight": 10,
+                        "textAlign": "right",
+                      }
+            }
+      >
+            a label
+      </Text>
+      <Svg
+            height={12}
+            viewBox="0 0 144 144"
+            width={12}
+      >
+            <G
+                  fill="#006699"
+            >
+                  <Path
+                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                  />
+            </G>
+      </Svg>
+</View>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <NextPageIcon
+        label="a label"
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "label": "a label",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <View
+          style={
+                    Object {
+                              "alignItems": "center",
+                              "flexDirection": "row",
+                              "paddingLeft": 10,
+                              "paddingRight": 12,
+                            }
+          }
+>
+          <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                              Object {
+                                        "color": "#006699",
+                                        "fontFamily": "GillSansMTStd-Medium",
+                                        "fontSize": 15,
+                                        "height": 15,
+                                        "paddingRight": 10,
+                                        "textAlign": "right",
+                                      }
+                    }
+          >
+                    a label
+          </Text>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                              />
+                    </G>
+          </Svg>
+</View>,
+        "_debugID": 4,
+        "_renderedOutput": <View
+          style={
+                    Object {
+                              "alignItems": "center",
+                              "flexDirection": "row",
+                              "paddingLeft": 10,
+                              "paddingRight": 12,
+                            }
+          }
+>
+          <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                              Object {
+                                        "color": "#006699",
+                                        "fontFamily": "GillSansMTStd-Medium",
+                                        "fontSize": 15,
+                                        "height": 15,
+                                        "paddingRight": 10,
+                                        "textAlign": "right",
+                                      }
+                    }
+          >
+                    a label
+          </Text>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                              />
+                    </G>
+          </Svg>
+</View>,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <NextPageIcon
+    label="a label"
+/>,
+}
+`;
+
+exports[`PaginationIcons Native Previous page icon renders out an svg and the passed in label 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <View
+    style={
+        Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "paddingLeft": 10,
+          }
+    }
+>
+    <Svg
+        height={12}
+        viewBox="0 0 144 144"
+        width={12}
+    >
+        <G
+            fill="#006699"
+        >
+            <Path
+                d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+            />
+        </G>
+    </Svg>
+    <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+        style={
+            Object {
+                "color": "#006699",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 15,
+                "height": 15,
+                "paddingLeft": 10,
+                "textAlign": "left",
+              }
+        }
+    >
+        a label
+    </Text>
+</View>,
+  "nodes": Array [
+    <View
+      style={
+            Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingLeft": 10,
+                }
+      }
+>
+      <Svg
+            height={12}
+            viewBox="0 0 144 144"
+            width={12}
+      >
+            <G
+                  fill="#006699"
+            >
+                  <Path
+                        d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+                  />
+            </G>
+      </Svg>
+      <Text
+            accessible={true}
+            allowFontScaling={true}
+            ellipsizeMode="tail"
+            style={
+                  Object {
+                        "color": "#006699",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 15,
+                        "height": 15,
+                        "paddingLeft": 10,
+                        "textAlign": "left",
+                      }
+            }
+      >
+            a label
+      </Text>
+</View>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <PreviousPageIcon
+        label="a label"
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "label": "a label",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <View
+          style={
+                    Object {
+                              "alignItems": "center",
+                              "flexDirection": "row",
+                              "paddingLeft": 10,
+                            }
+          }
+>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+                              />
+                    </G>
+          </Svg>
+          <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                              Object {
+                                        "color": "#006699",
+                                        "fontFamily": "GillSansMTStd-Medium",
+                                        "fontSize": 15,
+                                        "height": 15,
+                                        "paddingLeft": 10,
+                                        "textAlign": "left",
+                                      }
+                    }
+          >
+                    a label
+          </Text>
+</View>,
+        "_debugID": 2,
+        "_renderedOutput": <View
+          style={
+                    Object {
+                              "alignItems": "center",
+                              "flexDirection": "row",
+                              "paddingLeft": 10,
+                            }
+          }
+>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+                              />
+                    </G>
+          </Svg>
+          <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                              Object {
+                                        "color": "#006699",
+                                        "fontFamily": "GillSansMTStd-Medium",
+                                        "fontSize": 15,
+                                        "height": 15,
+                                        "paddingLeft": 10,
+                                        "textAlign": "left",
+                                      }
+                    }
+          >
+                    a label
+          </Text>
+</View>,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <PreviousPageIcon
+    label="a label"
+/>,
+}
+`;

--- a/packages/pagination/__tests__/__snapshots__/pagination-icons.native.test.js.snap
+++ b/packages/pagination/__tests__/__snapshots__/pagination-icons.native.test.js.snap
@@ -11,7 +11,7 @@ ShallowWrapper {
   "node": <View
     style={
         Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "flexDirection": "row",
             "paddingLeft": 10,
             "paddingRight": 12,
@@ -53,7 +53,7 @@ ShallowWrapper {
     <View
       style={
             Object {
-                  "alignItems": "center",
+                  "alignItems": "flex-start",
                   "flexDirection": "row",
                   "paddingLeft": 10,
                   "paddingRight": 12,
@@ -133,7 +133,7 @@ ShallowWrapper {
         "_currentElement": <View
           style={
                     Object {
-                              "alignItems": "center",
+                              "alignItems": "flex-start",
                               "flexDirection": "row",
                               "paddingLeft": 10,
                               "paddingRight": 12,
@@ -175,7 +175,7 @@ ShallowWrapper {
         "_renderedOutput": <View
           style={
                     Object {
-                              "alignItems": "center",
+                              "alignItems": "flex-start",
                               "flexDirection": "row",
                               "paddingLeft": 10,
                               "paddingRight": 12,
@@ -241,7 +241,7 @@ ShallowWrapper {
   "node": <View
     style={
         Object {
-            "alignItems": "center",
+            "alignItems": "flex-start",
             "flexDirection": "row",
             "paddingLeft": 10,
           }
@@ -282,7 +282,7 @@ ShallowWrapper {
     <View
       style={
             Object {
-                  "alignItems": "center",
+                  "alignItems": "flex-start",
                   "flexDirection": "row",
                   "paddingLeft": 10,
                 }
@@ -361,7 +361,7 @@ ShallowWrapper {
         "_currentElement": <View
           style={
                     Object {
-                              "alignItems": "center",
+                              "alignItems": "flex-start",
                               "flexDirection": "row",
                               "paddingLeft": 10,
                             }
@@ -402,7 +402,7 @@ ShallowWrapper {
         "_renderedOutput": <View
           style={
                     Object {
-                              "alignItems": "center",
+                              "alignItems": "flex-start",
                               "flexDirection": "row",
                               "paddingLeft": 10,
                             }

--- a/packages/pagination/__tests__/__snapshots__/pagination-icons.web.test.js.snap
+++ b/packages/pagination/__tests__/__snapshots__/pagination-icons.web.test.js.snap
@@ -1,0 +1,309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationIcons Web Next page icon renders out an svg and the passed in label 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <View
+    style={64}
+>
+    <Text
+        style={66}
+    >
+        a label
+    </Text>
+    <Svg
+        height={12}
+        viewBox="0 0 144 144"
+        width={12}
+    >
+        <G
+            fill="#006699"
+        >
+            <Path
+                d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+            />
+        </G>
+    </Svg>
+</View>,
+  "nodes": Array [
+    <View
+      style={64}
+>
+      <Text
+            style={66}
+      >
+            a label
+      </Text>
+      <Svg
+            height={12}
+            viewBox="0 0 144 144"
+            width={12}
+      >
+            <G
+                  fill="#006699"
+            >
+                  <Path
+                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                  />
+            </G>
+      </Svg>
+</View>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <NextPageIcon
+        label="a label"
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "label": "a label",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <View
+          style={64}
+>
+          <Text
+                    style={66}
+          >
+                    a label
+          </Text>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                              />
+                    </G>
+          </Svg>
+</View>,
+        "_debugID": 4,
+        "_renderedOutput": <View
+          style={64}
+>
+          <Text
+                    style={66}
+          >
+                    a label
+          </Text>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+                              />
+                    </G>
+          </Svg>
+</View>,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <NextPageIcon
+    label="a label"
+/>,
+}
+`;
+
+exports[`PaginationIcons Web Previous page icon renders out an svg and the passed in label 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <View
+    style={65}
+>
+    <Svg
+        height={12}
+        viewBox="0 0 144 144"
+        width={12}
+    >
+        <G
+            fill="#006699"
+        >
+            <Path
+                d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+            />
+        </G>
+    </Svg>
+    <Text
+        style={67}
+    >
+        a label
+    </Text>
+</View>,
+  "nodes": Array [
+    <View
+      style={65}
+>
+      <Svg
+            height={12}
+            viewBox="0 0 144 144"
+            width={12}
+      >
+            <G
+                  fill="#006699"
+            >
+                  <Path
+                        d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+                  />
+            </G>
+      </Svg>
+      <Text
+            style={67}
+      >
+            a label
+      </Text>
+</View>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 2,
+      "_context": Object {},
+      "_currentElement": <PreviousPageIcon
+        label="a label"
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": StatelessComponent {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "label": "a label",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": NoopInternalComponent {
+        "_currentElement": <View
+          style={65}
+>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+                              />
+                    </G>
+          </Svg>
+          <Text
+                    style={67}
+          >
+                    a label
+          </Text>
+</View>,
+        "_debugID": 2,
+        "_renderedOutput": <View
+          style={65}
+>
+          <Svg
+                    height={12}
+                    viewBox="0 0 144 144"
+                    width={12}
+          >
+                    <G
+                              fill="#006699"
+                    >
+                              <Path
+                                        d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+                              />
+                    </G>
+          </Svg>
+          <Text
+                    style={67}
+          >
+                    a label
+          </Text>
+</View>,
+      },
+      "_renderedNodeType": 1,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <PreviousPageIcon
+    label="a label"
+/>,
+}
+`;

--- a/packages/pagination/__tests__/__snapshots__/pagination.native.test.js.snap
+++ b/packages/pagination/__tests__/__snapshots__/pagination.native.test.js.snap
@@ -71,7 +71,7 @@ ShallowWrapper {
     >
         <View />
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
                 style={
                     Object {
@@ -82,8 +82,10 @@ ShallowWrapper {
                 }
                 url="./2"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
@@ -151,7 +153,7 @@ ShallowWrapper {
       >
             <View />
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
                         style={
                               Object {
@@ -162,8 +164,10 @@ ShallowWrapper {
                         }
                         url="./2"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -291,7 +295,7 @@ ShallowWrapper {
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -302,8 +306,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -371,7 +377,7 @@ ShallowWrapper {
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -382,8 +388,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -480,7 +488,7 @@ ShallowWrapper {
         }
     >
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
                 style={
                     Object {
@@ -491,11 +499,13 @@ ShallowWrapper {
                 }
                 url="./1"
             >
-                &lt; Previous
-            </TextLink>
+                <PreviousPageIcon
+                    label="Previous"
+                />
+            </Link>
         </View>
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
                 style={
                     Object {
@@ -506,8 +516,10 @@ ShallowWrapper {
                 }
                 url="./3"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
@@ -574,7 +586,7 @@ ShallowWrapper {
             }
       >
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
                         style={
                               Object {
@@ -585,11 +597,13 @@ ShallowWrapper {
                         }
                         url="./1"
                   >
-                        &lt; Previous
-                  </TextLink>
+                        <PreviousPageIcon
+                              label="Previous"
+                        />
+                  </Link>
             </View>
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
                         style={
                               Object {
@@ -600,8 +614,10 @@ ShallowWrapper {
                         }
                         url="./3"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -728,7 +744,7 @@ ShallowWrapper {
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -739,11 +755,13 @@ ShallowWrapper {
                                         }
                                         url="./1"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -754,8 +772,10 @@ ShallowWrapper {
                                         }
                                         url="./3"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -822,7 +842,7 @@ ShallowWrapper {
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -833,11 +853,13 @@ ShallowWrapper {
                                         }
                                         url="./1"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -848,8 +870,10 @@ ShallowWrapper {
                                         }
                                         url="./3"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -946,7 +970,7 @@ ShallowWrapper {
         }
     >
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
                 style={
                     Object {
@@ -957,8 +981,10 @@ ShallowWrapper {
                 }
                 url="./2"
             >
-                &lt; Previous
-            </TextLink>
+                <PreviousPageIcon
+                    label="Previous"
+                />
+            </Link>
         </View>
         <View />
     </View>
@@ -1026,7 +1052,7 @@ ShallowWrapper {
             }
       >
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
                         style={
                               Object {
@@ -1037,8 +1063,10 @@ ShallowWrapper {
                         }
                         url="./2"
                   >
-                        &lt; Previous
-                  </TextLink>
+                        <PreviousPageIcon
+                              label="Previous"
+                        />
+                  </Link>
             </View>
             <View />
       </View>
@@ -1166,7 +1194,7 @@ ShallowWrapper {
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -1177,8 +1205,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View />
           </View>
@@ -1246,7 +1276,7 @@ ShallowWrapper {
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -1257,8 +1287,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View />
           </View>
@@ -1357,7 +1389,7 @@ ShallowWrapper {
     >
         <View />
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
                 style={
                     Object {
@@ -1368,8 +1400,10 @@ ShallowWrapper {
                 }
                 url="./2"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
@@ -1437,7 +1471,7 @@ ShallowWrapper {
       >
             <View />
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
                         style={
                               Object {
@@ -1448,8 +1482,10 @@ ShallowWrapper {
                         }
                         url="./2"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -1577,7 +1613,7 @@ ShallowWrapper {
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -1588,8 +1624,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -1657,7 +1695,7 @@ ShallowWrapper {
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -1668,8 +1706,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -1734,7 +1774,7 @@ ShallowWrapper {
     >
         <View />
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
                 style={
                     Object {
@@ -1745,8 +1785,10 @@ ShallowWrapper {
                 }
                 url="./2"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
@@ -1781,7 +1823,7 @@ ShallowWrapper {
       >
             <View />
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
                         style={
                               Object {
@@ -1792,8 +1834,10 @@ ShallowWrapper {
                         }
                         url="./2"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -1888,7 +1932,7 @@ ShallowWrapper {
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -1899,8 +1943,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -1935,7 +1981,7 @@ ShallowWrapper {
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
                                         style={
                                                   Object {
@@ -1946,8 +1992,10 @@ ShallowWrapper {
                                         }
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,

--- a/packages/pagination/__tests__/__snapshots__/pagination.web.test.js.snap
+++ b/packages/pagination/__tests__/__snapshots__/pagination.web.test.js.snap
@@ -10,13 +10,13 @@ ShallowWrapper {
   "length": 1,
   "node": <View
     onLayout={[Function]}
-    style={68}
+    style={72}
 >
     <View
         style={
             Array [
-                69,
-                71,
+                73,
+                75,
                 null,
               ]
         }
@@ -24,7 +24,7 @@ ShallowWrapper {
         <Text
             style={
                 Array [
-                    70,
+                    74,
                   ]
             }
         >
@@ -34,33 +34,35 @@ ShallowWrapper {
     <View
         style={
             Array [
-                69,
-                67,
+                73,
+                71,
               ]
         }
     >
         <View />
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
-                style={66}
+                style={70}
                 url="./2"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
   "nodes": Array [
     <View
       onLayout={[Function]}
-      style={68}
+      style={72}
 >
       <View
             style={
                   Array [
-                        69,
-                        71,
+                        73,
+                        75,
                         null,
                       ]
             }
@@ -68,7 +70,7 @@ ShallowWrapper {
             <Text
                   style={
                         Array [
-                              70,
+                              74,
                             ]
                   }
             >
@@ -78,20 +80,22 @@ ShallowWrapper {
       <View
             style={
                   Array [
-                        69,
-                        67,
+                        73,
+                        71,
                       ]
             }
       >
             <View />
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
-                        style={66}
+                        style={70}
                         url="./2"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -158,13 +162,13 @@ ShallowWrapper {
       "_renderedComponent": NoopInternalComponent {
         "_currentElement": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -172,7 +176,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -182,33 +186,35 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
         "_debugID": 2,
         "_renderedOutput": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -216,7 +222,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -226,20 +232,22 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -276,13 +284,13 @@ ShallowWrapper {
   "length": 1,
   "node": <View
     onLayout={[Function]}
-    style={68}
+    style={72}
 >
     <View
         style={
             Array [
-                69,
-                71,
+                73,
+                75,
                 null,
               ]
         }
@@ -290,7 +298,7 @@ ShallowWrapper {
         <Text
             style={
                 Array [
-                    70,
+                    74,
                   ]
             }
         >
@@ -300,41 +308,45 @@ ShallowWrapper {
     <View
         style={
             Array [
-                69,
-                67,
+                73,
+                71,
               ]
         }
     >
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
-                style={66}
+                style={70}
                 url="./1"
             >
-                &lt; Previous
-            </TextLink>
+                <PreviousPageIcon
+                    label="Previous"
+                />
+            </Link>
         </View>
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
-                style={66}
+                style={70}
                 url="./3"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
   "nodes": Array [
     <View
       onLayout={[Function]}
-      style={68}
+      style={72}
 >
       <View
             style={
                   Array [
-                        69,
-                        71,
+                        73,
+                        75,
                         null,
                       ]
             }
@@ -342,7 +354,7 @@ ShallowWrapper {
             <Text
                   style={
                         Array [
-                              70,
+                              74,
                             ]
                   }
             >
@@ -352,28 +364,32 @@ ShallowWrapper {
       <View
             style={
                   Array [
-                        69,
-                        67,
+                        73,
+                        71,
                       ]
             }
       >
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
-                        style={66}
+                        style={70}
                         url="./1"
                   >
-                        &lt; Previous
-                  </TextLink>
+                        <PreviousPageIcon
+                              label="Previous"
+                        />
+                  </Link>
             </View>
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
-                        style={66}
+                        style={70}
                         url="./3"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -440,13 +456,13 @@ ShallowWrapper {
       "_renderedComponent": NoopInternalComponent {
         "_currentElement": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -454,7 +470,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -464,41 +480,45 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./1"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./3"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
         "_debugID": 8,
         "_renderedOutput": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -506,7 +526,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -516,28 +536,32 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./1"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./3"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -574,13 +598,13 @@ ShallowWrapper {
   "length": 1,
   "node": <View
     onLayout={[Function]}
-    style={68}
+    style={72}
 >
     <View
         style={
             Array [
-                69,
-                71,
+                73,
+                75,
                 null,
               ]
         }
@@ -588,7 +612,7 @@ ShallowWrapper {
         <Text
             style={
                 Array [
-                    70,
+                    74,
                   ]
             }
         >
@@ -598,19 +622,21 @@ ShallowWrapper {
     <View
         style={
             Array [
-                69,
-                67,
+                73,
+                71,
               ]
         }
     >
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
-                style={66}
+                style={70}
                 url="./2"
             >
-                &lt; Previous
-            </TextLink>
+                <PreviousPageIcon
+                    label="Previous"
+                />
+            </Link>
         </View>
         <View />
     </View>
@@ -618,13 +644,13 @@ ShallowWrapper {
   "nodes": Array [
     <View
       onLayout={[Function]}
-      style={68}
+      style={72}
 >
       <View
             style={
                   Array [
-                        69,
-                        71,
+                        73,
+                        75,
                         null,
                       ]
             }
@@ -632,7 +658,7 @@ ShallowWrapper {
             <Text
                   style={
                         Array [
-                              70,
+                              74,
                             ]
                   }
             >
@@ -642,19 +668,21 @@ ShallowWrapper {
       <View
             style={
                   Array [
-                        69,
-                        67,
+                        73,
+                        71,
                       ]
             }
       >
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
-                        style={66}
+                        style={70}
                         url="./2"
                   >
-                        &lt; Previous
-                  </TextLink>
+                        <PreviousPageIcon
+                              label="Previous"
+                        />
+                  </Link>
             </View>
             <View />
       </View>
@@ -722,13 +750,13 @@ ShallowWrapper {
       "_renderedComponent": NoopInternalComponent {
         "_currentElement": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -736,7 +764,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -746,19 +774,21 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View />
           </View>
@@ -766,13 +796,13 @@ ShallowWrapper {
         "_debugID": 6,
         "_renderedOutput": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -780,7 +810,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -790,19 +820,21 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        &lt; Previous
-                              </TextLink>
+                                        <PreviousPageIcon
+                                                  label="Previous"
+                                        />
+                              </Link>
                     </View>
                     <View />
           </View>
@@ -840,13 +872,13 @@ ShallowWrapper {
   "length": 1,
   "node": <View
     onLayout={[Function]}
-    style={68}
+    style={72}
 >
     <View
         style={
             Array [
-                69,
-                71,
+                73,
+                75,
                 null,
               ]
         }
@@ -854,7 +886,7 @@ ShallowWrapper {
         <Text
             style={
                 Array [
-                    70,
+                    74,
                   ]
             }
         >
@@ -864,33 +896,35 @@ ShallowWrapper {
     <View
         style={
             Array [
-                69,
-                67,
+                73,
+                71,
               ]
         }
     >
         <View />
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
-                style={66}
+                style={70}
                 url="./2"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
   "nodes": Array [
     <View
       onLayout={[Function]}
-      style={68}
+      style={72}
 >
       <View
             style={
                   Array [
-                        69,
-                        71,
+                        73,
+                        75,
                         null,
                       ]
             }
@@ -898,7 +932,7 @@ ShallowWrapper {
             <Text
                   style={
                         Array [
-                              70,
+                              74,
                             ]
                   }
             >
@@ -908,20 +942,22 @@ ShallowWrapper {
       <View
             style={
                   Array [
-                        69,
-                        67,
+                        73,
+                        71,
                       ]
             }
       >
             <View />
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
-                        style={66}
+                        style={70}
                         url="./2"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -988,13 +1024,13 @@ ShallowWrapper {
       "_renderedComponent": NoopInternalComponent {
         "_currentElement": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -1002,7 +1038,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -1012,33 +1048,35 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
         "_debugID": 10,
         "_renderedOutput": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        71,
+                                        73,
+                                        75,
                                         null,
                                       ]
                     }
@@ -1046,7 +1084,7 @@ ShallowWrapper {
                     <Text
                               style={
                                         Array [
-                                                  70,
+                                                  74,
                                                 ]
                               }
                     >
@@ -1056,20 +1094,22 @@ ShallowWrapper {
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
@@ -1106,50 +1146,54 @@ ShallowWrapper {
   "length": 1,
   "node": <View
     onLayout={[Function]}
-    style={68}
+    style={72}
 >
     <View
         style={
             Array [
-                69,
-                67,
+                73,
+                71,
               ]
         }
     >
         <View />
         <View>
-            <TextLink
+            <Link
                 onPress={[Function]}
-                style={66}
+                style={70}
                 url="./2"
             >
-                Next &gt;
-            </TextLink>
+                <NextPageIcon
+                    label="Next"
+                />
+            </Link>
         </View>
     </View>
 </View>,
   "nodes": Array [
     <View
       onLayout={[Function]}
-      style={68}
+      style={72}
 >
       <View
             style={
                   Array [
-                        69,
-                        67,
+                        73,
+                        71,
                       ]
             }
       >
             <View />
             <View>
-                  <TextLink
+                  <Link
                         onPress={[Function]}
-                        style={66}
+                        style={70}
                         url="./2"
                   >
-                        Next &gt;
-                  </TextLink>
+                        <NextPageIcon
+                              label="Next"
+                        />
+                  </Link>
             </View>
       </View>
 </View>,
@@ -1216,50 +1260,54 @@ ShallowWrapper {
       "_renderedComponent": NoopInternalComponent {
         "_currentElement": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,
         "_debugID": 4,
         "_renderedOutput": <View
           onLayout={[Function]}
-          style={68}
+          style={72}
 >
           <View
                     style={
                               Array [
-                                        69,
-                                        67,
+                                        73,
+                                        71,
                                       ]
                     }
           >
                     <View />
                     <View>
-                              <TextLink
+                              <Link
                                         onPress={[Function]}
-                                        style={66}
+                                        style={70}
                                         url="./2"
                               >
-                                        Next &gt;
-                              </TextLink>
+                                        <NextPageIcon
+                                                  label="Next"
+                                        />
+                              </Link>
                     </View>
           </View>
 </View>,

--- a/packages/pagination/__tests__/pagination-icons.native.test.js
+++ b/packages/pagination/__tests__/pagination-icons.native.test.js
@@ -1,0 +1,4 @@
+/* eslint-env jest */
+import tests from './test-icons-helper';
+
+describe("PaginationIcons Native", tests);

--- a/packages/pagination/__tests__/pagination-icons.native.test.js
+++ b/packages/pagination/__tests__/pagination-icons.native.test.js
@@ -1,4 +1,4 @@
 /* eslint-env jest */
-import tests from './test-icons-helper';
+import tests from "./test-icons-helper";
 
 describe("PaginationIcons Native", tests);

--- a/packages/pagination/__tests__/pagination-icons.web.test.js
+++ b/packages/pagination/__tests__/pagination-icons.web.test.js
@@ -1,0 +1,4 @@
+/* eslint-env jest */
+import tests from './test-icons-helper';
+
+describe("PaginationIcons Web", tests);

--- a/packages/pagination/__tests__/pagination-icons.web.test.js
+++ b/packages/pagination/__tests__/pagination-icons.web.test.js
@@ -1,4 +1,4 @@
 /* eslint-env jest */
-import tests from './test-icons-helper';
+import tests from "./test-icons-helper";
 
 describe("PaginationIcons Web", tests);

--- a/packages/pagination/__tests__/test-icons-helper.js
+++ b/packages/pagination/__tests__/test-icons-helper.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+import React from 'react';
+import {Text} from 'react-native';
+import { shallow } from "enzyme";
+
+import tests from "./test-helper";
+import {PreviousPageIcon, NextPageIcon} from "../pagination-icons";
+
+export default () => {
+  describe("Previous page icon", () => {
+  it("renders out an svg and the passed in label", () => {
+    const icon = shallow(<PreviousPageIcon label="a label" />);
+    expect(icon).toMatchSnapshot();
+  });
+});
+
+  describe("Next page icon", () => {
+    it("renders out an svg and the passed in label", () => {
+      const icon = shallow(<NextPageIcon label="a label" />);
+      expect(icon).toMatchSnapshot();
+    });
+  });
+}

--- a/packages/pagination/__tests__/test-icons-helper.js
+++ b/packages/pagination/__tests__/test-icons-helper.js
@@ -1,18 +1,15 @@
 /* eslint-env jest */
-import React from 'react';
-import {Text} from 'react-native';
+import React from "react";
 import { shallow } from "enzyme";
-
-import tests from "./test-helper";
-import {PreviousPageIcon, NextPageIcon} from "../pagination-icons";
+import { PreviousPageIcon, NextPageIcon } from "../pagination-icons";
 
 export default () => {
   describe("Previous page icon", () => {
-  it("renders out an svg and the passed in label", () => {
-    const icon = shallow(<PreviousPageIcon label="a label" />);
-    expect(icon).toMatchSnapshot();
+    it("renders out an svg and the passed in label", () => {
+      const icon = shallow(<PreviousPageIcon label="a label" />);
+      expect(icon).toMatchSnapshot();
+    });
   });
-});
 
   describe("Next page icon", () => {
     it("renders out an svg and the passed in label", () => {
@@ -20,4 +17,4 @@ export default () => {
       expect(icon).toMatchSnapshot();
     });
   });
-}
+};

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -69,7 +69,8 @@
     "@times-components/link": "0.8.0",
     "prop-types": "15.5.10",
     "react-display-name": "0.2.3",
-    "react-native-web": "0.0.119"
+    "react-native-web": "0.0.119",
+    "svgs": "2.3.0"
   },
   "peerDependencies": {
     "react": ">=15",

--- a/packages/pagination/pagination-icons.js
+++ b/packages/pagination/pagination-icons.js
@@ -21,13 +21,13 @@ const container = {
   paddingLeft: 10,
   ...Platform.select({
     web: {
-      alignItems: "center"
+      alignItems: "flex-start"
     },
     android: {
-      alignItems: "baseline"
+      alignItems: "flex-end"
     },
     ios: {
-      alignItems: "center"
+      alignItems: "flex-start"
     }
   })
 };
@@ -61,42 +61,27 @@ const styles = StyleSheet.create({
   )
 });
 
-const svgData = {
-  next: {
-    d: "M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
-  },
-  previous: {
-    d: "M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
-  }
-};
-
-const IconSvg = d => (
-  <Svg width={12} height={12} viewBox="0 0 144 144">
-    <G fill="#006699">
-      <Path d={d} />
-    </G>
-  </Svg>
+export const NextPageIcon = props => (
+  <View style={styles.nextContainer}>
+    <Text style={styles.nextText}>{props.label}</Text>
+    <Svg width={12} height={12} viewBox="0 0 144 144">
+      <G fill="#006699">
+        <Path d="M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z" />
+      </G>
+    </Svg>
+  </View>
 );
 
-export const NextPageIcon = props => {
-  const iconData = svgData.next;
-  return (
-    <View style={styles.nextContainer}>
-      <Text style={styles.nextText}>{props.label}</Text>
-      {IconSvg(iconData.d)}
-    </View>
-  );
-};
-
-export const PreviousPageIcon = props => {
-  const iconData = svgData.previous;
-  return (
-    <View style={styles.previousContainer}>
-      {IconSvg(iconData.d)}
-      <Text style={styles.previousText}>{props.label}</Text>
-    </View>
-  );
-};
+export const PreviousPageIcon = props => (
+  <View style={styles.previousContainer}>
+    <Svg width={12} height={12} viewBox="0 0 144 144">
+      <G fill="#006699">
+        <Path d="M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z" />
+      </G>
+    </Svg>
+    <Text style={styles.previousText}>{props.label}</Text>
+  </View>
+);
 
 NextPageIcon.propTypes = {
   label: PropTypes.string.isRequired

--- a/packages/pagination/pagination-icons.js
+++ b/packages/pagination/pagination-icons.js
@@ -1,0 +1,107 @@
+import React from "react";
+import { Text, View, StyleSheet, Platform } from "react-native";
+import PropTypes from "prop-types";
+import Svg, { G, Path } from "svgs";
+
+const textStyle = {
+  height: 15,
+  fontFamily: "GillSansMTStd-Medium",
+  fontSize: 15,
+  color: "#006699",
+  ...Platform.select({
+    web: {
+      WebkitFontSmoothing: "antialiased",
+      MozOsxFontSmoothing: "grayscale"
+    }
+  })
+};
+
+const container = {
+  flexDirection: "row",
+  paddingLeft: 10,
+  ...Platform.select({
+    web: {
+      alignItems: "center"
+    },
+    android: {
+      alignItems: "baseline"
+    },
+    ios: {
+      alignItems: "center"
+    }
+  })
+};
+
+const styles = StyleSheet.create({
+  nextContainer: Object.assign(
+    {
+      paddingRight: 12
+    },
+    container
+  ),
+  previousContainer: Object.assign(
+    {
+      paddingLeft: 12
+    },
+    container
+  ),
+  nextText: Object.assign(
+    {
+      textAlign: "right",
+      paddingRight: 10
+    },
+    textStyle
+  ),
+  previousText: Object.assign(
+    {
+      textAlign: "left",
+      paddingLeft: 10
+    },
+    textStyle
+  )
+});
+
+const svgData = {
+  next: {
+    d: "M45.8,132L42,128.2,74.8,72,42,15.8,45.8,12,102,72Z"
+  },
+  previous: {
+    d: "M98.2,12l3.8,3.8L69.2,72,102,128.2,98.2,132,42,72Z"
+  }
+};
+
+const IconSvg = d => (
+  <Svg width={12} height={12} viewBox="0 0 144 144">
+    <G fill="#006699">
+      <Path d={d} />
+    </G>
+  </Svg>
+);
+
+export const NextPageIcon = props => {
+  const iconData = svgData.next;
+  return (
+    <View style={styles.nextContainer}>
+      <Text style={styles.nextText}>{props.label}</Text>
+      {IconSvg(iconData.d)}
+    </View>
+  );
+};
+
+export const PreviousPageIcon = props => {
+  const iconData = svgData.previous;
+  return (
+    <View style={styles.previousContainer}>
+      {IconSvg(iconData.d)}
+      <Text style={styles.previousText}>{props.label}</Text>
+    </View>
+  );
+};
+
+NextPageIcon.propTypes = {
+  label: PropTypes.string.isRequired
+};
+
+PreviousPageIcon.propTypes = {
+  label: PropTypes.string.isRequired
+};

--- a/packages/pagination/pagination.js
+++ b/packages/pagination/pagination.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { StyleSheet, Text, View, Platform } from "react-native";
 import PropTypes from "prop-types";
-import { TextLink } from "@times-components/link";
+import Link from "@times-components/link";
 import withPageState from "./pagination-wrapper";
+import { PreviousPageIcon, NextPageIcon } from "./pagination-icons";
 
 const styles = StyleSheet.create({
   absolute: {
@@ -108,27 +109,31 @@ class Pagination extends React.Component {
     const startResult = (page - 1) * pageSize + 1;
     const finalResult = Math.min(count, page * pageSize);
     const message = `Showing ${startResult} - ${finalResult} of ${count} results`;
+    const previousLabel = this.state.absolutePosition
+      ? "Previous Page"
+      : "Previous";
+    const nextLabel = this.state.absolutePosition ? "Next Page" : "Next";
 
     const prevComponent =
       startResult > pageSize ? (
-        <TextLink
+        <Link
           style={styles.arrow}
           onPress={(...params) => onPrev(page - 1, ...params)}
           url={generatePageLink(page - 1)}
         >
-          {"< Previous"}
-        </TextLink>
+          <PreviousPageIcon label={previousLabel} />
+        </Link>
       ) : null;
 
     const nextComponent =
       finalResult < count ? (
-        <TextLink
+        <Link
           style={styles.arrow}
           onPress={(...params) => onNext(page + 1, ...params)}
           url={generatePageLink(page + 1)}
         >
-          {"Next >"}
-        </TextLink>
+          <NextPageIcon label={nextLabel} />
+        </Link>
       ) : null;
 
     const messageComponent = !hideResults ? (

--- a/packages/pagination/pagination.stories.js
+++ b/packages/pagination/pagination.stories.js
@@ -5,6 +5,7 @@ import { storiesOf } from "@storybook/react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { action } from "@storybook/addon-actions";
 import Pagination, { withPageState } from "./pagination";
+import { PreviousPageIcon, NextPageIcon } from "./pagination-icons";
 
 storiesOf("Pagination", module)
   .addDecorator(story => <View style={{ paddingTop: 20 }}>{story()}</View>)
@@ -76,3 +77,8 @@ storiesOf("Pagination Helper", module)
   .add("Last page without results information", () => (
     <PageChanger page={3} count={60} hideResults />
   ));
+
+storiesOf("Pagination Icons", module)
+  .addDecorator(story => <View style={{ paddingTop: 20 }}>{story()}</View>)
+  .add("previous page icon", () => <PreviousPageIcon label="Previous Page" />)
+  .add("next page icon", () => <NextPageIcon label="Next Page" />);


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
This PR fixes the styling of the next and previous page icons in the pagination component.

Checked everything in storybook, and storybook native on all platforms.

### Android
![screen shot 2017-10-06 at 15 13 03](https://user-images.githubusercontent.com/7603827/31281924-dceeff84-aaa8-11e7-984e-3265e625510c.png)

### iOS
![screen shot 2017-10-06 at 15 12 25](https://user-images.githubusercontent.com/7603827/31281938-ebc4d22c-aaa8-11e7-8249-0d4bf4c1ad44.png)

### browser - narrow
![screen shot 2017-10-06 at 15 10 59](https://user-images.githubusercontent.com/7603827/31281953-fb486880-aaa8-11e7-9715-bab2fd0ffe37.png)

### browser - wide
![screen shot 2017-10-06 at 15 11 14](https://user-images.githubusercontent.com/7603827/31282022-304eca06-aaa9-11e7-8961-15b83e4982b9.png)


