### PR TITLE
fix: article summary font

### DIFF
--- a/packages/article-summary/__tests__/__snapshots__/article-summary.test.js.snap
+++ b/packages/article-summary/__tests__/__snapshots__/article-summary.test.js.snap
@@ -45,8 +45,9 @@ exports[`renders an article-summary component 1`] = `
       Object {
         "color": "#696969",
         "flexWrap": "wrap",
-        "fontFamily": "TimesDigitalW04",
+        "fontFamily": "TimesDigitalW04-Regular",
         "fontSize": 14,
+        "letterSpacing": 0.35,
         "lineHeight": 20,
         "marginBottom": 10,
       }
@@ -119,8 +120,9 @@ exports[`renders an article-summary component with content 1`] = `
       Object {
         "color": "#696969",
         "flexWrap": "wrap",
-        "fontFamily": "TimesDigitalW04",
+        "fontFamily": "TimesDigitalW04-Regular",
         "fontSize": 14,
+        "letterSpacing": 0.35,
         "lineHeight": 20,
         "marginBottom": 10,
       }

--- a/packages/article-summary/article-summary.js
+++ b/packages/article-summary/article-summary.js
@@ -1,11 +1,8 @@
 import React from "react";
-import { Text, View, Platform } from "react-native";
+import { Text, View } from "react-native";
 import PropTypes from "prop-types";
 import { renderTrees, treePropType } from "@times-components/markup";
 import DatePublication from "@times-components/date-publication";
-
-const fontFamilyWebAndIos = "TimesDigitalW04";
-const fontFamilyAndroid = "TimesDigitalW04-Regular";
 
 const styles = {
   container: {},
@@ -27,11 +24,11 @@ const styles = {
   text: {
     color: "#696969",
     fontSize: 14,
-    fontFamily:
-      Platform.OS === "android" ? fontFamilyAndroid : fontFamilyWebAndIos,
+    fontFamily: "TimesDigitalW04-Regular",
     lineHeight: 20,
     marginBottom: 10,
-    flexWrap: "wrap"
+    flexWrap: "wrap",
+    letterSpacing: 0.35
   }
 };
 

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -843,8 +843,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1000,8 +1001,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1137,8 +1139,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1310,8 +1313,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1503,8 +1507,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1696,8 +1701,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1889,8 +1895,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -2070,8 +2077,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -2263,8 +2271,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -2444,8 +2453,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3029,8 +3039,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3186,8 +3197,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3323,8 +3335,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3496,8 +3509,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3689,8 +3703,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3882,8 +3897,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -4075,8 +4091,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -4256,8 +4273,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -4449,8 +4467,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -4630,8 +4649,9 @@ exports[`renders profile content component 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -843,8 +843,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1000,8 +1001,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1137,8 +1139,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1310,8 +1313,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1503,8 +1507,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1696,8 +1701,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -1889,8 +1895,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -2070,8 +2077,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -2263,8 +2271,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -2444,8 +2453,9 @@ exports[`renders profile content 1`] = `
                     Object {
                       "color": "#696969",
                       "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
+                      "fontFamily": "TimesDigitalW04-Regular",
                       "fontSize": 14,
+                      "letterSpacing": 0.35,
                       "lineHeight": 20,
                       "marginBottom": 10,
                     }
@@ -3034,8 +3044,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -3199,8 +3210,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -3344,8 +3356,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -3525,8 +3538,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -3726,8 +3740,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -3927,8 +3942,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -4128,8 +4144,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -4317,8 +4334,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -4518,8 +4536,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }
@@ -4707,8 +4726,9 @@ exports[`renders profile content component 1`] = `
                   Object {
                     "color": "#696969",
                     "flexWrap": "wrap",
-                    "fontFamily": "TimesDigitalW04",
+                    "fontFamily": "TimesDigitalW04-Regular",
                     "fontSize": 14,
+                    "letterSpacing": 0.35,
                     "lineHeight": 20,
                     "marginBottom": 10,
                   }

--- a/packages/card/__tests__/__snapshots__/card.test.js.snap
+++ b/packages/card/__tests__/__snapshots__/card.test.js.snap
@@ -182,8 +182,9 @@ exports[`renders vertical by default 1`] = `
           Object {
             "color": "#696969",
             "flexWrap": "wrap",
-            "fontFamily": "TimesDigitalW04",
+            "fontFamily": "TimesDigitalW04-Regular",
             "fontSize": 14,
+            "letterSpacing": 0.35,
             "lineHeight": 20,
             "marginBottom": 10,
           }
@@ -289,8 +290,9 @@ exports[`renders without image 1`] = `
           Object {
             "color": "#696969",
             "flexWrap": "wrap",
-            "fontFamily": "TimesDigitalW04",
+            "fontFamily": "TimesDigitalW04-Regular",
             "fontSize": 14,
+            "letterSpacing": 0.35,
             "lineHeight": 20,
             "marginBottom": 10,
           }
@@ -396,8 +398,9 @@ exports[`renders without image url 1`] = `
           Object {
             "color": "#696969",
             "flexWrap": "wrap",
-            "fontFamily": "TimesDigitalW04",
+            "fontFamily": "TimesDigitalW04-Regular",
             "fontSize": 14,
+            "letterSpacing": 0.35,
             "lineHeight": 20,
             "marginBottom": 10,
           }


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Here are a list of screenshots that demonstrate what the fix has changed (designs [here](https://app.zeplin.io/project/59a6a2c092fb8c2b6944c504) for comparison).

ios old: 
![ios-original](https://user-images.githubusercontent.com/7603827/31348742-9286c9f0-ad18-11e7-9b4d-06e53185901b.png)
ios new:
![ios-fix](https://user-images.githubusercontent.com/7603827/31348745-971765a6-ad18-11e7-8d83-032ff373f36b.png)

desktop old: 
![desktop-original](https://user-images.githubusercontent.com/7603827/31348754-9ee6ada0-ad18-11e7-8db2-e2d92063db65.png)

desktop new:
![desktop-fix](https://user-images.githubusercontent.com/7603827/31348780-a66ea7e4-ad18-11e7-953f-fbdc04c61c49.png)

And to show that android is the same (as it was already using the correct font):
old:
![android-original](https://user-images.githubusercontent.com/7603827/31348797-ba88ce80-ad18-11e7-8e27-b7ba533292d0.png)
new:
![android-fix](https://user-images.githubusercontent.com/7603827/31348804-c0876a12-ad18-11e7-823b-5fbcad473d97.png)

