### PR TITLE
BREAKING CHANGE: change pagination event args order

### DIFF
--- a/packages/pagination/__tests__/test-wrapper-helper.js
+++ b/packages/pagination/__tests__/test-wrapper-helper.js
@@ -45,9 +45,7 @@ export default withPageState => () => {
     };
 
     const wrapper = shallow(<PageChanger {...props} />);
-    wrapper.instance().handleChangePage(1, {
-      preventDefault: () => {}
-    });
+    wrapper.instance().handleChangePage({ preventDefault: () => {} }, 1);
     wrapper.update();
 
     expect(wrapper.state().page).toEqual(1);
@@ -62,9 +60,7 @@ export default withPageState => () => {
     };
 
     const wrapper = shallow(<PageChanger {...props} />);
-    wrapper.instance().handleChangePage(3, {
-      preventDefault: () => {}
-    });
+    wrapper.instance().handleChangePage({ preventDefault: () => {} }, 3);
     wrapper.update();
 
     expect(wrapper.state().page).toEqual(3);

--- a/packages/pagination/pagination-wrapper.js
+++ b/packages/pagination/pagination-wrapper.js
@@ -19,7 +19,7 @@ export default Component => {
       );
     }
 
-    handleChangePage(page, event) {
+    handleChangePage(event, page) {
       this.setState({ page });
       event.preventDefault();
     }

--- a/packages/pagination/pagination.js
+++ b/packages/pagination/pagination.js
@@ -118,7 +118,7 @@ class Pagination extends React.Component {
       startResult > pageSize ? (
         <Link
           style={styles.arrow}
-          onPress={(...params) => onPrev(page - 1, ...params)}
+          onPress={e => onPrev(e, page - 1)}
           url={generatePageLink(page - 1)}
         >
           <PreviousPageIcon label={previousLabel} />
@@ -129,7 +129,7 @@ class Pagination extends React.Component {
       finalResult < count ? (
         <Link
           style={styles.arrow}
-          onPress={(...params) => onNext(page + 1, ...params)}
+          onPress={e => onNext(e, page + 1)}
           url={generatePageLink(page + 1)}
         >
           <NextPageIcon label={nextLabel} />


### PR DESCRIPTION
Makes synthetic event the first arg to the `onNext` and `onPrev` handlers to be consistent with  other components which use the same convention.

No visual changes.
