### PR TITLE
fix: update coverage patterns

### DIFF
--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-svg": "5.1.7",
+    "react-native-svg": "5.4.1",
     "react-native-web": "0.1.7",
     "svgs": "3.1.0"
   },

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -14,10 +14,8 @@
     "preset": "react-native",
     "rootDir": "../../",
     "collectCoverageFrom": [
-      "**/*.js",
-      "!**/*.stories.js",
-      "!__tests__/**",
-      "!coverage/**"
+      "**/packages/link/*.js",
+      "!**/packages/link/*.stories.js"
     ],
     "transformIgnorePatterns": ["node_modules/(?!@times-components)/"],
     "testMatch": ["<rootDir>/packages/link/__tests__/**/*.test.js"]

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -65,7 +65,7 @@
     "@times-components/link": "0.8.1",
     "prop-types": "15.6.0",
     "react-display-name": "0.2.3",
-    "react-native-svg": "5.1.7",
+    "react-native-svg": "5.4.1",
     "react-native-web": "0.1.7",
     "svgs": "3.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8680,9 +8680,9 @@ react-native-storybook-loader@1.5.1:
     glob "^7.1.1"
     yargs "^8.0.2"
 
-react-native-svg@5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-5.4.1.tgz#c46191c786adbe9d5007342b4279efd153db8839"
+react-native-svg@5.1.7:
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-5.1.7.tgz#444b18b51eb38ff63205befaf612f59a4cbf64be"
   dependencies:
     color "^0.11.1"
     lodash "^4.16.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8680,9 +8680,9 @@ react-native-storybook-loader@1.5.1:
     glob "^7.1.1"
     yargs "^8.0.2"
 
-react-native-svg@5.1.7:
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-5.1.7.tgz#444b18b51eb38ff63205befaf612f59a4cbf64be"
+react-native-svg@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-5.4.1.tgz#c46191c786adbe9d5007342b4279efd153db8839"
   dependencies:
     color "^0.11.1"
     lodash "^4.16.6"


### PR DESCRIPTION
Coverage is currently running on every `js` file, narrow to only the link package in order to restore sanity to the build

Also - the svg version were out of date with the other packages