### PR TITLE
chore: fixed time on CI to Europe/London

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 before_script:
   - chmod +x ./lib/publish.sh
+  - export TZ=Europe/London
 script:
   - yarn lint
   - yarn test


### PR DESCRIPTION
Accommodates for daylight savings when using recent articles for snapshots, where the articles contain dates since March 26th.

You can see the failing tests [here](https://travis-ci.org/newsuk/times-components/jobs/288511877).

Passing tests should appear [here](https://travis-ci.org/newsuk/times-components/builds/288576526).

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
