### PR TITLE
fix scrollRenderAheadDistance

### DIFF
--- a/packages/article/__tests__/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.android.test.js.snap
@@ -32,7 +32,7 @@ exports[`Article test on android renders article no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -695,7 +695,7 @@ exports[`Article test on android renders article no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -1463,7 +1463,7 @@ exports[`Article test on android renders article no label no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -2096,7 +2096,7 @@ exports[`Article test on android renders article no label no flags no standfirst
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -2711,7 +2711,7 @@ exports[`Article test on android renders article no standfirst 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -3491,7 +3491,7 @@ exports[`Article test on android renders article no standfirst no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -4136,7 +4136,7 @@ exports[`Article test on android renders article no standfirst no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -4886,7 +4886,7 @@ exports[`Article test on android renders full article 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View

--- a/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
@@ -32,7 +32,7 @@ exports[`Article test on ios renders article no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -695,7 +695,7 @@ exports[`Article test on ios renders article no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -1463,7 +1463,7 @@ exports[`Article test on ios renders article no label no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -2096,7 +2096,7 @@ exports[`Article test on ios renders article no label no flags no standfirst 1`]
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -2711,7 +2711,7 @@ exports[`Article test on ios renders article no standfirst 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -3491,7 +3491,7 @@ exports[`Article test on ios renders article no standfirst no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -4136,7 +4136,7 @@ exports[`Article test on ios renders article no standfirst no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View
@@ -4886,7 +4886,7 @@ exports[`Article test on ios renders full article 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
 >
   <View>
     <View

--- a/packages/article/article.js
+++ b/packages/article/article.js
@@ -28,7 +28,7 @@ import {
 const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 });
 const listViewPageSize = 1;
 const listViewSize = 10;
-const listViewScrollRenderAheadDistance = 10;
+const listViewScrollRenderAheadDistance = 500;
 
 const withAdComposer = (children, section = "article") => (
   <AdComposer section={section}>{children}</AdComposer>


### PR DESCRIPTION
I changed `scrollRenderAheadDistance` from 10 to 500 (my estimate of a device pixels height). The idea is to make loading ahead faster.
