### PR TITLE
fix scrollRenderAheadDistance

### DIFF
--- a/packages/article/__tests__/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.android.test.js.snap
@@ -55,7 +55,7 @@ exports[`Article test on android renders article no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -760,7 +760,7 @@ exports[`Article test on android renders article no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -1572,7 +1572,7 @@ exports[`Article test on android renders article no label no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -2245,7 +2245,7 @@ exports[`Article test on android renders article no label no flags no standfirst
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -2898,7 +2898,7 @@ exports[`Article test on android renders article no standfirst 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -3722,7 +3722,7 @@ exports[`Article test on android renders article no standfirst no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -4407,7 +4407,7 @@ exports[`Article test on android renders article no standfirst no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -5199,7 +5199,7 @@ exports[`Article test on android renders full article 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>

--- a/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
@@ -55,7 +55,7 @@ exports[`Article test on ios renders article no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -760,7 +760,7 @@ exports[`Article test on ios renders article no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -1572,7 +1572,7 @@ exports[`Article test on ios renders article no label no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -2245,7 +2245,7 @@ exports[`Article test on ios renders article no label no flags no standfirst 1`]
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -2898,7 +2898,7 @@ exports[`Article test on ios renders article no standfirst 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -3722,7 +3722,7 @@ exports[`Article test on ios renders article no standfirst no flags 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -4407,7 +4407,7 @@ exports[`Article test on ios renders article no standfirst no label 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>
@@ -5199,7 +5199,7 @@ exports[`Article test on ios renders full article 1`] = `
   pageSize={1}
   renderRow={[Function]}
   renderScrollComponent={[Function]}
-  scrollRenderAheadDistance={10}
+  scrollRenderAheadDistance={500}
   testID="listView"
 >
   <View>

--- a/packages/article/article.js
+++ b/packages/article/article.js
@@ -17,7 +17,7 @@ import ArticleMeta from "./article-meta";
 const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 });
 const listViewPageSize = 1;
 const listViewSize = 10;
-const listViewScrollRenderAheadDistance = 10;
+const listViewScrollRenderAheadDistance = 500;
 
 const withAdComposer = (children, section = "article") => (
   <AdComposer section={section}>{children}</AdComposer>


### PR DESCRIPTION
I changed `scrollRenderAheadDistance` from 10 to 500 (estimate of a device pixels height). The idea is to make loading ahead faster.
