### PR TITLE
chore: yarn android:device task

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,14 +97,10 @@ Follow these steps to deploy storybook native to a real android device.
 * Make sure your android device has trusted the connected computer and that `usb debugging / developer mode` has been turned on.
 * For Android <4.2 go to Developer Options => Enable USB Debugging, and for Android >=4.2 go to About Phone/Tablet => Tap Build Number 7 Times => Developer Options => Enable USB Debugging
 * Install android tooling through `brew cask install android-platform-tools`
-* Run `adb devices` and verify that your device is shown
 * Optionally start a local instance of [The Times Public Api](https://github.com/newsuk/times-public-api) (dependent on the stories you intend to view)
 * Run `yarn`
-* Run  `yarn storybook-native`
-* Run `adb reverse tcp:4000 tcp:4000` (to enable Times API)
-* Run `adb reverse tcp:8081 tcp:8081` (to enable live reloading)
-* Run `adb reverse tcp:7007 tcp:7007` (to enable Storybook native
-* Run `yarn android` this should install the app to your device
+* Run `yarn storybook-native`
+* Run `yarn android:device` (to enable Times API)
 * Open [storybook native](http:localhost:7007)  on your computer and load a story
 
 #### Troublshooting

--- a/lib/setup_device_connections.sh
+++ b/lib/setup_device_connections.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if ! adb devices -l | grep usb > /dev/null
+then
+  echo "No devices connected"
+  exit 1
+fi
+
+echo "Setting up socket connections..."
+
+echo "...local Times API"
+adb reverse tcp:4000 tcp:4000
+
+echo "...Storybook Native"
+adb reverse tcp:7007 tcp:7007
+
+echo "...enabling live reloading"
+adb reverse tcp:8081 tcp:8081

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ios": "react-native run-ios",
     "preandroid": "npm run fetch-fonts",
     "android": "react-native run-android",
+    "android:device": "./lib/setup_device_connections.sh && npm run android",
     "prettier:diff": "prettier --list-different 'packages/**/*.+(js|json)'",
     "fmt": "prettier --write '+(packages|storybook|.storybook.native|lib)/**/*.+(js|json)'",
     "packages:publish":


### PR DESCRIPTION
`yarn android:device` - Checks if a device is connected, sets up socket connections for live reloading, storybook and API, and runs the android task

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
