### PR TITLE
fix: style warning on android. Styles are not used in WebView

### DIFF
--- a/packages/article-headline/article-headline.android.js
+++ b/packages/article-headline/article-headline.android.js
@@ -2,11 +2,10 @@
 // https://github.com/facebook/react-native/pull/13199
 
 import React from "react";
-import StylePropTypes from "react-style-proptype";
 import PropTypes from "prop-types";
 import WebViewAutoHeight from "./WebView-auto-height";
 
-const ArticleHeadline = ({ text, style, baseUrl }) => {
+const ArticleHeadline = ({ text, baseUrl }) => {
   const html = `
     <div>
       <style>
@@ -30,17 +29,15 @@ const ArticleHeadline = ({ text, style, baseUrl }) => {
     </div>
   `;
 
-  return <WebViewAutoHeight source={{ html, baseUrl }} style={style} />;
+  return <WebViewAutoHeight source={{ html, baseUrl }} />;
 };
 
 ArticleHeadline.propTypes = {
   text: PropTypes.string.isRequired,
-  style: StylePropTypes,
   baseUrl: PropTypes.string
 };
 
 ArticleHeadline.defaultProps = {
-  style: null,
   baseUrl: "https://www.thetimes.co.uk/"
 };
 


### PR DESCRIPTION
Fix these warnings:

![image](https://user-images.githubusercontent.com/1150553/31885362-2cc0e008-b7e8-11e7-87fb-2eb549d89925.png)

![image](https://user-images.githubusercontent.com/1150553/31885373-35bed9da-b7e8-11e7-85d8-6ef58f481bd0.png)




