### PR TITLE
fix: article headline title

### DIFF
--- a/packages/article-headline/WebView-auto-height.js
+++ b/packages/article-headline/WebView-auto-height.js
@@ -58,8 +58,8 @@ class WebViewAutoHeight extends React.Component {
   }
 
   handleNavigationChange(navState) {
-    if (navState.text) {
-      const realContentHeight = parseInt(navState.text, 10) || 0; // turn NaN to 0
+    if (navState.title) {
+      const realContentHeight = parseInt(navState.title, 10) || 0; // turn NaN to 0
       this.setState({ realContentHeight });
     }
     if (typeof this.props.onNavigationStateChange === "function") {


### PR DESCRIPTION
Reverts https://github.com/newsuk/times-components/pull/283/commits/a4662e47a304c9061329b34facd70149ef03f073#diff-e0bac437a16d31411da016800dee1cb4L60

And fixes headline:
![image](https://user-images.githubusercontent.com/1150553/31950573-ce99f4be-b8d3-11e7-8513-2f31be2badea.png)
