### PR TITLE
Fix: font-forge hack metadata for TimesDigitalW04-RegularSC font

### DIFF
--- a/.fructose/head.html
+++ b/.fructose/head.html
@@ -14,8 +14,8 @@
     }
 
     @font-face {
-        font-family: TimesDigital-RegularSC;
-        src: url(/fonts/TimesDigital-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigital-RegularSC.woff) format("woff"), url(/fonts/TimesDigital-RegularSC.ttf) format("truetype");
+        font-family: TimesDigitalW04-RegularSC;
+        src: url(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"), url(/fonts/TimesDigitalW04-RegularSC.ttf) format("truetype");
         font-weight: 400;
         font-style: normal
     }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -14,8 +14,8 @@
     }
 
     @font-face {
-        font-family: TimesDigital-RegularSC;
-        src: url(/fonts/TimesDigital-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigital-RegularSC.woff) format("woff"), url(/fonts/TimesDigital-RegularSC.ttf) format("truetype");
+        font-family: TimesDigitalW04-RegularSC;
+        src: url(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"), url(/fonts/TimesDigitalW04-RegularSC.ttf) format("truetype");
         font-weight: 400;
         font-style: normal
     }

--- a/ios/storybooknative.xcodeproj/project.pbxproj
+++ b/ios/storybooknative.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		27603C561F98F5E1003F3296 /* RNTFullscreenAutoPresentingView.m in Sources */ = {isa = PBXBuildFile; fileRef = 27603C501F98F5E1003F3296 /* RNTFullscreenAutoPresentingView.m */; };
 		27603C571F98F5E1003F3296 /* RNTBrightcoveFullscreenManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 27603C511F98F5E1003F3296 /* RNTBrightcoveFullscreenManager.m */; };
 		515F7D171F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */; };
-		515F7D191F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */; };
+		515F7D191F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D151F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf */; };
 		515F7D1A1F0E7BA000966DF3 /* TimesModern-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 515F7D161F0E7BA000966DF3 /* TimesModern-Bold.ttf */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		6352792727934A4A80BA505A /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F99A760D4DBA4C06BAA2763C /* libRNSVG.a */; };
@@ -328,7 +328,7 @@
 		27603C501F98F5E1003F3296 /* RNTFullscreenAutoPresentingView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RNTFullscreenAutoPresentingView.m; path = "../packages/brightcove-video/ios/RNTBrightcove/RNTFullscreenAutoPresentingView.m"; sourceTree = "<group>"; };
 		27603C511F98F5E1003F3296 /* RNTBrightcoveFullscreenManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RNTBrightcoveFullscreenManager.m; path = "../packages/brightcove-video/ios/RNTBrightcove/RNTBrightcoveFullscreenManager.m"; sourceTree = "<group>"; };
 		515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "GillSansMTStd-Medium.ttf"; path = "../dist/public/fonts/GillSansMTStd-Medium.ttf"; sourceTree = "<group>"; };
-		515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesDigital-RegularSC.ttf"; path = "../dist/public/fonts/TimesDigital-RegularSC.ttf"; sourceTree = "<group>"; };
+		515F7D151F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesDigitalW04-RegularSC.ttf"; path = "../dist/public/fonts/TimesDigitalW04-RegularSC.ttf"; sourceTree = "<group>"; };
 		515F7D161F0E7BA000966DF3 /* TimesModern-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "TimesModern-Bold.ttf"; path = "../dist/public/fonts/TimesModern-Bold.ttf"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		6062F30799E544E8909E64C2 /* RNSVG.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
@@ -496,7 +496,7 @@
 			isa = PBXGroup;
 			children = (
 				515F7D131F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf */,
-				515F7D151F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf */,
+				515F7D151F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf */,
 				515F7D161F0E7BA000966DF3 /* TimesModern-Bold.ttf */,
 				A81179791F72B75A00BEE77B /* TimesModern-Regular.ttf */,
 				A811795C1F72B6D600BEE77B /* TimesDigitalW04-Bold.ttf */,
@@ -999,7 +999,7 @@
 				A811797A1F72B75A00BEE77B /* TimesModern-Regular.ttf in Resources */,
 				87396A391EF3E9F10076CBAD /* bcovpuiiconfont.ttf in Resources */,
 				515F7D1A1F0E7BA000966DF3 /* TimesModern-Bold.ttf in Resources */,
-				515F7D191F0E7BA000966DF3 /* TimesDigital-RegularSC.ttf in Resources */,
+				515F7D191F0E7BA000966DF3 /* TimesDigitalW04-RegularSC.ttf in Resources */,
 				A811797D1F72B76200BEE77B /* TimesDigitalW04-Regular.ttf in Resources */,
 				515F7D171F0E7BA000966DF3 /* GillSansMTStd-Medium.ttf in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,

--- a/ios/storybooknative/Info.plist
+++ b/ios/storybooknative/Info.plist
@@ -5,7 +5,7 @@
 	<key>UIAppFonts</key>
 	<array>
 		<string>GillSansMTStd-Medium.ttf</string>
-		<string>TimesDigital-RegularSC.ttf</string>
+		<string>TimesDigitalW04-RegularSC.ttf</string>
 		<string>TimesModern-Bold.ttf</string>
 		<string>TimesModern-Regular.ttf</string>
 		<string>TimesDigitalW04-Regular.ttf</string>

--- a/lib/fetch-fonts.js
+++ b/lib/fetch-fonts.js
@@ -55,8 +55,8 @@ const fonts = [
     ]
   },
   {
-    family: "TimesDigital-RegularSC",
-    fontFamily: "TimesDigital-RegularSC",
+    family: "TimesDigitalW04-RegularSC",
+    fontFamily: "TimesDigitalW04-RegularSC",
     sources: [
       `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2`,
       `${fontCdn}/TimesDigital/TimesDigitalW04-RegularSC-a06bfa24de.woff`,

--- a/packages/article-flag/__test__/__snapshots__/article-flag.android.native.test.js.snap
+++ b/packages/article-flag/__test__/__snapshots__/article-flag.android.native.test.js.snap
@@ -42,7 +42,7 @@ exports[`Article Flag test on android renders Exclusive flag correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 10,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -101,7 +101,7 @@ exports[`Article Flag test on android renders New flag correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 10,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -160,7 +160,7 @@ exports[`Article Flag test on android renders Sponsored flag correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 10,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -219,7 +219,7 @@ exports[`Article Flag test on android renders Updated flag correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 10,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -278,7 +278,7 @@ exports[`Article Flag test on android renders correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 10,
           "fontWeight": "400",
           "letterSpacing": 1.4,

--- a/packages/article-flag/__test__/__snapshots__/article-flag.test.js.snap
+++ b/packages/article-flag/__test__/__snapshots__/article-flag.test.js.snap
@@ -42,7 +42,7 @@ exports[`Article Flag test on web and ios renders Exclusive flag correctly 1`] =
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -101,7 +101,7 @@ exports[`Article Flag test on web and ios renders New flag correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -160,7 +160,7 @@ exports[`Article Flag test on web and ios renders Sponsored flag correctly 1`] =
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -219,7 +219,7 @@ exports[`Article Flag test on web and ios renders Updated flag correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
           "letterSpacing": 1.4,
@@ -278,7 +278,7 @@ exports[`Article Flag test on web and ios renders correctly 1`] = `
     style={
       Array [
         Object {
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 12,
           "fontWeight": "400",
           "letterSpacing": 1.4,

--- a/packages/article-flag/article-flag.js
+++ b/packages/article-flag/article-flag.js
@@ -16,7 +16,7 @@ const styles = {
     marginBottom: 1
   },
   title: {
-    fontFamily: "TimesDigital-RegularSC",
+    fontFamily: "TimesDigitalW04-RegularSC",
     fontSize: Platform.OS === "android" ? 10 : 12,
     fontWeight: "400",
     letterSpacing: 1.4

--- a/packages/article/__tests__/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.android.test.js.snap
@@ -908,7 +908,7 @@ exports[`Article test on android renders article no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -972,7 +972,7 @@ exports[`Article test on android renders article no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -3058,7 +3058,7 @@ exports[`Article test on android renders article no standfirst 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -3122,7 +3122,7 @@ exports[`Article test on android renders article no standfirst 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -4535,7 +4535,7 @@ exports[`Article test on android renders article no standfirst no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -4599,7 +4599,7 @@ exports[`Article test on android renders article no standfirst no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -5379,7 +5379,7 @@ exports[`Article test on android renders full article 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -5443,7 +5443,7 @@ exports[`Article test on android renders full article 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 10,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,

--- a/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.ios.test.js.snap
@@ -908,7 +908,7 @@ exports[`Article test on ios renders article no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -972,7 +972,7 @@ exports[`Article test on ios renders article no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -3058,7 +3058,7 @@ exports[`Article test on ios renders article no standfirst 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -3122,7 +3122,7 @@ exports[`Article test on ios renders article no standfirst 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -4535,7 +4535,7 @@ exports[`Article test on ios renders article no standfirst no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -4599,7 +4599,7 @@ exports[`Article test on ios renders article no standfirst no label 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -5379,7 +5379,7 @@ exports[`Article test on ios renders full article 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,
@@ -5443,7 +5443,7 @@ exports[`Article test on ios renders full article 1`] = `
               style={
                 Array [
                   Object {
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": 12,
                     "fontWeight": "400",
                     "letterSpacing": 1.4,

--- a/packages/article/__tests__/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/__snapshots__/article.web.test.js.snap
@@ -441,7 +441,7 @@ exports[`Article test on web renders article no label 1`] = `
                 style={
                   Object {
                     "color": "rgba(227,70,5,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -490,7 +490,7 @@ exports[`Article test on web renders article no label 1`] = `
                 style={
                   Object {
                     "color": "rgba(197,29,36,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -1253,7 +1253,7 @@ exports[`Article test on web renders article no standfirst 1`] = `
                 style={
                   Object {
                     "color": "rgba(227,70,5,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -1302,7 +1302,7 @@ exports[`Article test on web renders article no standfirst 1`] = `
                 style={
                   Object {
                     "color": "rgba(197,29,36,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -1830,7 +1830,7 @@ exports[`Article test on web renders article no standfirst no label 1`] = `
                 style={
                   Object {
                     "color": "rgba(227,70,5,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -1879,7 +1879,7 @@ exports[`Article test on web renders article no standfirst no label 1`] = `
                 style={
                   Object {
                     "color": "rgba(197,29,36,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -2186,7 +2186,7 @@ exports[`Article test on web renders full article 1`] = `
                 style={
                   Object {
                     "color": "rgba(227,70,5,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }
@@ -2235,7 +2235,7 @@ exports[`Article test on web renders full article 1`] = `
                 style={
                   Object {
                     "color": "rgba(197,29,36,1)",
-                    "fontFamily": "TimesDigital-RegularSC",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
                     "fontSize": "12px",
                     "letterSpacing": "1.4px",
                   }

--- a/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
+++ b/packages/author-head/__tests__/__snapshots__/author-head.test.js.snap
@@ -52,7 +52,7 @@ exports[`renders 1`] = `
       style={
         Object {
           "color": "#696969",
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 15,
         }
       }
@@ -132,7 +132,7 @@ exports[`renders with data 1`] = `
       style={
         Object {
           "color": "#696969",
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 15,
         }
       }
@@ -307,7 +307,7 @@ exports[`renders without profile picture 1`] = `
       style={
         Object {
           "color": "#696969",
-          "fontFamily": "TimesDigital-RegularSC",
+          "fontFamily": "TimesDigitalW04-RegularSC",
           "fontSize": 15,
         }
       }

--- a/packages/author-head/author-head.js
+++ b/packages/author-head/author-head.js
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
     paddingTop: 32
   },
   title: {
-    fontFamily: "TimesDigital-RegularSC",
+    fontFamily: "TimesDigitalW04-RegularSC",
     fontSize: 15,
     color: "#696969",
     ...Platform.select({

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -228,7 +228,7 @@ exports[`renders profile content 1`] = `
               style={
                 Object {
                   "color": "#696969",
-                  "fontFamily": "TimesDigital-RegularSC",
+                  "fontFamily": "TimesDigitalW04-RegularSC",
                   "fontSize": 15,
                 }
               }
@@ -828,7 +828,7 @@ exports[`renders profile content component 1`] = `
               style={
                 Object {
                   "color": "#696969",
-                  "fontFamily": "TimesDigital-RegularSC",
+                  "fontFamily": "TimesDigitalW04-RegularSC",
                   "fontSize": 15,
                 }
               }

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -24,7 +24,7 @@ exports[`renders profile content 1`] = `
       </h1>
       <h2
         aria-level="2"
-        className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-147hge9 rn-fontSize-a023e6 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+        className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-yvv7r8 rn-fontSize-a023e6 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
         dir="auto"
         role="heading"
       >
@@ -144,7 +144,7 @@ exports[`renders profile content component 1`] = `
       </h1>
       <h2
         aria-level="2"
-        className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-147hge9 rn-fontSize-a023e6 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+        className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-yvv7r8 rn-fontSize-a023e6 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
         dir="auto"
         role="heading"
       >


### PR DESCRIPTION
Changed the font metadata on the fetch-fonts script, as we had a typo on it. This fixes CPS-Content-Render for [TAP 135](https://nidigitalsolutions.jira.com/browse/TAP-135). I still need to investigate (and change?) the native android and iphone apps, as they have the old filename.

This shouldn't interfere with [TAP-186](https://nidigitalsolutions.jira.com/browse/TAP-186) or [TAP-159](https://nidigitalsolutions.jira.com/browse/TAP-159).

Screenshots: 
<img width="796" alt="screen shot 2017-10-27 at 15 27 51" src="https://user-images.githubusercontent.com/8755205/32110134-b3bccf7e-bb2e-11e7-9116-fad31d758c61.png">
<img width="381" alt="screen shot 2017-10-27 at 15 28 39" src="https://user-images.githubusercontent.com/8755205/32110136-b3ea503e-bb2e-11e7-9b99-557dfe2296a4.png">
<img width="399" alt="screen shot 2017-10-27 at 15 28 54" src="https://user-images.githubusercontent.com/8755205/32110137-b4076d0e-bb2e-11e7-87d1-7eaf1d16aa28.png">


