### PR TITLE
Compilation fails after RN0.49 upgrade

### DIFF
--- a/packages/brightcove-video/android/build.gradle
+++ b/packages/brightcove-video/android/build.gradle
@@ -25,6 +25,6 @@ repositories {
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:0.49.3"
-    api "com.brightcove.player:exoplayer:5.2.0"
+    compile "com.facebook.react:react-native:0.49.3"
+    compile "com.brightcove.player:exoplayer:5.2.0"
 }


### PR DESCRIPTION
Hi there,

Ran into an issue today after upgrading React Native to v0.49.* and `@times-components/brightcove-video` to the latest version (but I think it's also related to the version of the android build-tools.

I could not build my app anymore because of this error:
```
* What went wrong:
A problem occurred evaluating project ':@times-components/brightcove-video'.
> Could not find method api() for arguments [com.brightcove.player:exoplayer:5.2.0] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

found out that solution : https://stackoverflow.com/questions/45615474/gradle-error-could-not-find-method-implementation-for-arguments-com-android 

Do you know more about that?
I'm not sure if this is going to create the opposite problem to someone with an older version of the build-tools, though ⚠️ 
