### PR TITLE
fix: replaces View.propTypes with ViewPropTypes

### DIFF
--- a/packages/ad/placeholder.js
+++ b/packages/ad/placeholder.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, View, Text, Platform } from "react-native";
+import { StyleSheet, View, Text, Platform, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
 import TimesWatermark from "./ad-watermark";
@@ -57,7 +57,7 @@ const Placeholder = ({ width, height, style }) => {
 Placeholder.propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
-  style: View.propTypes.style
+  style: ViewPropTypes.style
 };
 
 Placeholder.defaultProps = {

--- a/packages/article-byline/article-byline-proptypes.js
+++ b/packages/article-byline/article-byline-proptypes.js
@@ -1,11 +1,11 @@
 import PropTypes from "prop-types";
-import { Text, View } from "react-native";
+import { Text, ViewPropTypes } from "react-native";
 import { treePropType } from "@times-components/markup";
 
 export const articleBylinePropTypes = {
   ast: PropTypes.arrayOf(treePropType).isRequired,
   style: PropTypes.shape({
-    container: View.propTypes.style,
+    container: ViewPropTypes.style,
     byline: Text.propTypes.style,
     link: Text.propTypes.style
   })

--- a/packages/image/image-prop-types.js
+++ b/packages/image/image-prop-types.js
@@ -1,10 +1,10 @@
 import PropTypes from "prop-types";
-import { View } from "react-native";
+import { ViewPropTypes } from "react-native";
 
 const propTypes = {
   uri: PropTypes.string.isRequired,
   aspectRatio: PropTypes.number.isRequired,
-  style: View.propTypes.style
+  style: ViewPropTypes.style
 };
 
 export default propTypes;

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -13,12 +13,8 @@
   "jest": {
     "preset": "react-native",
     "rootDir": "../../",
-    "transformIgnorePatterns": [
-      "node_modules/(?!@times-components)/"
-    ],
-    "testMatch": [
-      "<rootDir>/packages/watermark/**.test.js"
-    ]
+    "transformIgnorePatterns": ["node_modules/(?!@times-components)/"],
+    "testMatch": ["<rootDir>/packages/watermark/**.test.js"]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
View.propTypes has been deprecated - using ViewPropTypes instead.
