### PR TITLE
chore: publish storybook using CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+cache:
+  yarn: true
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ language: node_js
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH="$HOME/.yarn/bin:$PATH"
-before_script:
-  - chmod +x ./lib/publish.sh
+# before_script:
+#   - chmod +x ./lib/publish.sh
 script:
-  - yarn lint
-  - yarn test
-after_success:
-  - yarn coverage:publish
-  - ./lib/publish.sh
+  - echo "Dummy build"
+  # - yarn lint
+  # - yarn test
+# after_success:
+#   - yarn coverage:publish
+#   - ./lib/publish.sh
 deploy:
   provider: script
   script: lib/publish_storybook.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
 #   - yarn coverage:publish
 #   - ./lib/publish.sh
 deploy:
+  skip_cleanup: true
   provider: script
   script: lib/publish_storybook.sh
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ script:
 after_success:
   - yarn coverage:publish
   - ./lib/publish.sh
+deploy:
+  provider: script
+  script: lib/publish_storybook.sh
+  on:
+    branch: storybook-publish-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-cache:
-  yarn: true
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,17 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH="$HOME/.yarn/bin:$PATH"
-# before_script:
-#   - chmod +x ./lib/publish.sh
+before_script:
+  - chmod +x ./lib/publish.sh
 script:
-  - echo "Dummy build"
-  # - yarn lint
-  # - yarn test
-# after_success:
-#   - yarn coverage:publish
-#   - ./lib/publish.sh
+  - yarn lint
+  - yarn test
+after_success:
+  - yarn coverage:publish
+  - ./lib/publish.sh
 deploy:
   skip_cleanup: true
   provider: script
   script: lib/publish_storybook.sh
   on:
-    branch: storybook-publish-ci
+    branch: master

--- a/lib/publish_storybook.sh
+++ b/lib/publish_storybook.sh
@@ -4,14 +4,6 @@
 
 set -e # exit with nonzero exit code if anything fails
 
-# get GIT url
-
-GIT_URL=`git config --get remote.origin.url`
-if [[ $GIT_URL == "" ]]; then
-  echo "This project is not configured with a remote git repo".
-  exit 1
-fi
-
 # clear and re-create the out directory
 rm -rf storybook-static || exit 0;
 mkdir storybook-static;
@@ -27,6 +19,9 @@ git init
 git config user.name "GH Pages Bot"
 git config user.email "hello@ghbot.com"
 
+# set origin url with token for write access
+git remote set-url origin https://${GH_TOKEN}@github.com/newsuk/times-components.git > /dev/null 2>&1
+
 # The first and only commit to this new Git repo contains all the
 # files present with the commit message "Deploy to GitHub Pages".
 git add .
@@ -36,7 +31,7 @@ git commit -m "Deploy Storybook to GitHub Pages"
 # repo's gh-pages branch. (All previous history on the gh-pages branch
 # will be lost, since we are overwriting it.) We redirect any output to
 # /dev/null to hide any sensitive credential data that might otherwise be exposed.
-git push --force --quiet $GIT_URL master:gh-pages > /dev/null 2>&1
+git push --force --quiet origin master:gh-pages > /dev/null 2>&1
 cd ..
 rm -rf storybook:build
 

--- a/lib/publish_storybook.sh
+++ b/lib/publish_storybook.sh
@@ -20,7 +20,7 @@ git config user.name "GH Pages Bot"
 git config user.email "hello@ghbot.com"
 
 # set origin url with token for write access
-git remote set-url origin https://${GH_TOKEN}@github.com/newsuk/times-components.git > /dev/null 2>&1
+git remote add origin https://${GH_TOKEN}@github.com/newsuk/times-components.git > /dev/null 2>&1
 
 # The first and only commit to this new Git repo contains all the
 # files present with the commit message "Deploy to GitHub Pages".

--- a/packages/article/fixtures/full-article.json
+++ b/packages/article/fixtures/full-article.json
@@ -3,7 +3,7 @@
     "article": {
       "id": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
       "headline":
-        "Test",
+        "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
       "publicationName": "TIMES",
       "publishedTime": "2015-03-13T18:54:58.000Z",
       "label": "HURRICANE IRMA",

--- a/packages/article/fixtures/full-article.json
+++ b/packages/article/fixtures/full-article.json
@@ -3,7 +3,7 @@
     "article": {
       "id": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
       "headline":
-        "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+        "Test",
       "publicationName": "TIMES",
       "publishedTime": "2015-03-13T18:54:58.000Z",
       "label": "HURRICANE IRMA",


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->

Storybook will get published whenever any commits occur on master (including PR merges).

You can see the build log for a test deployment [here](https://travis-ci.org/newsuk/times-components/builds/295691376). The publishing appears under the _Deploying application_ section of the logs.

The `lib/publish_storybook.sh` script builds and deploys the storybook. This gets executed by Travis.

Tested it by:
* tracking a branch other than master
* changing fixtures and pushing to see if the storybook updated
* verifying that the gh-pages branch updated
* verified that the GH_TOKEN is not printed in the log
* disabled linting and testing to speed up builds