### PR TITLE
TAP-226: Update font paths to load fonts from www.thetimes.co.uk

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,35 +1,36 @@
 <style>
   @font-face {
     font-family: TimesModern-Bold;
-    src: url(/fonts/TimesModern-Bold.woff2) format("woff2"), url(/fonts/TimesModern-Bold.woff) format("woff"), url(/fonts/TimesModern-Bold.ttf) format("truetype");
+    src: url(/fonts/TimesModern-Bold.woff2) format("woff2"), url(/fonts/TimesModern-Bold.woff) format("woff"), url(/fonts/TimesModern-Bold.ttf) format("truetype"), url(https://www.thetimes.co.uk/d/fonts/TimesModern/TimesModern-Bold-62eb027e67.woff2) format("woff2"), url(https://www.thetimes.co.uk/d/fonts/TimesModern/TimesModern-Bold-828aec4ccd.woff) format("woff");
     font-weight: 400;
     font-style: normal
   }
 
   @font-face {
     font-family: TimesModern-Regular;
-    src: url(/fonts/TimesModern-Regular.woff2) format("woff2"), url(/fonts/TimesModern-Regular.woff) format("woff"), url(/fonts/TimesModern-Regular.ttf) format("truetype");
+    src: url(/fonts/TimesModern-Regular.woff2) format("woff2"), url(/fonts/TimesModern-Regular.woff) format("woff"), url(/fonts/TimesModern-Regular.ttf) format("truetype"), url(
+      https://www.thetimes.co.uk/d/fonts/TimesModern/TimesModern-Regular-f3419df85d.woff2) format("woff2"), url(https://www.thetimes.co.uk/d/fonts/TimesModern/TimesModern-Regular-39c619f4ef.woff) format("woff");
     font-weight: 400;
     font-style: normal
   }
 
   @font-face {
     font-family: TimesDigitalW04-RegularSC;
-    src: url(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"), url(/fonts/TimesDigitalW04-RegularSC.ttf) format("truetype");
+    src: url(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"), url(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"), url(/fonts/TimesDigitalW04-RegularSC.ttf) format("truetype"), url(https://www.thetimes.co.uk/d/fonts/TimesDigital/TimesDigitalW04-RegularSC-5fc97c82cd.woff2) format("woff2"), url(https://www.thetimes.co.uk/d/fonts/TimesDigital/TimesDigitalW04-RegularSC-a06bfa24de.woff) format("woff");
     font-weight: 400;
     font-style: normal
   }
 
   @font-face {
     font-family: GillSansMTStd-Medium;
-    src: url(/fonts/GillSansMTStd-Medium.woff2) format("woff2"), url(/fonts/GillSansMTStd-Medium.woff) format("woff"), url(/fonts/GillSansMTStd-Medium.ttf) format("truetype");
+    src: url(/fonts/GillSansMTStd-Medium.woff2) format("woff2"), url(/fonts/GillSansMTStd-Medium.woff) format("woff"), url(/fonts/GillSansMTStd-Medium.ttf) format("truetype"), url(https://www.thetimes.co.uk/d/fonts/GillSans/GillSansMTStd-Medium-ff809aff43.woff2) format("woff2"), url(https://www.thetimes.co.uk/d/fonts/GillSans/GillSansMTStd-Medium-f147e4bbf2.woff) format("woff");
     font-weight: 400;
     font-style: normal
   }
 
   @font-face {
     font-family: TimesDigitalW04;
-    src: url(/fonts/TimesDigitalW04.woff2) format("woff2"), url(/fonts/TimesDigitalW04.woff) format("woff"), url(/fonts/TimesDigitalW04.ttf) format("truetype");
+    src: url(/fonts/TimesDigitalW04.woff2) format("woff2"), url(/fonts/TimesDigitalW04.woff) format("woff"), url(/fonts/TimesDigitalW04.ttf) format("truetype"), url(https://www.thetimes.co.uk/d/fonts/TimesDigital/TimesDigitalW04-Regular-dca82eac02.woff2) format("woff2"), url(https://www.thetimes.co.uk/d/fonts/TimesDigital/TimesDigitalW04-Regular-c93f4e13dd.woff) format("woff");
     font-weight: 400;
     font-style: normal
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,13 +265,13 @@
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
+"@types/node@*":
+  version "8.0.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.50.tgz#dc545448e128c88c4eec7cd64025fcc3b7604541"
+
 "@types/node@6.0.66":
   version "6.0.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.66.tgz#5680b74a6135d33d4c00447e7c3dc691a4601625"
-
-"@types/node@^6.0.46":
-  version "6.0.90"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.90.tgz#0ed74833fa1b73dcdb9409dcb1c97ec0a8b13b02"
 
 "@types/react@^16.0.18":
   version "16.0.19"
@@ -3792,8 +3792,8 @@ enzyme-adapter-react-16@1.0.1:
     prop-types "^15.5.10"
 
 enzyme-adapter-react-16@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.3.tgz#f40e654f850b62e3ff71639141685e0bb129be34"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.4.tgz#67f898cc053452f5c786424e395fe0c63a0607fe"
   dependencies:
     enzyme-adapter-utils "^1.1.0"
     lodash "^4.17.4"
@@ -3803,8 +3803,8 @@ enzyme-adapter-react-16@^1.0.0:
     react-test-renderer "^16.0.0-0"
 
 enzyme-adapter-utils@^1.0.0, enzyme-adapter-utils@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.1.0.tgz#7d765b2e7ebd305899e99b2eb60e77382369d8de"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.1.1.tgz#689de8853f0751710590d6dfa730ff4056ea36b2"
   dependencies:
     lodash "^4.17.4"
     object.assign "^4.0.4"
@@ -7781,10 +7781,10 @@ parse5@^1.5.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
 parse5@^3.0.1, parse5@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   dependencies:
-    "@types/node" "^6.0.46"
+    "@types/node" "*"
 
 parseqs@0.0.5:
   version "0.0.5"
@@ -8804,12 +8804,20 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@16.0.0, react-test-renderer@^16.0.0-0:
+react-test-renderer@16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
+
+react-test-renderer@^16.0.0-0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.1.0.tgz#33a1d3ce896311e0dd1547649b1456ffa7fda415"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-timer-mixin@^0.13.2, react-timer-mixin@^0.13.3:
   version "0.13.3"


### PR DESCRIPTION
CNAME is in place now so this can be merged.
