### PR TITLE
fix: stop limiting future yarn versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "engines": {
     "node": ">=8.0.0",
-    "yarn": "1.2.1"
+    "yarn": ">=1.2.1"
   },
   "bin": {
     "times-components": "times-components"


### PR DESCRIPTION
Super annoying if you've updated yarn or just installed it.