### PR TITLE
feat: query pagination count

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -56,7 +56,7 @@ exports[`renders profile content 1`] = `
   ItemSeparatorComponent={[Function]}
   ListFooterComponent={
     <AuthorProfilePagination
-      count={undefined}
+      count={10}
       hideResults={true}
       onNext={[Function]}
       onPrev={[Function]}
@@ -131,7 +131,7 @@ exports[`renders profile content 1`] = `
         uri="https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg?crop=854,854,214,0&resize=200"
       />
       <AuthorProfilePagination
-        count={undefined}
+        count={10}
         hideResults={false}
         onNext={[Function]}
         onPrev={[Function]}
@@ -500,7 +500,7 @@ exports[`renders profile content 1`] = `
                     ]
                   }
                 >
-                  Showing 1 - 0 of 0 results
+                  Showing 1 - 10 of 10 results
                 </Text>
               </View>
               <View

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -147,7 +147,7 @@ exports[`renders profile content 1`] = `
               className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-a023e6 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
               dir="auto"
             >
-              Showing 1 - 0 of 0 results
+              Showing 1 - 10 of 10 results
             </div>
           </div>
           <div

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -23,7 +23,8 @@ const AuthorProfile = ({
     return <AuthorProfileError {...error} />;
   }
 
-  const { biography, name, image: uri, jobTitle, twitter } = author || {};
+  const { biography, name, image: uri, jobTitle, twitter, articles } =
+    author || {};
 
   return (
     <ArticleListProviderWithPageState
@@ -48,7 +49,7 @@ const AuthorProfile = ({
           jobTitle={jobTitle}
           twitter={twitter}
           onTwitterLinkPress={onTwitterLinkPress}
-          count={get(data, "articles.count")}
+          count={get(articles, "count", 0)}
           onNext={onNext}
           onPrev={onPrev}
           page={page}

--- a/packages/author-profile/fixtures/author-profile.json
+++ b/packages/author-profile/fixtures/author-profile.json
@@ -60,6 +60,9 @@
       "image":
         "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg?crop=854,854,214,0&resize=200",
       "twitter": "jdoe",
+      "articles": {
+        "count": 10
+      },
       "__typename": "Author"
     }
   }

--- a/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-profile-provider.test.js.snap
@@ -3,6 +3,11 @@
 exports[`returns query result 1`] = `
 Object {
   "__typename": "Author",
+  "articles": Object {
+    "__typename": "Articles",
+    "count": 24,
+    Symbol(id): "$ROOT_QUERY.author({\\"slug\\":\\"fiona-hamilton\\"}).articles",
+  },
   "biography": Array [
     Object {
       "attributes": Object {

--- a/packages/provider/author-profile-provider.js
+++ b/packages/provider/author-profile-provider.js
@@ -9,6 +9,9 @@ export const query = gql`
       biography
       image
       twitter
+      articles {
+        count
+      }
     }
   }
 `;


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->

In order to keep the total number of articles between page changes we need to pull them to an "upper level". One way to do it (this PR) is to query the number of articles when getting the author information.

Another considered option was to create a new provider just to fetch the articles count that would wrap the articles list but this the complexity of having to manage one more loading state doesn't pay off.
