### PR TITLE
fix: stop unmounting and re-render

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders profile 1`] = `
-<Pagination Helper (Component)
+<Pagination Helper (Apollo(Wrapper))
   articleImageRatio="3:2"
   page={1}
   pageSize={10}

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not re-render the author head if the name changes 1`] = `
+<Text
+  accessibilityRole="heading"
+  accessible={true}
+  allowFontScaling={true}
+  aria-level="1"
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "#000",
+      "fontFamily": "TimesModern-Bold",
+      "fontSize": 45,
+      "paddingTop": 32,
+    }
+  }
+  testID="author-name"
+>
+  Fiona Hamilton
+</Text>
+`;
+
+exports[`does re-render the author head if the loading state changes 1`] = `
+<Text
+  accessibilityRole="heading"
+  accessible={true}
+  allowFontScaling={true}
+  aria-level="1"
+  ellipsizeMode="tail"
+  style={
+    Object {
+      "color": "#000",
+      "fontFamily": "TimesModern-Bold",
+      "fontSize": 45,
+      "paddingTop": 32,
+    }
+  }
+  testID="author-name"
+>
+  second name
+</Text>
+`;
+
 exports[`renders profile 1`] = `
 <Pagination Helper (Apollo(Wrapper))
   articleImageRatio="3:2"
@@ -6956,4 +6998,106 @@ exports[`renders profile separator 1`] = `
     }
   }
 />
+`;
+
+exports[`renders the author head 1`] = `
+<View
+  pointerEvents="box-none"
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "transparent",
+      "paddingBottom": 50,
+    }
+  }
+>
+  <View
+    accessibilityRole="banner"
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#F9F8F3",
+        "flexDirection": "column",
+        "paddingBottom": 50,
+        "width": "100%",
+      }
+    }
+  >
+    <Text
+      accessibilityRole="heading"
+      accessible={true}
+      allowFontScaling={true}
+      aria-level="1"
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#000",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 45,
+          "paddingTop": 32,
+        }
+      }
+      testID="author-name"
+    >
+      Fiona Hamilton
+    </Text>
+    <Text
+      accessibilityRole="heading"
+      accessible={true}
+      allowFontScaling={true}
+      aria-level="2"
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#696969",
+          "fontFamily": "TimesDigitalW04-RegularSC",
+          "fontSize": 15,
+        }
+      }
+    >
+      
+    </Text>
+    <Text
+      accessibilityRole="link"
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      href="https://twitter.com/jdoe"
+      onPress={[Function]}
+      style={
+        Array [
+          Object {
+            "textDecorationLine": "underline",
+          },
+          Object {
+            "color": "#006699",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 18,
+            "paddingTop": 16,
+            "textDecorationLine": "none",
+          },
+        ]
+      }
+    >
+      @
+      jdoe
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#333",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 16,
+          "lineHeight": 26,
+          "maxWidth": "88%",
+          "paddingBottom": 32,
+          "textAlign": "center",
+        }
+      }
+    />
+  </View>
+</View>
 `;

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders profile 1`] = `
-<Pagination Helper (Component)
+<Pagination Helper (Apollo(Wrapper))
   articleImageRatio="3:2"
   page={1}
   pageSize={10}

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not re-render the author head if the name changes 1`] = `
+<Text
+  accessibilityRole="heading"
+  aria-level="1"
+  style={72}
+  testID="author-name"
+>
+  Fiona Hamilton
+</Text>
+`;
+
+exports[`does re-render the author head if the loading state changes 1`] = `
+<Text
+  accessibilityRole="heading"
+  aria-level="1"
+  style={72}
+  testID="author-name"
+>
+  second name
+</Text>
+`;
+
 exports[`renders profile 1`] = `
 <Pagination Helper (Apollo(Wrapper))
   articleImageRatio="3:2"
@@ -2440,4 +2462,48 @@ exports[`renders profile separator 1`] = `
 <div
   className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"
 />
+`;
+
+exports[`renders the author head 1`] = `
+<div
+  className="rn-alignItems-1awozwy rn-backgroundColor-wib322 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-5v6cpj rn-pointerEvents-12vffkv rn-position-bnwqim"
+>
+  <header
+    className="rn-alignItems-1awozwy rn-backgroundColor-1178u4u rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-5v6cpj rn-position-bnwqim rn-width-13qz1uu"
+    role="banner"
+  >
+    <h1
+      aria-level="1"
+      className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-15b02fe rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1tsn96g rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-paddingTop-fd4yh7 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+      data-testid="author-name"
+      dir="auto"
+      role="heading"
+    >
+      Fiona Hamilton
+    </h1>
+    <h2
+      aria-level="2"
+      className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-yvv7r8 rn-fontSize-a023e6 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+      dir="auto"
+      role="heading"
+    >
+      
+    </h2>
+    <a
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-1i10wst rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-paddingTop-95jzfe rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+      dir="auto"
+      href="https://twitter.com/jdoe"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="link"
+    >
+      @
+      jdoe
+    </a>
+    <div
+      className="rn-MozOsxFontSmoothing-t3ofa rn-WebkitFontSmoothing-1vzmqqg rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-1feecvn rn-fontSize-ubezar rn-lineHeight-eaezby rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-maxWidth-1eyxye4 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-11rk87y rn-textAlign-q4m81j rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+      dir="auto"
+    />
+  </header>
+</div>
 `;

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -280,14 +280,14 @@ export default AuthorProfileContent => {
 
   it("renders the author head", () => {
     const component = renderer.create(
-      <AuthorHead {...authorProfileFixture.data.author} />
+      <AuthorHead {...authorProfileFixture.data.author} onTwitterLinkPress={() => {}} />
     );
 
     expect(component).toMatchSnapshot();
   });
 
   it("does not re-render the author head if the name changes", () => {
-    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} />);
+    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} onTwitterLinkPress={() => {}} />);
 
     el.setProps({
       name: "second name"
@@ -303,7 +303,7 @@ export default AuthorProfileContent => {
   });
 
   it("does re-render the author head if the loading state changes", () => {
-    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} />);
+    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} onTwitterLinkPress={() => {}} />);
 
     el.setProps({
       name: "second name",

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -280,14 +280,22 @@ export default AuthorProfileContent => {
 
   it("renders the author head", () => {
     const component = renderer.create(
-      <AuthorHead {...authorProfileFixture.data.author} onTwitterLinkPress={() => {}} />
+      <AuthorHead
+        {...authorProfileFixture.data.author}
+        onTwitterLinkPress={() => {}}
+      />
     );
 
     expect(component).toMatchSnapshot();
   });
 
   it("does not re-render the author head if the name changes", () => {
-    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} onTwitterLinkPress={() => {}} />);
+    const el = shallow(
+      <AuthorHead
+        {...authorProfileFixture.data.author}
+        onTwitterLinkPress={() => {}}
+      />
+    );
 
     el.setProps({
       name: "second name"
@@ -303,7 +311,12 @@ export default AuthorProfileContent => {
   });
 
   it("does re-render the author head if the loading state changes", () => {
-    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} onTwitterLinkPress={() => {}} />);
+    const el = shallow(
+      <AuthorHead
+        {...authorProfileFixture.data.author}
+        onTwitterLinkPress={() => {}}
+      />
+    );
 
     el.setProps({
       name: "second name",

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -13,6 +13,7 @@ import { query as authorProfileQuery } from "@times-components/provider/author-p
 import { query as articleListQuery } from "@times-components/provider/article-list-provider";
 import AuthorProfile from "../author-profile";
 import AuthorProfileItem from "../author-profile-item";
+import AuthorHead from "../author-profile-author-head";
 import AuthorProfileItemSeparator from "../author-profile-item-separator";
 import authorProfileFixture from "../fixtures/author-profile.json";
 import articleListFixture from "../fixtures/article-list.json";
@@ -275,6 +276,47 @@ export default AuthorProfileContent => {
     );
 
     expect(component).toMatchSnapshot();
+  });
+
+  it("renders the author head", () => {
+    const component = renderer.create(
+      <AuthorHead {...authorProfileFixture.data.author} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it("does not re-render the author head if the name changes", () => {
+    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} />);
+
+    el.setProps({
+      name: "second name"
+    });
+
+    expect(
+      el
+        .dive()
+        .dive()
+        .dive()
+        .find({ testID: "author-name" })
+    ).toMatchSnapshot();
+  });
+
+  it("does re-render the author head if the loading state changes", () => {
+    const el = shallow(<AuthorHead {...authorProfileFixture.data.author} />);
+
+    el.setProps({
+      name: "second name",
+      isLoading: false
+    });
+
+    expect(
+      el
+        .dive()
+        .dive()
+        .dive()
+        .find({ testID: "author-name" })
+    ).toMatchSnapshot();
   });
 
   it("tracks page view", () => {

--- a/packages/author-profile/author-profile-author-head.js
+++ b/packages/author-profile/author-profile-author-head.js
@@ -37,10 +37,7 @@ const styles = StyleSheet.create({
 
 class AuthorProfileAuthorHead extends React.Component {
   shouldComponentUpdate(nextProps) {
-    return (
-      this.props.name !== nextProps.name ||
-      this.props.isLoading !== nextProps.isLoading
-    );
+    return this.props.isLoading !== nextProps.isLoading;
   }
 
   render() {

--- a/packages/author-profile/author-profile-author-head.js
+++ b/packages/author-profile/author-profile-author-head.js
@@ -37,7 +37,10 @@ const styles = StyleSheet.create({
 
 class AuthorProfileAuthorHead extends React.Component {
   shouldComponentUpdate(nextProps) {
-    return this.props.name !== nextProps.name;
+    return (
+      this.props.name !== nextProps.name ||
+      this.props.isLoading !== nextProps.isLoading
+    );
   }
 
   render() {

--- a/packages/author-profile/author-profile-author-head.js
+++ b/packages/author-profile/author-profile-author-head.js
@@ -35,22 +35,29 @@ const styles = StyleSheet.create({
   }
 });
 
-const AuthorProfileAuthorHead = ({ isLoading, ...props }) => {
-  if (isLoading) {
-    return (
-      <View style={styles.wrapper}>
-        <View style={styles.container} />
-        <View style={styles.photoContainer}>
-          <View style={styles.roundImage}>
-            <Gradient style={styles.gradient} />
-          </View>
-        </View>
-      </View>
-    );
+class AuthorProfileAuthorHead extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return this.props.name !== nextProps.name;
   }
 
-  return <AuthorHead {...props} />;
-};
+  render() {
+    const { isLoading, ...props } = this.props;
+    if (isLoading) {
+      return (
+        <View style={styles.wrapper}>
+          <View style={styles.container} />
+          <View style={styles.photoContainer}>
+            <View style={styles.roundImage}>
+              <Gradient style={styles.gradient} />
+            </View>
+          </View>
+        </View>
+      );
+    }
+
+    return <AuthorHead {...props} />;
+  }
+}
 
 AuthorProfileAuthorHead.propTypes = AuthorHead.propTypes;
 export default AuthorProfileAuthorHead;

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -8,6 +8,7 @@ import get from "lodash.get";
 import AuthorProfileError from "./author-profile-error";
 import AuthorProfileContent from "./author-profile-content";
 
+const ArticleListProviderWithPageState = withPageState(ArticleListProvider);
 const AuthorProfile = ({
   author,
   error,
@@ -23,7 +24,6 @@ const AuthorProfile = ({
   }
 
   const { biography, name, image: uri, jobTitle, twitter } = author || {};
-  const ArticleListProviderWithPageState = withPageState(ArticleListProvider);
 
   return (
     <ArticleListProviderWithPageState

--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -30,19 +30,13 @@ const connectGraphql = (query, propsToVariables = identity) => {
       ...props
     });
 
-  const Component = props => {
-    const variables = pick(propsToVariables(props), variableNames);
-
-    const Graphql = graphql(query, {
-      options: {
-        variables
-      }
-    })(Wrapper);
-
-    return <Graphql {...props} />;
-  };
-
-  return Component;
+  return graphql(query, {
+    options(props) {
+      return {
+        variables: pick(propsToVariables(props), variableNames)
+      };
+    }
+  })(Wrapper);
 };
 
 export default connectGraphql;

--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -1,4 +1,3 @@
-import React from "react";
 import pick from "lodash.pick";
 import { graphql } from "react-apollo";
 


### PR DESCRIPTION
On Android it became noticeable that the author head re-rendered on paging, on closer inspection it was fully unmounting and mounting again. This was because our GraphQL connect helper returned a new component every time it was rendered.

By refactoring the helper to dynamically calculate the GraphQL config options based on props, a new component didn't need to be returned each time.

In addition a SCU was added to `AuthorHead` to avoid a re-render and also keep consistency between web and Native, where Native has to have the head "within the content" to render in a recycler view, where traditionally in the web you would have it sitting outside the paged component.