### PR TITLE
chore: fix prop types

### DIFF
--- a/packages/ad/ad.js
+++ b/packages/ad/ad.js
@@ -1,10 +1,18 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { View, WebView, Dimensions, Linking, StyleSheet } from "react-native";
-import StylePropTypes from "react-style-proptype";
+import {
+  View,
+  ViewPropTypes,
+  WebView,
+  Dimensions,
+  Linking,
+  StyleSheet
+} from "react-native";
 import { getSlotConfig } from "./generate-config";
 import { pbjs as pbjsConfig } from "./config";
 import Placeholder from "./placeholder";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const styles = StyleSheet.create({
   children: {
@@ -216,7 +224,7 @@ Ad.propTypes = {
   code: PropTypes.string.isRequired,
   section: PropTypes.string.isRequired,
   baseUrl: PropTypes.string,
-  style: StylePropTypes
+  style: ViewPropTypesStyle
 };
 
 Ad.defaultProps = {

--- a/packages/ad/ad.web.js
+++ b/packages/ad/ad.web.js
@@ -1,10 +1,11 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { StyleSheet } from "react-native";
-import StylePropTypes from "react-style-proptype";
+import { StyleSheet, ViewPropTypes } from "react-native";
 import { Subscriber } from "react-broadcast";
 import AdComposer from "./ad-composer";
 import GPT from "./gpt";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const styles = StyleSheet.create({
   container: {
@@ -35,7 +36,7 @@ class Ad extends Component {
 
 Ad.propTypes = {
   code: PropTypes.string.isRequired,
-  style: StylePropTypes
+  style: ViewPropTypesStyle
 };
 
 Ad.defaultProps = {

--- a/packages/ad/gpt.js
+++ b/packages/ad/gpt.js
@@ -1,10 +1,11 @@
 import React, { Component } from "react";
-import { Dimensions, StyleSheet, View } from "react-native";
+import { Dimensions, StyleSheet, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
-import StylePropTypes from "react-style-proptype";
 import AdManager from "./ad-manager";
 import Placeholder from "./placeholder";
 import { getSlotConfig } from "./generate-config";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const getStyles = config =>
   StyleSheet.create({
@@ -75,7 +76,7 @@ class GPT extends Component {
 
 GPT.propTypes = {
   code: PropTypes.string.isRequired,
-  style: StylePropTypes,
+  style: ViewPropTypesStyle,
   adManager: PropTypes.instanceOf(AdManager).isRequired
 };
 GPT.defaultProps = {

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -65,8 +65,7 @@
     "@times-components/watermark": "0.0.6",
     "prop-types": "15.6.0",
     "react-broadcast": "0.5.2",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/article-headline/WebView-auto-height.js
+++ b/packages/article-headline/WebView-auto-height.js
@@ -2,9 +2,10 @@
 // the main trick here is that when window.location.hash is changed, handleNavigationChange() function is called
 
 import React from "react";
-import { WebView } from "react-native";
+import { WebView, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
-import StylePropTypes from "react-style-proptype";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const script = `
 <script>
@@ -94,7 +95,7 @@ WebViewAutoHeight.propTypes = {
   }).isRequired,
   minHeight: PropTypes.number,
   onNavigationStateChange: PropTypes.func,
-  style: StylePropTypes
+  style: ViewPropTypesStyle
 };
 
 WebViewAutoHeight.defaultProps = {

--- a/packages/article-headline/article-headline.js
+++ b/packages/article-headline/article-headline.js
@@ -1,7 +1,8 @@
 import React from "react";
-import { Text } from "react-native";
+import { Text, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
-import StylePropTypes from "react-style-proptype";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const styles = {
   text: {
@@ -22,7 +23,7 @@ const ArticleHeadline = ({ text, style }) => (
 
 ArticleHeadline.propTypes = {
   text: PropTypes.string.isRequired,
-  style: StylePropTypes
+  style: ViewPropTypesStyle
 };
 
 ArticleHeadline.defaultProps = {

--- a/packages/article-headline/package.json
+++ b/packages/article-headline/package.json
@@ -62,8 +62,7 @@
   },
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -66,8 +66,7 @@
     "@times-components/markup": "0.12.7",
     "date-fns": "1.28.5",
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -73,8 +73,7 @@
     "lodash.merge": "4.6.0",
     "prop-types": "15.6.0",
     "react-apollo": "1.4.16",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/caption/caption.js
+++ b/packages/caption/caption.js
@@ -1,7 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { View, Text, StyleSheet, Platform } from "react-native";
-import StylePropTypes from "react-style-proptype";
+import { View, ViewPropTypes, Text, StyleSheet, Platform } from "react-native";
+
+const { style: TextPropTypesStyle } = Text.propTypes;
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const lineHeightStyle = Platform.select({
   ios: {
@@ -73,8 +75,8 @@ Caption.propTypes = {
   text: PropTypes.string,
   credits: PropTypes.string,
   style: PropTypes.shape({
-    text: StylePropTypes,
-    container: StylePropTypes
+    text: TextPropTypesStyle,
+    container: ViewPropTypesStyle
   }),
   children: PropTypes.element
 };

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -62,8 +62,7 @@
   },
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -72,7 +72,6 @@
     "@times-components/image": "1.6.3",
     "prop-types": "15.6.0",
     "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0",
     "svgs": "3.1.0"
   },
   "peerDependencies": {

--- a/packages/date-publication/date-publication.js
+++ b/packages/date-publication/date-publication.js
@@ -2,7 +2,8 @@ import React from "react";
 import { Text } from "react-native";
 import format from "date-fns/format";
 import PropTypes from "prop-types";
-import StylePropTypes from "react-style-proptype";
+
+const { style: TextPropTypesStyle } = Text.propTypes;
 
 const styles = {
   default: {
@@ -28,7 +29,7 @@ const DatePublication = ({ date, publication, style }) => (
 DatePublication.propTypes = {
   date: PropTypes.instanceOf(Date),
   publication: PropTypes.oneOf(Object.keys(publications)).isRequired,
-  style: StylePropTypes
+  style: TextPropTypesStyle
 };
 
 DatePublication.defaultProps = {

--- a/packages/date-publication/date-publication.js
+++ b/packages/date-publication/date-publication.js
@@ -29,7 +29,7 @@ const DatePublication = ({ date, publication, style }) => (
 DatePublication.propTypes = {
   date: PropTypes.instanceOf(Date),
   publication: PropTypes.oneOf(Object.keys(publications)),
-  style: StylePropTypes
+  style: TextPropTypesStyle
 };
 
 DatePublication.defaultProps = {

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -63,8 +63,7 @@
   "dependencies": {
     "date-fns": "1.28.5",
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/error-view/error-view.js
+++ b/packages/error-view/error-view.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, ViewPropTypes, Text, StyleSheet } from "react-native";
 import PropTypes from "prop-types";
-import ReactStyleProp from "react-style-proptype";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const styles = StyleSheet.create({
   text: { color: "white" },
@@ -23,11 +24,14 @@ const errorPropType = PropTypes.shape({
   code: PropTypes.string,
   message: PropTypes.string
 });
+
 ErrorView.defaultProps = { style: {} };
+
 ErrorView.propTypes = {
-  style: ReactStyleProp,
+  style: ViewPropTypesStyle,
   errors: PropTypes.arrayOf(errorPropType).isRequired
 };
+
 export default ErrorView;
 
 export const addErrorHandler = WrappedComponent => {

--- a/packages/error-view/error-view.stories.js
+++ b/packages/error-view/error-view.stories.js
@@ -1,7 +1,12 @@
 /* eslint import/no-unresolved: "off" */
 
 import React from "react";
-import { TouchableWithoutFeedback, View, Text } from "react-native";
+import {
+  TouchableWithoutFeedback,
+  View,
+  ViewPropTypes,
+  Text
+} from "react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from "@storybook/react-native";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -9,9 +14,10 @@ import { decorateAction } from "@storybook/addon-actions";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import BrightcoveVideo from "@times-components/brightcove-video";
 import PropTypes from "prop-types";
-import StylePropTypes from "react-style-proptype";
 
 import ErrorView, { addErrorHandler } from "./error-view";
+
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 const stringifyAction = decorateAction([args => [JSON.stringify(args[0])]]);
 
@@ -26,7 +32,7 @@ const ErrorOnClick = ({ style, onError, ...otherProps }) => (
 );
 ErrorOnClick.defaultProps = { style: {}, onError: () => {} };
 ErrorOnClick.propTypes = {
-  style: StylePropTypes,
+  style: ViewPropTypesStyle,
   onError: PropTypes.func
 };
 

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -63,8 +63,7 @@
   },
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/gradient/gradient.js
+++ b/packages/gradient/gradient.js
@@ -1,10 +1,9 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, View, ViewPropTypes } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
-import StylePropTypes from "react-style-proptype";
 
-const { supportingArrays } = StylePropTypes;
+const { style: ViewPropTypesStyle } = ViewPropTypes;
 const styles = StyleSheet.create({
   container: {
     flex: 1
@@ -60,7 +59,7 @@ Gradient.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element)
   ]),
-  style: supportingArrays
+  style: ViewPropTypesStyle
 };
 
 export default Gradient;

--- a/packages/gradient/gradient.web.js
+++ b/packages/gradient/gradient.web.js
@@ -1,9 +1,9 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { View } from "react-native";
-import StylePropTypes from "react-style-proptype";
+import { View, ViewPropTypes } from "react-native";
 
-const { supportingArrays } = StylePropTypes;
+const { style: ViewPropTypesStyle } = ViewPropTypes;
+
 const Gradient = ({ degrees, children, style }) => (
   <View
     style={[
@@ -31,7 +31,7 @@ Gradient.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element)
   ]),
-  style: supportingArrays
+  style: ViewPropTypesStyle
 };
 
 export default Gradient;

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -64,8 +64,7 @@
   },
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -70,7 +70,6 @@
     "@times-components/gradient": "0.1.3",
     "prop-types": "15.6.0",
     "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0",
     "svgs": "3.1.0"
   },
   "peerDependencies": {

--- a/packages/image/placeholder/index.js
+++ b/packages/image/placeholder/index.js
@@ -1,10 +1,10 @@
 import React from "react";
-import { StyleSheet, View } from "react-native";
-import StylePropTypes from "react-style-proptype";
+import { StyleSheet, View, ViewPropTypes } from "react-native";
 import Gradient from "@times-components/gradient";
 import T from "./t";
 
-const { supportingArrays } = StylePropTypes;
+const { style: ViewPropTypesStyle } = ViewPropTypes;
+
 const styles = StyleSheet.create({
   container: {
     flex: 1
@@ -55,7 +55,7 @@ Placeholder.defaultProps = {
 };
 
 Placeholder.propTypes = {
-  style: supportingArrays
+  style: ViewPropTypesStyle
 };
 
 export default Placeholder;

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -67,8 +67,7 @@
   "dependencies": {
     "lodash.pick": "4.4.0",
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.7",
-    "react-style-proptype": "3.1.0"
+    "react-native-web": "0.1.7"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/link/text-link.js
+++ b/packages/link/text-link.js
@@ -1,7 +1,8 @@
 import React from "react";
 import { Text, StyleSheet } from "react-native";
 import PropTypes from "prop-types";
-import StylePropTypes from "react-style-proptype";
+
+const { style: StylePropType } = Text.propTypes;
 
 const styles = StyleSheet.create({
   textLink: {
@@ -21,10 +22,7 @@ const TextLink = ({ style, url, onPress, children }) => (
 );
 
 TextLink.propTypes = {
-  style: PropTypes.oneOfType([
-    PropTypes.arrayOf(StylePropTypes),
-    StylePropTypes
-  ]),
+  style: StylePropType,
   url: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,8 +266,8 @@
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
 "@types/node@*":
-  version "8.0.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.51.tgz#b31d716fb8d58eeb95c068a039b9b6292817d5fb"
+  version "8.0.53"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
 "@types/node@6.0.66":
   version "6.0.66"
@@ -3799,8 +3799,8 @@ enzyme-adapter-react-16@1.0.1:
     prop-types "^15.5.10"
 
 enzyme-adapter-react-16@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.4.tgz#67f898cc053452f5c786424e395fe0c63a0607fe"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz#86c5db7c10f0be6ec25d54ca41b59f2abb397cf4"
   dependencies:
     enzyme-adapter-utils "^1.1.0"
     lodash "^4.17.4"
@@ -8811,7 +8811,7 @@ react-stubber@^1.0.0:
   dependencies:
     babel-runtime "^6.5.0"
 
-react-style-proptype@3.1.0, react-style-proptype@^3.0.0:
+react-style-proptype@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.1.0.tgz#c8912fc13460f5b0c1ec1114c729d535b52b8073"
   dependencies:


### PR DESCRIPTION
`react-style-proptype` doesn't take into account `StyleSheets` being numbers and tries to run `Object.keys` on them.

In retrospect depending on the third party which doesn't fully appreciate React Native to avoid slightly awkward syntax isn't that useful, use React Native propTypes instead

Hopefully this plays well with Babel `propType` stripping....