### PR TITLE
Add an .npmrc to each package / scaffolding files to ensure exact NPM versions are used

### DIFF
--- a/lib/cli/files/.npmrc
+++ b/lib/cli/files/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/ad/.npmrc
+++ b/packages/ad/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/article-byline/.npmrc
+++ b/packages/article-byline/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/article-flag/.npmrc
+++ b/packages/article-flag/.npmrc
@@ -1,0 +1,1 @@
+vsave-exact=true

--- a/packages/article-headline/.npmrc
+++ b/packages/article-headline/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/article-image/.npmrc
+++ b/packages/article-image/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/article-label/.npmrc
+++ b/packages/article-label/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/article-summary/.npmrc
+++ b/packages/article-summary/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/article/.npmrc
+++ b/packages/article/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/author-head/.npmrc
+++ b/packages/author-head/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/author-profile/.npmrc
+++ b/packages/author-profile/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/brightcove-video/.npmrc
+++ b/packages/brightcove-video/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/caption/.npmrc
+++ b/packages/caption/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/card/.npmrc
+++ b/packages/card/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/date-publication/.npmrc
+++ b/packages/date-publication/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/error-view/.npmrc
+++ b/packages/error-view/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/gradient/.npmrc
+++ b/packages/gradient/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/image/.npmrc
+++ b/packages/image/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/jest-configurator/.npmrc
+++ b/packages/jest-configurator/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/link/.npmrc
+++ b/packages/link/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/markup/.npmrc
+++ b/packages/markup/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/pagination/.npmrc
+++ b/packages/pagination/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/provider/.npmrc
+++ b/packages/provider/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/tracking/.npmrc
+++ b/packages/tracking/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/packages/watermark/.npmrc
+++ b/packages/watermark/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
This should help developers avoid the situation where a package dependency is installed with a ^, which can cause the knock-on problem of a version of that dependency being installed which is newer than the version used in other packages and hoisted; if this occurs a package-lock.json will be generated in the package's folder which can cause the lint task to fail.