### PR TITLE
feat: add pending

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -12,6 +12,36 @@ exports[`does not re-render the author head if the name changes 1`] = `
 </Text>
 `;
 
+exports[`does not render good quality images if the item is quickly scrolled passed 1`] = `
+Array [
+  <img
+    alt=""
+    src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=100"
+    style="display: block; width: 100%; z-index: 1; position: absolute;"
+  />,
+  <img
+    alt=""
+    src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=440"
+    style="display: block; width: 100%; z-index: 1; position: absolute;"
+  />,
+  <img
+    alt=""
+    src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=440"
+    style="display: block; width: 100%; z-index: 1; position: absolute;"
+  />,
+  <img
+    alt=""
+    src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F06c0e50a-c667-11e7-9914-a38dcc178fcd.jpg?crop=3600%2C2400%2C0%2C0&resize=440"
+    style="display: block; width: 100%; z-index: 1; position: absolute;"
+  />,
+  <img
+    alt=""
+    src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1d663086-c625-11e7-9914-a38dcc178fcd.jpg?crop=907%2C605%2C87%2C93&resize=440"
+    style="display: block; width: 100%; z-index: 1; position: absolute;"
+  />,
+]
+`;
+
 exports[`does re-render the author head if the loading state changes 1`] = `
 <Text
   accessibility-label="author-name"
@@ -2883,6 +2913,6 @@ exports[`renders the author head 1`] = `
 exports[`renders with an intersection observer which uses the expected options 1`] = `
 Object {
   "rootMargin": "50px",
-  "threshold": 1,
+  "threshold": 0.5,
 }
 `;

--- a/packages/author-profile/__tests__/author-profile-content.web.test.js
+++ b/packages/author-profile/__tests__/author-profile-content.web.test.js
@@ -377,27 +377,7 @@ it("disconnects from the IntersectionObserver when unmounting", async () => {
     />
   );
 
-  const makeEntries = nodes =>
-    [...nodes].map((node, indx) => ({
-      target: node,
-      intersectionRatio: indx === 0 ? 0.75 : 0
-    }));
-  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
-
-  await delay(20);
-
-  const makeNewEntries = nodes =>
-    [...nodes].map((node, indx) => ({
-      target: node,
-      intersectionRatio: indx === 0 ? 0.25 : 0.75
-    }));
-  window.IntersectionObserver.dispatchEntriesForInstance(1, makeNewEntries);
-
-  await delay(0);
-
   component.unmount();
-
-  await delay(100);
 
   expect(disconnectSpy).toHaveBeenCalled();
 

--- a/packages/author-profile/__tests__/author-profile-content.web.test.js
+++ b/packages/author-profile/__tests__/author-profile-content.web.test.js
@@ -9,6 +9,8 @@ import authorProfileFixture from "../fixtures/author-profile.json";
 import articleListFixture from "../fixtures/article-list.json";
 import pagedResult from "./paged-result";
 
+const delay = ms => new Promise(res => setTimeout(res, ms));
+
 test(AuthorProfileContent);
 
 const results = {
@@ -40,13 +42,14 @@ class FakeIntersectionObserver {
     intersectionObserverInstances[this.instanceId].nodes.add(node);
   }
 
-  static dispatchEntriesForInstance(instanceId) {
+  static dispatchEntriesForInstance(instanceId, makeEntries) {
     const instance = intersectionObserverInstances[instanceId];
-    const entries = [...instance.nodes].map((node, indx) => ({
-      target: node,
-      isIntersecting: indx === 0
-    }));
-    instance.cb(entries);
+
+    instance.cb(makeEntries(instance.nodes));
+  }
+
+  disconnect() {
+    return this;
   }
 }
 
@@ -107,7 +110,7 @@ it("renders with an intersection observer which uses the expected options", () =
   expect(optsSpy.mock.calls[1][0]).toMatchSnapshot();
 });
 
-it("renders a good quality image if it is visible", () => {
+it("renders a good quality image if it is visible", async () => {
   window.IntersectionObserver = FakeIntersectionObserver;
 
   const component = mount(
@@ -133,7 +136,15 @@ it("renders a good quality image if it is visible", () => {
     "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=100"
   );
 
-  window.IntersectionObserver.dispatchEntriesForInstance(1);
+  const makeEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.75 : 0
+    }));
+
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
+
+  await delay(100);
 
   expect(
     component
@@ -143,7 +154,7 @@ it("renders a good quality image if it is visible", () => {
   ).toMatchSnapshot();
 });
 
-it("renders a poor quality image if it is not visible", () => {
+it("renders a poor quality image if it is not visible", async () => {
   window.IntersectionObserver = FakeIntersectionObserver;
 
   const component = mount(
@@ -159,7 +170,15 @@ it("renders a poor quality image if it is not visible", () => {
     />
   );
 
-  window.IntersectionObserver.dispatchEntriesForInstance(1);
+  const makeEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.75 : 0
+    }));
+
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
+
+  await delay(100);
 
   expect(
     component
@@ -211,6 +230,199 @@ it("renders good quality images if there is no IntersectionObserver", () => {
   expect(component.find("TimesImage")).toMatchSnapshot();
 });
 
+it("does not render good quality images if the item is quickly scrolled passed", async () => {
+  window.IntersectionObserver = FakeIntersectionObserver;
+
+  const component = mount(
+    <AuthorProfileContent
+      articles={results.data.author.articles.list.slice(0, 5)}
+      author={authorProfileFixture.data.author}
+      slug="fiona-hamilton"
+      page={1}
+      pageSize={3}
+      imageRatio={3 / 2}
+      onTwitterLinkPress={() => {}}
+      onArticlePress={() => {}}
+    />
+  );
+
+  const makeEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.75 : 0
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
+
+  await delay(20);
+
+  const makeNewEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.25 : 0.75
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeNewEntries);
+
+  await delay(100);
+
+  expect(component.render().find("img")).toMatchSnapshot();
+});
+
+it("does no work if there are no pending items", async () => {
+  window.IntersectionObserver = FakeIntersectionObserver;
+
+  const spy = jest.spyOn(AuthorProfileContent.prototype, "setState");
+
+  mount(
+    <AuthorProfileContent
+      articles={results.data.author.articles.list.slice(0, 5)}
+      author={authorProfileFixture.data.author}
+      slug="fiona-hamilton"
+      page={1}
+      pageSize={3}
+      imageRatio={3 / 2}
+      onTwitterLinkPress={() => {}}
+      onArticlePress={() => {}}
+    />
+  );
+
+  // View all items
+  const makeEntries = nodes =>
+    [...nodes].map(node => ({
+      target: node,
+      intersectionRatio: 0.75
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
+
+  await delay(20);
+
+  // Scroll passed all items before setting state
+  const makeNewEntries = nodes =>
+    [...nodes].map(node => ({
+      target: node,
+      intersectionRatio: 0
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeNewEntries);
+
+  await delay(100);
+
+  // No work was done
+  expect(spy).not.toHaveBeenCalled();
+
+  spy.mockRestore();
+});
+
+it("does not set state after unmounting", async () => {
+  window.IntersectionObserver = FakeIntersectionObserver;
+
+  const setStateSpy = jest.spyOn(AuthorProfileContent.prototype, "setState");
+
+  const component = mount(
+    <AuthorProfileContent
+      articles={results.data.author.articles.list.slice(0, 5)}
+      author={authorProfileFixture.data.author}
+      slug="fiona-hamilton"
+      page={1}
+      pageSize={3}
+      imageRatio={3 / 2}
+      onTwitterLinkPress={() => {}}
+      onArticlePress={() => {}}
+    />
+  );
+
+  const makeEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.75 : 0
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
+
+  await delay(20);
+
+  const makeNewEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.25 : 0.75
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeNewEntries);
+
+  await delay(0);
+
+  component.unmount();
+
+  await delay(100);
+
+  expect(setStateSpy.mock.calls.length).toBe(0);
+
+  setStateSpy.mockRestore();
+});
+
+it("disconnects from the IntersectionObserver when unmounting", async () => {
+  window.IntersectionObserver = FakeIntersectionObserver;
+
+  const disconnectSpy = jest.spyOn(
+    window.IntersectionObserver.prototype,
+    "disconnect"
+  );
+
+  const component = mount(
+    <AuthorProfileContent
+      articles={results.data.author.articles.list.slice(0, 5)}
+      author={authorProfileFixture.data.author}
+      slug="fiona-hamilton"
+      page={1}
+      pageSize={3}
+      imageRatio={3 / 2}
+      onTwitterLinkPress={() => {}}
+      onArticlePress={() => {}}
+    />
+  );
+
+  const makeEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.75 : 0
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeEntries);
+
+  await delay(20);
+
+  const makeNewEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      intersectionRatio: indx === 0 ? 0.25 : 0.75
+    }));
+  window.IntersectionObserver.dispatchEntriesForInstance(1, makeNewEntries);
+
+  await delay(0);
+
+  component.unmount();
+
+  await delay(100);
+
+  expect(disconnectSpy).toHaveBeenCalled();
+
+  disconnectSpy.mockRestore();
+});
+
+it("does not throw when unmounting with no IntersectionObserver", async () => {
+  delete window.IntersectionObserver;
+
+  const component = mount(
+    <AuthorProfileContent
+      articles={results.data.author.articles.list.slice(0, 5)}
+      author={authorProfileFixture.data.author}
+      slug="fiona-hamilton"
+      page={1}
+      pageSize={3}
+      imageRatio={3 / 2}
+      onTwitterLinkPress={() => {}}
+      onArticlePress={() => {}}
+    />
+  );
+
+  expect(component.unmount.bind(component)).not.toThrow();
+});
+
 it("emits scroll tracking events for author profile content", () => {
   window.IntersectionObserver = FakeIntersectionObserver;
   const reporter = jest.fn();
@@ -241,7 +453,13 @@ it("emits scroll tracking events for author profile content", () => {
     }
   );
 
-  window.IntersectionObserver.dispatchEntriesForInstance(0);
+  const makeEntries = nodes =>
+    [...nodes].map((node, indx) => ({
+      target: node,
+      isIntersecting: indx === 0
+    }));
+
+  window.IntersectionObserver.dispatchEntriesForInstance(0, makeEntries);
 
   expect(reporter).toHaveBeenCalledWith(
     expect.objectContaining({


### PR DESCRIPTION
The current naïve implementation of lazy images does a lot of work on scroll which can cause jank on some machines/browsers. This effectively debounces any pending changes until the observations/scrolling stops before doing the JS work and reflowing to give better UX.

A small tweak to the threshold improved loading on mobile views where the cards are laid vertically and the image starts at the top.

Here are the profiles of scrolling fast down a list of 20 items

Before (lots of work and long frames): 

<img width="1680" alt="screen shot 2017-11-25 at 18 16 58" src="https://user-images.githubusercontent.com/12942968/33260961-3bd81dea-d359-11e7-97d1-d3e675b0a3b8.png">

After (less work with one hit at the end):

<img width="1669" alt="screen shot 2017-11-25 at 18 18 10" src="https://user-images.githubusercontent.com/12942968/33260982-3ecab6ca-d359-11e7-8d7a-e6b053e28711.png">
