### PR TITLE
feat: use summary and headline for author profile

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -3946,7 +3946,20 @@ exports[`renders profile content component 1`] = `
     Array [
       Object {
         "__typename": "Article",
-        "content": Array [
+        "headline": "Top medal for forces dog who took a bite out of the Taliban",
+        "id": "d98c257c-cb16-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "leadAsset": Object {
+          "__typename": "Image",
+          "crop": Object {
+            "__typename": "Crop",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0",
+          },
+          "title": "Title",
+        },
+        "publicationName": "TIMES",
+        "publishedTime": 2017-11-17T00:01:00.000Z,
+        "summary": Array [
           Object {
             "attributes": Object {},
             "children": Array [
@@ -3961,24 +3974,24 @@ exports[`renders profile content component 1`] = `
             "name": "paragraph",
           },
         ],
-        "id": "d98c257c-cb16-11e7-b529-95e3fc05f40f",
+        "url": "https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f",
+      },
+      Object {
+        "__typename": "Article",
+        "headline": "Social media must raise game to beat terrorists, says UN chief",
+        "id": "4e6894ec-cb18-11e7-b529-95e3fc05f40f",
         "label": "",
         "leadAsset": Object {
           "__typename": "Image",
           "crop": Object {
             "__typename": "Crop",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745",
           },
           "title": "Title",
         },
         "publicationName": "TIMES",
         "publishedTime": 2017-11-17T00:01:00.000Z,
-        "title": "Top medal for forces dog who took a bite out of the Taliban",
-        "url": "https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f",
-      },
-      Object {
-        "__typename": "Article",
-        "content": Array [
+        "summary": Array [
           Object {
             "attributes": Object {},
             "children": Array [
@@ -3993,24 +4006,24 @@ exports[`renders profile content component 1`] = `
             "name": "paragraph",
           },
         ],
-        "id": "4e6894ec-cb18-11e7-b529-95e3fc05f40f",
+        "url": "https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0",
+      },
+      Object {
+        "__typename": "Article",
+        "headline": "Cuts have left the army 20 years out of date, says former general",
+        "id": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f",
         "label": "",
         "leadAsset": Object {
           "__typename": "Image",
           "crop": Object {
             "__typename": "Crop",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0",
           },
-          "title": "Title",
+          "title": "Nad e Ali in Helmand province, Afghanistan.",
         },
         "publicationName": "TIMES",
-        "publishedTime": 2017-11-17T00:01:00.000Z,
-        "title": "Social media must raise game to beat terrorists, says UN chief",
-        "url": "https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0",
-      },
-      Object {
-        "__typename": "Article",
-        "content": Array [
+        "publishedTime": 2017-11-14T17:00:00.000Z,
+        "summary": Array [
           Object {
             "attributes": Object {},
             "children": Array [
@@ -4025,19 +4038,6 @@ exports[`renders profile content component 1`] = `
             "name": "paragraph",
           },
         ],
-        "id": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f",
-        "label": "",
-        "leadAsset": Object {
-          "__typename": "Image",
-          "crop": Object {
-            "__typename": "Crop",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0",
-          },
-          "title": "Nad e Ali in Helmand province, Afghanistan.",
-        },
-        "publicationName": "TIMES",
-        "publishedTime": 2017-11-14T17:00:00.000Z,
-        "title": "Cuts have left the army 20 years out of date, says former general",
         "url": "https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn",
       },
     ]

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -404,7 +404,7 @@ export default AuthorProfileContent => {
       action: "Pressed",
       attrs: {
         articleId: "d98c257c-cb16-11e7-b529-95e3fc05f40f",
-        articleTitle:
+        articleHeadline:
           "Top medal for forces dog who took a bite out of the Taliban"
       }
     });

--- a/packages/author-profile/author-profile-item.js
+++ b/packages/author-profile/author-profile-item.js
@@ -15,13 +15,13 @@ const styles = StyleSheet.create({
 const AuthorProfileItem = item => {
   const {
     style,
-    content,
+    summary,
     label,
     isLoading,
     onPress,
     publicationName,
     publishedTime,
-    title,
+    headline,
     url,
     imageRatio,
     imageSize
@@ -45,8 +45,8 @@ const AuthorProfileItem = item => {
     <Link url={url} onPress={onPress}>
       <View style={[styles.container, style]}>
         <Card
-          headline={title}
-          text={content}
+          headline={headline}
+          text={summary}
           image={imageUri ? { uri: imageUri } : null}
           imageRatio={imageRatio}
           imageSize={imageSize}
@@ -64,7 +64,10 @@ export default withTrackEvents(AuthorProfileItem, {
     {
       eventName: "onPress",
       actionName: "Pressed",
-      getAttrs: ({ title, id }) => ({ articleTitle: title, articleId: id })
+      getAttrs: ({ headline, id }) => ({
+        articleHeadline: headline,
+        articleId: id
+      })
     }
   ]
 });

--- a/packages/author-profile/fixtures/article-list.json
+++ b/packages/author-profile/fixtures/article-list.json
@@ -5,7 +5,7 @@
         "count": 20,
         "list": [
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -34,14 +34,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-17T00:01:00.000Z",
-            "title":
+            "headline":
               "Top medal for forces dog who took a bite out of the Taliban",
             "url":
               "https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -70,14 +70,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-17T00:01:00.000Z",
-            "title":
+            "headline":
               "Social media must raise game to beat terrorists, says UN chief",
             "url":
               "https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -106,14 +106,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-14T17:00:00.000Z",
-            "title":
+            "headline":
               "Cuts have left the army 20 years out of date, says former general",
             "url":
               "https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -142,13 +142,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-11T00:01:00.000Z",
-            "title": "MoD recruits more civilians as Royal Marines face axe",
+            "headline": "MoD recruits more civilians as Royal Marines face axe",
             "url":
               "https://www.thetimes.co.uk/article/mod-recruits-more-civilians-as-royal-marines-face-axe-nqdh8v3zd",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {
@@ -192,14 +192,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-11T00:01:00.000Z",
-            "title":
+            "headline":
               "Suits you: poppy power is branching out for Remembrance appeal",
             "url":
               "https://www.thetimes.co.uk/article/remembrance-appeal-branches-out-with-poppy-onesies-mj2crrd8x",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -228,14 +228,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-10T00:01:00.000Z",
-            "title":
+            "headline":
               "MoD heralds a \u2018renewed\u2019 US special relationship",
             "url":
               "https://www.thetimes.co.uk/article/mod-heralds-a-renewed-special-relationship-with-us-d6wfnx3fs",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -264,14 +264,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-09T00:01:00.000Z",
-            "title":
+            "headline":
               "Defence cuts will hit Britain\u2019s standing, warns US general",
             "url":
               "https://www.thetimes.co.uk/article/us-general-ben-hodges-warns-britain-against-more-defence-cuts-wh7d6pn76",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -301,13 +301,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-04T00:00:00.000Z",
-            "title": "RAF ready to withdraw as Isis battle enters endgame",
+            "headline": "RAF ready to withdraw as Isis battle enters endgame",
             "url":
               "https://www.thetimes.co.uk/article/raf-ready-to-withdraw-as-isis-battle-enters-endgame-jj7l3b02v",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -349,14 +349,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-03T00:01:00.000Z",
-            "title":
+            "headline":
               "Fallon denies lewd comment about Leadsom\u2019s cold hands",
             "url":
               "https://www.thetimes.co.uk/article/fallon-denies-lewd-comment-about-leadsom-s-cold-hands-gkp3wnzn0",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -385,13 +385,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-03T00:01:00.000Z",
-            "title": "Gavin who? Shock at MoD\u2019s latest recruit",
+            "headline": "Gavin who? Shock at MoD\u2019s latest recruit",
             "url":
               "https://www.thetimes.co.uk/article/who-shock-at-mod-s-latest-recruit-gavin-williamson-968n7tdck",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -433,13 +433,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-02T00:01:00.000Z",
-            "title": "Fallon resigns as new sleaze claims emerge",
+            "headline": "Fallon resigns as new sleaze claims emerge",
             "url":
               "https://www.thetimes.co.uk/article/fallon-resigns-as-new-sleaze-claims-emerge-khsks7jpb",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -482,13 +482,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-02T00:01:00.000Z",
-            "title": "Fallon admits falling short and leaves the job he loved",
+            "headline":
+              "Fallon admits falling short and leaves the job he loved",
             "url":
               "https://www.thetimes.co.uk/article/sir-michael-fallon-admits-falling-short-and-leaves-the-job-he-loved-mdvrzvwq6",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -517,14 +518,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-01T00:01:00.000Z",
-            "title":
+            "headline":
               "Troops posted to Iraq face losing \u00a329 daily allowance",
             "url":
               "https://www.thetimes.co.uk/article/british-troops-posted-to-iraq-face-losing-29-daily-allowance-qnnk80qb9",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -553,13 +554,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-11-01T00:01:00.000Z",
-            "title": "Navy has to scavenge more parts",
+            "headline": "Navy has to scavenge more parts",
             "url":
               "https://www.thetimes.co.uk/article/royal-navy-has-to-scavenge-more-parts-national-audit-office-says-gzdxx7zpm",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -588,13 +589,14 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-10-30T00:01:00.000Z",
-            "title": "Scrapping assault ships risks Nato role, military told",
+            "headline":
+              "Scrapping assault ships risks Nato role, military told",
             "url":
               "https://www.thetimes.co.uk/article/scrapping-assault-ships-risks-nato-role-military-told-69ddr6qqr",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -623,13 +625,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-10-27T23:01:00.000Z",
-            "title": "New warplane costs $1\u00a0trillion to operate",
+            "headline": "New warplane costs $1\u00a0trillion to operate",
             "url":
               "https://www.thetimes.co.uk/article/new-f-35-warplane-costs-1-trillion-to-operate-sp6p3wdw2",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -658,13 +660,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-10-26T23:01:00.000Z",
-            "title": "Forces must find \u00a3300m for rising Trident costs",
+            "headline": "Forces must find \u00a3300m for rising Trident costs",
             "url":
               "https://www.thetimes.co.uk/article/forces-must-find-300m-for-rising-trident-costs-bmxnl9577",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -706,13 +708,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-10-25T23:01:00.000Z",
-            "title": "Britain mulls warships sale as military cuts deepen",
+            "headline": "Britain mulls warships sale as military cuts deepen",
             "url":
               "https://www.thetimes.co.uk/article/britain-mulls-warships-sale-as-military-cuts-deepen-2j0d0s5bs",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -754,13 +756,13 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-10-25T23:01:00.000Z",
-            "title": "\u2018MP criticism could harm arms deal\u2019",
+            "headline": "\u2018MP criticism could harm arms deal\u2019",
             "url":
               "https://www.thetimes.co.uk/article/mp-criticism-could-harm-saudi-arms-deal-warns-fallon-k97dxp3vj",
             "__typename": "Article"
           },
           {
-            "content": [
+            "summary": [
               {
                 "name": "paragraph",
                 "attributes": {},
@@ -803,7 +805,8 @@
             },
             "publicationName": "TIMES",
             "publishedTime": "2017-10-24T23:01:00.000Z",
-            "title": "US military officers raise fears over Royal Marine cuts",
+            "headline":
+              "US military officers raise fears over Royal Marine cuts",
             "url":
               "https://www.thetimes.co.uk/article/us-military-officers-raise-fears-over-royal-marine-cuts-gphqtd6pq",
             "__typename": "Article"

--- a/packages/provider/article-list-provider.js
+++ b/packages/provider/article-list-provider.js
@@ -12,7 +12,7 @@ export const query = gql`
       articles {
         count
         list(first: $first, skip: $skip) {
-          content(maxCharCount: 145, markupType: "paragraph")
+          summary(maxCharCount: 145)
           id
           label
           leadAsset {
@@ -33,7 +33,7 @@ export const query = gql`
           }
           publicationName
           publishedTime
-          title
+          headline
           url
         }
       }

--- a/packages/provider/schema.json
+++ b/packages/provider/schema.json
@@ -51,6 +51,41 @@
               "type": { "kind": "OBJECT", "name": "Article", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "sports",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": { "kind": "OBJECT", "name": "Sport", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "competition",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Competition",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -111,7 +146,8 @@
             },
             {
               "name": "twitter",
-              "description": "Twitter handle for an author",
+              "description":
+                "Twitter handle for an author (can be an empty string)",
               "args": [],
               "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
@@ -237,109 +273,11 @@
           "description": "",
           "fields": [
             {
-              "name": "id",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "title",
-              "description": "",
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
-              "isDeprecated": true,
-              "deprecationReason":
-                "Use headline instead which is more descriptive in the context of an article"
-            },
-            {
-              "name": "headline",
-              "description": "",
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "byline",
               "description":
                 "An AST of one or more authors that may contain job titles and/or locations",
               "args": [],
               "type": { "kind": "SCALAR", "name": "Markup", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "label",
-              "description": "A free piece of text to describe an article",
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "standfirst",
-              "description":
-                "A brief introductory summary, typically appearing immediately after the headline and typographically distinct from the rest of the article",
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "flags",
-              "description": "Article's flags",
-              "args": [],
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": { "kind": "ENUM", "name": "Flag", "ofType": null }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "publicationName",
-              "description": "",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "PublicationName",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "publishedTime",
-              "description": "",
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "DateTime", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "url",
-              "description": "",
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "URL", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "leadAsset",
-              "description": "",
-              "args": [],
-              "type": { "kind": "UNION", "name": "Media", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -374,6 +312,120 @@
                 }
               ],
               "type": { "kind": "SCALAR", "name": "Markup", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "flags",
+              "description": "A list of time dependent with pair dependencies",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": { "kind": "ENUM", "name": "Flag", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "headline",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": "A free piece of text to describe an article",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "leadAsset",
+              "description": "",
+              "args": [],
+              "type": { "kind": "UNION", "name": "Media", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicationName",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PublicationName",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishedTime",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "DateTime", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "standfirst",
+              "description":
+                "A brief introductory summary, typically appearing immediately after the headline and typographically distinct from the rest of the article",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "summary",
+              "description":
+                "A predefined truncated version of the article with a max length of the teaser, can optionally choose a shorter length. Use this to avoid ACS.",
+              "args": [
+                {
+                  "name": "maxCharCount",
+                  "description": "",
+                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "defaultValue": null
+                }
+              ],
+              "type": { "kind": "SCALAR", "name": "Markup", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": true,
+              "deprecationReason":
+                "Use headline instead which is more descriptive in the context of an article"
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "URL", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -419,32 +471,10 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "PublicationName",
-          "description": "",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "SUNDAYTIMES",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TIMES",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
           "kind": "SCALAR",
-          "name": "DateTime",
-          "description": "Represents a date and time of day in ISO 8601",
+          "name": "ID",
+          "description":
+            "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -476,7 +506,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -537,7 +567,7 @@
         {
           "kind": "SCALAR",
           "name": "Ratio",
-          "description": "Two floats comma delimited as a string",
+          "description": "Two floats colon delimited as a string",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -547,7 +577,7 @@
         {
           "kind": "OBJECT",
           "name": "Crop",
-          "description": "The selected area for a given image and it's ratio",
+          "description": "The selected area for a given image and its ratio",
           "fields": [
             {
               "name": "ratio",
@@ -583,7 +613,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -603,13 +633,252 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "ID",
-          "description":
-            "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "kind": "ENUM",
+          "name": "PublicationName",
+          "description": "",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SUNDAYTIMES",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TIMES",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "DateTime",
+          "description": "Represents a date and time of day in ISO 8601",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Sport",
+          "description": "A sport in the sports video hub",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "competitions",
+              "description": "A list of competitions associated to a sport",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Competition",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Competition",
+          "description": "A sport competition in the sports video hub",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "imageUrl",
+              "description":
+                "Poster image of the most recent video of a competition",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "URL", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "logoUrl",
+              "description": "Non-vector logo for competition",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "URL", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groups",
+              "description":
+                "A list of video groupings associated to a sport competition",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SportVideoGroup",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SportVideoGroup",
+          "description":
+            "A group of sport videos (e.g. round, match day, extras, ...)",
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "videos",
+              "description":
+                "A list of sport videos ordered by time of creation",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SportVideo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SportVideo",
+          "description":
+            "A video in the sports video hub. Note that some of these videos are only licensed on mobile applications.",
+          "fields": [
+            {
+              "name": "brightcoveId",
+              "description": "Brightcove identifier of a sport video",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subtitle",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "imageUrl",
+              "description": "Poster image of a sport video",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "URL", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishedTime",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "DateTime", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "brightcoveAccountId",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "brightcovePolicyKey",
+              "description": "",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9916,8 +9916,8 @@ styled-components@2.2.3:
     supports-color "^3.2.3"
 
 stylis@3.x:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.4.tgz#7dbc7e3ca3c8707b796cd217fe6f8fbe81e78464"
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.5.tgz#d7b9595fc18e7b9c8775eca8270a9a1d3e59806e"
 
 subcommander@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
At the moment if a client wants an article summary which is well within the teased limit, the API still needs to check with ACS because it queries article content.

Change to query `summary` which doesn't touch ACS and use `headline` instead of title which has SEO benefits

chore: update schema in provider for linting