### PR TITLE
Author profiles tracking

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -44,15 +44,6 @@ exports[`does re-render the author head if the loading state changes 1`] = `
 </Text>
 `;
 
-exports[`renders profile 1`] = `
-<Apollo(Wrapper)
-  articleImageRatio="3:2"
-  page={1}
-  pageSize={10}
-  slug="fiona-hamilton"
-/>
-`;
-
 exports[`renders profile content 1`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -45,7 +45,7 @@ exports[`does re-render the author head if the loading state changes 1`] = `
 `;
 
 exports[`renders profile 1`] = `
-<Pagination Helper (Apollo(Wrapper))
+<Apollo(Wrapper)
   articleImageRatio="3:2"
   page={1}
   pageSize={10}

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -265,15 +265,6 @@ Array [
 ]
 `;
 
-exports[`renders profile 1`] = `
-<Apollo(Wrapper)
-  articleImageRatio="3:2"
-  page={1}
-  pageSize={10}
-  slug="fiona-hamilton"
-/>
-`;
-
 exports[`renders profile content 1`] = `
 <div
   className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim"

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -266,7 +266,7 @@ Array [
 `;
 
 exports[`renders profile 1`] = `
-<Pagination Helper (Apollo(Wrapper))
+<Apollo(Wrapper)
   articleImageRatio="3:2"
   page={1}
   pageSize={10}

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -125,7 +125,9 @@ const withMockProvider = child => (
 
 export default AuthorProfileContent => {
   it("renders profile", () => {
-    const wrapper = shallow(<AuthorProfile {...props} />).dive();
+    const wrapper = shallow(<AuthorProfile {...props} />)
+      .dive()
+      .dive();
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -361,6 +361,7 @@ export default AuthorProfileContent => {
       action: "Viewed",
       attrs: expect.objectContaining({
         authorName: "Fiona Hamilton",
+        articlesCount: 20,
         page: 1,
         pageSize: 10
       })

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -124,14 +124,6 @@ const withMockProvider = child => (
 );
 
 export default AuthorProfileContent => {
-  it("renders profile", () => {
-    const wrapper = shallow(<AuthorProfile {...props} />)
-      .dive()
-      .dive();
-
-    expect(wrapper).toMatchSnapshot();
-  });
-
   it("renders profile content", () => {
     const component = renderer.create(
       withMockProvider(

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -15,14 +15,15 @@ const ratioTextToFloat = s => {
   return !Number.isNaN(ratio) ? ratio : 1;
 };
 
-const ArticleListProviderWithPageState = withPageState(ArticleListProvider);
 const AuthorProfile = ({
   author,
   error,
   isLoading,
   onArticlePress,
   onTwitterLinkPress,
-  page: initPage,
+  page,
+  onNext,
+  onPrev,
   pageSize: initPageSize,
   slug
 }) => {
@@ -34,17 +35,14 @@ const AuthorProfile = ({
     author || {};
 
   return (
-    <ArticleListProviderWithPageState
+    <ArticleListProvider
       articleImageRatio="3:2"
       slug={slug}
-      page={initPage}
+      page={page}
       pageSize={initPageSize}
     >
       {({
         author: data,
-        onNext,
-        onPrev,
-        page,
         pageSize,
         isLoading: articlesLoading,
         variables: { imageRatio }
@@ -79,7 +77,7 @@ const AuthorProfile = ({
           />
         );
       }}
-    </ArticleListProviderWithPageState>
+    </ArticleListProvider>
   );
 };
 
@@ -90,6 +88,8 @@ AuthorProfile.defaultProps = {
   onArticlePress: () => {},
   onTwitterLinkPress: () => {},
   page: 1,
+  onNext: () => {},
+  onPrev: () => {},
   pageSize: 10
 };
 
@@ -104,13 +104,15 @@ AuthorProfile.propTypes = {
     twitter: PropTypes.string
   }),
   page: PropTypes.number,
+  onNext: PropTypes.func,
+  onPrev: PropTypes.func,
   pageSize: PropTypes.number,
   onTwitterLinkPress: PropTypes.func,
   onArticlePress: PropTypes.func,
   slug: PropTypes.string.isRequired
 };
 
-export default withTrackingContext(AuthorProfile, {
+const AuthorProfileWithTracking = withTrackingContext(AuthorProfile, {
   getAttrs: ({ author, page, pageSize } = {}) => ({
     authorName: author && author.name,
     page,
@@ -119,3 +121,5 @@ export default withTrackingContext(AuthorProfile, {
   }),
   trackingObject: "AuthorProfile"
 });
+
+export default withPageState(AuthorProfileWithTracking);

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -114,7 +114,8 @@ export default withTrackingContext(AuthorProfile, {
   getAttrs: ({ author, page, pageSize } = {}) => ({
     authorName: author && author.name,
     page,
-    pageSize
+    pageSize,
+    articlesCount: get(author, "articles.count", 0)
   }),
   trackingObject: "AuthorProfile"
 });


### PR DESCRIPTION
* Pull page state up above author-profile so that correct page prop can be used for tracking
* Add `articlesCount` field to author profile tracking events
* Remove redundant test - can re-instate if it desired but didn't appear to be adding any value


