### PR TITLE
Chore: REPLAT-922: Change fixtures as per design review

### DIFF
--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -7396,8 +7396,8 @@ exports[`Article test on android renders full article 1`] = `
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits",
             "display": "primary",
-            "ratio": "1500:1200",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+            "ratio": "1500:1000",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
           },
           "children": Array [],
           "name": "image",
@@ -8300,7 +8300,7 @@ exports[`Article test on android renders full article 1`] = `
             style={undefined}
           >
             <View
-              aspectRatio={1.25}
+              aspectRatio={1.5}
               style={Object {}}
             >
               <View
@@ -8315,7 +8315,7 @@ exports[`Article test on android renders full article 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
                     }
                   }
                   style={

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -7397,7 +7397,7 @@ exports[`Article test on android renders full article 1`] = `
             "credits": "The credits",
             "display": "primary",
             "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
           },
           "children": Array [],
           "name": "image",

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -7397,7 +7397,7 @@ exports[`Article test on android renders full article 1`] = `
             "credits": "The credits",
             "display": "primary",
             "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
           },
           "children": Array [],
           "name": "image",
@@ -8315,7 +8315,7 @@ exports[`Article test on android renders full article 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
                     }
                   }
                   style={

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -7032,8 +7032,8 @@ exports[`Article test on ios renders full article 1`] = `
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits",
             "display": "primary",
-            "ratio": "1500:1200",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+            "ratio": "1500:1000",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
           },
           "children": Array [],
           "name": "image",
@@ -7889,7 +7889,7 @@ exports[`Article test on ios renders full article 1`] = `
             style={undefined}
           >
             <View
-              aspectRatio={1.25}
+              aspectRatio={1.5}
               style={Object {}}
             >
               <View
@@ -7904,7 +7904,7 @@ exports[`Article test on ios renders full article 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
                     }
                   }
                   style={

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -7033,7 +7033,7 @@ exports[`Article test on ios renders full article 1`] = `
             "credits": "The credits",
             "display": "primary",
             "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
           },
           "children": Array [],
           "name": "image",

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -7033,7 +7033,7 @@ exports[`Article test on ios renders full article 1`] = `
             "credits": "The credits",
             "display": "primary",
             "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
           },
           "children": Array [],
           "name": "image",
@@ -7904,7 +7904,7 @@ exports[`Article test on ios renders full article 1`] = `
                   onLoad={[Function]}
                   source={
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
                     }
                   }
                   style={

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -3235,7 +3235,7 @@ exports[`Article test on web renders full article 1`] = `
               >
                 <img
                   alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0"
+                  src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0"
                   style={
                     Object {
                       "display": "block",

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -3235,7 +3235,7 @@ exports[`Article test on web renders full article 1`] = `
               >
                 <img
                   alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600"
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0"
                   style={
                     Object {
                       "display": "block",

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -3229,13 +3229,13 @@ exports[`Article test on web renders full article 1`] = `
                     "display": "table",
                     "height": 0,
                     "overflow": "hidden",
-                    "paddingBottom": "80%",
+                    "paddingBottom": "66.66666666666667%",
                   }
                 }
               >
                 <img
                   alt=""
-                  src="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0"
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600"
                   style={
                     Object {
                       "display": "block",

--- a/packages/article/fixtures/full-article-typename.json
+++ b/packages/article/fixtures/full-article-typename.json
@@ -529,7 +529,7 @@
         "crop": {
           "ratio": "16:9",
           "url":
-            "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprodmigration%2Fweb%2Fbin%2F4995ecc6-216d-33b2-a90c-8ca0c510a48c.jpg?crop=1500%2C1000%2C0%2C0&resize=1200",
+            "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F94d46672-d8e2-11e7-9b16-edd3826708d6.jpg?crop=1155%2C650%2C46%2C248&resize=685",
           "__typename": "Crop"
         },
         "__typename": "Image"

--- a/packages/article/fixtures/full-article-typename.json
+++ b/packages/article/fixtures/full-article-typename.json
@@ -529,7 +529,7 @@
         "crop": {
           "ratio": "16:9",
           "url":
-            "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F94d46672-d8e2-11e7-9b16-edd3826708d6.jpg?crop=1155%2C650%2C46%2C248&resize=685",
+            "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F94d46672-d8e2-11e7-9b16-edd3826708d6.jpg?crop=1155%2C650%2C46%2C248",
           "__typename": "Crop"
         },
         "__typename": "Image"

--- a/packages/article/fixtures/full-article.json
+++ b/packages/article/fixtures/full-article.json
@@ -113,7 +113,7 @@
             "display": "primary",
             "ratio": "1500:1000",
             "url":
-              "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+              "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },

--- a/packages/article/fixtures/full-article.json
+++ b/packages/article/fixtures/full-article.json
@@ -113,7 +113,7 @@
             "display": "primary",
             "ratio": "1500:1000",
             "url":
-              "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
+              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },

--- a/packages/article/fixtures/full-article.json
+++ b/packages/article/fixtures/full-article.json
@@ -111,9 +111,9 @@
           "name": "image",
           "attributes": {
             "display": "primary",
-            "ratio": "1500:1200",
+            "ratio": "1500:1000",
             "url":
-              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+              "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },

--- a/packages/article/fixtures/full-long-article.json
+++ b/packages/article/fixtures/full-long-article.json
@@ -111,9 +111,9 @@
           "name": "image",
           "attributes": {
             "display": "primary",
-            "ratio": "1500:1200",
+            "ratio": "1500:1000",
             "url":
-              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },

--- a/packages/article/fixtures/full-long-article.json
+++ b/packages/article/fixtures/full-long-article.json
@@ -113,7 +113,7 @@
             "display": "primary",
             "ratio": "1500:1000",
             "url":
-              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },

--- a/packages/article/fixtures/no-ads.json
+++ b/packages/article/fixtures/no-ads.json
@@ -111,9 +111,9 @@
           "name": "image",
           "attributes": {
             "display": "primary",
-            "ratio": "1500:1200",
+            "ratio": "1500:1000",
             "url":
-              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0",
+              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },

--- a/packages/article/fixtures/no-ads.json
+++ b/packages/article/fixtures/no-ads.json
@@ -113,7 +113,7 @@
             "display": "primary",
             "ratio": "1500:1000",
             "url":
-              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0&resize=600",
+              "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
             "caption": "All the latest stories in culture and books.",
             "credits": "The credits"
           },


### PR DESCRIPTION
Addressing the comments in design review

- Fixture image ratio should be 16:9 or 3:2 (Inline primary image)
- Fixing fixture for provider data story, which was related to the iamge