### PR TITLE
chore: update getting started docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,13 +48,8 @@ When developing a component it's easiest to use the
 [storybooks](https://github.com/storybooks/storybook) with hot reloading. Make
 sure you follow the
 [React Native instructions](https://facebook.github.io/react-native/docs/getting-started.html)
-to get up and running first
-
-* `npm run storybook` will build the storybook and allow you to develop
-  components in the browser
-* `npm run storybook-native` will build the storybook and watch for JS changes.
-  In a separate terminal run `react-native run-[platform]`. This will allow you
-  to develop in your storybook on a device or in an emulator.
+to get up and running first. See [README.md](../README.md) for commands to run
+the storybook.
 
 > #### Caution
 >

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ platforms
 We require MacOS with [Node.js](https://nodejs.org) (version >=8 with npm v5),
 [yarn](https://yarnpkg.com) (latest) and
 [watchman](https://facebook.github.io/watchman) installed. Native development
-requires [Xcode](https://developer.apple.com/xcode) and
-[Android Studio](https://developer.android.com/studio/index.html).
+requires [Xcode](https://developer.apple.com/xcode),
+[Android Studio](https://developer.android.com/studio/index.html) and
+[JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html).
 
 You can try without these requirements, but you'd be on your own.
 
@@ -31,8 +32,14 @@ You can try without these requirements, but you'd be on your own.
   2. go to http://localhost:9001
 * native storybook
   1. `yarn storybook-native` and leave it running
-  2. `yarn ios` and/or `yarn android` to start the (sim|em)ulators
-  3. go to http://localhost:7007
+  2. `yarn ios` to start the iOS app
+  3. To start the Android app:
+     * [Start a virtual device](https://developer.android.com/studio/run/managing-avds.html)
+     * `yarn android`
+     * If you get build errors, check your JDK version with `javac -version`,
+       which should print `javac 1.8.XXXX`. Earlier or later versions may not
+       work.
+  4. go to http://localhost:7007
 
 ### Fonts ⚠️
 


### PR DESCRIPTION
 * The docs now point out that the build requires JDK 8 and won’t work
on more recent JDKs.
 *  Removed old storybook run commands in .github/CONTRIBUTING.md now
superseded by instructions in README.md

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
