### PR TITLE
fix: set font weight as a string

### DIFF
--- a/packages/article/styles/header/shared.js
+++ b/packages/article/styles/header/shared.js
@@ -4,7 +4,8 @@ const sharedStyles = {
     lineHeight: 32,
     color: "#1d1d1b",
     marginBottom: 7,
-    fontFamily: "TimesModern-Bold"
+    fontFamily: "TimesModern-Bold",
+    fontWeight: "400"
   },
   standFirst: {
     fontSize: 20,


### PR DESCRIPTION
fontWeight should be a string as per: https://facebook.github.io/react-native/docs/text.html
