### PR TITLE
fix: make packages public

### DIFF
--- a/packages/eslint-config-thetimes/package.json
+++ b/packages/eslint-config-thetimes/package.json
@@ -28,5 +28,8 @@
   },
   "peerDependencies": {
     "eslint": "4.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -45,5 +45,8 @@
     "react": "16.0.0",
     "react-dom": "16.0.0",
     "react-native": "0.50.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
If packages can't be published then the public storybook won't be updated/platforms can't take the latest versions