### PR TITLE
feat: remove font anti-aliasing of article headline on web

### DIFF
--- a/packages/article-summary/__tests__/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/__snapshots__/article-summary.web.test.js.snap
@@ -24,6 +24,7 @@ exports[`renders an article-summary component with content 1`] = `
     dir="auto"
     style={
       Object {
+        "WebkitFontSmoothing": "auto",
         "color": "rgba(51,51,51,1)",
         "fontFamily": "TimesModern-Bold",
         "fontSize": "22px",
@@ -109,6 +110,7 @@ exports[`renders an article-summary component with content including line breaks
     dir="auto"
     style={
       Object {
+        "WebkitFontSmoothing": "auto",
         "color": "rgba(51,51,51,1)",
         "fontFamily": "TimesModern-Bold",
         "fontSize": "22px",
@@ -213,6 +215,7 @@ exports[`renders an article-summary component with empty content at the end trim
     dir="auto"
     style={
       Object {
+        "WebkitFontSmoothing": "auto",
         "color": "rgba(51,51,51,1)",
         "fontFamily": "TimesModern-Bold",
         "fontSize": "22px",
@@ -304,6 +307,7 @@ exports[`renders an article-summary component with headline and no content 1`] =
     dir="auto"
     style={
       Object {
+        "WebkitFontSmoothing": "auto",
         "color": "rgba(51,51,51,1)",
         "fontFamily": "TimesModern-Bold",
         "fontSize": "22px",

--- a/packages/article-summary/article-summary.js
+++ b/packages/article-summary/article-summary.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { Text, View, Platform } from "react-native";
 import PropTypes from "prop-types";
 import { renderTrees, treePropType } from "@times-components/markup";
 import DatePublication from "@times-components/date-publication";
@@ -20,7 +20,10 @@ const styles = {
     lineHeight: 22,
     marginBottom: 8,
     fontFamily: "TimesModern-Bold",
-    fontWeight: "400"
+    fontWeight: "400",
+    ...Platform.select({
+      web: { WebkitFontSmoothing: "auto" }
+    })
   },
   text: {
     color: "#696969",

--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.web.test.js.snap
@@ -1760,6 +1760,7 @@ exports[`renders profile content component 1`] = `
                       dir="auto"
                       style={
                         Object {
+                          "WebkitFontSmoothing": "auto",
                           "fontSize": "22px",
                           "fontWeight": "400",
                           "lineHeight": "22px",
@@ -1904,6 +1905,7 @@ exports[`renders profile content component 1`] = `
                       dir="auto"
                       style={
                         Object {
+                          "WebkitFontSmoothing": "auto",
                           "fontSize": "22px",
                           "fontWeight": "400",
                           "lineHeight": "22px",
@@ -2048,6 +2050,7 @@ exports[`renders profile content component 1`] = `
                       dir="auto"
                       style={
                         Object {
+                          "WebkitFontSmoothing": "auto",
                           "fontSize": "22px",
                           "fontWeight": "400",
                           "lineHeight": "22px",
@@ -2249,6 +2252,7 @@ exports[`renders profile content item component 1`] = `
               dir="auto"
               style={
                 Object {
+                  "WebkitFontSmoothing": "auto",
                   "fontSize": "22px",
                   "fontWeight": "400",
                   "lineHeight": "22px",
@@ -2387,6 +2391,7 @@ exports[`renders profile content item component with a specific image size 1`] =
               dir="auto"
               style={
                 Object {
+                  "WebkitFontSmoothing": "auto",
                   "fontSize": "22px",
                   "fontWeight": "400",
                   "lineHeight": "22px",
@@ -2482,6 +2487,7 @@ exports[`renders profile content item component with no image 1`] = `
               dir="auto"
               style={
                 Object {
+                  "WebkitFontSmoothing": "auto",
                   "fontSize": "22px",
                   "fontWeight": "400",
                   "lineHeight": "22px",

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -152,6 +152,7 @@ exports[`Card test on web renders 1`] = `
           dir="auto"
           style={
             Object {
+              "WebkitFontSmoothing": "auto",
               "color": "rgba(51,51,51,1)",
               "fontFamily": "TimesModern-Bold",
               "fontSize": "22px",
@@ -438,6 +439,7 @@ exports[`Card test on web renders without image 1`] = `
           dir="auto"
           style={
             Object {
+              "WebkitFontSmoothing": "auto",
               "color": "rgba(51,51,51,1)",
               "fontFamily": "TimesModern-Bold",
               "fontSize": "22px",
@@ -572,6 +574,7 @@ exports[`Card test on web renders without image url 1`] = `
           dir="auto"
           style={
             Object {
+              "WebkitFontSmoothing": "auto",
               "color": "rgba(51,51,51,1)",
               "fontFamily": "TimesModern-Bold",
               "fontSize": "22px",


### PR DESCRIPTION
Don't use antialiasing on article summary headline on web
# Web
## Before
![image](https://user-images.githubusercontent.com/4660500/33902911-6fc9f076-df6e-11e7-8f82-dd64c9ff8779.png)

## After
![image](https://user-images.githubusercontent.com/4660500/33902858-473c573e-df6e-11e7-9dc9-fa95c132e96e.png)
