### PR TITLE
Fix/react-native-web peer

### DIFF
--- a/lib/cli/package-json.js
+++ b/lib/cli/package-json.js
@@ -53,13 +53,13 @@ module.exports = variables => ({
     webpack: "3.3.0"
   },
   dependencies: {
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   peerDependencies: {
     react: ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   publishConfig: {
     access: "public"

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -66,13 +66,13 @@
   "dependencies": {
     "@times-components/watermark": "0.2.1",
     "prop-types": "15.6.0",
-    "react-broadcast": "0.5.2",
-    "react-native-web": "0.1.14"
+    "react-broadcast": "0.5.2"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -55,13 +55,13 @@
   "dependencies": {
     "@times-components/link": "0.12.1",
     "@times-components/markup": "0.14.2",
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -68,13 +68,13 @@
   "dependencies": {
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -67,7 +67,7 @@
     "react": ">=16",
     "react-dom": ">=16",
     "react-native": ">=0.50",
-    "react-native-web": "0.1.14"
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -56,13 +56,13 @@
     "webpack": "3.3.0"
   },
   "dependencies": {
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -56,13 +56,13 @@
     "@times-components/date-publication": "0.7.1",
     "@times-components/markup": "0.14.2",
     "date-fns": "1.28.5",
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -76,13 +76,13 @@
     "@times-components/tracking": "0.5.4",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.14",
     "styled-components": "2.2.3"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -68,7 +68,6 @@
     "react-dom": "16.2.0",
     "react-native": "0.50.1",
     "react-test-renderer": "16.2.0",
-    "styled-components": "2.2.3",
     "webpack": "3.3.0"
   },
   "dependencies": {
@@ -78,6 +77,7 @@
     "@times-components/responsive-styles": "0.2.2",
     "@times-components/tracking": "0.5.4",
     "prop-types": "15.6.0",
+    "styled-components": "2.2.3",
     "svgs": "3.1.1"
   },
   "peerDependencies": {

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -78,13 +78,13 @@
     "@times-components/responsive-styles": "0.2.2",
     "@times-components/tracking": "0.5.4",
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -77,13 +77,13 @@
     "@times-components/tracking": "0.5.4",
     "lodash.get": "4.4.2",
     "lodash.merge": "4.6.0",
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -68,13 +68,13 @@
   "dependencies": {
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "_timesComponentsCliVariables": {
     "component": "BrightcoveVideo",

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -66,13 +66,13 @@
     "webpack": "3.3.0"
   },
   "dependencies": {
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -67,13 +67,13 @@
     "@times-components/responsive-styles": "0.2.2",
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -67,13 +67,13 @@
   },
   "dependencies": {
     "date-fns": "1.28.5",
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -68,13 +68,13 @@
     "webpack": "3.3.0"
   },
   "dependencies": {
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -65,14 +65,14 @@
     "webpack": "3.3.0"
   },
   "dependencies": {
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
     "react-native": ">=0.50",
-    "react-native-linear-gradient": ">=2.3"
+    "react-native-linear-gradient": ">=2.3",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -61,14 +61,14 @@
     "@times-components/gradient": "0.3.1",
     "@times-components/jest-configurator": "0.0.13",
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
     "react-native": ">=0.50",
-    "react-native-linear-gradient": ">=2.3"
+    "react-native-linear-gradient": ">=2.3",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -70,13 +70,13 @@
   },
   "dependencies": {
     "lodash.pick": "4.4.0",
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -56,13 +56,13 @@
   },
   "dependencies": {
     "@times-components/ad": "0.6.1",
-    "prop-types": "15.6.0",
-    "react-native-web": "0.1.14"
+    "prop-types": "15.6.0"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -66,13 +66,13 @@
     "prop-types": "15.6.0",
     "react-display-name": "0.2.3",
     "react-native-svg": "5.5.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -73,13 +73,13 @@
     "lodash.get": "4.4.2",
     "lodash.pick": "4.4.0",
     "prop-types": "15.6.0",
-    "react-apollo": "2.0.1",
-    "react-native-web": "0.1.14"
+    "react-apollo": "2.0.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/responsive-styles/package.json
+++ b/packages/responsive-styles/package.json
@@ -52,13 +52,13 @@
   },
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-web": "0.1.14",
     "styled-components": "2.2.3"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -50,7 +50,7 @@
     "prettier": "1.8.2"
   },
   "peerDependencies": {
-    "react-native-web": "0.1.14"
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -60,13 +60,13 @@
     "hoist-non-react-statics": "2.3.1",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.0",
-    "react-display-name": "0.2.3",
-    "react-native-web": "0.1.14"
+    "react-display-name": "0.2.3"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -65,13 +65,13 @@
   "dependencies": {
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
-    "react-native-web": "0.1.14",
     "svgs": "3.1.1"
   },
   "peerDependencies": {
     "react": ">=16",
     "react-dom": ">=16",
-    "react-native": ">=0.50"
+    "react-native": ">=0.50",
+    "react-native-web": ">=0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,24 +273,24 @@
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
 
 "@types/lodash@^4.14.85":
-  version "4.14.88"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.88.tgz#97eaf2dc668f33ed8e511a5b627035f4ea20b0f5"
+  version "4.14.91"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.91.tgz#794611b28056d16b5436059c6d800b39d573cd3a"
 
 "@types/mkdirp@^0.3.29":
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
 
 "@types/node@*", "@types/node@^8.0.19":
-  version "8.0.58"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.58.tgz#5b3881c0be3a646874803fee3197ea7f1ed6df90"
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
 
 "@types/node@6.0.66":
   version "6.0.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.66.tgz#5680b74a6135d33d4c00447e7c3dc691a4601625"
 
 "@types/react@^16.0.18":
-  version "16.0.29"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.29.tgz#4eea6a8de9f40ca71d580ae7a9f3b4b77b368de8"
+  version "16.0.31"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.31.tgz#5285da62f3ac62b797f6d0729a1d6181f3180c3e"
 
 "@types/zen-observable@0.5.3", "@types/zen-observable@^0.5.3":
   version "0.5.3"
@@ -774,19 +774,19 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^7.1.6:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.2.tgz#082293b964be00602efacc59aa4aa7df5158bb6e"
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.3.tgz#c2841e38b7940c2d0a9bbffd72c75f33637854f8"
   dependencies:
     browserslist "^2.10.0"
-    caniuse-lite "^1.0.30000780"
+    caniuse-lite "^1.0.30000783"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^6.0.14"
     postcss-value-parser "^3.2.3"
 
 aws-sdk@^2.90.0:
-  version "2.169.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.169.0.tgz#c2d72737a30afb9a64f7ceb88ff1d5367f8eeb69"
+  version "2.171.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.171.0.tgz#69c2565e98e353d437402477cc3064a13caedc9c"
   dependencies:
     buffer "4.9.1"
     crypto-browserify "1.0.9"
@@ -2445,7 +2445,7 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000783"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000783.tgz#16b30d47266a4f515cc69ae0316b670c9603cdbe"
 
-caniuse-lite@^1.0.30000780:
+caniuse-lite@^1.0.30000780, caniuse-lite@^1.0.30000783:
   version "1.0.30000783"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000783.tgz#9b5499fb1b503d2345d12aa6b8612852f4276ffd"
 
@@ -2674,6 +2674,10 @@ color-string@^0.3.0:
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
   dependencies:
     color-name "^1.0.0"
+
+color-support@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
 
 color@^0.11.0, color@^0.11.1:
   version "0.11.4"
@@ -3923,9 +3927,15 @@ enzyme-adapter-utils@^1.1.0:
     object.assign "^4.0.4"
     prop-types "^15.5.10"
 
-enzyme-to-json@3.2.2, enzyme-to-json@^3.2.2:
+enzyme-to-json@3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.2.2.tgz#110047c68dda97aaeb7af3cee7d995fe3d17e82a"
+  dependencies:
+    lodash "^4.17.4"
+
+enzyme-to-json@^3.2.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.0.tgz#553e23a09ffb4b0cf09287e2edf9c6539fddaa84"
   dependencies:
     lodash "^4.17.4"
 
@@ -3990,8 +4000,8 @@ es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-symbol "~3.1.1"
 
 es5-shim@^4.5.9:
-  version "4.5.9"
-  resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.9.tgz#2a1e2b9e583ff5fed0c20a3ee2cbf3f75230a5c0"
+  version "4.5.10"
+  resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.10.tgz#b7e17ef4df2a145b821f1497b50c25cf94026205"
 
 es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.3"
@@ -4429,10 +4439,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fancy-log@^1.1.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.1.tgz#c4a3462ba14adf5dfbab79731fd3844a2069cbbb"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
     ansi-gray "^0.1.1"
+    color-support "^1.1.3"
     time-stamp "^1.0.0"
 
 fast-deep-equal@^1.0.0:
@@ -4512,8 +4523,8 @@ file-entry-cache@^2.0.0:
     object-assign "^4.0.1"
 
 file-loader@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.5.tgz#91c25b6b6fbe56dae99f10a425fd64933b5c9daa"
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.6.tgz#7b9a8f2c58f00a77fddf49e940f7ac978a3ea0e8"
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
@@ -5460,8 +5471,8 @@ ignore@^3.3.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 image-size@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.1.tgz#98122a562d59dcc097ef1b2c8191866eb8f5d663"
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.2.tgz#8ee316d4298b028b965091b673d5f1537adee5b4"
 
 immutable@^3.8.1:
   version "3.8.2"
@@ -8515,23 +8526,6 @@ react-native-web@0.1.14:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.3"
 
-react-native-web@>=0.1:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.1.16.tgz#e0d1a43b3b59a8371cdb538c11088d206b29f2b1"
-  dependencies:
-    animated "^0.2.0"
-    array-find-index "^1.0.2"
-    babel-runtime "^6.26.0"
-    create-react-class "^15.6.2"
-    debounce "1.0.2"
-    deep-assign "^2.0.0"
-    fbjs "^0.8.16"
-    hyphenate-style-name "^1.0.2"
-    inline-style-prefixer "^3.0.8"
-    normalize-css-color "^1.0.2"
-    prop-types "^15.6.0"
-    react-timer-mixin "^0.13.3"
-
 react-native@0.50.1:
   version "0.50.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.50.1.tgz#3d8bb7c96dd3151788e795a22155d305f15abfd1"
@@ -10772,8 +10766,8 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 xhr@^2.0.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.4.0.tgz#e16e66a45f869861eeefab416d5eff722dc40993"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.4.1.tgz#ba982cced205ae5eec387169ac9dc77ca4853d38"
   dependencies:
     global "~4.3.0"
     is-function "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8515,6 +8515,23 @@ react-native-web@0.1.14:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.3"
 
+react-native-web@>=0.1:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.1.16.tgz#e0d1a43b3b59a8371cdb538c11088d206b29f2b1"
+  dependencies:
+    animated "^0.2.0"
+    array-find-index "^1.0.2"
+    babel-runtime "^6.26.0"
+    create-react-class "^15.6.2"
+    debounce "1.0.2"
+    deep-assign "^2.0.0"
+    fbjs "^0.8.16"
+    hyphenate-style-name "^1.0.2"
+    inline-style-prefixer "^3.0.8"
+    normalize-css-color "^1.0.2"
+    prop-types "^15.6.0"
+    react-timer-mixin "^0.13.3"
+
 react-native@0.50.1:
   version "0.50.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.50.1.tgz#3d8bb7c96dd3151788e795a22155d305f15abfd1"


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
Using `react-native-web` as a dependency could lead to some unexpected behaviour in scenarios like this:

```
- cps-content-render (react-native-web 0.1.14 in package.json dep)
  - node-modules
    - @times-components
      - package 1 (react-native-web 0.1.7 in package.json dep)
        - node_modules
          - react-native-web (0.1.7)
      - package 2 (react-native-web 0.1.14 in package.json dep)
          - node_modules
    - react-native-web (0.1.14)
```
eg: react-native-web StyleSheet use a global object to register (and cache) globally all stylesheets so in this case we'll have two instances of the global cache

