### PR TITLE
fix: guard against no observer

### DIFF
--- a/packages/tracking/track-scroll-depth.web.js
+++ b/packages/tracking/track-scroll-depth.web.js
@@ -77,7 +77,7 @@ export default (
     }
 
     observeChildren() {
-      if (this.childList)
+      if (this.observer && this.childList)
         this.childList.forEach((props, index) => {
           if (!this.childData.elementId) {
             this.observeChild({


### PR DESCRIPTION
For now if browsers don't support `IntersectionObserver` (safari), they won't get the advanced tracking