### PR TITLE
Bump storybook version to 3.2.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/fructose": "3.1.8",
     "chromeless": "1.3.0",
     "coveralls": "2.13.1",

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/jest-configurator": "0.0.13",
     "@times-components/utils": "0.0.8",

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/jest-configurator": "0.0.13",
     "babel-cli": "6.24.1",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/jest-configurator": "0.0.13",
     "@times-components/utils": "0.0.8",

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -44,8 +44,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/jest-configurator": "0.0.13",
     "@times-components/storybook": "0.2.0",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/error-view": "0.7.4",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/tealium": "0.1.4",

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/image": "1.8.4",
     "babel-cli": "6.24.1",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/article-summary": "0.12.6",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/jest-configurator": "0.0.13",

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -45,8 +45,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/brightcove-video": "1.9.3",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/brightcove-video": "1.9.3",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -46,8 +46,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/storybook": "0.2.0",
     "babel-cli": "6.24.1",

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/storybook": "0.2.0",
     "babel-cli": "6.24.1",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -32,8 +32,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.2.17",
-    "@storybook/react-native": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/storybook": "0.2.0",
     "babel-cli": "6.24.1",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/utils": "0.0.8",
     "apollo-utilities": "1.0.2",

--- a/packages/responsive-styles/package.json
+++ b/packages/responsive-styles/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/jest-configurator": "0.0.13",
     "babel-cli": "6.24.1",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
     "prettier": "1.8.2"
   },
   "dependencies": {
-    "@storybook/addon-actions": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
     "eslint": "4.9.0",
     "eslint-config-airbnb": "16.1.0",
     "eslint-config-prettier": "2.6.0",

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "dependencies": {
-    "@storybook/addon-actions": "3.2.17",
+    "@storybook/addon-actions": "3.2.18",
     "react-native": "0.50.1"
   },
   "devDependencies": {

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "@times-components/storybook": "0.2.0",
     "@times-components/tealium": "0.1.4",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/react-native": "3.2.17",
+    "@storybook/react-native": "3.2.18",
     "@times-components/eslint-config-thetimes": "0.0.2",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,49 +6,49 @@
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
 
-"@storybook/addon-actions@3.2.17", "@storybook/addon-actions@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.17.tgz#e85d38f743125157fdaf6669708e089bc2008e50"
+"@storybook/addon-actions@3.2.18", "@storybook/addon-actions@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.18.tgz#46d97b0add955698d66becb5d51e68a4d387b822"
   dependencies:
-    "@storybook/addons" "^3.2.17"
+    "@storybook/addons" "^3.2.18"
     deep-equal "^1.0.1"
     json-stringify-safe "^5.0.1"
     prop-types "^15.6.0"
-    react-inspector "^2.2.1"
+    react-inspector "^2.2.2"
     uuid "^3.1.0"
 
-"@storybook/addon-links@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.2.17.tgz#fb1d5f5f16575e56d560955d70c2a756c9f5b612"
+"@storybook/addon-links@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.2.18.tgz#a1fd96dd91d56204da92632baa36a2263d2aeebb"
   dependencies:
-    "@storybook/addons" "^3.2.17"
+    "@storybook/addons" "^3.2.18"
 
-"@storybook/addons@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.17.tgz#5c2ece24c5f7fbf7cedf4cfe503c5e356543e62d"
+"@storybook/addons@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.18.tgz#2c1d42a0b661db2e429d1c406e79765ae5c71458"
 
-"@storybook/channel-postmessage@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.2.17.tgz#530c1d6852b2c77df08490988fa943ba1373b1ec"
+"@storybook/channel-postmessage@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.2.18.tgz#8193e2fbae4f46a20a58fb6cdfd722c1743a3dd0"
   dependencies:
-    "@storybook/channels" "^3.2.17"
+    "@storybook/channels" "^3.2.18"
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
 
-"@storybook/channel-websocket@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-3.2.17.tgz#c72e39905c15e991b04ba1b47b3a41aafdfdc5d7"
+"@storybook/channel-websocket@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-3.2.18.tgz#9718336cd36a6eee08235bf8e4e1391272184bbf"
   dependencies:
-    "@storybook/channels" "^3.2.17"
+    "@storybook/channels" "^3.2.18"
     global "^4.3.2"
 
-"@storybook/channels@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.17.tgz#09219a512564d1aa2292419d8d6064dbf7f5a5b3"
+"@storybook/channels@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.2.18.tgz#c5d8c4ac780c6ebb4b1c360d8faf9207fd4fbafd"
 
-"@storybook/components@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.2.17.tgz#318c6e6a1d3ffb469523b5dcfee775639ccc500b"
+"@storybook/components@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.2.18.tgz#142dd10414a717c24734f063af6b2b7b9bd06b4a"
   dependencies:
     glamor "^2.20.40"
     glamorous "^4.11.0"
@@ -81,16 +81,16 @@
     lodash.pick "^4.4.0"
     shallowequal "^0.2.2"
 
-"@storybook/react-native@3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/react-native/-/react-native-3.2.17.tgz#36b72ffd76f79fee2a0ad661d43da415f73e9f7d"
+"@storybook/react-native@3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/react-native/-/react-native-3.2.18.tgz#cb25bd473b7d867048c1c3b1efe5c6504785c21f"
   dependencies:
-    "@storybook/addon-actions" "^3.2.17"
-    "@storybook/addon-links" "^3.2.17"
-    "@storybook/addons" "^3.2.17"
-    "@storybook/channel-websocket" "^3.2.17"
-    "@storybook/ui" "^3.2.17"
-    autoprefixer "^7.1.6"
+    "@storybook/addon-actions" "^3.2.18"
+    "@storybook/addon-links" "^3.2.18"
+    "@storybook/addons" "^3.2.18"
+    "@storybook/channel-websocket" "^3.2.18"
+    "@storybook/ui" "^3.2.18"
+    autoprefixer "^7.2.3"
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
     babel-plugin-syntax-async-functions "^6.13.0"
@@ -107,7 +107,7 @@
     babel-preset-stage-0 "^6.24.1"
     babel-runtime "^6.26.0"
     case-sensitive-paths-webpack-plugin "^2.1.1"
-    commander "^2.12.1"
+    commander "^2.12.2"
     css-loader "^0.28.7"
     events "^1.1.1"
     express "^4.16.2"
@@ -121,15 +121,15 @@
     react-native-compat "^1.0.0"
     react-native-iphone-x-helper "^1.0.1"
     shelljs "^0.7.8"
-    style-loader "^0.18.2"
+    style-loader "^0.19.1"
     url-loader "^0.6.2"
     url-parse "^1.1.9"
     util-deprecate "^1.0.2"
     uuid "^3.1.0"
-    webpack "^3.8.1"
+    webpack "^3.10.0"
     webpack-dev-middleware "^1.12.2"
     webpack-hot-middleware "^2.21.0"
-    ws "^3.3.2"
+    ws "^3.3.3"
 
 "@storybook/react-simple-di@^1.2.1":
   version "1.3.0"
@@ -146,17 +146,17 @@
   dependencies:
     babel-runtime "^6.5.0"
 
-"@storybook/react@3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.2.17.tgz#c7b0595efef049d4dae89202994c17f332ee4662"
+"@storybook/react@3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.2.18.tgz#bb0a86cf808c3c90fedc11e489f10660f650c781"
   dependencies:
-    "@storybook/addon-actions" "^3.2.17"
-    "@storybook/addon-links" "^3.2.17"
-    "@storybook/addons" "^3.2.17"
-    "@storybook/channel-postmessage" "^3.2.17"
-    "@storybook/ui" "^3.2.17"
-    airbnb-js-shims "^1.3.0"
-    autoprefixer "^7.1.6"
+    "@storybook/addon-actions" "^3.2.18"
+    "@storybook/addon-links" "^3.2.18"
+    "@storybook/addons" "^3.2.18"
+    "@storybook/channel-postmessage" "^3.2.18"
+    "@storybook/ui" "^3.2.18"
+    airbnb-js-shims "^1.4.0"
+    autoprefixer "^7.2.3"
     babel-core "^6.26.0"
     babel-loader "^7.1.2"
     babel-plugin-react-docgen "^1.8.0"
@@ -170,10 +170,10 @@
     babel-runtime "^6.26.0"
     case-sensitive-paths-webpack-plugin "^2.1.1"
     chalk "^2.3.0"
-    commander "^2.12.1"
+    commander "^2.12.2"
     common-tags "^1.5.1"
     configstore "^3.1.1"
-    core-js "^2.5.1"
+    core-js "^2.5.3"
     css-loader "^0.28.7"
     dotenv-webpack "^1.5.4"
     express "^4.16.2"
@@ -186,7 +186,6 @@
     json-stringify-safe "^5.0.1"
     json5 "^0.5.1"
     lodash.flattendeep "^4.4.0"
-    lodash.pick "^4.4.0"
     postcss-flexbugs-fixes "^3.2.0"
     postcss-loader "^2.0.9"
     prop-types "^15.6.0"
@@ -195,20 +194,20 @@
     request "^2.83.0"
     serve-favicon "^2.4.5"
     shelljs "^0.7.8"
-    style-loader "^0.18.2"
+    style-loader "^0.19.1"
     url-loader "^0.6.2"
     util-deprecate "^1.0.2"
     uuid "^3.1.0"
-    webpack "^3.8.1"
+    webpack "^3.10.0"
     webpack-dev-middleware "^1.12.2"
     webpack-hot-middleware "^2.21.0"
 
-"@storybook/ui@^3.2.17":
-  version "3.2.17"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.17.tgz#8838fc5bbe21cedfafc65ee90fe525499370118a"
+"@storybook/ui@^3.2.18":
+  version "3.2.18"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.2.18.tgz#4d19f8daff7ec37cebe4d2b5d20e81e3676d8938"
   dependencies:
     "@hypnosphi/fuse.js" "^3.0.9"
-    "@storybook/components" "^3.2.17"
+    "@storybook/components" "^3.2.18"
     "@storybook/mantra-core" "^1.7.0"
     "@storybook/react-fuzzy" "^0.4.3"
     "@storybook/react-komposer" "^2.0.0"
@@ -225,8 +224,8 @@
     prop-types "^15.6.0"
     qs "^6.5.1"
     react-icons "^2.2.7"
-    react-inspector "^2.2.1"
-    react-modal "^3.1.4"
+    react-inspector "^2.2.2"
+    react-modal "^3.1.8"
     react-split-pane "^0.1.71"
     react-treebeard "^2.0.3"
     redux "^3.7.2"
@@ -374,7 +373,7 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
-airbnb-js-shims@^1.3.0:
+airbnb-js-shims@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/airbnb-js-shims/-/airbnb-js-shims-1.4.0.tgz#b920b0bc9fafe8b8ae2a073f29fb10303b1b2b18"
   dependencies:
@@ -773,7 +772,7 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-autoprefixer@^7.1.6:
+autoprefixer@^7.2.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.3.tgz#c2841e38b7940c2d0a9bbffd72c75f33637854f8"
   dependencies:
@@ -2732,7 +2731,7 @@ commander@2.1.x, commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
 
-commander@2.12.x, commander@^2.12.1, commander@^2.12.2, commander@^2.8.1, commander@^2.9.0, commander@~2.12.1:
+commander@2.12.x, commander@^2.12.2, commander@^2.8.1, commander@^2.9.0, commander@~2.12.1:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
 
@@ -3092,7 +3091,7 @@ core-js@^1.0.0, core-js@^1.1.1:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.1:
+core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
@@ -8461,14 +8460,14 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-inspector@^2.2.1:
+react-inspector@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
   dependencies:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-modal@^3.1.4:
+react-modal@^3.1.8:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.8.tgz#7d6b1958f44828babd2a1ce826c28fa40d026b0f"
   dependencies:
@@ -9717,9 +9716,9 @@ strong-log-transformer@^1.0.6:
     moment "^2.6.0"
     through "^2.3.4"
 
-style-loader@^0.18.2:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.18.2.tgz#cc31459afbcd6d80b7220ee54b291a9fd66ff5eb"
+style-loader@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.19.1.tgz#591ffc80bcefe268b77c5d9ebc0505d772619f85"
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
@@ -10551,7 +10550,7 @@ webpack@3.3.0:
     webpack-sources "^1.0.1"
     yargs "^6.0.0"
 
-webpack@^3.8.1:
+webpack@^3.10.0, webpack@^3.8.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
   dependencies:
@@ -10745,9 +10744,17 @@ ws@^2.0.3:
     safe-buffer "~5.0.1"
     ultron "~1.1.0"
 
-ws@^3.2.0, ws@^3.3.2, ws@~3.3.1:
+ws@^3.2.0, ws@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.2.tgz#96c1d08b3fefda1d5c1e33700d3bfaa9be2d5608"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
+ws@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"


### PR DESCRIPTION
3.2.18 includes a fix for a bug that broke storybook in IE11: https://github.com/storybooks/storybook/pull/2428