### PR TITLE
fix: ensure consistent scrolling behaviour on author profile

### DIFF
--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -104,7 +104,7 @@ class AuthorProfileContent extends React.Component {
           offset: 0,
           animated: true
         });
-      }, 0);
+      });
     };
 
     const paginationComponent = (hideResults = false) => (

--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -38,6 +38,10 @@ class AuthorProfileContent extends React.Component {
     this.onViewableItemsChanged = this.onViewableItemsChanged.bind(this);
   }
 
+  componentWillUnmount() {
+    global.cancelAnimationFrame(this.scrollAnimationFrame);
+  }
+
   onViewableItemsChanged(info) {
     if (!info.changed.length) return [];
 
@@ -95,7 +99,7 @@ class AuthorProfileContent extends React.Component {
     }
 
     const scrollToTopNextFrame = () => {
-      setTimeout(() => {
+      this.scrollAnimationFrame = global.requestAnimationFrame(() => {
         this.listRef.scrollToOffset({
           offset: 0,
           animated: true

--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -94,23 +94,26 @@ class AuthorProfileContent extends React.Component {
       );
     }
 
+    const scrollToTopNextFrame = () => {
+      setTimeout(() => {
+        this.listRef.scrollToOffset({
+          offset: 0,
+          animated: true
+        });
+      }, 0);
+    };
+
     const paginationComponent = (hideResults = false) => (
       <AuthorProfilePagination
         count={count}
         hideResults={hideResults}
         onNext={(...args) => {
           onNext(...args);
-          this.listRef.scrollToOffset({
-            offset: 0,
-            animated: true
-          });
+          scrollToTopNextFrame();
         }}
         onPrev={(...args) => {
           onPrev(...args);
-          this.listRef.scrollToOffset({
-            offset: 0,
-            animated: true
-          });
+          scrollToTopNextFrame();
         }}
         page={page}
         pageSize={pageSize}


### PR DESCRIPTION
The Next and Prev buttons should scroll to the top of the page when
clicked. Previously, they would scroll upwards, but either scroll too
far or not far enough. This was because the layout was recalculated
while the scroll was happening. This change delays the scroll until
after the layout so that it always scrolls to the top.

**iOS before fix after clicking "Next"**

<img src="https://user-images.githubusercontent.com/838984/34302426-b75b59ae-e728-11e7-96fe-d222618040ab.png" width=250>

**iOS after fix after clicking "Next"**

<img src="https://user-images.githubusercontent.com/838984/34302434-c5595718-e728-11e7-8a47-f47cc67fcbc1.png" width=250>

**android before fix after clicking "Next"**

<img src="https://user-images.githubusercontent.com/838984/34302481-fc0d56e2-e728-11e7-915d-14d797ebef17.png" width=250>

**android after fix after clicking "Next"**

<img src="https://user-images.githubusercontent.com/838984/34302525-349ed4fe-e729-11e7-8e89-06f89372602e.png" width=250>

**web after fix after clicking "Next"**

(web never had an issue, but this shows it doesn't regress)

<img src="https://user-images.githubusercontent.com/838984/34302675-d94504e2-e729-11e7-819a-683d1522fab9.png" width=250>
