### PR TITLE
chore: use jest setup file to configure enzyme

### DIFF
--- a/packages/author-head/__tests__/author-head.test.js
+++ b/packages/author-head/__tests__/author-head.test.js
@@ -2,14 +2,11 @@
 
 import "react-native";
 import React from "react";
-import Enzyme, { shallow } from "enzyme";
-import React16Adapter from "enzyme-adapter-react-16";
+import { shallow } from "enzyme";
 import renderer from "react-test-renderer";
 import AuthorHead from "../author-head";
 
 const data = require("../fixtures/profile.json");
-
-Enzyme.configure({ adapter: new React16Adapter() });
 
 const extra = { onTwitterLinkPress: () => {} };
 

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -58,7 +58,6 @@
     "babel-preset-react-native": "1.9.2",
     "dextrose": "1.2.8",
     "enzyme": "3.2.0",
-    "enzyme-adapter-react-16": "1.1.0",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/card/__tests__/web/card.web.test.js
+++ b/packages/card/__tests__/web/card.web.test.js
@@ -1,8 +1,7 @@
 /* eslint-env jest */
 
 import React from "react";
-import Enzyme, { shallow } from "enzyme";
-import React16Adapter from "enzyme-adapter-react-16";
+import { shallow } from "enzyme";
 import renderer from "react-test-renderer";
 import "jest-styled-components";
 import Card from "../../card";
@@ -16,8 +15,6 @@ const cardProps = {
   imageSize: 360,
   showImage: true
 };
-
-Enzyme.configure({ adapter: new React16Adapter() });
 
 describe("Card test on web", () => {
   it("renders", () => {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -47,7 +47,6 @@
     "babel-preset-react-native": "1.9.2",
     "dextrose": "1.2.8",
     "enzyme": "3.2.0",
-    "enzyme-adapter-react-16": "1.1.0",
     "enzyme-to-json": "3.2.2",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",

--- a/packages/image/__tests__/placeholder.test.js
+++ b/packages/image/__tests__/placeholder.test.js
@@ -1,12 +1,9 @@
 /* eslint-env jest */
 
 import "react-native";
-import Enzyme, { shallow } from "enzyme";
-import React16Adapter from "enzyme-adapter-react-16";
+import { shallow } from "enzyme";
 import React from "react";
 import Placeholder from "../placeholder";
-
-Enzyme.configure({ adapter: new React16Adapter() });
 
 export default () => {
   it("renders loading image when width set", () => {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -44,7 +44,6 @@
     "babel-preset-react-native": "1.9.2",
     "dextrose": "1.2.8",
     "enzyme": "3.2.0",
-    "enzyme-adapter-react-16": "1.1.0",
     "enzyme-to-json": "3.2.2",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",

--- a/packages/jest-configurator/jest-configurator.js
+++ b/packages/jest-configurator/jest-configurator.js
@@ -47,7 +47,9 @@ const config = (component, platform) => ({
   testPathIgnorePatterns: [
     `<rootDir>/packages/${component}/__tests__/${platform}/jest.config.js`
   ],
-  snapshotSerializers: ["enzyme-to-json/serializer"]
+  snapshotSerializers: ["enzyme-to-json/serializer"],
+  setupTestFrameworkScriptFile:
+    "<rootDir>/packages/jest-configurator/setup-jest.js"
 });
 
 module.exports = config;

--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -42,6 +42,10 @@
       "<rootDir>/packages/jest-configurator/__tests__/*.test.js"
     ]
   },
+  "dependencies": {
+    "enzyme": "3.2.0",
+    "enzyme-adapter-react-16": "1.1.0"
+  },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.0.2",
     "eslint": "4.9.0",

--- a/packages/jest-configurator/setup-jest.js
+++ b/packages/jest-configurator/setup-jest.js
@@ -1,0 +1,4 @@
+import Adapter from "enzyme-adapter-react-16";
+import Enzyme from "enzyme";
+
+Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
Move `Enzyme.configure` call to setup file in jest-configurator so it doesn't need to be repeated for every file that uses enzyme