### PR TITLE
Fix: clean up properly after a graphql error

### DIFF
--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pick from "lodash.pick";
-import { graphql } from "react-apollo";
+import { graphql } from "react-apollo-temp";
 
 const identity = a => a;
 
@@ -30,6 +30,7 @@ const connectGraphql = (query, propsToVariables = identity) => {
     }
 
     refetch() {
+      this.state.data.retry(); // FIXME: remove this after react-apollo fixes https://github.com/apollographql/apollo-client/issues/2513
       this.state.data.refetch().then(response => {
         this.setState(prevState => ({
           ...prevState,

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -73,7 +73,7 @@
     "lodash.get": "4.4.2",
     "lodash.pick": "4.4.0",
     "prop-types": "15.6.0",
-    "react-apollo": "2.0.1"
+    "react-apollo-temp": "2.0.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/utils/graphql.js
+++ b/packages/utils/graphql.js
@@ -2,8 +2,8 @@
 
 import React, { Component } from "react";
 import ApolloClient from "apollo-client";
-import { ApolloProvider } from "react-apollo";
-import { MockLink } from "react-apollo/test-links";
+import { ApolloProvider } from "react-apollo-temp";
+import { MockLink } from "react-apollo-temp/lib/test-links";
 import {
   InMemoryCache as Cache,
   IntrospectionFragmentMatcher

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -56,6 +56,6 @@
     "graphql": "0.11.7",
     "prop-types": "15.6.0",
     "react": "16.2.0",
-    "react-apollo": "2.0.1"
+    "react-apollo-temp": "2.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8430,9 +8430,9 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.0.1.tgz#43997db9f294d81bd229eb705944fb36d5164607"
+react-apollo-temp@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-apollo-temp/-/react-apollo-temp-2.0.5.tgz#3a44901a252c7721b600fe63f906492a12f90229"
   dependencies:
     apollo-link "^1.0.0"
     hoist-non-react-statics "^2.2.0"


### PR DESCRIPTION
replace react-apollo with npmjs.com/package/react-apollo-temp which is
a fork that provides a workaround to this issue
https://github.com/apollographql/apollo-client/issues/2513