### PR TITLE
Modal image component

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -23,10 +23,13 @@ exports[`ModalImage test on android renders correctly 1`] = `
         accessibilityLabel={undefined}
         accessibilityTraits={undefined}
         accessible={true}
-        collapsable={undefined}
         hitSlop={undefined}
-        isTVSelectable={true}
-        nativeID={undefined}
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackground",
+            "type": "ThemeAttrAndroid",
+          }
+        }
         onLayout={undefined}
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
@@ -34,13 +37,8 @@ exports[`ModalImage test on android renders correctly 1`] = `
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
-        style={
-          Object {
-            "opacity": 1,
-          }
-        }
+        pointerEvents="box-only"
         testID={undefined}
-        tvParallaxProperties={undefined}
       >
         <svg
           height="48"
@@ -208,10 +206,13 @@ exports[`ModalImage test on android renders correctly 1`] = `
     accessibilityLabel={undefined}
     accessibilityTraits={undefined}
     accessible={true}
-    collapsable={undefined}
     hitSlop={undefined}
-    isTVSelectable={true}
-    nativeID={undefined}
+    nativeBackgroundAndroid={
+      Object {
+        "attribute": "selectableItemBackground",
+        "type": "ThemeAttrAndroid",
+      }
+    }
     onLayout={undefined}
     onResponderGrant={[Function]}
     onResponderMove={[Function]}
@@ -219,13 +220,8 @@ exports[`ModalImage test on android renders correctly 1`] = `
     onResponderTerminate={[Function]}
     onResponderTerminationRequest={[Function]}
     onStartShouldSetResponder={[Function]}
-    style={
-      Object {
-        "opacity": 1,
-      }
-    }
+    pointerEvents="box-only"
     testID={undefined}
-    tvParallaxProperties={undefined}
   >
     <View
       aspectRatio={1.5}

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -1,0 +1,356 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalImage test on android renders correctly 1`] = `
+<View>
+  <Modal
+    hardwareAccelerated={false}
+    onRequestClose={[Function]}
+    presentationStyle="fullScreen"
+    visible={false}
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#000",
+          "flexDirection": "column",
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        collapsable={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <svg
+          height="48"
+          style={Object {}}
+          viewBox="0 0 24 24"
+          width="48"
+        >
+          <g
+            fill="#dddddd"
+            style={Object {}}
+          >
+            <path
+              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              style={Object {}}
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+              style={Object {}}
+            />
+          </g>
+        </svg>
+      </View>
+      <View
+        style={
+          Object {
+            "flexGrow": 1,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          aspectRatio={1.5}
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <Image
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://example.com/image.jpg&preview=true",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  },
+                  undefined,
+                ]
+              }
+            />
+            <View
+              style={
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <Image
+                onLoad={[Function]}
+                source={
+                  Object {
+                    "uri": "http://example.com/image.jpg",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "bottom": 0,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    },
+                    Object {
+                      "height": "100%",
+                      "width": "100%",
+                    },
+                    undefined,
+                  ]
+                }
+              />
+              <View
+                onLayout={[Function]}
+                style={
+                  Array [
+                    Object {
+                      "flex": 1,
+                    },
+                    null,
+                  ]
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <BVLinearGradient
+                    colors={
+                      Array [
+                        "#f9f9f9",
+                        "#ededed",
+                      ]
+                    }
+                    end={
+                      Object {
+                        "x": -0.09302964577578221,
+                        "y": 0.11488204504197774,
+                      }
+                    }
+                    locations={
+                      Array [
+                        0,
+                        1,
+                      ]
+                    }
+                    start={
+                      Object {
+                        "x": 1,
+                        "y": 0,
+                      }
+                    }
+                    style={
+                      Array [
+                        Object {
+                          "flex": 1,
+                        },
+                      ]
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    collapsable={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      aspectRatio={1.5}
+      style={Object {}}
+    >
+      <View
+        style={
+          Object {
+            "height": "100%",
+            "width": "100%",
+          }
+        }
+      >
+        <Image
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "http://example.com/image.jpg&preview=true",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              Object {
+                "height": "100%",
+                "width": "100%",
+              },
+              undefined,
+            ]
+          }
+        />
+        <View
+          style={
+            Object {
+              "height": "100%",
+              "width": "100%",
+            }
+          }
+        >
+          <Image
+            onLoad={[Function]}
+            source={
+              Object {
+                "uri": "http://example.com/image.jpg",
+              }
+            }
+            style={
+              Array [
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                },
+                undefined,
+              ]
+            }
+          />
+          <View
+            onLayout={[Function]}
+            style={
+              Array [
+                Object {
+                  "flex": 1,
+                },
+                null,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flex": 1,
+                }
+              }
+            >
+              <BVLinearGradient
+                colors={
+                  Array [
+                    "#f9f9f9",
+                    "#ededed",
+                  ]
+                }
+                end={
+                  Object {
+                    "x": -0.09302964577578221,
+                    "y": 0.11488204504197774,
+                  }
+                }
+                locations={
+                  Array [
+                    0,
+                    1,
+                  ]
+                }
+                start={
+                  Object {
+                    "x": 1,
+                    "y": 0,
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/image/__tests__/android/modal-image.android.test.js
+++ b/packages/image/__tests__/android/modal-image.android.test.js
@@ -1,0 +1,16 @@
+/* eslint-env jest */
+
+import tests from "../modal-image.native.test";
+
+jest.mock("react-native", () => {
+  const reactNative = require.requireActual("react-native");
+  reactNative.Platform.OS = "android";
+  jest
+    .spyOn(reactNative.Platform, "select")
+    .mockImplementation(obj => obj.android || obj.default);
+  return reactNative;
+});
+
+describe("ModalImage test on android", () => {
+  tests();
+});

--- a/packages/image/__tests__/image.native.test.js
+++ b/packages/image/__tests__/image.native.test.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import renderer from "react-test-renderer";
-import Image from "../../image";
+import Image from "../image";
 
 export default () => {
   it("renders correctly", () => {

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -1,0 +1,290 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalImage test on ios renders correctly 1`] = `
+<View>
+  <Modal
+    hardwareAccelerated={false}
+    onRequestClose={[Function]}
+    presentationStyle="fullScreen"
+    visible={false}
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#000",
+          "flexDirection": "column",
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        collapsable={undefined}
+        hitSlop={undefined}
+        isTVSelectable={true}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+        testID={undefined}
+        tvParallaxProperties={undefined}
+      >
+        <svg
+          height="48"
+          style={Object {}}
+          viewBox="0 0 24 24"
+          width="48"
+        >
+          <g
+            fill="#dddddd"
+            style={Object {}}
+          >
+            <path
+              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              style={Object {}}
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+              style={Object {}}
+            />
+          </g>
+        </svg>
+      </View>
+      <View
+        style={
+          Object {
+            "flexGrow": 1,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          aspectRatio={1.5}
+          style={
+            Object {
+              "width": "100%",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <Image
+              onLoad={[Function]}
+              source={
+                Object {
+                  "uri": "http://example.com/image.jpg",
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  },
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  },
+                  undefined,
+                ]
+              }
+            />
+            <View
+              onLayout={[Function]}
+              style={
+                Array [
+                  Object {
+                    "flex": 1,
+                  },
+                  null,
+                ]
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
+              >
+                <BVLinearGradient
+                  colors={
+                    Array [
+                      "#f9f9f9",
+                      "#ededed",
+                    ]
+                  }
+                  end={
+                    Object {
+                      "x": -0.09302964577578221,
+                      "y": 0.11488204504197774,
+                    }
+                  }
+                  locations={
+                    Array [
+                      0,
+                      1,
+                    ]
+                  }
+                  start={
+                    Object {
+                      "x": 1,
+                      "y": 0,
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "flex": 1,
+                      },
+                    ]
+                  }
+                />
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </Modal>
+  <View
+    accessibilityComponentType={undefined}
+    accessibilityLabel={undefined}
+    accessibilityTraits={undefined}
+    accessible={true}
+    collapsable={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "opacity": 1,
+      }
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <View
+      aspectRatio={1.5}
+      style={Object {}}
+    >
+      <View
+        style={
+          Object {
+            "height": "100%",
+            "width": "100%",
+          }
+        }
+      >
+        <Image
+          onLoad={[Function]}
+          source={
+            Object {
+              "uri": "http://example.com/image.jpg",
+            }
+          }
+          style={
+            Array [
+              Object {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              Object {
+                "height": "100%",
+                "width": "100%",
+              },
+              undefined,
+            ]
+          }
+        />
+        <View
+          onLayout={[Function]}
+          style={
+            Array [
+              Object {
+                "flex": 1,
+              },
+              null,
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <BVLinearGradient
+              colors={
+                Array [
+                  "#f9f9f9",
+                  "#ededed",
+                ]
+              }
+              end={
+                Object {
+                  "x": -0.09302964577578221,
+                  "y": 0.11488204504197774,
+                }
+              }
+              locations={
+                Array [
+                  0,
+                  1,
+                ]
+              }
+              start={
+                Object {
+                  "x": 1,
+                  "y": 0,
+                }
+              }
+              style={
+                Array [
+                  Object {
+                    "flex": 1,
+                  },
+                ]
+              }
+            />
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/image/__tests__/ios/modal-image.ios.test.js
+++ b/packages/image/__tests__/ios/modal-image.ios.test.js
@@ -1,0 +1,16 @@
+/* eslint-env jest */
+
+import tests from "../modal-image.native.test";
+
+jest.mock("react-native", () => {
+  const reactNative = require.requireActual("react-native");
+  reactNative.Platform.OS = "ios";
+  jest
+    .spyOn(reactNative.Platform, "select")
+    .mockImplementation(obj => obj.ios || obj.default);
+  return reactNative;
+});
+
+describe("ModalImage test on ios", () => {
+  tests();
+});

--- a/packages/image/__tests__/modal-image.native.test.js
+++ b/packages/image/__tests__/modal-image.native.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+
+import React from "react";
+import renderer from "react-test-renderer";
+import { shallow } from "enzyme";
+import ModalImage from "../modal-image";
+
+export default () => {
+  it("renders correctly", () => {
+    const tree = renderer
+      .create(
+        <ModalImage uri="http://example.com/image.jpg" aspectRatio={3 / 2} />
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("shows modal on click", () => {
+    const component = shallow(
+      <ModalImage uri="http://example.com/image.jpg" aspectRatio={3 / 2} />
+    );
+
+    const imageLink = component
+      .dive()
+      .find("Link")
+      .at(1);
+
+    imageLink.simulate("press");
+    component.update();
+
+    const modal = component.children().at(0);
+    expect(modal.props().visible).toBe(true);
+  });
+
+  it("closes modal on click", () => {
+    const component = shallow(
+      <ModalImage uri="http://example.com/image.jpg" aspectRatio={3 / 2} />
+    );
+    component.setState({ showModal: true });
+
+    const closeButton = component
+      .dive()
+      .find("Link")
+      .at(0);
+    closeButton.simulate("press");
+    component.update();
+
+    const modal = component.children().at(0);
+    expect(modal.props().visible).toBe(false);
+  });
+};

--- a/packages/image/__tests__/modal-image.native.test.js
+++ b/packages/image/__tests__/modal-image.native.test.js
@@ -29,7 +29,7 @@ export default () => {
     imageLink.simulate("press");
     component.update();
 
-    const modal = component.children().at(0);
+    const modal = component.childAt(0);
     expect(modal.props().visible).toBe(true);
   });
 
@@ -46,7 +46,7 @@ export default () => {
     closeButton.simulate("press");
     component.update();
 
-    const modal = component.children().at(0);
+    const modal = component.childAt(0);
     expect(modal.props().visible).toBe(false);
   });
 };

--- a/packages/image/__tests__/web/__snapshots__/modal-image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/modal-image.web.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders passes through to Image 1`] = `
+<div
+  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+>
+  <div
+    style={
+      Object {
+        "display": "table",
+        "height": 0,
+        "overflow": "hidden",
+        "paddingBottom": "66.66666666666667%",
+      }
+    }
+  >
+    <img
+      alt=""
+      src="http://example.com/image.jpg"
+      style={
+        Object {
+          "display": "block",
+          "position": "absolute",
+          "width": "100%",
+          "zIndex": 1,
+        }
+      }
+    />
+    <div
+      className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-bottom-1p0dtai rn-boxSizing-deolkf rn-display-6koalj rn-flex-13awgt0 rn-flexGrow-1m1wadx rn-flexShrink-1awmn5t rn-flexDirection-eqz5dr rn-left-1d2f490 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-u8s1d rn-right-zchlnj rn-top-ipm5af rn-zIndex-1lgpqti"
+    >
+      <div
+        className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flex-13awgt0 rn-flexGrow-1m1wadx rn-flexShrink-1awmn5t rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+        style={
+          Object {
+            "backgroundImage": "linear-gradient(264deg, #f9f9f9 0%, #ededed 100%)",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/image/__tests__/web/__snapshots__/modal-image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/modal-image.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders passes through to Image 1`] = `
+exports[`passes through to Image 1`] = `
 <div
   className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
 >

--- a/packages/image/__tests__/web/modal-image.web.test.js
+++ b/packages/image/__tests__/web/modal-image.web.test.js
@@ -3,7 +3,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import ModalImage from "../../modal-image";
 
-it("renders passes through to Image", () => {
+it("passes through to Image", () => {
   const tree = renderer
     .create(
       <ModalImage uri="http://example.com/image.jpg" aspectRatio={3 / 2} />

--- a/packages/image/__tests__/web/modal-image.web.test.js
+++ b/packages/image/__tests__/web/modal-image.web.test.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+import React from "react";
+import renderer from "react-test-renderer";
+import ModalImage from "../../modal-image";
+
+it("renders passes through to Image", () => {
+  const tree = renderer
+    .create(
+      <ModalImage uri="http://example.com/image.jpg" aspectRatio={3 / 2} />
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -11,9 +11,6 @@ const style = StyleSheet.create({
         height: "100%",
         flexDirection: "column"
     },
-    text: {
-        color: 'white'
-    },
     imageContainer: {
         flexGrow: 1,
         justifyContent: 'center'

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -3,6 +3,7 @@ import { Modal, View, StyleSheet } from "react-native";
 import Button from "@times-components/link";
 import Svg, { Path, G } from "svgs";
 import Image from "./image";
+import { defaultProps, propTypes } from "./image-prop-types";
 
 const style = StyleSheet.create({
   modal: {
@@ -69,5 +70,8 @@ class ModalImage extends Component {
     );
   }
 }
+
+ModalImage.propTypes = propTypes;
+ModalImage.defaultProps = defaultProps;
 
 export default ModalImage;

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -1,0 +1,62 @@
+import React, {Component} from "react"
+import {Modal, View, StyleSheet, Text} from "react-native"
+import Image from "./image";
+import Link from "@times-components/link";
+
+const style = StyleSheet.create({
+    modal: {
+        backgroundColor: '#000',
+        width: "100%",
+        height: "100%",
+        flexDirection: "column"
+    },
+    text: {
+        color: 'white'
+    },
+    imageContainer: {
+        flexGrow: 1,
+        justifyContent: 'center'
+    },
+    image: {
+        width: '100%'
+    }
+})
+
+class ModalImage extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showModal: false
+        }
+    }
+
+    showModal() {
+        this.setState({showModal: true});
+    }
+
+    hideModal() {
+        this.setState({showModal: false});
+    }
+
+    render() {
+        return (<View>
+            <Modal visible={this.state.showModal}
+                onRequestClose={() => this.hideModal()}
+                presentationStyle="fullScreen">
+                <View style={style.modal}>
+                    <Link onPress={() => this.hideModal()}>
+                        <Text style={style.text}>CLOSE ME</Text>
+                    </Link>
+                    <View style={style.imageContainer}>
+                        <Image {...this.props} style={style.image} />
+                    </View>
+                </View>
+            </Modal>
+            <Link onPress={() => {this.showModal()}}>
+                <Image {...this.props} />
+            </Link>
+        </View>);
+    }
+}
+
+export default ModalImage;

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -1,65 +1,75 @@
-import React, {Component} from "react"
-import {Modal, View, StyleSheet, Text} from "react-native"
+import React, { Component } from "react";
+import { Modal, View, StyleSheet, Text } from "react-native";
 import Image from "./image";
 import Link from "@times-components/link";
 import Svg, { Path, G } from "svgs";
 
 const style = StyleSheet.create({
-    modal: {
-        backgroundColor: '#000',
-        width: "100%",
-        height: "100%",
-        flexDirection: "column"
-    },
-    imageContainer: {
-        flexGrow: 1,
-        justifyContent: 'center'
-    },
-    image: {
-        width: '100%'
-    }
-})
+  modal: {
+    backgroundColor: "#000",
+    width: "100%",
+    height: "100%",
+    flexDirection: "column"
+  },
+  imageContainer: {
+    flexGrow: 1,
+    justifyContent: "center"
+  },
+  image: {
+    width: "100%"
+  }
+});
 
 class ModalImage extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            showModal: false
-        }
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      showModal: false
+    };
+  }
 
-    showModal() {
-        this.setState({showModal: true});
-    }
+  showModal() {
+    this.setState({ showModal: true });
+  }
 
-    hideModal() {
-        this.setState({showModal: false});
-    }
+  hideModal() {
+    this.setState({ showModal: false });
+  }
 
-    render() {
-        const closeButton = (<Svg height="48" viewBox="0 0 24 24" width="48">
-            <G fill="#dddddd">
-                <Path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
-                <Path d="M0 0h24v24H0z" fill="none"/>
-            </G>
-        </Svg>);
+  render() {
+    const closeButton = (
+      <Svg height="48" viewBox="0 0 24 24" width="48">
+        <G fill="#dddddd">
+          <Path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          <Path d="M0 0h24v24H0z" fill="none" />
+        </G>
+      </Svg>
+    );
 
-        return (<View>
-            <Modal visible={this.state.showModal}
-                onRequestClose={() => this.hideModal()}
-                presentationStyle="fullScreen">
-                <View style={style.modal}>
-                    <Link onPress={() => this.hideModal()}>{closeButton}</Link>
-                    <View style={style.imageContainer}>
-                        <Image {...this.props} style={style.image} />
-                    </View>
-                </View>
-            </Modal>
-            <Link onPress={() => {this.showModal()}}>
-                <Image {...this.props} />
-            </Link>
-        </View>);
-    }
+    return (
+      <View>
+        <Modal
+          visible={this.state.showModal}
+          onRequestClose={() => this.hideModal()}
+          presentationStyle="fullScreen"
+        >
+          <View style={style.modal}>
+            <Link onPress={() => this.hideModal()}>{closeButton}</Link>
+            <View style={style.imageContainer}>
+              <Image {...this.props} style={style.image} />
+            </View>
+          </View>
+        </Modal>
+        <Link
+          onPress={() => {
+            this.showModal();
+          }}
+        >
+          <Image {...this.props} />
+        </Link>
+      </View>
+    );
+  }
 }
 
 export default ModalImage;

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -26,6 +26,8 @@ class ModalImage extends Component {
     this.state = {
       showModal: false
     };
+    this.hideModal = this.hideModal.bind(this);
+    this.showModal = this.showModal.bind(this);
   }
 
   showModal() {
@@ -50,21 +52,17 @@ class ModalImage extends Component {
       <View>
         <Modal
           visible={this.state.showModal}
-          onRequestClose={() => this.hideModal()}
+          onRequestClose={this.hideModal}
           presentationStyle="fullScreen"
         >
           <View style={style.modal}>
-            <Link onPress={() => this.hideModal()}>{closeButton}</Link>
+            <Link onPress={this.hideModal}>{closeButton}</Link>
             <View style={style.imageContainer}>
               <Image {...this.props} style={style.image} />
             </View>
           </View>
         </Modal>
-        <Link
-          onPress={() => {
-            this.showModal();
-          }}
-        >
+        <Link onPress={this.showModal}>
           <Image {...this.props} />
         </Link>
       </View>

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
-import { Modal, View, StyleSheet, Text } from "react-native";
-import Image from "./image";
+import { Modal, View, StyleSheet } from "react-native";
 import Link from "@times-components/link";
 import Svg, { Path, G } from "svgs";
+import Image from "./image";
 
 const style = StyleSheet.create({
   modal: {

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -2,6 +2,7 @@ import React, {Component} from "react"
 import {Modal, View, StyleSheet, Text} from "react-native"
 import Image from "./image";
 import Link from "@times-components/link";
+import Svg, { Path, G } from "svgs";
 
 const style = StyleSheet.create({
     modal: {
@@ -39,14 +40,19 @@ class ModalImage extends Component {
     }
 
     render() {
+        const closeButton = (<Svg height="48" viewBox="0 0 24 24" width="48">
+            <G fill="#dddddd">
+                <Path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                <Path d="M0 0h24v24H0z" fill="none"/>
+            </G>
+        </Svg>);
+
         return (<View>
             <Modal visible={this.state.showModal}
                 onRequestClose={() => this.hideModal()}
                 presentationStyle="fullScreen">
                 <View style={style.modal}>
-                    <Link onPress={() => this.hideModal()}>
-                        <Text style={style.text}>CLOSE ME</Text>
-                    </Link>
+                    <Link onPress={() => this.hideModal()}>{closeButton}</Link>
                     <View style={style.imageContainer}>
                         <Image {...this.props} style={style.image} />
                     </View>

--- a/packages/image/modal-image.js
+++ b/packages/image/modal-image.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { Modal, View, StyleSheet } from "react-native";
-import Link from "@times-components/link";
+import Button from "@times-components/link";
 import Svg, { Path, G } from "svgs";
 import Image from "./image";
 
@@ -56,15 +56,15 @@ class ModalImage extends Component {
           presentationStyle="fullScreen"
         >
           <View style={style.modal}>
-            <Link onPress={this.hideModal}>{closeButton}</Link>
+            <Button onPress={this.hideModal}>{closeButton}</Button>
             <View style={style.imageContainer}>
               <Image {...this.props} style={style.image} />
             </View>
           </View>
         </Modal>
-        <Link onPress={this.showModal}>
+        <Button onPress={this.showModal}>
           <Image {...this.props} />
-        </Link>
+        </Button>
       </View>
     );
   }

--- a/packages/image/modal-image.stories.native.js
+++ b/packages/image/modal-image.stories.native.js
@@ -1,0 +1,15 @@
+/* eslint-disable react/no-danger */
+import React from "react";
+import { View } from "react-native";
+import { storiesOf } from "dextrose/storiesOfOverloader";
+import ModalImage from "./modal-image";
+
+const uri =
+  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78&resize=685";
+
+storiesOf("ModalImage", module)
+  .add("Default", () => (
+    <View>
+        <ModalImage uri={uri} aspectRatio={16 / 9} />
+    </View>
+  ));

--- a/packages/image/modal-image.stories.native.js
+++ b/packages/image/modal-image.stories.native.js
@@ -7,9 +7,8 @@ import ModalImage from "./modal-image";
 const uri =
   "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78&resize=685";
 
-storiesOf("ModalImage", module)
-  .add("Default", () => (
-    <View>
-        <ModalImage uri={uri} aspectRatio={16 / 9} />
-    </View>
-  ));
+storiesOf("ModalImage", module).add("Default", () => (
+  <View>
+    <ModalImage uri={uri} aspectRatio={16 / 9} />
+  </View>
+));

--- a/packages/image/modal-image.web.js
+++ b/packages/image/modal-image.web.js
@@ -1,0 +1,3 @@
+import Image from "./image";
+
+export default Image;

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@times-components/gradient": "0.3.7",
     "@times-components/jest-configurator": "0.0.15",
-    "@times-components/link": "0.13.1",
+    "@times-components/link": "0.13.4",
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
     "svgs": "3.1.1"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -60,6 +60,7 @@
     "@times-components/gradient": "0.3.7",
     "@times-components/jest-configurator": "0.0.15",
     "prop-types": "15.6.0",
+    "react-native-svg": "5.5.0",
     "svgs": "3.1.1"
   },
   "peerDependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@times-components/gradient": "0.3.7",
     "@times-components/jest-configurator": "0.0.15",
+    "@times-components/link": "0.13.1",
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
     "svgs": "3.1.1"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@times-components/gradient": "0.3.7",
     "@times-components/jest-configurator": "0.0.15",
-    "@times-components/link": "0.13.4",
+    "@times-components/link": "0.13.1",
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",
     "svgs": "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,6 +255,13 @@
     webpack-dev-server "^2.9.5"
     webpack-merge "^4.1.1"
 
+"@times-components/link@0.13.4":
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-0.13.4.tgz#417ba449f6e616f2567f79d3e533a607b9dab031"
+  dependencies:
+    lodash.pick "4.4.0"
+    prop-types "15.6.0"
+
 "@types/async@2.0.45":
   version "2.0.45"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.45.tgz#0cfe971d7ed5542695740338e0455c91078a0e83"

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,13 +255,6 @@
     webpack-dev-server "^2.9.5"
     webpack-merge "^4.1.1"
 
-"@times-components/link@0.13.4":
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-0.13.4.tgz#417ba449f6e616f2567f79d3e533a607b9dab031"
-  dependencies:
-    lodash.pick "4.4.0"
-    prop-types "15.6.0"
-
 "@types/async@2.0.45":
   version "2.0.45"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.45.tgz#0cfe971d7ed5542695740338e0455c91078a0e83"


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->

Currently working on native only, this introduces `ModalImage` as a component, so that we can have an image open fullscreen.

`.web` implementation right now passes through to `Image`.

The :x: to close the modal is https://material.io/icons/#ic_close

| iOS | Android |
| --- | --- |
| ![iOS](https://user-images.githubusercontent.com/1263058/34679702-ae532cce-f48e-11e7-9969-707fa4e3edf3.gif) | ![android](https://user-images.githubusercontent.com/1263058/34679966-813a9c6c-f48f-11e7-85c2-b9b32c261b28.gif) |