### PR TITLE
chore: make Tealium a peer dependency so not installed on web

### DIFF
--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -41,8 +41,7 @@
     ]
   },
   "dependencies": {
-    "@storybook/addon-actions": "3.2.18",
-    "react-native": "0.50.1"
+    "@storybook/addon-actions": "3.2.18"
   },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.1.0",
@@ -50,6 +49,7 @@
     "prettier": "1.8.2"
   },
   "peerDependencies": {
+    "react-native": ">=0.50",
     "react-native-web": ">=0.1"
   },
   "publishConfig": {


### PR DESCRIPTION
Moved react-native to be a peer dependency inline with the other packages. This will mean it won't need to be installed on web