### PR TITLE
feat: add debouncing to all graphql queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "coveralls": "2.13.1",
     "cz-conventional-changelog": "2.1.0",
     "detox": "5.8.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "eslint-config-airbnb": "16.1.0",
     "eslint-config-prettier": "2.6.0",

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -52,7 +52,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -44,7 +44,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -41,7 +41,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -51,7 +51,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -56,7 +56,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -47,7 +47,7 @@
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
     "chance": "1.0.10",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "1.1.0",
     "enzyme-to-json": "3.2.2",

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -53,7 +53,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -55,7 +55,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -45,7 +45,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-to-json": "3.2.2",
     "eslint": "4.9.0",

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -51,7 +51,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "1.1.0",
     "eslint": "4.9.0",

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -56,7 +56,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -52,7 +52,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-to-json": "3.2.2",
     "eslint": "4.9.0",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -46,7 +46,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "1.1.0",
     "enzyme-to-json": "3.2.2",

--- a/packages/provider/.eslintrc.js
+++ b/packages/provider/.eslintrc.js
@@ -10,8 +10,5 @@ module.exports = {
       }
     ]
   },
-  plugins: ["graphql"],
-  env: {
-    jest: true
-  }
+  plugins: ["graphql"]
 };

--- a/packages/provider/.eslintrc.js
+++ b/packages/provider/.eslintrc.js
@@ -10,5 +10,8 @@ module.exports = {
       }
     ]
   },
-  plugins: ["graphql"]
+  plugins: ["graphql"],
+  env: {
+    jest: true
+  }
 };

--- a/packages/provider/__tests__/.eslintrc.js
+++ b/packages/provider/__tests__/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    jest: true
+  }
+};

--- a/packages/provider/__tests__/connect.test.js
+++ b/packages/provider/__tests__/connect.test.js
@@ -1,0 +1,23 @@
+import { makeGraphqlOptions } from "../connect";
+
+it("Picks only required variables from the supplied props", () => {
+  const options = makeGraphqlOptions(["a", "b"]);
+  const props = { a: 1, b: 2, c: 3 };
+
+  expect(options(props)).toEqual({ variables: { a: 1, b: 2 } });
+});
+
+it("Prefers the debouncedProps object, if it exists", () => {
+  const options = makeGraphqlOptions(["a", "b"]);
+  const props = { a: 1, b: 2, c: 3, debouncedProps: { a: 10, b: 20, c: 30 } };
+
+  expect(options(props)).toEqual({ variables: { a: 10, b: 20 } });
+});
+
+it("Transforms props with the propsToVariables function", () => {
+  const propsToVariables = ({a, b}) => ({A: a + 10, B: b + 10});
+  const options = makeGraphqlOptions(["A", "B"], propsToVariables);
+  const props = { a: 1, b: 2, c: 3 };
+
+  expect(options(props)).toEqual({ variables: { A: 11, B: 12 } });
+});

--- a/packages/provider/__tests__/connect.test.js
+++ b/packages/provider/__tests__/connect.test.js
@@ -15,7 +15,7 @@ it("Prefers the debouncedProps object, if it exists", () => {
 });
 
 it("Transforms props with the propsToVariables function", () => {
-  const propsToVariables = ({a, b}) => ({A: a + 10, B: b + 10});
+  const propsToVariables = ({ a, b }) => ({ A: a + 10, B: b + 10 });
   const options = makeGraphqlOptions(["A", "B"], propsToVariables);
   const props = { a: 1, b: 2, c: 3 };
 

--- a/packages/provider/__tests__/debounce.test.js
+++ b/packages/provider/__tests__/debounce.test.js
@@ -1,0 +1,142 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Enzyme, { shallow, mount } from "enzyme";
+import React16Adapter from "enzyme-adapter-react-16";
+
+import withDebounce from "../debounce";
+
+Enzyme.configure({ adapter: new React16Adapter() });
+
+jest.useFakeTimers();
+
+// Alias the confusingly misnamed runTimersToTime to advanceTimersByTime
+// Jest has done this in v22, so this can be removed if we upgrade
+jest.advanceTimersByTime = jest.runTimersToTime;
+
+/* eslint react/prop-types: 0 */
+class Inner extends React.Component {
+  constructor(props) {
+    super(props);
+    this.numberOfDebouncedPropsUpdates = 0;
+  }
+
+  componentWillReceiveProps(props) {
+    if (this.props.debouncedProps !== props.debouncedProps) {
+      this.numberOfDebouncedPropsUpdates += 1;
+    }
+  }
+
+  render() {
+    return "hello";
+  }
+}
+
+it("adds debounceProps to the props passed to the inner component", () => {
+  const Outer = withDebounce(Inner, 1000);
+  const component = shallow(<Outer foo="initialFoo" />);
+  expect(component.find("Inner").props()).toEqual({
+    foo: "initialFoo",
+    debouncedProps: { foo: "initialFoo" },
+    isDebouncing: false
+  });
+});
+
+const testUpdateInnerPropsAfterDelay = delay => {
+  const Outer = withDebounce(Inner, delay);
+  const component = shallow(<Outer foo="initialFoo" />);
+
+  component.setProps({ foo: "updatedFoo" });
+  expect(component.find("Inner").props()).toEqual({
+    foo: "updatedFoo",
+    debouncedProps: { foo: "initialFoo" },
+    isDebouncing: true
+  });
+
+  jest.advanceTimersByTime(0.99 * delay);
+  expect(
+    component
+      .update()
+      .find("Inner")
+      .props().debouncedProps
+  ).toEqual({ foo: "initialFoo" });
+
+  jest.advanceTimersByTime(0.02 * delay);
+  expect(
+    component
+      .update()
+      .find("Inner")
+      .props().debouncedProps
+  ).toEqual({ foo: "updatedFoo" });
+};
+
+it("immediately updates props, but delays update of debouncedProps", () => {
+  testUpdateInnerPropsAfterDelay(1000);
+});
+
+it("handles different debounce delays", () => {
+  testUpdateInnerPropsAfterDelay(2500);
+});
+
+it("updates debounceProps once for many closely spaced props updates", () => {
+  const Outer = withDebounce(Inner, 1000);
+  const component = mount(<Outer foo="initialFoo" />);
+
+  const numberOfDebouncedPropsUpdates = () =>
+    component
+      .update()
+      .find("Inner")
+      .instance().numberOfDebouncedPropsUpdates;
+
+  expect(numberOfDebouncedPropsUpdates()).toEqual(0);
+
+  component.setProps({ foo: "updatedFoo1" });
+  jest.advanceTimersByTime(600);
+  component.setProps({ foo: "updatedFoo2" });
+  jest.advanceTimersByTime(600);
+  component.setProps({ foo: "updatedFoo3" });
+  jest.advanceTimersByTime(600);
+  component.setProps({ foo: "updatedFoo4" });
+  jest.advanceTimersByTime(1200);
+
+  expect(numberOfDebouncedPropsUpdates()).toEqual(1);
+});
+
+it("does not atttempt to update props after unmount", () => {
+  const Outer = withDebounce(Inner, 1000);
+  const component = shallow(<Outer foo="initialFoo" />);
+  const setState = jest.spyOn(component.instance(), "handleDebounceTimer");
+
+  expect(setState.mock.calls.length).toEqual(0);
+
+  component.setProps({ foo: "updatedFoo1" });
+  jest.advanceTimersByTime(1200);
+  expect(setState.mock.calls.length).toEqual(1);
+
+  component.unmount();
+  component.setProps({ foo: "updatedFoo2" });
+  jest.advanceTimersByTime(1200);
+  expect(setState.mock.calls.length).toEqual(1);
+});
+
+it("has appropriate static members on the outer component", () => {
+  /* eslint react/no-multi-comp: 0 */
+  class InnerWithStatics extends React.Component {
+    static staticMember = "staticMemberValue";
+    render() {
+      return this.props.foo;
+    }
+  }
+  InnerWithStatics.propTypes = {
+    foo: PropTypes.string
+  };
+  InnerWithStatics.defaultProps = {
+    foo: ""
+  };
+  InnerWithStatics.displayName = "InnerWithStatics";
+
+  const Outer = withDebounce(InnerWithStatics, 1000);
+  expect(Outer.displayName).toEqual("WithDebounce(InnerWithStatics)");
+  expect(Outer.staticMember).toEqual("staticMemberValue");
+  expect(Outer.propTypes).toEqual({ foo: PropTypes.string });
+  expect(Outer.defaultProps).toEqual(InnerWithStatics.defaultProps);
+});

--- a/packages/provider/__tests__/debounce.test.js
+++ b/packages/provider/__tests__/debounce.test.js
@@ -31,112 +31,114 @@ class Inner extends React.Component {
   }
 }
 
-it("adds debounceProps to the props passed to the inner component", () => {
-  const Outer = withDebounce(Inner, 1000);
-  const component = shallow(<Outer foo="initialFoo" />);
-  expect(component.find("Inner").props()).toEqual({
-    foo: "initialFoo",
-    debouncedProps: { foo: "initialFoo" },
-    isDebouncing: false
-  });
-});
-
-const testUpdateInnerPropsAfterDelay = delay => {
-  const Outer = withDebounce(Inner, delay);
-  const component = shallow(<Outer foo="initialFoo" />);
-
-  component.setProps({ foo: "updatedFoo" });
-  expect(component.find("Inner").props()).toEqual({
-    foo: "updatedFoo",
-    debouncedProps: { foo: "initialFoo" },
-    isDebouncing: true
+describe("Debounce Tests", () => {
+  it("adds debounceProps to the props passed to the inner component", () => {
+    const Outer = withDebounce(Inner, 1000);
+    const component = shallow(<Outer foo="initialFoo" />);
+    expect(component.find("Inner").props()).toEqual({
+      foo: "initialFoo",
+      debouncedProps: { foo: "initialFoo" },
+      isDebouncing: false
+    });
   });
 
-  jest.advanceTimersByTime(0.99 * delay);
-  expect(
-    component
-      .update()
-      .find("Inner")
-      .props().debouncedProps
-  ).toEqual({ foo: "initialFoo" });
+  const testUpdateInnerPropsAfterDelay = delay => {
+    const Outer = withDebounce(Inner, delay);
+    const component = shallow(<Outer foo="initialFoo" />);
 
-  jest.advanceTimersByTime(0.02 * delay);
-  expect(
-    component
-      .update()
-      .find("Inner")
-      .props().debouncedProps
-  ).toEqual({ foo: "updatedFoo" });
-};
+    component.setProps({ foo: "updatedFoo" });
+    expect(component.find("Inner").props()).toEqual({
+      foo: "updatedFoo",
+      debouncedProps: { foo: "initialFoo" },
+      isDebouncing: true
+    });
 
-it("immediately updates props, but delays update of debouncedProps", () => {
-  testUpdateInnerPropsAfterDelay(1000);
-});
+    jest.advanceTimersByTime(0.99 * delay);
+    expect(
+      component
+        .update()
+        .find("Inner")
+        .props().debouncedProps
+    ).toEqual({ foo: "initialFoo" });
 
-it("handles different debounce delays", () => {
-  testUpdateInnerPropsAfterDelay(2500);
-});
+    jest.advanceTimersByTime(0.02 * delay);
+    expect(
+      component
+        .update()
+        .find("Inner")
+        .props().debouncedProps
+    ).toEqual({ foo: "updatedFoo" });
+  };
 
-it("updates debounceProps once for many closely spaced props updates", () => {
-  const Outer = withDebounce(Inner, 1000);
-  const component = mount(<Outer foo="initialFoo" />);
+  it("immediately updates props, but delays update of debouncedProps", () => {
+    testUpdateInnerPropsAfterDelay(1000);
+  });
 
-  const numberOfDebouncedPropsUpdates = () =>
-    component
-      .update()
-      .find("Inner")
-      .instance().numberOfDebouncedPropsUpdates;
+  it("handles different debounce delays", () => {
+    testUpdateInnerPropsAfterDelay(2500);
+  });
 
-  expect(numberOfDebouncedPropsUpdates()).toEqual(0);
+  it("updates debounceProps once for many closely spaced props updates", () => {
+    const Outer = withDebounce(Inner, 1000);
+    const component = mount(<Outer foo="initialFoo" />);
 
-  component.setProps({ foo: "updatedFoo1" });
-  jest.advanceTimersByTime(600);
-  component.setProps({ foo: "updatedFoo2" });
-  jest.advanceTimersByTime(600);
-  component.setProps({ foo: "updatedFoo3" });
-  jest.advanceTimersByTime(600);
-  component.setProps({ foo: "updatedFoo4" });
-  jest.advanceTimersByTime(1200);
+    const numberOfDebouncedPropsUpdates = () =>
+      component
+        .update()
+        .find("Inner")
+        .instance().numberOfDebouncedPropsUpdates;
 
-  expect(numberOfDebouncedPropsUpdates()).toEqual(1);
-});
+    expect(numberOfDebouncedPropsUpdates()).toEqual(0);
 
-it("does not atttempt to update props after unmount", () => {
-  const Outer = withDebounce(Inner, 1000);
-  const component = shallow(<Outer foo="initialFoo" />);
-  const setState = jest.spyOn(component.instance(), "handleDebounceTimer");
+    component.setProps({ foo: "updatedFoo1" });
+    jest.advanceTimersByTime(600);
+    component.setProps({ foo: "updatedFoo2" });
+    jest.advanceTimersByTime(600);
+    component.setProps({ foo: "updatedFoo3" });
+    jest.advanceTimersByTime(600);
+    component.setProps({ foo: "updatedFoo4" });
+    jest.advanceTimersByTime(1200);
 
-  expect(setState.mock.calls.length).toEqual(0);
+    expect(numberOfDebouncedPropsUpdates()).toEqual(1);
+  });
 
-  component.setProps({ foo: "updatedFoo1" });
-  jest.advanceTimersByTime(1200);
-  expect(setState.mock.calls.length).toEqual(1);
+  it("does not atttempt to update props after unmount", () => {
+    const Outer = withDebounce(Inner, 1000);
+    const component = shallow(<Outer foo="initialFoo" />);
+    const setState = jest.spyOn(component.instance(), "handleDebounceTimer");
 
-  component.unmount();
-  component.setProps({ foo: "updatedFoo2" });
-  jest.advanceTimersByTime(1200);
-  expect(setState.mock.calls.length).toEqual(1);
-});
+    expect(setState.mock.calls.length).toEqual(0);
 
-it("has appropriate static members on the outer component", () => {
-  /* eslint react/no-multi-comp: 0 */
-  class InnerWithStatics extends React.Component {
-    static staticMember = "staticMemberValue";
-    render() {
-      return this.props.foo;
+    component.setProps({ foo: "updatedFoo1" });
+    jest.advanceTimersByTime(1200);
+    expect(setState.mock.calls.length).toEqual(1);
+
+    component.unmount();
+    component.setProps({ foo: "updatedFoo2" });
+    jest.advanceTimersByTime(1200);
+    expect(setState.mock.calls.length).toEqual(1);
+  });
+
+  it("has appropriate static members on the outer component", () => {
+    /* eslint react/no-multi-comp: 0 */
+    class InnerWithStatics extends React.Component {
+      static staticMember = "staticMemberValue";
+      render() {
+        return this.props.foo;
+      }
     }
-  }
-  InnerWithStatics.propTypes = {
-    foo: PropTypes.string
-  };
-  InnerWithStatics.defaultProps = {
-    foo: ""
-  };
-  InnerWithStatics.displayName = "InnerWithStatics";
+    InnerWithStatics.propTypes = {
+      foo: PropTypes.string
+    };
+    InnerWithStatics.defaultProps = {
+      foo: ""
+    };
+    InnerWithStatics.displayName = "InnerWithStatics";
 
-  const Outer = withDebounce(InnerWithStatics, 1000);
-  expect(Outer.displayName).toEqual("WithDebounce(InnerWithStatics)");
-  expect(Outer.staticMember).toEqual("staticMemberValue");
-  expect(Outer.propTypes).toEqual({ foo: PropTypes.string });
-  expect(Outer.defaultProps).toEqual(InnerWithStatics.defaultProps);
+    const Outer = withDebounce(InnerWithStatics, 1000);
+    expect(Outer.displayName).toEqual("WithDebounce(InnerWithStatics)");
+    expect(Outer.staticMember).toEqual("staticMemberValue");
+    expect(Outer.propTypes).toEqual({ foo: PropTypes.string });
+    expect(Outer.defaultProps).toEqual(InnerWithStatics.defaultProps);
+  });
 });

--- a/packages/provider/__tests__/debounce.test.js
+++ b/packages/provider/__tests__/debounce.test.js
@@ -13,15 +13,14 @@ jest.useFakeTimers();
 // Jest has done this in v22, so this can be removed if we upgrade
 jest.advanceTimersByTime = jest.runTimersToTime;
 
-/* eslint react/prop-types: 0 */
 class Inner extends React.Component {
   constructor(props) {
     super(props);
     this.numberOfDebouncedPropsUpdates = 0;
   }
 
-  componentWillReceiveProps(props) {
-    if (this.props.debouncedProps !== props.debouncedProps) {
+  componentWillReceiveProps({ debouncedProps }) {
+    if (debouncedProps !== this.props.debouncedProps) {
       this.numberOfDebouncedPropsUpdates += 1;
     }
   }
@@ -30,6 +29,9 @@ class Inner extends React.Component {
     return "hello";
   }
 }
+Inner.propTypes = {
+  debouncedProps: PropTypes.shape({}).isRequired
+};
 
 describe("Debounce Tests", () => {
   it("adds debounceProps to the props passed to the inner component", () => {
@@ -120,15 +122,13 @@ describe("Debounce Tests", () => {
   });
 
   it("has appropriate static members on the outer component", () => {
-    /* eslint react/no-multi-comp: 0 */
-    class InnerWithStatics extends React.Component {
-      static staticMember = "staticMemberValue";
-      render() {
-        return this.props.foo;
-      }
-    }
+    const InnerWithStatics = props => props.foo;
+    InnerWithStatics.staticMember = "staticMemberValue";
     InnerWithStatics.propTypes = {
-      foo: PropTypes.string
+      foo: PropTypes.string,
+      debouncedProps: PropTypes.shape({
+        foo: PropTypes.string
+      }).isRequired
     };
     InnerWithStatics.defaultProps = {
       foo: ""
@@ -138,7 +138,7 @@ describe("Debounce Tests", () => {
     const Outer = withDebounce(InnerWithStatics, 1000);
     expect(Outer.displayName).toEqual("WithDebounce(InnerWithStatics)");
     expect(Outer.staticMember).toEqual("staticMemberValue");
-    expect(Outer.propTypes).toEqual({ foo: PropTypes.string });
+    expect(Outer.propTypes).toEqual({ foo: PropTypes.string }); // debouncedProps removed
     expect(Outer.defaultProps).toEqual(InnerWithStatics.defaultProps);
   });
 });

--- a/packages/provider/__tests__/provider.test.js
+++ b/packages/provider/__tests__/provider.test.js
@@ -29,11 +29,7 @@ const mocks = [
   }
 ];
 
-
-const renderComponent = (child, customMocks) =>
-  renderer.create(constructComponent(child, customMocks));
-
-export const constructComponent = (child, customMocks, debounceTimeMs = 0) => {
+const constructComponent = (child, customMocks, debounceTimeMs = 0) => {
   const ConnectedComponent = connectGraphql(query, debounceTimeMs);
   return (
     <MockedProvider mocks={customMocks || mocks} removeTypename>
@@ -42,7 +38,10 @@ export const constructComponent = (child, customMocks, debounceTimeMs = 0) => {
       </ConnectedComponent>
     </MockedProvider>
   );
-}
+};
+
+const renderComponent = (child, customMocks) =>
+  renderer.create(constructComponent(child, customMocks));
 
 it("returns query result", done => {
   renderComponent(({ isLoading, author }) => {
@@ -60,8 +59,10 @@ it("complains if you omit the debounceTimeMs parameter to connectGraphql", () =>
 });
 
 it("Doesn't use a Debounce HOC wrapper if debounceTimeMs is 0", () => {
-  expect(connectGraphql(query, 500).displayName).toEqual("WithDebounce(Apollo(Wrapper))")
-  expect(connectGraphql(query, 0).displayName).toEqual("Apollo(Wrapper)")
+  expect(connectGraphql(query, 500).displayName).toEqual(
+    "WithDebounce(Apollo(Wrapper))"
+  );
+  expect(connectGraphql(query, 0).displayName).toEqual("Apollo(Wrapper)");
 });
 
 it("returns loading state with no author", done => {

--- a/packages/provider/__tests__/provider.test.js
+++ b/packages/provider/__tests__/provider.test.js
@@ -29,16 +29,20 @@ const mocks = [
   }
 ];
 
-const ConnectedComponent = connectGraphql(query, undefined, 0);
 
 const renderComponent = (child, customMocks) =>
-  renderer.create(
+  renderer.create(constructComponent(child, customMocks));
+
+export const constructComponent = (child, customMocks, debounceTimeMs = 0) => {
+  const ConnectedComponent = connectGraphql(query, debounceTimeMs);
+  return (
     <MockedProvider mocks={customMocks || mocks} removeTypename>
       <ConnectedComponent config1="c1" config2="c2">
         {child}
       </ConnectedComponent>
     </MockedProvider>
   );
+}
 
 it("returns query result", done => {
   renderComponent(({ isLoading, author }) => {
@@ -53,6 +57,11 @@ it("returns query result", done => {
 
 it("complains if you omit the debounceTimeMs parameter to connectGraphql", () => {
   expect(() => connectGraphql(query)).toThrowError();
+});
+
+it("Doesn't use a Debounce HOC wrapper if debounceTimeMs is 0", () => {
+  expect(connectGraphql(query, 500).displayName).toEqual("WithDebounce(Apollo(Wrapper))")
+  expect(connectGraphql(query, 0).displayName).toEqual("Apollo(Wrapper)")
 });
 
 it("returns loading state with no author", done => {

--- a/packages/provider/__tests__/provider.test.js
+++ b/packages/provider/__tests__/provider.test.js
@@ -29,7 +29,7 @@ const mocks = [
   }
 ];
 
-const ConnectedComponent = connectGraphql(query);
+const ConnectedComponent = connectGraphql(query, undefined, 0);
 
 const renderComponent = (child, customMocks) =>
   renderer.create(
@@ -49,6 +49,10 @@ it("returns query result", done => {
 
     return null;
   });
+});
+
+it("complains if you omit the debounceTimeMs parameter to connectGraphql", () => {
+  expect(() => connectGraphql(query)).toThrowError();
 });
 
 it("returns loading state with no author", done => {

--- a/packages/provider/article.js
+++ b/packages/provider/article.js
@@ -29,4 +29,4 @@ export const query = gql`
   }
 `;
 
-export default connectGraphql(query, undefined, debounceTimeFrameBatching);
+export default connectGraphql(query, debounceTimeFrameBatching);

--- a/packages/provider/article.js
+++ b/packages/provider/article.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import connectGraphql from "./connect";
+import connectGraphql, { debounceTimeFrameBatching } from "./connect";
 
 export const query = gql`
   query ArticleQuery($id: ID!) {
@@ -29,4 +29,4 @@ export const query = gql`
   }
 `;
 
-export default connectGraphql(query);
+export default connectGraphql(query, undefined, debounceTimeFrameBatching);

--- a/packages/provider/author-articles-no-images.js
+++ b/packages/provider/author-articles-no-images.js
@@ -43,6 +43,6 @@ const propsToVariables = ({
 
 export default connectGraphql(
   query,
-  propsToVariables,
-  debounceTimeFrameBatching
+  debounceTimeFrameBatching,
+  propsToVariables
 );

--- a/packages/provider/author-articles-no-images.js
+++ b/packages/provider/author-articles-no-images.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import connectGraphql from "./connect";
+import connectGraphql, { debounceTimeFrameBatching } from "./connect";
 
 export const query = gql`
   query ArticleListQuery(
@@ -41,4 +41,8 @@ const propsToVariables = ({
   longSummaryLength
 });
 
-export default connectGraphql(query, propsToVariables);
+export default connectGraphql(
+  query,
+  propsToVariables,
+  debounceTimeFrameBatching
+);

--- a/packages/provider/author-articles-with-images.js
+++ b/packages/provider/author-articles-with-images.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import connectGraphql from "./connect";
+import connectGraphql, { debounceTimeFrameBatching } from "./connect";
 
 export const query = gql`
   query ArticleListQuery(
@@ -53,4 +53,8 @@ const propsToVariables = ({
   imageRatio: articleImageRatio
 });
 
-export default connectGraphql(query, propsToVariables);
+export default connectGraphql(
+  query,
+  propsToVariables,
+  debounceTimeFrameBatching
+);

--- a/packages/provider/author-articles-with-images.js
+++ b/packages/provider/author-articles-with-images.js
@@ -55,6 +55,6 @@ const propsToVariables = ({
 
 export default connectGraphql(
   query,
-  propsToVariables,
-  debounceTimeFrameBatching
+  debounceTimeFrameBatching,
+  propsToVariables
 );

--- a/packages/provider/author-profile.js
+++ b/packages/provider/author-profile.js
@@ -23,6 +23,6 @@ const propsToVariables = ({ slug }) => ({
 
 export default connectGraphql(
   query,
-  propsToVariables,
-  debounceTimeFrameBatching
+  debounceTimeFrameBatching,
+  propsToVariables
 );

--- a/packages/provider/author-profile.js
+++ b/packages/provider/author-profile.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import connectGraphql from "./connect";
+import connectGraphql, { debounceTimeFrameBatching } from "./connect";
 
 export const query = gql`
   query AuthorQuery($slug: Slug!) {
@@ -21,4 +21,4 @@ const propsToVariables = ({ slug }) => ({
   slug
 });
 
-export default connectGraphql(query, propsToVariables);
+export default connectGraphql(query, propsToVariables, debounceTimeFrameBatching);

--- a/packages/provider/author-profile.js
+++ b/packages/provider/author-profile.js
@@ -21,4 +21,8 @@ const propsToVariables = ({ slug }) => ({
   slug
 });
 
-export default connectGraphql(query, propsToVariables, debounceTimeFrameBatching);
+export default connectGraphql(
+  query,
+  propsToVariables,
+  debounceTimeFrameBatching
+);

--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -27,7 +27,7 @@ const getQueryVariables = definitions =>
     )
   );
 
-const connectGraphql = (query, propsToVariables = identity, debounceTimeMs) => {
+const connectGraphql = (query, debounceTimeMs, propsToVariables = identity) => {
   if (
     process.env.NODE_ENV !== "production" &&
     typeof debounceTimeMs !== "number"

--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -27,6 +27,16 @@ const getQueryVariables = definitions =>
     )
   );
 
+export const makeGraphqlOptions = (
+  variableNames,
+  propsToVariables = identity
+) => props => ({
+  variables: _pick(
+    propsToVariables(props.debouncedProps || props),
+    variableNames
+  )
+});
+
 const connectGraphql = (query, debounceTimeMs, propsToVariables) => {
   if (
     process.env.NODE_ENV !== "production" &&
@@ -64,17 +74,3 @@ const connectGraphql = (query, debounceTimeMs, propsToVariables) => {
 };
 
 export default connectGraphql;
-
-export const makeGraphqlOptions = (
-  variableNames,
-  propsToVariables = identity
-) => {
-  return props => {
-    return {
-      variables: _pick(
-        propsToVariables(props.debouncedProps || props),
-        variableNames
-      )
-    };
-  };
-};

--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -1,5 +1,17 @@
 import _pick from "lodash.pick";
 import { graphql } from "react-apollo-temp";
+import withDebounce from "./debounce";
+
+// use this debounce time to prevent multiple queries as the user flicks through
+// content, e.g. while paging to get to a specific page number
+export const debounceTimeRapidUserAction = 250;
+
+// use this debounce time to if the query variables may depend on asynchronous
+// operations and take a few animation frames to stabilise
+export const debounceTimeFrameBatching = 50;
+
+// use this debounce time to disable debouncing
+export const debounceTimeNone = 0;
 
 const identity = a => a;
 
@@ -15,7 +27,15 @@ const getQueryVariables = definitions =>
     )
   );
 
-const connectGraphql = (query, propsToVariables = identity) => {
+const connectGraphql = (query, propsToVariables = identity, debounceTimeMs) => {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    typeof debounceTimeMs !== "number"
+  ) {
+    throw new Error(
+      "Explicit debounceTimeMs required for connectGraphql, establish an appropriate debounce time or pass 0 to disable debouncing"
+    );
+  }
   const variableNames = getQueryVariables(query.definitions);
   const Wrapper = ({
     data: { error, loading, refetch, retry, ...result },
@@ -28,18 +48,26 @@ const connectGraphql = (query, propsToVariables = identity) => {
         retry(); // FIXME: remove this after react-apollo fixes https://github.com/apollographql/apollo-client/issues/2513
         refetch();
       },
-      isLoading: loading,
+      isLoading: loading || props.isDebouncing,
       ...result,
       ...props
     });
 
-  return graphql(query, {
+  const GraphQlComponent = graphql(query, {
     options(props) {
       return {
-        variables: _pick(propsToVariables(props), variableNames)
+        variables: _pick(
+          propsToVariables(props.debouncedProps || props),
+          variableNames
+        )
       };
     }
   })(Wrapper);
+
+  if (debounceTimeMs === 0) {
+    return GraphQlComponent;
+  }
+  return withDebounce(GraphQlComponent, debounceTimeMs);
 };
 
 export default connectGraphql;

--- a/packages/provider/connect.js
+++ b/packages/provider/connect.js
@@ -27,7 +27,7 @@ const getQueryVariables = definitions =>
     )
   );
 
-const connectGraphql = (query, debounceTimeMs, propsToVariables = identity) => {
+const connectGraphql = (query, debounceTimeMs, propsToVariables) => {
   if (
     process.env.NODE_ENV !== "production" &&
     typeof debounceTimeMs !== "number"
@@ -54,14 +54,7 @@ const connectGraphql = (query, debounceTimeMs, propsToVariables = identity) => {
     });
 
   const GraphQlComponent = graphql(query, {
-    options(props) {
-      return {
-        variables: _pick(
-          propsToVariables(props.debouncedProps || props),
-          variableNames
-        )
-      };
-    }
+    options: makeGraphqlOptions(variableNames, propsToVariables)
   })(Wrapper);
 
   if (debounceTimeMs === 0) {
@@ -71,3 +64,17 @@ const connectGraphql = (query, debounceTimeMs, propsToVariables = identity) => {
 };
 
 export default connectGraphql;
+
+export const makeGraphqlOptions = (
+  variableNames,
+  propsToVariables = identity
+) => {
+  return props => {
+    return {
+      variables: _pick(
+        propsToVariables(props.debouncedProps || props),
+        variableNames
+      )
+    };
+  };
+};

--- a/packages/provider/debounce.js
+++ b/packages/provider/debounce.js
@@ -1,0 +1,49 @@
+import React from "react";
+import getDisplayName from "react-display-name";
+import hoistNonReactStatic from "hoist-non-react-statics";
+
+const withDebounce = (WrappedComponent, debounceTimeMs) => {
+  class WithDebounce extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        debouncedProps: props,
+        isDebouncing: false
+      };
+      this.debounceTimeout = null;
+    }
+
+    componentWillReceiveProps() {
+      clearTimeout(this.debounceTimeout);
+      this.debounceTimeout = setTimeout(
+        this.handleDebounceTimer,
+        debounceTimeMs
+      );
+      this.setState({ isDebouncing: true });
+    }
+
+    componentWillUnmount() {
+      clearTimeout(this.debounceTimeout);
+    }
+
+    handleDebounceTimer = () => {
+      this.debounceTimeout = null;
+      this.setState({ debouncedProps: this.props, isDebouncing: false });
+    };
+
+    render() {
+      return <WrappedComponent {...this.props} {...this.state} />;
+    }
+  }
+
+  WithDebounce.displayName = `WithDebounce(${getDisplayName(
+    WrappedComponent
+  )})`;
+  WithDebounce.propTypes = WrappedComponent.propTypes;
+  WithDebounce.defaultProps = WrappedComponent.defaultProps;
+  hoistNonReactStatic(WithDebounce, WrappedComponent);
+
+  return WithDebounce;
+};
+
+export default withDebounce;

--- a/packages/provider/debounce.js
+++ b/packages/provider/debounce.js
@@ -39,7 +39,9 @@ const withDebounce = (WrappedComponent, debounceTimeMs) => {
   WithDebounce.displayName = `WithDebounce(${getDisplayName(
     WrappedComponent
   )})`;
-  WithDebounce.propTypes = WrappedComponent.propTypes;
+  WithDebounce.propTypes = { ...WrappedComponent.propTypes };
+  delete WithDebounce.propTypes.debouncedProps;
+  delete WithDebounce.propTypes.isDebouncing;
   WithDebounce.defaultProps = WrappedComponent.defaultProps;
   hoistNonReactStatic(WithDebounce, WrappedComponent);
 

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -58,7 +58,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "1.1.0",
     "eslint": "4.9.0",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -15,6 +15,7 @@
   "jest": {
     "preset": "react-native",
     "rootDir": "../../",
+    "testEnvironment": "jsdom",
     "coverageDirectory": "<rootDir>/packages/provider/coverage/",
     "collectCoverageFrom": [
       "**/packages/provider/*.js",
@@ -74,10 +75,12 @@
   },
   "dependencies": {
     "graphql-tag": "2.5.0",
+    "hoist-non-react-statics": "2.3.1",
     "lodash.get": "4.4.2",
     "lodash.pick": "4.4.0",
     "prop-types": "15.6.0",
-    "react-apollo-temp": "2.0.5"
+    "react-apollo-temp": "2.0.5",
+    "react-display-name": "0.2.3"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/provider/provider.stories.js
+++ b/packages/provider/provider.stories.js
@@ -24,7 +24,7 @@ storiesOf("Provider", module)
       }
     `;
 
-    const WithData = connectGraphql(query);
+    const WithData = connectGraphql(query, 0);
 
     const mocks = [
       {
@@ -58,7 +58,7 @@ storiesOf("Provider", module)
       }
     `;
 
-    const WithData = connectGraphql(query);
+    const WithData = connectGraphql(query, 0);
 
     const mocks = [
       {

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -42,7 +42,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "enzyme": "3.2.0",
     "enzyme-adapter-react-16": "1.1.0",
     "eslint": "4.9.0",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -51,7 +51,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.5",
     "babel-preset-flow": "6.23.0",
     "babel-preset-react-native": "1.9.2",
-    "dextrose": "1.2.14",
+    "dextrose": "1.2.15",
     "eslint": "4.9.0",
     "flow-bin": "0.42.0",
     "jest": "21.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,9 +3839,9 @@ detox@5.8.2:
     telnet-client "0.15.3"
     ws "^1.1.1"
 
-dextrose@1.2.14:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/dextrose/-/dextrose-1.2.14.tgz#b9013df987fd84db5a6b63cc812c8f114971ca27"
+dextrose@1.2.15:
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/dextrose/-/dextrose-1.2.15.tgz#930af4620316f5d214f5afeca78576089aa219c8"
   dependencies:
     babel-core "6.26.0"
     babel-preset-react-native "4.0.0"


### PR DESCRIPTION
BREAKING CHANGE: The connectGraphql function now has a mandatory
third parameter debounceTimeMs and will throw an error if it is not
provided.

This has been tested in /storybook(-native)?/, which uses mocked data. A second round of testing should be done when it's integrated into Render.