### PR TITLE
test: added jest setup to the tracking package

### DIFF
--- a/packages/tracking/.eslintignore
+++ b/packages/tracking/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 **/coverage/*
 dist
+jest.setup.js

--- a/packages/tracking/__tests__/list-component.js
+++ b/packages/tracking/__tests__/list-component.js
@@ -1,6 +1,5 @@
-/* global PropTypes */
-import React from "react";
-import { Text, FlatList } from "react-native";
+/* global React, PropTypes */
+import { FlatList, Text } from "react-native";
 
 class ListComponent extends React.Component {
   static get propTypes() {

--- a/packages/tracking/__tests__/list-component.js
+++ b/packages/tracking/__tests__/list-component.js
@@ -1,6 +1,6 @@
+/* global PropTypes */
 import React from "react";
 import { Text, FlatList } from "react-native";
-import PropTypes from "prop-types";
 
 class ListComponent extends React.Component {
   static get propTypes() {

--- a/packages/tracking/__tests__/shared-tracking-tests.js
+++ b/packages/tracking/__tests__/shared-tracking-tests.js
@@ -1,4 +1,4 @@
-/* global React, PropTypes, reactTestRenderer */
+/* global React, PropTypes, renderer */
 import { Text } from "react-native";
 
 const TestComponent = props => <Text>{props.someProp}</Text>;
@@ -10,14 +10,14 @@ export default trackingEnhancer => {
   it("renders when tracking context is missing", () => {
     const WithTracking = trackingEnhancer(TestComponent);
 
-    const tree = reactTestRenderer.create(<WithTracking />).toJSON();
+    const tree = renderer.create(<WithTracking />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it("forwards props to wrapped component", () => {
     const WithTracking = trackingEnhancer(TestComponent);
-    const tree = reactTestRenderer.create(<WithTracking someProp="bar" />);
+    const tree = renderer.create(<WithTracking someProp="bar" />);
 
     expect(tree).toMatchSnapshot();
   });

--- a/packages/tracking/__tests__/shared-tracking-tests.js
+++ b/packages/tracking/__tests__/shared-tracking-tests.js
@@ -1,6 +1,6 @@
+/* global PropTypes */
 import { Text } from "react-native";
 import React from "react";
-import PropTypes from "prop-types";
 import renderer from "react-test-renderer";
 
 const TestComponent = props => <Text>{props.someProp}</Text>;

--- a/packages/tracking/__tests__/shared-tracking-tests.js
+++ b/packages/tracking/__tests__/shared-tracking-tests.js
@@ -1,7 +1,5 @@
-/* global PropTypes */
+/* global React, PropTypes, reactTestRenderer */
 import { Text } from "react-native";
-import React from "react";
-import renderer from "react-test-renderer";
 
 const TestComponent = props => <Text>{props.someProp}</Text>;
 TestComponent.propTypes = { someProp: PropTypes.string };
@@ -12,14 +10,14 @@ export default trackingEnhancer => {
   it("renders when tracking context is missing", () => {
     const WithTracking = trackingEnhancer(TestComponent);
 
-    const tree = renderer.create(<WithTracking />).toJSON();
+    const tree = reactTestRenderer.create(<WithTracking />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
   it("forwards props to wrapped component", () => {
     const WithTracking = trackingEnhancer(TestComponent);
-    const tree = renderer.create(<WithTracking someProp="bar" />);
+    const tree = reactTestRenderer.create(<WithTracking someProp="bar" />);
 
     expect(tree).toMatchSnapshot();
   });

--- a/packages/tracking/__tests__/test-tracking-context.js
+++ b/packages/tracking/__tests__/test-tracking-context.js
@@ -1,4 +1,5 @@
-import React, { Component } from "react";
+/* global React */
+import { Component } from "react";
 import trackingContextTypes from "../tracking-context-types";
 
 export default WrappedComponent => {

--- a/packages/tracking/__tests__/track-events.test.js
+++ b/packages/tracking/__tests__/track-events.test.js
@@ -1,7 +1,5 @@
-/* global PropTypes */
-import React from "react";
+/* global React, PropTypes, reactTestRenderer */
 import { Text } from "react-native";
-import renderer from "react-test-renderer";
 import { withTrackEvents } from "../tracking";
 import withTrackingContext from "./test-tracking-context";
 import sharedTrackingTests from "./shared-tracking-tests";
@@ -38,7 +36,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext analyticsStream={reporter} {...props} />
     );
 
@@ -53,7 +51,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext analyticsStream={reporter} {...props} />
     );
 
@@ -108,7 +106,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext analyticsStream={reporter} {...props} />
     );
 
@@ -135,7 +133,7 @@ describe("TrackEvents", () => {
     );
     const reporter = jest.fn();
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext
         aProp="propValue"
         analyticsStream={reporter}
@@ -181,7 +179,7 @@ describe("TrackEvents", () => {
     );
     const reporter = jest.fn();
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext
         aProp="propValue"
         analyticsStream={reporter}
@@ -201,7 +199,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext
         analyticsStream={reporter}
         {...props}

--- a/packages/tracking/__tests__/track-events.test.js
+++ b/packages/tracking/__tests__/track-events.test.js
@@ -1,4 +1,4 @@
-/* global React, PropTypes, reactTestRenderer */
+/* global React, PropTypes, renderer */
 import { Text } from "react-native";
 import { withTrackEvents } from "../tracking";
 import withTrackingContext from "./test-tracking-context";
@@ -36,7 +36,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext analyticsStream={reporter} {...props} />
     );
 
@@ -51,7 +51,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext analyticsStream={reporter} {...props} />
     );
 
@@ -106,7 +106,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext analyticsStream={reporter} {...props} />
     );
 
@@ -133,7 +133,7 @@ describe("TrackEvents", () => {
     );
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext
         aProp="propValue"
         analyticsStream={reporter}
@@ -179,7 +179,7 @@ describe("TrackEvents", () => {
     );
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext
         aProp="propValue"
         analyticsStream={reporter}
@@ -199,7 +199,7 @@ describe("TrackEvents", () => {
       })
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext
         analyticsStream={reporter}
         {...props}

--- a/packages/tracking/__tests__/track-events.test.js
+++ b/packages/tracking/__tests__/track-events.test.js
@@ -1,7 +1,7 @@
+/* global PropTypes */
 import React from "react";
 import { Text } from "react-native";
 import renderer from "react-test-renderer";
-import PropTypes from "prop-types";
 import { withTrackEvents } from "../tracking";
 import withTrackingContext from "./test-tracking-context";
 import sharedTrackingTests from "./shared-tracking-tests";

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -1,4 +1,4 @@
-/* global React, PropTypes, reactTestRenderer */
+/* global React, PropTypes, renderer */
 import { Text } from "react-native";
 import trackingContextTypes from "../tracking-context-types";
 import { withTrackingContext } from "../tracking";
@@ -38,7 +38,7 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
+    renderer.create(
       <WithTrackingAndContext keyTwo="two" analyticsStream={reporter} />
     );
 
@@ -59,9 +59,7 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
-      <WithTrackingAndContext analyticsStream={reporter} />
-    );
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -80,9 +78,7 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
-      <WithTrackingAndContext analyticsStream={reporter} />
-    );
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -101,9 +97,7 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
-      <WithTrackingAndContext analyticsStream={reporter} />
-    );
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -121,9 +115,7 @@ describe("WithTrackingContext", () => {
     );
 
     const render = () =>
-      reactTestRenderer.create(
-        <WithTrackingAndContext analyticsStream={() => {}} />
-      );
+      renderer.create(<WithTrackingAndContext analyticsStream={() => {}} />);
 
     expect(render).toThrowErrorMatchingSnapshot();
   });
@@ -134,9 +126,7 @@ describe("WithTrackingContext", () => {
     });
     const reporter = jest.fn();
 
-    reactTestRenderer.create(
-      <WithTrackingAndContext analyticsStream={reporter} />
-    );
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -153,7 +143,7 @@ describe("WithTrackingContext", () => {
       trackingObject: "AuthorProfile"
     });
     const reporter = jest.fn();
-    const testRenderer = reactTestRenderer.create(
+    const testRenderer = renderer.create(
       <WithTrackingAndContext analyticsStream={reporter} />
     );
     testRenderer.update(<WithTrackingAndContext analyticsStream={reporter} />);
@@ -167,9 +157,7 @@ describe("WithTrackingContext", () => {
     const reporter = jest.fn();
     global.Date = jest.fn(() => new RealDate("2017-09-26T15:25:56.206Z"));
 
-    reactTestRenderer.create(
-      <WithTrackingAndContext analyticsStream={reporter} />
-    );
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -184,7 +172,7 @@ describe("WithTrackingContext", () => {
       { trackingObject: "TestObject2" }
     );
 
-    const render = () => reactTestRenderer.create(<WithTrackingAndContext />);
+    const render = () => renderer.create(<WithTrackingAndContext />);
 
     expect(render).toThrowErrorMatchingSnapshot();
   });
@@ -194,7 +182,7 @@ describe("WithTrackingContext", () => {
       trackingObject: "AuthorProfile"
     });
 
-    const tree = reactTestRenderer.create(
+    const tree = renderer.create(
       <WithTrackingContext someProp="bar" analyticsStream={() => {}} />
     );
 

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -1,7 +1,5 @@
-/* global PropTypes */
-import React from "react";
+/* global React, PropTypes, reactTestRenderer */
 import { Text } from "react-native";
-import renderer from "react-test-renderer";
 import trackingContextTypes from "../tracking-context-types";
 import { withTrackingContext } from "../tracking";
 
@@ -40,7 +38,7 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    renderer.create(
+    reactTestRenderer.create(
       <WithTrackingAndContext keyTwo="two" analyticsStream={reporter} />
     );
 
@@ -61,7 +59,9 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    reactTestRenderer.create(
+      <WithTrackingAndContext analyticsStream={reporter} />
+    );
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -80,7 +80,9 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    reactTestRenderer.create(
+      <WithTrackingAndContext analyticsStream={reporter} />
+    );
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -99,7 +101,9 @@ describe("WithTrackingContext", () => {
     );
     const reporter = jest.fn();
 
-    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    reactTestRenderer.create(
+      <WithTrackingAndContext analyticsStream={reporter} />
+    );
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -117,7 +121,9 @@ describe("WithTrackingContext", () => {
     );
 
     const render = () =>
-      renderer.create(<WithTrackingAndContext analyticsStream={() => {}} />);
+      reactTestRenderer.create(
+        <WithTrackingAndContext analyticsStream={() => {}} />
+      );
 
     expect(render).toThrowErrorMatchingSnapshot();
   });
@@ -128,7 +134,9 @@ describe("WithTrackingContext", () => {
     });
     const reporter = jest.fn();
 
-    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    reactTestRenderer.create(
+      <WithTrackingAndContext analyticsStream={reporter} />
+    );
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -145,7 +153,7 @@ describe("WithTrackingContext", () => {
       trackingObject: "AuthorProfile"
     });
     const reporter = jest.fn();
-    const testRenderer = renderer.create(
+    const testRenderer = reactTestRenderer.create(
       <WithTrackingAndContext analyticsStream={reporter} />
     );
     testRenderer.update(<WithTrackingAndContext analyticsStream={reporter} />);
@@ -159,7 +167,9 @@ describe("WithTrackingContext", () => {
     const reporter = jest.fn();
     global.Date = jest.fn(() => new RealDate("2017-09-26T15:25:56.206Z"));
 
-    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    reactTestRenderer.create(
+      <WithTrackingAndContext analyticsStream={reporter} />
+    );
 
     expect(reporter).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -174,7 +184,7 @@ describe("WithTrackingContext", () => {
       { trackingObject: "TestObject2" }
     );
 
-    const render = () => renderer.create(<WithTrackingAndContext />);
+    const render = () => reactTestRenderer.create(<WithTrackingAndContext />);
 
     expect(render).toThrowErrorMatchingSnapshot();
   });
@@ -184,7 +194,7 @@ describe("WithTrackingContext", () => {
       trackingObject: "AuthorProfile"
     });
 
-    const tree = renderer.create(
+    const tree = reactTestRenderer.create(
       <WithTrackingContext someProp="bar" analyticsStream={() => {}} />
     );
 

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -1,6 +1,6 @@
+/* global PropTypes */
 import React from "react";
 import { Text } from "react-native";
-import PropTypes from "prop-types";
 import renderer from "react-test-renderer";
 import trackingContextTypes from "../tracking-context-types";
 import { withTrackingContext } from "../tracking";

--- a/packages/tracking/__tests__/tracking.test.js
+++ b/packages/tracking/__tests__/tracking.test.js
@@ -1,6 +1,4 @@
-/* global shallow */
-import React from "react";
-import renderer from "react-test-renderer";
+/* global React, shallow, reactTestRenderer */
 import { withTrackScrollDepth } from "../tracking";
 import withTestContext from "./test-tracking-context";
 import sharedTrackingTests from "./shared-tracking-tests";
@@ -20,7 +18,7 @@ describe("WithTrackScrollDepth", () => {
       { trackingObject: "TestObject" }
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         onViewed={() => {}}

--- a/packages/tracking/__tests__/tracking.test.js
+++ b/packages/tracking/__tests__/tracking.test.js
@@ -1,4 +1,4 @@
-/* global React, shallow, reactTestRenderer */
+/* global React, shallow, renderer */
 import { withTrackScrollDepth } from "../tracking";
 import withTestContext from "./test-tracking-context";
 import sharedTrackingTests from "./shared-tracking-tests";
@@ -18,7 +18,7 @@ describe("WithTrackScrollDepth", () => {
       { trackingObject: "TestObject" }
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         onViewed={() => {}}

--- a/packages/tracking/__tests__/tracking.test.js
+++ b/packages/tracking/__tests__/tracking.test.js
@@ -1,13 +1,10 @@
+/* global shallow */
 import React from "react";
 import renderer from "react-test-renderer";
-import Enzyme, { shallow } from "enzyme";
-import React16Adapter from "enzyme-adapter-react-16";
 import { withTrackScrollDepth } from "../tracking";
 import withTestContext from "./test-tracking-context";
 import sharedTrackingTests from "./shared-tracking-tests";
 import ListComponent from "./list-component";
-
-Enzyme.configure({ adapter: new React16Adapter() });
 
 const items = [
   { someKey: "1", someValue: "one", elementId: "1" },

--- a/packages/tracking/__tests__/tracking.web.test.js
+++ b/packages/tracking/__tests__/tracking.web.test.js
@@ -1,4 +1,4 @@
-/* global React, PropTypes, reactTestRenderer, mount */
+/* global React, PropTypes, renderer, mount */
 import { Text, View } from "react-native";
 import { withTrackScrollDepth } from "../tracking";
 import withTestContext from "./test-tracking-context";
@@ -100,7 +100,7 @@ describe("WithTrackScrollDepth", () => {
       { trackingObject: "TestObject" }
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[
@@ -152,7 +152,7 @@ describe("WithTrackScrollDepth", () => {
       })
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[{ someKey: "1", someValue: "one", elementId: 1 }]}
@@ -179,7 +179,7 @@ describe("WithTrackScrollDepth", () => {
       })
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[{ someKey: "1", someValue: "one" }]}
@@ -204,7 +204,7 @@ describe("WithTrackScrollDepth", () => {
       withTrackScrollDepth(ListComponent)
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[
@@ -235,7 +235,7 @@ describe("WithTrackScrollDepth", () => {
       withTrackScrollDepth(ListComponent)
     );
 
-    reactTestRenderer
+    renderer
       .create(<ListWithChildTracking analyticsStream={() => {}} items={[]} />)
       .unmount();
 
@@ -252,7 +252,7 @@ describe("WithTrackScrollDepth", () => {
     );
 
     const renderComponent = () =>
-      reactTestRenderer
+      renderer
         .create(<ListWithChildTracking analyticsStream={() => {}} items={[]} />)
         .unmount();
 
@@ -271,7 +271,7 @@ describe("WithTrackScrollDepth", () => {
     delete global.window.IntersectionObserver;
 
     const renderComponent = () =>
-      reactTestRenderer.create(
+      renderer.create(
         <ListWithChildTracking analyticsStream={() => {}} items={[]} />
       );
 
@@ -284,7 +284,7 @@ describe("WithTrackScrollDepth", () => {
     const ListWithChildTracking = withTrackScrollDepth(ListComponent);
 
     const renderComponent = () => {
-      reactTestRenderer.create(
+      renderer.create(
         <ListWithChildTracking
           analyticsStream={() => {}}
           items={[
@@ -306,7 +306,7 @@ describe("WithTrackScrollDepth", () => {
     );
 
     const renderComponent = () => {
-      reactTestRenderer.create(
+      renderer.create(
         <ListWithChildTracking
           analyticsStream={() => {}}
           items={[
@@ -331,7 +331,7 @@ describe("WithTrackScrollDepth", () => {
       { trackingObject: "TestObject" }
     );
 
-    reactTestRenderer.create(
+    renderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[

--- a/packages/tracking/__tests__/tracking.web.test.js
+++ b/packages/tracking/__tests__/tracking.web.test.js
@@ -1,6 +1,6 @@
+/* global PropTypes */
 import { View, Text } from "react-native";
 import React from "react";
-import PropTypes from "prop-types";
 import renderer from "react-test-renderer";
 import Enzyme, { mount } from "enzyme";
 import React16Adapter from "enzyme-adapter-react-16";

--- a/packages/tracking/__tests__/tracking.web.test.js
+++ b/packages/tracking/__tests__/tracking.web.test.js
@@ -1,14 +1,8 @@
-/* global PropTypes */
-import { View, Text } from "react-native";
-import React from "react";
-import renderer from "react-test-renderer";
-import Enzyme, { mount } from "enzyme";
-import React16Adapter from "enzyme-adapter-react-16";
+/* global React, PropTypes, reactTestRenderer, mount */
+import { Text, View } from "react-native";
 import { withTrackScrollDepth } from "../tracking";
 import withTestContext from "./test-tracking-context";
 import sharedTrackingTests from "./shared-tracking-tests";
-
-Enzyme.configure({ adapter: new React16Adapter() });
 
 class FakeIntersectionObserver {
   static clearObserving() {
@@ -106,7 +100,7 @@ describe("WithTrackScrollDepth", () => {
       { trackingObject: "TestObject" }
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[
@@ -158,7 +152,7 @@ describe("WithTrackScrollDepth", () => {
       })
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[{ someKey: "1", someValue: "one", elementId: 1 }]}
@@ -185,7 +179,7 @@ describe("WithTrackScrollDepth", () => {
       })
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[{ someKey: "1", someValue: "one" }]}
@@ -210,7 +204,7 @@ describe("WithTrackScrollDepth", () => {
       withTrackScrollDepth(ListComponent)
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[
@@ -241,7 +235,7 @@ describe("WithTrackScrollDepth", () => {
       withTrackScrollDepth(ListComponent)
     );
 
-    renderer
+    reactTestRenderer
       .create(<ListWithChildTracking analyticsStream={() => {}} items={[]} />)
       .unmount();
 
@@ -258,7 +252,7 @@ describe("WithTrackScrollDepth", () => {
     );
 
     const renderComponent = () =>
-      renderer
+      reactTestRenderer
         .create(<ListWithChildTracking analyticsStream={() => {}} items={[]} />)
         .unmount();
 
@@ -277,7 +271,7 @@ describe("WithTrackScrollDepth", () => {
     delete global.window.IntersectionObserver;
 
     const renderComponent = () =>
-      renderer.create(
+      reactTestRenderer.create(
         <ListWithChildTracking analyticsStream={() => {}} items={[]} />
       );
 
@@ -290,7 +284,7 @@ describe("WithTrackScrollDepth", () => {
     const ListWithChildTracking = withTrackScrollDepth(ListComponent);
 
     const renderComponent = () => {
-      renderer.create(
+      reactTestRenderer.create(
         <ListWithChildTracking
           analyticsStream={() => {}}
           items={[
@@ -312,7 +306,7 @@ describe("WithTrackScrollDepth", () => {
     );
 
     const renderComponent = () => {
-      renderer.create(
+      reactTestRenderer.create(
         <ListWithChildTracking
           analyticsStream={() => {}}
           items={[
@@ -337,7 +331,7 @@ describe("WithTrackScrollDepth", () => {
       { trackingObject: "TestObject" }
     );
 
-    renderer.create(
+    reactTestRenderer.create(
       <ListWithChildTracking
         analyticsStream={reporter}
         items={[

--- a/packages/tracking/jest.config.json
+++ b/packages/tracking/jest.config.json
@@ -5,5 +5,6 @@
   "coveragePathIgnorePatterns": ["/__tests__/"],
   "transformIgnorePatterns": ["node_modules/(?!@times-components)/"],
   "testMatch": ["<rootDir>/packages/tracking/__tests__/**.test.js"],
-  "testPathIgnorePatterns": ["web.test.js$"]
+  "testPathIgnorePatterns": ["web.test.js$"],
+  "setupFiles": ["<rootDir>/packages/tracking/jest.setup.js"]
 }

--- a/packages/tracking/jest.config.web.json
+++ b/packages/tracking/jest.config.web.json
@@ -9,5 +9,5 @@
     "react-native": "react-native-web"
   },
   "moduleFileExtensions": ["web.js", "js", "json"],
-  "setupFiles": ["raf/polyfill"]
+  "setupFiles": ["<rootDir>/packages/tracking/jest.setup.js", "raf/polyfill"]
 }

--- a/packages/tracking/jest.setup.js
+++ b/packages/tracking/jest.setup.js
@@ -3,7 +3,7 @@ import Adapter from "enzyme-adapter-react-16";
 
 import React from "react";
 import PropTypes from "prop-types";
-import reactTestRenderer from "react-test-renderer";
+import renderer from "react-test-renderer";
 
 configure({ adapter: new Adapter() });
 
@@ -11,4 +11,4 @@ global.mount = mount;
 global.shallow = shallow;
 global.React = React;
 global.PropTypes = PropTypes;
-global.reactTestRenderer = reactTestRenderer;
+global.renderer = renderer;

--- a/packages/tracking/jest.setup.js
+++ b/packages/tracking/jest.setup.js
@@ -1,9 +1,14 @@
 import { configure, mount, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+
+import React from "react";
 import PropTypes from "prop-types";
+import reactTestRenderer from "react-test-renderer";
 
 configure({ adapter: new Adapter() });
 
 global.mount = mount;
 global.shallow = shallow;
+global.React = React;
 global.PropTypes = PropTypes;
+global.reactTestRenderer = reactTestRenderer;

--- a/packages/tracking/jest.setup.js
+++ b/packages/tracking/jest.setup.js
@@ -1,0 +1,9 @@
+import { configure, mount, shallow } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import PropTypes from "prop-types";
+
+configure({ adapter: new Adapter() });
+
+global.mount = mount;
+global.shallow = shallow;
+global.PropTypes = PropTypes;


### PR DESCRIPTION
Added a jest.setup.js file in order to better manage global imports used across all tests, we can add _all_ duplicated imports into it, and call any pre-test setup methods neccessary all in one place