### PR TITLE
Added isDataReady check for pageView tracking

### DIFF
--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -150,7 +150,8 @@ const AuthorProfileWithTracking = withTrackingContext(AuthorProfile, {
     pageSize,
     articlesCount: get(author, "articles.count", 0)
   }),
-  trackingObject: "AuthorProfile"
+  trackingObject: "AuthorProfile",
+  isDataReady: ({ isLoading }) => !isLoading
 });
 
 export default withPageState(AuthorProfileWithTracking);

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -176,7 +176,7 @@ describe("WithTrackingContext", () => {
   });
 
   it("only tracks page views when data is ready, with multiple updates", () => {
-    isReady = false;
+    let isReady = false;
     const WithTrackingAndContext = withTrackingContext(TestComponent, {
       trackingObject: "AuthorProfile",
       isDataReady: () => isReady

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -182,8 +182,9 @@ describe("WithTrackingContext", () => {
       isDataReady: () => isReady
     });
     const reporter = jest.fn();
-
-    testRenderer = renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    const testRenderer = renderer.create(
+      <WithTrackingAndContext analyticsStream={reporter} />
+    );
     expect(reporter).not.toHaveBeenCalled();
 
     isReady = true;

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -166,13 +166,7 @@ describe("WithTrackingContext", () => {
 
     renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
 
-    expect(reporter).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        object: "AuthorProfile",
-        action: "Viewed",
-        component: "Page"
-      })
-    );
+    expect(reporter).not.toHaveBeenCalled();
   });
 
   it("only tracks page views when data is ready, with multiple updates", () => {

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -139,6 +139,60 @@ describe("WithTrackingContext", () => {
     );
   });
 
+  it("tracks page views when data is ready", () => {
+    const WithTrackingAndContext = withTrackingContext(TestComponent, {
+      trackingObject: "AuthorProfile",
+      isDataReady: () => true
+    });
+    const reporter = jest.fn();
+
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object: "AuthorProfile",
+        action: "Viewed",
+        component: "Page"
+      })
+    );
+  });
+
+  it("doesnt track page views when data is not ready", () => {
+    const WithTrackingAndContext = withTrackingContext(TestComponent, {
+      trackingObject: "AuthorProfile",
+      isDataReady: () => false
+    });
+    const reporter = jest.fn();
+
+    renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+
+    expect(reporter).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        object: "AuthorProfile",
+        action: "Viewed",
+        component: "Page"
+      })
+    );
+  });
+
+  it("only tracks page views when data is ready, with multiple updates", () => {
+    isReady = false;
+    const WithTrackingAndContext = withTrackingContext(TestComponent, {
+      trackingObject: "AuthorProfile",
+      isDataReady: () => isReady
+    });
+    const reporter = jest.fn();
+
+    testRenderer = renderer.create(<WithTrackingAndContext analyticsStream={reporter} />);
+    expect(reporter).not.toHaveBeenCalled();
+
+    isReady = true;
+    testRenderer.update(<WithTrackingAndContext analyticsStream={reporter} />);
+    testRenderer.update(<WithTrackingAndContext analyticsStream={reporter} />);
+
+    expect(reporter).toHaveBeenCalledTimes(1);
+  });
+
   /* This can occur if the child accidentally unmounts and is remounted */
   it("doesn't fire a second page view event if root element is re-rendered", () => {
     const WithTrackingAndContext = withTrackingContext(TestComponent, {

--- a/packages/tracking/tracking-context.js
+++ b/packages/tracking/tracking-context.js
@@ -8,8 +8,7 @@ import resolveAttrs from "./resolve-attrs";
 
 const withTrackingContext = (
   WrappedComponent,
-  // eslint-disable-next-line no-unused-vars
-  { getAttrs = () => ({}), trackingObject, isDataReady = props => true } = {}
+  { getAttrs = () => ({}), trackingObject, isDataReady = () => true } = {}
 ) => {
   const componentName = getDisplayName(WrappedComponent);
 

--- a/packages/tracking/tracking-context.js
+++ b/packages/tracking/tracking-context.js
@@ -41,14 +41,14 @@ const withTrackingContext = (
     }
 
     componentDidMount() {
-      this.trackPageEvent(this.props);
+      this.attemptTrackPageEvent(this.props);
     }
 
     componentWillReceiveProps(nextProps) {
-      this.trackPageEvent(nextProps);
+      this.attemptTrackPageEvent(nextProps);
     }
 
-    trackPageEvent(props) {
+    attemptTrackPageEvent(props) {
       if (
         isDataReady(props) &&
         this.isRootTrackingContext() &&


### PR DESCRIPTION
Problem: 
The author name for the page view event on author profile was null. This is due to the page view being triggered on `componentDidMount`, but author name is only populated after the api request.

Solution:
Added a `isDataReady` callback on tracking context which only fires page view event when data is ready
