### PR TITLE
chore(Script fix): Removed set -e from jest script

### DIFF
--- a/packages/jest-configurator/setup.sh
+++ b/packages/jest-configurator/setup.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-mkdir fixtures/all/node_modules
-mkdir fixtures/ignore/node_modules
+set -e
+
+mkdir -p fixtures/all/node_modules
+mkdir -p fixtures/ignore/node_modules

--- a/packages/jest-configurator/setup.sh
+++ b/packages/jest-configurator/setup.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-set -e
-
 mkdir fixtures/all/node_modules
 mkdir fixtures/ignore/node_modules


### PR DESCRIPTION
Jest script was failing when the folder is already there, which is the case if you already have an
older version of the package installed.
