### PR TITLE
feat: debounce author profile paging

### DIFF
--- a/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
+++ b/packages/author-profile/__tests__/__snapshots__/author-profile-content.native.test.js.snap
@@ -121,8 +121,7 @@ exports[`renders profile 1`] = `
       count={20}
       hideResults={true}
       hideTopKeyline={false}
-      onNext={[Function]}
-      onPrev={[Function]}
+      onChangePage={[Function]}
       page={1}
       pageSize={3}
     />
@@ -172,8 +171,7 @@ exports[`renders profile 1`] = `
         count={20}
         hideResults={false}
         hideTopKeyline={true}
-        onNext={[Function]}
-        onPrev={[Function]}
+        onChangePage={[Function]}
         page={1}
         pageSize={3}
       />
@@ -1736,8 +1734,7 @@ exports[`renders profile content component 1`] = `
       count={undefined}
       hideResults={true}
       hideTopKeyline={false}
-      onNext={[Function]}
-      onPrev={[Function]}
+      onChangePage={[Function]}
       page={1}
       pageSize={3}
     />
@@ -1787,8 +1784,7 @@ exports[`renders profile content component 1`] = `
         count={undefined}
         hideResults={false}
         hideTopKeyline={true}
-        onNext={[Function]}
-        onPrev={[Function]}
+        onChangePage={[Function]}
         page={1}
         pageSize={3}
       />
@@ -2983,8 +2979,7 @@ exports[`renders profile content empty 1`] = `
       count={undefined}
       hideResults={true}
       hideTopKeyline={false}
-      onNext={[Function]}
-      onPrev={[Function]}
+      onChangePage={[Function]}
       page={undefined}
       pageSize={undefined}
     />
@@ -3004,8 +2999,7 @@ exports[`renders profile content empty 1`] = `
         count={undefined}
         hideResults={false}
         hideTopKeyline={true}
-        onNext={[Function]}
-        onPrev={[Function]}
+        onChangePage={[Function]}
         page={undefined}
         pageSize={undefined}
       />
@@ -3660,8 +3654,7 @@ exports[`renders profile content loading 1`] = `
       count={undefined}
       hideResults={true}
       hideTopKeyline={false}
-      onNext={[Function]}
-      onPrev={[Function]}
+      onChangePage={[Function]}
       page={undefined}
       pageSize={undefined}
     />
@@ -3681,8 +3674,7 @@ exports[`renders profile content loading 1`] = `
         count={undefined}
         hideResults={false}
         hideTopKeyline={true}
-        onNext={[Function]}
-        onPrev={[Function]}
+        onChangePage={[Function]}
         page={undefined}
         pageSize={undefined}
       />
@@ -4377,8 +4369,7 @@ exports[`renders profile loading 1`] = `
       count={undefined}
       hideResults={true}
       hideTopKeyline={false}
-      onNext={[Function]}
-      onPrev={[Function]}
+      onChangePage={[Function]}
       page={undefined}
       pageSize={3}
     />
@@ -4398,8 +4389,7 @@ exports[`renders profile loading 1`] = `
         count={undefined}
         hideResults={false}
         hideTopKeyline={true}
-        onNext={[Function]}
-        onPrev={[Function]}
+        onChangePage={[Function]}
         page={undefined}
         pageSize={3}
       />
@@ -5787,8 +5777,7 @@ exports[`renders with no author 1`] = `
       count={0}
       hideResults={true}
       hideTopKeyline={false}
-      onNext={[Function]}
-      onPrev={[Function]}
+      onChangePage={[Function]}
       page={1}
       pageSize={3}
     />
@@ -5808,8 +5797,7 @@ exports[`renders with no author 1`] = `
         count={0}
         hideResults={false}
         hideTopKeyline={true}
-        onNext={[Function]}
-        onPrev={[Function]}
+        onChangePage={[Function]}
         page={1}
         pageSize={3}
       />

--- a/packages/author-profile/__tests__/author-profile-content.native.test.js
+++ b/packages/author-profile/__tests__/author-profile-content.native.test.js
@@ -192,8 +192,13 @@ it("handles an article press", () => {
   });
 });
 
-it("invokes onPrev when the previous link is pressed", () => {
-  const onPrev = jest.fn();
+const testInvokesOnChangePageWhenLinkPressed = (
+  linkIndex,
+  onChangePageArgs
+) => {
+  jest.useFakeTimers();
+
+  const onChangePage = jest.fn();
   const results = pagedResult(0, 3);
 
   const comp = RCT.create(
@@ -209,49 +214,24 @@ it("invokes onPrev when the previous link is pressed", () => {
       imageRatio={3 / 2}
       onTwitterLinkPress={() => {}}
       onArticlePress={() => {}}
-      onPrev={onPrev}
+      onChangePage={onChangePage}
     />
   ).root;
 
-  comp
-    .findAllByType(Pagination)[0]
-    .findAllByType(Link)[0]
-    .props.onPress();
+  const links = comp.findAllByType(Pagination)[0].findAllByType(Link);
+  links[linkIndex].props.onPress();
 
-  expect(onPrev).toHaveBeenCalled();
+  jest.runAllTimers();
+
+  expect(onChangePage).toHaveBeenCalledWith(...onChangePageArgs);
+};
+
+it("invokes onPrev when the previous link is pressed", () => {
+  testInvokesOnChangePageWhenLinkPressed(0, [1, "previous"]);
 });
 
 it("invokes onNext when the next link is pressed", () => {
-  const onNext = jest.fn();
-  const results = pagedResult(0, 3);
-
-  const comp = RCT.create(
-    <AuthorProfileContent
-      count={10}
-      articles={results.data.author.articles.list}
-      author={authorProfileFixture.data.author}
-      isLoading={false}
-      articlesLoading={false}
-      slug="deborah-haynes"
-      page={2}
-      pageSize={3}
-      imageRatio={3 / 2}
-      onTwitterLinkPress={() => {}}
-      onArticlePress={() => {}}
-      onNext={onNext}
-    />
-  ).root;
-
-  comp
-    .findAllByType(Pagination)[0]
-    .findAllByType(Link)[1]
-    .props.onPress();
-
-  expect(onNext).toHaveBeenCalled();
+  testInvokesOnChangePageWhenLinkPressed(1, [3, "next"]);
 });
-
-it("scrolls to top when next page is clicked");
-
-it("scrolls to top when prev page is clicked");
 
 test(AuthorProfileContent);

--- a/packages/author-profile/__tests__/author-profile-content.web.test.js
+++ b/packages/author-profile/__tests__/author-profile-content.web.test.js
@@ -433,40 +433,32 @@ it("emits scroll tracking events for author profile content", () => {
   );
 });
 
-it("scrolls to the top when moving to the previous page", () => {
+const checkScrollToTop = next => {
+  jest.useFakeTimers();
+
   const onScroll = jest.spyOn(window, "scroll");
-  const onPrev = jest.fn();
   const component = mount(
     <AuthorProfileContent
       {...authorProfileContentProps}
       page={2}
-      onPrev={onPrev}
+      onChangePage={() => {}}
     />
   );
 
   component
-    .find({ href: "?page=1" })
+    .find({ href: next ? "?page=3" : "?page=1" })
     .first()
     .simulate("click");
 
+  jest.runAllTimers();
+
   expect(onScroll).toHaveBeenCalledWith({ left: 0, top: 0 });
+};
+
+it("scrolls to the top when moving to the previous page", () => {
+  checkScrollToTop(false);
 });
 
 it("scrolls to the top when moving to the next page", () => {
-  const onScroll = jest.spyOn(window, "scroll");
-  const onNext = jest.fn();
-  const component = mount(
-    <AuthorProfileContent
-      {...authorProfileContentProps}
-      page={2}
-      onNext={onNext}
-    />
-  );
-
-  component
-    .find({ href: "?page=3" })
-    .first()
-    .simulate("click");
-
-  expect(onScroll).toHaveBeenCalledWith({ left: 0, top: 0 });
+  checkScrollToTop(true);
 });

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -224,7 +224,7 @@ export default AuthorProfileContent => {
         __typename: "Image"
       },
       publicationName: "TIMES",
-      publishedTime: new Date("2017-11-17T00:01:00.000Z"),
+      publishedTime: "2017-11-17T00:01:00.000Z",
       headline: "Top medal for forces dog who took a bite out of the Taliban",
       url:
         "https://www.thetimes.co.uk/article/d98c257c-cb16-11e7-b529-95e3fc05f40f",

--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -64,8 +64,7 @@ class AuthorProfileContent extends React.Component {
       jobTitle,
       name,
       onArticlePress,
-      onNext,
-      onPrev,
+      onChangePage,
       onTwitterLinkPress,
       page,
       pageSize,
@@ -98,15 +97,6 @@ class AuthorProfileContent extends React.Component {
       );
     }
 
-    const scrollToTopNextFrame = () => {
-      this.scrollAnimationFrame = global.requestAnimationFrame(() => {
-        this.listRef.scrollToOffset({
-          offset: 0,
-          animated: true
-        });
-      });
-    };
-
     const paginationComponent = (
       { hideResults = false, hideTopKeyline = false } = {}
     ) => (
@@ -114,13 +104,14 @@ class AuthorProfileContent extends React.Component {
         count={count}
         hideResults={hideResults}
         hideTopKeyline={hideTopKeyline}
-        onNext={(...args) => {
-          onNext(...args);
-          scrollToTopNextFrame();
-        }}
-        onPrev={(...args) => {
-          onPrev(...args);
-          scrollToTopNextFrame();
+        onChangePage={(...args) => {
+          onChangePage(...args);
+          this.scrollAnimationFrame = global.requestAnimationFrame(() => {
+            this.listRef.scrollToOffset({
+              offset: 0,
+              animated: true
+            });
+          });
         }}
         page={page}
         pageSize={pageSize}

--- a/packages/author-profile/author-profile-content.web.js
+++ b/packages/author-profile/author-profile-content.web.js
@@ -36,17 +36,6 @@ const ContentContainer = withResponsiveStyles(View, {
   `
 });
 
-const scrollUpToPaging = () => {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.scroll({
-    top: 0,
-    left: 0
-  });
-};
-
 class AuthorProfileContent extends Component {
   constructor(props) {
     super(props);
@@ -143,8 +132,7 @@ class AuthorProfileContent extends Component {
       isLoading,
       name,
       onArticlePress,
-      onNext,
-      onPrev,
+      onChangePage,
       onTwitterLinkPress,
       page,
       pageSize,
@@ -164,13 +152,9 @@ class AuthorProfileContent extends Component {
         count={count}
         hideResults={hideResults}
         hideTopKeyline={hideTopKeyline}
-        onNext={(...args) => {
-          onNext(...args);
-          scrollUpToPaging();
-        }}
-        onPrev={(...args) => {
-          onPrev(...args);
-          scrollUpToPaging();
+        onChangePage={(...args) => {
+          onChangePage(...args);
+          window.scroll({ top: 0, left: 0 });
         }}
         page={page}
         pageSize={pageSize}

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -14,7 +14,7 @@ const castArticle = (page, pageSize) => article => ({
   ...article,
   page,
   pageSize,
-  publishedTime: new Date(article.publishedTime)
+  publishedTime: article.publishedTime
 });
 
 const AuthorProfile = ({

--- a/packages/author-profile/author-profile.js
+++ b/packages/author-profile/author-profile.js
@@ -25,8 +25,7 @@ const AuthorProfile = ({
   onArticlePress,
   onTwitterLinkPress,
   page,
-  onNext,
-  onPrev,
+  onChangePage,
   pageSize: initPageSize,
   slug
 }) => {
@@ -94,8 +93,7 @@ const AuthorProfile = ({
             twitter={twitter}
             onTwitterLinkPress={onTwitterLinkPress}
             count={get(articles, "count", 0)}
-            onNext={onNext}
-            onPrev={onPrev}
+            onChangePage={onChangePage}
             page={page}
             pageSize={pageSize}
             imageRatio={ratioTextToFloat(imageRatio)}
@@ -117,8 +115,7 @@ AuthorProfile.defaultProps = {
   onArticlePress: () => {},
   onTwitterLinkPress: () => {},
   page: 1,
-  onNext: () => {},
-  onPrev: () => {},
+  onChangePage: () => {},
   pageSize: 10,
   refetch: () => {}
 };
@@ -134,8 +131,7 @@ AuthorProfile.propTypes = {
     twitter: PropTypes.string
   }),
   page: PropTypes.number,
-  onNext: PropTypes.func,
-  onPrev: PropTypes.func,
+  onChangePage: PropTypes.func,
   pageSize: PropTypes.number,
   onTwitterLinkPress: PropTypes.func,
   onArticlePress: PropTypes.func,

--- a/packages/card/card.stories.js
+++ b/packages/card/card.stories.js
@@ -16,7 +16,6 @@ const cardProps = {
   showImage: true
 };
 
-articleSummaryProps.date = new Date("2017-07-01T14:32:00.000Z");
 storiesOf("Card", module)
   .addDecorator(LateralSpacingDecorator)
   .add("Loading", () => (

--- a/packages/card/card.stories.web.js
+++ b/packages/card/card.stories.web.js
@@ -7,8 +7,6 @@ import ArticleSummary from "@times-components/article-summary";
 import Card from "./card";
 import articleSummaryProps from "./fixtures/article-summary-props.json";
 
-articleSummaryProps.date = new Date("2017-07-01T14:32:00.000Z");
-
 const cardProps = {
   image: {
     uri:

--- a/packages/pagination/__tests__/pagination.web.test.js
+++ b/packages/pagination/__tests__/pagination.web.test.js
@@ -46,4 +46,15 @@ describe("Pagination Web", () => {
     expect(onChangePage).toHaveBeenCalledTimes(1);
     expect(getResultsText()).toEqual("Showing 81 - 100 of 500 results");
   });
+
+  it("Updates displayPage immediately when props.page is updated", () => {
+    const component = mount(<Pagination count={41} page={1} />);
+    expect(component.find("Results").text()).toEqual(
+      "Showing 1 - 20 of 41 results"
+    );
+    component.setProps({ page: 2 });
+    expect(component.find("Results").text()).toEqual(
+      "Showing 21 - 40 of 41 results"
+    );
+  });
 });

--- a/packages/pagination/__tests__/pagination.web.test.js
+++ b/packages/pagination/__tests__/pagination.web.test.js
@@ -1,5 +1,49 @@
 import "jest-styled-components";
-import tests from "./test-helper";
-import Pagination from "../pagination";
+import React from "react";
+import Enzyme, { mount } from "enzyme";
+import React16Adapter from "enzyme-adapter-react-16";
 
-describe("Pagination Web", tests(Pagination));
+import tests from "./test-helper";
+import Pagination, { PaginationWithoutTrackEvents } from "../pagination";
+
+Enzyme.configure({ adapter: new React16Adapter() });
+
+jest.useFakeTimers();
+
+describe("Pagination Web", () => {
+  tests(Pagination)();
+
+  it("debounces calls to onChangePage", () => {
+    const onChangePage = jest.fn();
+    const component = mount(
+      <PaginationWithoutTrackEvents
+        count={500}
+        page={2}
+        onChangePage={onChangePage}
+      />
+    );
+
+    const clickNextLink = () =>
+      component
+        .find("Link")
+        .at(1)
+        .simulate("click");
+    const getResultsText = () => component.find("Results").props().children;
+
+    expect(getResultsText()).toEqual("Showing 21 - 40 of 500 results");
+    clickNextLink();
+    jest.runTimersToTime(50);
+    expect(getResultsText()).toEqual("Showing 41 - 60 of 500 results");
+    clickNextLink();
+    jest.runTimersToTime(50);
+    expect(getResultsText()).toEqual("Showing 61 - 80 of 500 results");
+    clickNextLink();
+    jest.runTimersToTime(50);
+    expect(getResultsText()).toEqual("Showing 81 - 100 of 500 results");
+
+    expect(onChangePage).toHaveBeenCalledTimes(0);
+    jest.runAllTimers();
+    expect(onChangePage).toHaveBeenCalledTimes(1);
+    expect(getResultsText()).toEqual("Showing 81 - 100 of 500 results");
+  });
+});

--- a/packages/pagination/__tests__/test-helper.js
+++ b/packages/pagination/__tests__/test-helper.js
@@ -7,97 +7,75 @@ import React16Adapter from "enzyme-adapter-react-16";
 Enzyme.configure({ adapter: new React16Adapter() });
 
 export default Pagination => () => {
-  it("renders correctly", () => {
-    const props = {
-      count: 21,
-      page: 1
-    };
-
+  const checkMatchesSnapshot = props => {
     const component = renderer.create(<Pagination {...props} />).toJSON();
     expect(component).toMatchSnapshot();
+  };
+
+  it("renders correctly", () => {
+    checkMatchesSnapshot({
+      count: 21,
+      page: 1
+    });
   });
 
   it("renders results message", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 21,
       page: 1
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-
-    expect(component).toMatchSnapshot();
+    });
   });
 
   it("renders with hidden results", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 21,
       page: 1,
       hideResults: true
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-
-    expect(component).toMatchSnapshot();
+    });
   });
 
   it("renders with hidden topKeyline", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 21,
       page: 1,
       hideTopKeyline: true
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-
-    expect(component).toMatchSnapshot();
+    });
   });
 
   it("renders with hidden bottomKeyline", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 21,
       page: 1,
       hideBottomKeyline: true
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-
-    expect(component).toMatchSnapshot();
+    });
   });
 
   it("renders prev link", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 41,
       page: 3
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-    expect(component).toMatchSnapshot();
+    });
   });
 
   it("renders prev and next link", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 41,
       page: 2
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-    expect(component).toMatchSnapshot();
+    });
   });
 
   it("renders next link", () => {
-    const props = {
+    checkMatchesSnapshot({
       count: 41,
       page: 1
-    };
-
-    const component = renderer.create(<Pagination {...props} />).toJSON();
-
-    expect(component).toMatchSnapshot();
+    });
   });
 
-  it("tracks next page interaction", () => {
+  const testPageInteraction = (startPage, attrs) => {
+    jest.useFakeTimers();
+
     const stream = jest.fn();
-    const component = shallow(<Pagination count={21} page={1} />, {
+    const component = shallow(<Pagination count={21} page={startPage} />, {
       context: { tracking: { analytics: stream } }
     });
 
@@ -106,34 +84,43 @@ export default Pagination => () => {
       .find("Link")
       .simulate("press");
 
+    jest.runAllTimers();
+
     expect(stream).toHaveBeenCalledWith({
       component: "Pagination",
       action: "Pressed",
-      attrs: {
-        direction: "next",
-        destinationPage: 2
-      }
+      attrs
+    });
+  };
+
+  it("tracks next page interaction", () => {
+    testPageInteraction(1, {
+      direction: "next",
+      destinationPage: 2
     });
   });
 
   it("tracks previous page interaction", () => {
-    const stream = jest.fn();
-    const component = shallow(<Pagination count={21} page={2} />, {
-      context: { tracking: { analytics: stream } }
-    });
-
-    component
-      .dive()
-      .find("Link")
-      .simulate("press");
-
-    expect(stream).toHaveBeenCalledWith({
-      component: "Pagination",
-      action: "Pressed",
-      attrs: {
-        direction: "previous",
-        destinationPage: 1
-      }
+    testPageInteraction(2, {
+      direction: "previous",
+      destinationPage: 1
     });
   });
+
+  // it("debounces calls to onChangePage", () => {
+
+  //   // jest.useFakeTimers();
+  //   const onChangePage = jest.fn();
+  //   const component = shallow(<Pagination count={500} page={2} onChangePage={onChangePage} />);
+
+  //   const clickNextLink = () => component.dive().find("Link").at(1).simulate("press");
+  //   const getResultsText = () => component.update().dive().find("Results").props().children;
+
+  //   expect(getResultsText()).toEqual("Showing 21 - 40 of 500 results");
+  //   clickNextLink();
+  //   expect(component.update().dive().state()).toEqual({displayPage: 3});
+  //   expect(getResultsText()).toEqual("Showing 21 - 40 of 500 results");
+
+  //   // jest.runAllTimers();
+  // });
 };

--- a/packages/pagination/__tests__/test-helper.js
+++ b/packages/pagination/__tests__/test-helper.js
@@ -106,21 +106,4 @@ export default Pagination => () => {
       destinationPage: 1
     });
   });
-
-  // it("debounces calls to onChangePage", () => {
-
-  //   // jest.useFakeTimers();
-  //   const onChangePage = jest.fn();
-  //   const component = shallow(<Pagination count={500} page={2} onChangePage={onChangePage} />);
-
-  //   const clickNextLink = () => component.dive().find("Link").at(1).simulate("press");
-  //   const getResultsText = () => component.update().dive().find("Results").props().children;
-
-  //   expect(getResultsText()).toEqual("Showing 21 - 40 of 500 results");
-  //   clickNextLink();
-  //   expect(component.update().dive().state()).toEqual({displayPage: 3});
-  //   expect(getResultsText()).toEqual("Showing 21 - 40 of 500 results");
-
-  //   // jest.runAllTimers();
-  // });
 };

--- a/packages/pagination/__tests__/test-wrapper-helper.js
+++ b/packages/pagination/__tests__/test-wrapper-helper.js
@@ -32,7 +32,7 @@ export default withPageState => () => {
   const testRenderingInnerComponentWithPage = (currentPage, navigateToPage) => {
     const Component = props => <Text>page:{props.page}</Text>;
     Component.propTypes = {
-      page: PropTypes.string.isRequired
+      page: PropTypes.number.isRequired
     };
     const PageChanger = withPageState(Component);
 

--- a/packages/pagination/__tests__/test-wrapper-helper.js
+++ b/packages/pagination/__tests__/test-wrapper-helper.js
@@ -1,6 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { Text } from "react-native";
+import PropTypes from "prop-types";
 import Enzyme, { shallow } from "enzyme";
 import React16Adapter from "enzyme-adapter-react-16";
 
@@ -11,11 +12,7 @@ export default withPageState => () => {
     const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
     const PageChanger = withPageState(Component);
 
-    const props = {
-      page: 1
-    };
-
-    const component = renderer.create(<PageChanger {...props} />).toJSON();
+    const component = renderer.create(<PageChanger page={1} />).toJSON();
     expect(component).toMatchSnapshot();
   });
 
@@ -23,12 +20,7 @@ export default withPageState => () => {
     const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
     const PageChanger = withPageState(Component);
 
-    const props = {
-      foo: "not bar",
-      page: 1
-    };
-
-    const wrapper = shallow(<PageChanger {...props} />);
+    const wrapper = shallow(<PageChanger page={1} foo="not bar" />);
 
     wrapper.setProps({ foo: "bar" });
     wrapper.update();
@@ -37,33 +29,31 @@ export default withPageState => () => {
     expect(wrapper.state().page).toEqual(1);
   });
 
-  it("renders inner component with prev page", () => {
-    const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
+  const testRenderingInnerComponentWithPage = (currentPage, navigateToPage) => {
+    const Component = props => <Text>page:{props.page}</Text>;
+    Component.propTypes = {
+      page: PropTypes.string.isRequired
+    };
     const PageChanger = withPageState(Component);
 
-    const props = {
-      page: 2
-    };
-
-    const wrapper = shallow(<PageChanger {...props} />);
-    wrapper.instance().handleChangePage({ preventDefault: () => {} }, 1);
+    const wrapper = shallow(<PageChanger page={currentPage} />);
+    wrapper.instance().onChangePage(navigateToPage);
     wrapper.update();
 
-    expect(wrapper.state().page).toEqual(1);
+    expect(wrapper.state().page).toEqual(navigateToPage);
+    expect(
+      wrapper
+        .dive()
+        .dive()
+        .text()
+    ).toEqual(`page:${navigateToPage}`);
+  };
+
+  it("renders inner component with prev page", () => {
+    testRenderingInnerComponentWithPage(2, 1);
   });
 
   it("renders inner component with next page", () => {
-    const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
-    const PageChanger = withPageState(Component);
-
-    const props = {
-      page: 2
-    };
-
-    const wrapper = shallow(<PageChanger {...props} />);
-    wrapper.instance().handleChangePage({ preventDefault: () => {} }, 3);
-    wrapper.update();
-
-    expect(wrapper.state().page).toEqual(3);
+    testRenderingInnerComponentWithPage(2, 3);
   });
 };

--- a/packages/pagination/pagination-wrapper.js
+++ b/packages/pagination/pagination-wrapper.js
@@ -7,8 +7,6 @@ export default Component => {
     constructor(props) {
       super(props);
       this.state = props;
-
-      this.handleChangePage = this.handleChangePage.bind(this);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -19,19 +17,12 @@ export default Component => {
       );
     }
 
-    handleChangePage(event, page) {
+    onChangePage = page => {
       this.setState({ page });
-      event.preventDefault();
-    }
+    };
 
     render() {
-      return (
-        <Component
-          {...this.state}
-          onNext={this.handleChangePage}
-          onPrev={this.handleChangePage}
-        />
-      );
+      return <Component {...this.state} onChangePage={this.onChangePage} />;
     }
   }
 

--- a/packages/pagination/pagination.js
+++ b/packages/pagination/pagination.js
@@ -40,67 +40,96 @@ const styles = StyleSheet.create({
   }
 });
 
-const Pagination = ({
-  count,
-  generatePageLink,
-  onNext,
-  onPrev,
-  page,
-  pageSize,
-  hideResults,
-  hideTopKeyline,
-  hideBottomKeyline
-}) => {
-  const finalResult = Math.min(count, page * pageSize);
-  const startResult = Math.min(finalResult, (page - 1) * pageSize + 1);
-  const message = `Showing ${startResult} - ${finalResult} of ${count} results`;
+class Pagination extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayPage: props.page
+    };
+  }
 
-  const prevComponent =
-    startResult > pageSize ? (
-      <Link
-        style={styles.arrow}
-        onPress={e => onPrev(e, page - 1)}
-        url={generatePageLink(page - 1)}
-      >
-        <PreviousPageIcon />
-      </Link>
-    ) : null;
+  componentWillReceiveProps(nextProps) {
+    this.setState({ displayPage: nextProps.page });
+  }
 
-  const nextComponent =
-    finalResult < count ? (
-      <Link
-        style={styles.arrow}
-        onPress={e => onNext(e, page + 1)}
-        url={generatePageLink(page + 1)}
-      >
-        <NextPageIcon />
-      </Link>
-    ) : null;
+  navigate(e, nextPage, direction) {
+    if (e) {
+      e.preventDefault();
+    }
+    this.setState({ displayPage: nextPage });
+    clearTimeout(this.debounceTimeout);
+    this.debounceTimeout = setTimeout(
+      this.props.onChangePage,
+      250,
+      nextPage,
+      direction
+    );
+  }
 
-  const messageComponent = !hideResults ? <Results>{message}</Results> : null;
+  render() {
+    const {
+      count,
+      generatePageLink,
+      pageSize,
+      hideResults,
+      hideTopKeyline,
+      hideBottomKeyline
+    } = this.props;
 
-  return (
-    <View style={styles.container}>
-      {messageComponent}
-      <View
-        style={[
-          styles.border,
-          !hideTopKeyline && styles.borderTop,
-          !hideBottomKeyline && styles.borderBottom
-        ]}
-      >
-        <View>{prevComponent}</View>
-        <View>{nextComponent}</View>
+    const { displayPage } = this.state;
+
+    const finalResult = Math.min(count, displayPage * pageSize);
+    const startResult = Math.min(finalResult, (displayPage - 1) * pageSize + 1);
+    const message = `Showing ${startResult} - ${finalResult} of ${
+      count
+    } results`;
+
+    const prevComponent =
+      startResult > pageSize ? (
+        <Link
+          style={styles.arrow}
+          onPress={e => this.navigate(e, displayPage - 1, "previous")}
+          url={generatePageLink(displayPage - 1)}
+        >
+          <PreviousPageIcon />
+        </Link>
+      ) : null;
+
+    const nextComponent =
+      finalResult < count ? (
+        <Link
+          style={styles.arrow}
+          onPress={e => this.navigate(e, displayPage + 1, "next")}
+          url={generatePageLink(displayPage + 1)}
+        >
+          <NextPageIcon />
+        </Link>
+      ) : null;
+
+    const messageComponent = !hideResults ? <Results>{message}</Results> : null;
+
+    return (
+      <View style={styles.container}>
+        {messageComponent}
+        <View
+          style={[
+            styles.border,
+            !hideTopKeyline && styles.borderTop,
+            !hideBottomKeyline && styles.borderBottom
+          ]}
+        >
+          <View>{prevComponent}</View>
+          <View>{nextComponent}</View>
+        </View>
       </View>
-    </View>
-  );
-};
+    );
+  }
+}
 
 Pagination.propTypes = {
   count: PropTypes.number,
   generatePageLink: PropTypes.func,
-  onNext: PropTypes.func,
-  onPrev: PropTypes.func,
+  onChangePage: PropTypes.func,
   page: PropTypes.number,
   pageSize: PropTypes.number,
   hideResults: PropTypes.bool,
@@ -111,8 +140,7 @@ Pagination.propTypes = {
 Pagination.defaultProps = {
   count: 0,
   generatePageLink: page => `./${page}`,
-  onNext: () => {},
-  onPrev: () => {},
+  onChangePage: () => {},
   page: 1,
   pageSize: 20,
   hideResults: false,
@@ -123,22 +151,14 @@ Pagination.defaultProps = {
 export default withTrackEvents(Pagination, {
   analyticsEvents: [
     {
-      eventName: "onNext",
+      eventName: "onChangePage",
       actionName: "Pressed",
-      getAttrs: (props, [, destinationPage]) => ({
+      getAttrs: (props, [destinationPage, direction]) => ({
         destinationPage,
-        direction: "next"
-      })
-    },
-    {
-      eventName: "onPrev",
-      actionName: "Pressed",
-      getAttrs: (props, [, destinationPage]) => ({
-        destinationPage,
-        direction: "previous"
+        direction
       })
     }
   ]
 });
 
-export { withPageState };
+export { withPageState, Pagination as PaginationWithoutTrackEvents };

--- a/packages/pagination/pagination.js
+++ b/packages/pagination/pagination.js
@@ -40,6 +40,8 @@ const styles = StyleSheet.create({
   }
 });
 
+const debounceIntervalMs = 250;
+
 class Pagination extends React.Component {
   constructor(props) {
     super(props);
@@ -60,7 +62,7 @@ class Pagination extends React.Component {
     clearTimeout(this.debounceTimeout);
     this.debounceTimeout = setTimeout(
       this.props.onChangePage,
-      250,
+      debounceIntervalMs,
       nextPage,
       direction
     );

--- a/packages/pagination/pagination.stories.js
+++ b/packages/pagination/pagination.stories.js
@@ -13,33 +13,25 @@ storiesOf("Pagination", module)
     <Pagination
       page={1}
       count={60}
-      onNext={action("first-page-next")}
-      onPrev={action("first-page-prev")}
+      onChangePage={action("first-page-change")}
     />
   ))
   .add("Another page", () => (
     <Pagination
       page={2}
       count={60}
-      onNext={action("another-page-next")}
-      onPrev={action("another-page-prev")}
+      onChangePage={action("another-page-change")}
     />
   ))
   .add("Last page", () => (
-    <Pagination
-      page={3}
-      count={60}
-      onNext={action("last-page-next")}
-      onPrev={action("last-page-prev")}
-    />
+    <Pagination page={3} count={60} onChangePage={action("last-page-change")} />
   ))
   .add("First page without results information", () => (
     <Pagination
       page={1}
       count={60}
       hideResults
-      onNext={action("first-page-next-compact")}
-      onPrev={action("first-page-prev-compact")}
+      onChangePage={action("first-page-change-compact")}
     />
   ))
   .add("Another page without results information", () => (
@@ -47,8 +39,7 @@ storiesOf("Pagination", module)
       page={2}
       count={60}
       hideResults
-      onNext={action("another-page-next-compact")}
-      onPrev={action("another-page-prev-compact")}
+      onChangePage={action("another-page-change-compact")}
     />
   ))
   .add("Last page without results information", () => (
@@ -56,8 +47,7 @@ storiesOf("Pagination", module)
       page={3}
       count={60}
       hideResults
-      onNext={action("last-page-next-compact")}
-      onPrev={action("last-page-prev-compact")}
+      onChangePage={action("last-page-change-compact")}
     />
   ))
   .add("Without top keyline", () => (
@@ -65,8 +55,7 @@ storiesOf("Pagination", module)
       page={2}
       count={60}
       hideTopKeyline
-      onNext={action("without-top-keyline-next")}
-      onPrev={action("without-top-keyline-prev")}
+      onChangePage={action("without-top-keyline-change-page")}
     />
   ))
   .add("Without bottom keyline", () => (
@@ -74,12 +63,10 @@ storiesOf("Pagination", module)
       page={2}
       count={60}
       hideBottomKeyline
-      onNext={action("without-bottom-keyline-next")}
-      onPrev={action("without-bottom-keyline-prev")}
+      onChangePage={action("without-bottom-keyline-change-page")}
     />
   ))
   .add("Tracking", () => {
-    const pageHandler = e => e.preventDefault();
     const PaginationWithTrackingContext = withTrackingContext(Pagination, {
       trackingObject: "Story"
     });
@@ -89,8 +76,6 @@ storiesOf("Pagination", module)
         count={60}
         hideResults
         analyticsStream={action("analytics-event")}
-        onNext={pageHandler}
-        onPrev={pageHandler}
       />
     );
   });


### PR DESCRIPTION
1. Debounce author profile paging within the UI component - the display page (Showing 1 to 20 of 41) updates immediately, the query is delayed until no page changes have hapened in the last 250ms
2. Refactor pagination component to use onChangePage instead of onNext and onPrev
3. Fixed some errors relating to article publication date formats that had found their way into master after PR 525