### PR TITLE
chore: Moved jest setup script to pretest instead of postinstall

### DIFF
--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -5,7 +5,7 @@
   "main": "lib/jest-configurator.js",
   "scripts": {
     "prepublishOnly": "babel src -d lib",
-    "postinstall": "./setup.sh",
+    "pretest": "./setup.sh",
     "test:watch": "jest --bail --verbose --watchAll",
     "test": "jest --bail --ci --coverage",
     "prettier:diff": "prettier --list-different '**/*.*'",


### PR DESCRIPTION
Setup script was being run on each install, but it should be running before tests only