### PR TITLE
chore: Improve preandroid script to wait for emulator

### DIFF
--- a/lib/start_android_emulator.sh
+++ b/lib/start_android_emulator.sh
@@ -1,13 +1,33 @@
 #!/usr/bin/env bash
+{
+  EMULATOR=$(emulator -list-avds | head -n 1)
 
-EMULATOR=$(emulator -list-avds | head -n 1)
+  if [[ -z $EMULATOR ]]
+  then
+    echo "You don't have an emulator set up"
+    exit 0
+  fi
 
-if [[ -z $EMULATOR ]]
-then
-  echo "You don't have an emulator set up"
-  exit 0
-fi
+  $ANDROID_HOME/tools/emulator @${EMULATOR} &
 
-$ANDROID_HOME/tools/emulator @${EMULATOR}
+  bootanim=""
+  failcounter=0
+  timeout_in_sec=360
 
+  until [[ "$bootanim" =~ "stopped" ]]; do
+    bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+    if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+      || "$bootanim" =~ "running" ]]; then
+      let "failcounter += 1"
+      echo "Waiting for emulator to start"
+      if [[ $failcounter -gt timeout_in_sec ]]; then
+        echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+        exit 1
+      fi
+    fi
+    sleep 1
+  done
+}
+
+echo "Emulator is ready"
 exit 0

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "storybook-native": "storybook -c .storybook.native start -p 7007",
     "preios": "yarn fetch-fonts",
     "ios": "react-native run-ios",
-    "start-emulator": "./lib/start_android_emulator.sh &",
+    "start-emulator": "./lib/start_android_emulator.sh",
     "preandroid": "yarn fetch-fonts && yarn start-emulator",
     "android": "react-native run-android",
     "android:device": "./lib/setup_device_connections.sh && yarn android",


### PR DESCRIPTION
Pre-android script launches an emulator but the app build doesn't wait for the emulator to be ready.

Added a wait script on start-emulator. Running yarn android should fire up an emulator and build the
app when the emulator has finished booting