### PR TITLE
Do not spin up emulator if device connected

### DIFF
--- a/lib/start_android_emulator.sh
+++ b/lib/start_android_emulator.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 {
-  EMULATOR=$(emulator -list-avds | head -n 1)
-
-  if [[ -z $EMULATOR ]]
+  adb_cmd="$ANDROID_HOME/platform-tools/adb"
+  device=$($adb_cmd devices | tail -n +2)
+  if [[ ! -z $device ]]
   then
-    echo "You don't have an emulator set up"
+    echo "Device is already running"
     exit 0
   fi
 
-  $ANDROID_HOME/tools/emulator @${EMULATOR} &
+  emulator_cmd="$ANDROID_HOME/tools/emulator"
+
+  avd=$($emulator_cmd -list-avds | head -n 1)
+
+  if [[ -z $avd ]]
+  then
+    echo "You don't have an emulator set up"
+    exit 1
+  fi
+
+  $ANDROID_HOME/tools/emulator @${avd} &
 
   bootanim=""
   failcounter=0

--- a/lib/start_android_emulator.sh
+++ b/lib/start_android_emulator.sh
@@ -18,7 +18,7 @@
     exit 1
   fi
 
-  $ANDROID_HOME/tools/emulator @${avd} &
+  $emulator_cmd @${avd} &
 
   bootanim=""
   failcounter=0


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->


This PR makes sure not to spin an emulator up if there's already a device (real or emulator) connected.

Also:

1. Renamed the vars to be lowercase, as reserved vars will _always_ be uppercase, this way we don't risk name clashes.
2. Used correct path (with `$ANDROID_HOME`) as `emulator` might not be set as an alias.