### PR TITLE
Fix/pagination tracking name

### DIFF
--- a/packages/author-profile/author-profile-item.js
+++ b/packages/author-profile/author-profile-item.js
@@ -75,6 +75,7 @@ export default withTrackEvents(AuthorProfileItem, {
     {
       eventName: "onPress",
       actionName: "Pressed",
+      trackingName: "AuthorProfileItem",
       getAttrs: ({ headline, id }) => ({
         articleHeadline: headline,
         articleId: id

--- a/packages/author-profile/author-profile-item.web.js
+++ b/packages/author-profile/author-profile-item.web.js
@@ -101,6 +101,7 @@ export default withTrackEvents(AuthorProfileItem, {
     {
       eventName: "onPress",
       actionName: "Pressed",
+      trackingName: "AuthorProfileItem",
       getAttrs: ({ headline, id }) => ({
         articleHeadline: headline,
         articleId: id

--- a/packages/pagination/pagination.js
+++ b/packages/pagination/pagination.js
@@ -95,6 +95,7 @@ export default withTrackEvents(Pagination, {
     {
       eventName: "onNext",
       actionName: "Pressed",
+      trackingName: "Pagination",
       getAttrs: (props, [, destinationPage]) => ({
         destinationPage,
         direction: "next"
@@ -103,6 +104,7 @@ export default withTrackEvents(Pagination, {
     {
       eventName: "onPrev",
       actionName: "Pressed",
+      trackingName: "Pagination",
       getAttrs: (props, [, destinationPage]) => ({
         destinationPage,
         direction: "previous"


### PR DESCRIPTION
Component displayName is null for release builds so trackingName must be added for all components.

Added trackingName to Pagination and AuthorProfileItem events.