### PR TITLE
Fix/tracking display name

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -202,17 +202,17 @@ eg
 
 ## Babel config for native apps (Required for tracking)
 
- Tracking package uses component.displayName. By default, react-native bundler removes displayName in release versions. To keep the display name, the projects that use times-components tracking feature, should follow these steps:
+ Tracking package uses `component.displayName`. By default, the react-native bundler removes `displayName` in release versions. To keep the display name, the projects that use the `times-components` tracking feature, should follow these steps:
   * Add `babel-plugin-add-react-displayname` as a dev dependency (`yarn add --dev babel-plugin-add-react-displayname`)
-  * Create .babelrc in base directory
-  * .babelrc should contain following plugins and presets:
+  * Create a `.babelrc` in the base directory
+  * The `.babelrc` should contain the following plugins and presets:
   ```
   {
     "presets": ["react-native"],
     "plugins": ["add-react-displayname"]
   }
   ```
-  * Updating babelrc requires a cache clean-up for react-native bundler. Bundle with `react-native bundle --reset-cache` for the first time.
+  * Updating the `.babelrc` requires a cache clean-up for the react-native bundler. Bundle with `react-native bundle --reset-cache` for the first time.
 
 ## Folder Structure
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -200,6 +200,20 @@ eg
 * FontName / Full name = GillSansMTStd-Medium
 * FamilyName = GillSansMTStd-Medium
 
+## Babel config for native apps (Required for tracking)
+
+ Tracking package uses component.displayName. By default, react-native bundler removes displayName in release versions. To keep the display name, the projects that use times-components tracking feature, should follow these steps:
+  * Add `babel-plugin-add-react-displayname` as a dev dependency (`yarn add --dev babel-plugin-add-react-displayname`)
+  * Create .babelrc in base directory
+  * .babelrc should contain following plugins and presets:
+  ```
+  {
+    "presets": ["react-native"],
+    "plugins": ["add-react-displayname"]
+  }
+  ```
+  * Updating babelrc requires a cache clean-up for react-native bundler. Bundle with `react-native bundle --reset-cache` for the first time.
+
 ## Folder Structure
 
 An example component/package looks like this:

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -55,6 +55,7 @@
     "react-display-name": "0.2.3"
   },
   "peerDependencies": {
+    "babel-plugin-add-react-displayname": "0.0.4",
     "babel-preset-env": "1.6.1",
     "babel-preset-stage-2": "6.24.1",
     "react": ">=16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,6 +1163,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-react-displayname@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.4.tgz#bc2a74bcbee6e505025b3352fea85ee7bc4c6f7c"
+
 babel-plugin-check-es2015-constants@^6.22.0, babel-plugin-check-es2015-constants@^6.5.0, babel-plugin-check-es2015-constants@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"


### PR DESCRIPTION
Analytics component name requires component displayName, which in turn requires
babel-plugin-add-react-displayname to be able to fetch display name on release builds

Updated peer dependencies
Updated contributing docs
