### PR TITLE
fix: fix fonts by removing local font definitions

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,60 +1,77 @@
 <style>
   @font-face {
     font-family: TimesModern-Bold;
-    src: url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.woff) format("woff"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.eot?iefix) format("eot"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.ttf) format("truetype"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.svg#webfont) format("svg");
+    src: url(/fonts/TimesModern-Bold.woff2) format("woff2"),
+        url(/fonts/TimesModern-Bold.woff) format("woff"),
+        url(/fonts/TimesModern-Bold.ttf) format("ttf"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.eot?iefix) format("eot"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.svg#webfont) format("svg");
     font-weight: 400;
     font-style: normal;
   }
 
   @font-face {
     font-family: TimesModern-Regular;
-    src: url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.woff) format("woff"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.eot?iefix) format("eot"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.ttf) format("truetype"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.svg#webfont) format("svg");
+    src: url(/fonts/TimesModern-Regular.woff2) format("woff2"),
+        url(/fonts/TimesModern-Regular.woff) format("woff"),
+        url(/fonts/TimesModern-Regular.ttf) format("ttf"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.woff) format("woff"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.eot?iefix) format("eot"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.svg#webfont) format("svg");
     font-weight: 400;
     font-style: normal;
   }
 
   @font-face {
     font-family: TimesDigitalW04-RegularSC;
-    src: url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff2) format("woff2"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff) format("woff"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.ttf) format("truetype"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.eot?iefix) format("eot"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.svg#webfont) format("svg");
+    src: url(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"),
+        url(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"),
+        url(/fonts/TimesDigitalW04-RegularSC.ttf) format("ttf"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff) format("woff"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.eot?iefix) format("eot"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.svg#webfont) format("svg");
     font-weight: 400;
     font-style: normal;
   }
 
   @font-face {
     font-family: GillSansMTStd-Medium;
-    src: url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff2) format("woff2"),
-         url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff) format("woff"),
-         url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.eot?iefix) format("eot"),
-         url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.svg#webfont) format("svg");
+    src: url(/fonts/GillSansMTStd-Medium.woff2) format("woff2"),
+        url(/fonts/GillSansMTStd-Medium.woff) format("woff"),
+        url(/fonts/GillSansMTStd-Medium.ttf) format("ttf"),
+        url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff) format("woff"),
+        url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.eot?iefix) format("eot"),
+        url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.svg#webfont) format("svg");
     font-weight: 400;
     font-style: normal;
   }
 
   @font-face {
     font-family: TimesDigitalW04;
-    src: url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff) format("woff");
+    src: url(/fonts/TimesDigitalW04.woff2) format("woff2"),
+        url(/fonts/TimesDigitalW04.woff) format("woff"),
+        url(/fonts/TimesDigitalW04.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff) format("woff");
     font-weight: 400;
     font-style: normal;
   }
 
   @font-face {
     font-family: TimesDigitalW04-Regular;
-    src: url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff) format("woff"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.ttf) format("truetype"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.eot?iefix) format("eot"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.svg#webfont) format("svg");
+    src: url(/fonts/TimesDigitalW04-Regular.woff2) format("woff2"),
+        url(/fonts/TimesDigitalW04-Regular.woff) format("woff"),
+        url(/fonts/TimesDigitalW04-Regular.ttf) format("ttf"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff) format("woff"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.eot?iefix) format("eot"),
+        url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.svg#webfont) format("svg");
     font-weight: 400;
     font-style: normal;
   }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,10 +1,7 @@
 <style>
   @font-face {
     font-family: TimesModern-Bold;
-    src: local(/fonts/TimesModern-Bold.woff2) format("woff2"),
-         local(/fonts/TimesModern-Bold.woff) format("woff"),
-         local(/fonts/TimesModern-Bold.ttf) format("ttf"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.woff) format("woff"),
+    src: url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.woff) format("woff"),
          url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.eot?iefix) format("eot"),
          url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.ttf) format("truetype"),
          url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.svg#webfont) format("svg");
@@ -14,10 +11,7 @@
 
   @font-face {
     font-family: TimesModern-Regular;
-    src: local(/fonts/TimesModern-Regular.woff2) format("woff2"),
-         local(/fonts/TimesModern-Regular.woff) format("woff"),
-         local(/fonts/TimesModern-Regular.ttf) format("ttf"),
-         url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.woff) format("woff"),
+    src: url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.woff) format("woff"),
          url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.eot?iefix) format("eot"),
          url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.ttf) format("truetype"),
          url(https://www.thetimes.co.uk/fonts/TimesModern-Regular.svg#webfont) format("svg");
@@ -27,10 +21,7 @@
 
   @font-face {
     font-family: TimesDigitalW04-RegularSC;
-    src: local(/fonts/TimesDigitalW04-RegularSC.woff2) format("woff2"),
-         local(/fonts/TimesDigitalW04-RegularSC.woff) format("woff"),
-         local(/fonts/TimesDigitalW04-RegularSC.ttf) format("ttf"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff2) format("woff2"),
+    src: url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff2) format("woff2"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.woff) format("woff"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.ttf) format("truetype"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-RegularSC.eot?iefix) format("eot"),
@@ -41,10 +32,7 @@
 
   @font-face {
     font-family: GillSansMTStd-Medium;
-    src: local(/fonts/GillSansMTStd-Medium.woff2) format("woff2"),
-         local(/fonts/GillSansMTStd-Medium.woff) format("woff"),
-         local(/fonts/GillSansMTStd-Medium.ttf) format("ttf"),
-         url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff2) format("woff2"),
+    src: url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff2) format("woff2"),
          url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.woff) format("woff"),
          url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.eot?iefix) format("eot"),
          url(https://www.thetimes.co.uk/fonts/GillSansW01-Medium.svg#webfont) format("svg");
@@ -54,10 +42,7 @@
 
   @font-face {
     font-family: TimesDigitalW04;
-    src: local(/fonts/TimesDigitalW04.woff2) format("woff2"),
-         local(/fonts/TimesDigitalW04.woff) format("woff"),
-         local(/fonts/TimesDigitalW04.ttf) format("truetype"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
+    src: url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff) format("woff");
     font-weight: 400;
     font-style: normal;
@@ -65,10 +50,7 @@
 
   @font-face {
     font-family: TimesDigitalW04-Regular;
-    src: local(/fonts/TimesDigitalW04-Regular.woff2) format("woff2"),
-         local(/fonts/TimesDigitalW04-Regular.woff) format("woff"),
-         local(/fonts/TimesDigitalW04-Regular.ttf) format("ttf"),
-         url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
+    src: url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff2) format("woff2"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.woff) format("woff"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.ttf) format("truetype"),
          url(https://www.thetimes.co.uk/fonts/TimesDigital-Regular.eot?iefix) format("eot"),


### PR DESCRIPTION
@craigbilner this seems legit - have tested on gh-pages and fonts are back. I missed them.