### PR TITLE
Feature/proptype docs

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,10 +1,18 @@
-import { configure } from "@storybook/react";
+import { configure, addDecorator } from "@storybook/react";
+import { Text, View } from 'react-native';
+import { withInfo, setDefaults } from '@storybook/addon-info';
 
 const req = require.context(
   "../packages",
   true,
   /^((?!node_modules).)*\.(stories|stories.web)\.js$/
 );
+
+setDefaults({
+  propTablesExclude: [Text, View]
+})
+
+addDecorator((story, context) => withInfo('')(story)(context));
 
 const loadStories = () => req.keys().forEach(filename => req(filename));
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@storybook/addon-actions": "3.3.11",
+    "@storybook/addon-info": "3.3.11",
     "@storybook/addons": "3.3.11",
     "@storybook/react": "3.3.11",
     "@storybook/react-native": "3.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,20 @@
     react-inspector "^2.2.2"
     uuid "^3.1.0"
 
+"@storybook/addon-info@3.3.11":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.3.11.tgz#865307ed6ccb8cb3c0e189779d12f31b9adde683"
+  dependencies:
+    "@storybook/client-logger" "^3.3.11"
+    "@storybook/components" "^3.3.11"
+    babel-runtime "^6.26.0"
+    global "^4.3.2"
+    marksy "^6.0.2"
+    nested-object-assign "^1.0.1"
+    prop-types "^15.6.0"
+    react-addons-create-fragment "^15.5.3"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-links@^3.3.11":
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.3.11.tgz#7bc57baddd1502153ee94cf11fcb88d49131b211"
@@ -2100,6 +2114,10 @@ babel-runtime@6.26.0, babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-standalone@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.26.0:
   version "6.26.0"
@@ -4973,7 +4991,7 @@ fbjs-scripts@^0.8.1:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -5864,7 +5882,7 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.x:
+he@1.1.x, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -7627,6 +7645,14 @@ marked@^0.3.9:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
 
+marksy@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.0.3.tgz#6079076e8689b563b61be058942090c7ba1f5d20"
+  dependencies:
+    babel-standalone "^6.26.0"
+    he "^1.1.1"
+    marked "^0.3.9"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -8045,6 +8071,10 @@ negotiator@0.5.3:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+nested-object-assign@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.2.tgz#9a84ef51b5c11298b5476d6c65b26458c9eae82b"
 
 ngrok@^2.2.24:
   version "2.2.25"
@@ -9447,6 +9477,14 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-addons-create-fragment@^15.5.3:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
+  dependencies:
+    fbjs "^0.8.4"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.0"
 
 react-apollo-temp@2.0.5:
   version "2.0.5"


### PR DESCRIPTION
Installs and applies a doc generating decorator for our storybook.

It seems there is a better addon: https://github.com/tuchk4/storybook-readme
I didn't manage to figure out how to configure it to extract the proptypes.
I think it requires a react docgen specific babel plugin. 
We should revisit once we have more readmes in our packages