### PR TITLE
Chore: Move jest-configurator from dependencies to devDependencies

### DIFF
--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "@times-components/gradient": "0.3.15",
     "@times-components/image": "1.13.2",
-    "@times-components/jest-configurator": "0.0.22",
     "@times-components/responsive-styles": "0.2.14",
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@storybook/react-native": "3.3.9",
     "@times-components/eslint-config-thetimes": "0.1.3",
+    "@times-components/jest-configurator": "0.0.22",
     "@times-components/storybook": "0.2.5",
     "dextrose": "1.3.2",
     "enzyme": "3.3.0",
@@ -48,7 +49,6 @@
     "react-test-renderer": "16.2.0"
   },
   "dependencies": {
-    "@times-components/jest-configurator": "0.0.22",
     "prop-types": "15.6.0"
   },
   "peerDependencies": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@storybook/react-native": "3.3.9",
     "@times-components/eslint-config-thetimes": "0.1.3",
+    "@times-components/jest-configurator": "0.0.22",
     "dextrose": "1.3.2",
     "enzyme": "3.3.0",
     "enzyme-to-json": "3.3.0",
@@ -50,7 +51,6 @@
   "dependencies": {
     "@times-components/gestures": "1.1.1",
     "@times-components/gradient": "0.3.15",
-    "@times-components/jest-configurator": "0.0.22",
     "@times-components/link": "0.13.14",
     "prop-types": "15.6.0",
     "react-native-svg": "5.5.0",


### PR DESCRIPTION
`jest-configurator` was incorrectly added as a dependency in `gestures`, `card` and `image` packages. This PR moves to `devDependencies`.