### PR TITLE
chore: only use since flag for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ script:
   - yarn lint
   - ./lib/run_tests.sh
 after_success:
-  - yarn coverage:publish
   - ./lib/publish.sh
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - chmod +x ./lib/publish.sh
 script:
   - yarn lint
-  - yarn test
+  - ./lib/run_tests.sh
 after_success:
   - yarn coverage:publish
   - ./lib/publish.sh

--- a/lib/publish.sh
+++ b/lib/publish.sh
@@ -45,6 +45,8 @@ then
   exit 0
 fi
 
+yarn coverage:publish
+
 # set npm credentials
 echo "Setting up npm"
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc

--- a/lib/run_tests.sh
+++ b/lib/run_tests.sh
@@ -8,3 +8,4 @@ then
 fi
 
 yarn test --since
+yarn coverage:publish

--- a/lib/run_tests.sh
+++ b/lib/run_tests.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 set -ev
 
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ]
+if [ $TRAVIS_BRANCH != 'master' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]
 then
+  echo "Publishing branch changes to coveralls for PR"
   yarn test --since
   yarn coverage:publish
   exit 0
 fi
 
+if [ $TRAVIS_PULL_REQUEST = 'false' ]
+then
+  echo "Running all the tests for master"
+  yarn test
+  exit 0
+fi
+
+echo "Running all the tests for the PR with no publish"
 yarn test

--- a/lib/run_tests.sh
+++ b/lib/run_tests.sh
@@ -3,9 +3,9 @@ set -ev
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]
 then
-  yarn test
+  yarn test --since
   exit 0
 fi
 
-yarn test --since
+yarn test
 yarn coverage:publish

--- a/lib/run_tests.sh
+++ b/lib/run_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ev
+
+if [ "${TRAVIS_PULL_REQUEST}" = "true" ]
+then
+  yarn test --since
+  exit 0
+fi
+
+yarn test

--- a/lib/run_tests.sh
+++ b/lib/run_tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -ev
 
-if [ "${TRAVIS_PULL_REQUEST}" = "true" ]
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]
 then
-  yarn test --since
+  yarn test
   exit 0
 fi
 
-yarn test
+yarn test --since

--- a/lib/run_tests.sh
+++ b/lib/run_tests.sh
@@ -4,8 +4,8 @@ set -ev
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]
 then
   yarn test --since
+  yarn coverage:publish
   exit 0
 fi
 
 yarn test
-yarn coverage:publish

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "native": "node node_modules/react-native/local-cli/cli.js start",
-    "test": "yarn storybook:test-build && jest ./lib && lerna run test --stream",
+    "test": "yarn storybook:test-build && jest ./lib --coverage && lerna run test --stream",
     "functional-test:web": "./lib/functional_tests/run-web.sh",
     "functional-test:ios": "./lib/functional_tests/run-ios.sh",
     "functional-test:android": "./lib/functional_tests/run-android.sh",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "visual-snapshot-ios": "./lib/visual_snapshots/run-ios-dextrose.sh",
     "visual-snapshot-web": "./lib/visual_snapshots/run-web-dextrose.sh",
     "visual-snapshot-android": "./lib/visual_snapshots/run-android-dextrose.sh",
-    "coverage:publish": "lcov-result-merger ./packages/**/lcov.info | coveralls",
+    "coverage:publish": "lcov-result-merger ./**/lcov.info | coveralls",
     "prelint": "eslint . && prettier --list-different '**/*.*'",
     "lint": "lerna run lint --since",
     "fetch-fonts": "node ./lib/fetch-fonts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "native": "node node_modules/react-native/local-cli/cli.js start",
-    "test": "yarn storybook:test-build && jest ./lib && lerna run test --since --stream",
+    "test": "yarn storybook:test-build && jest ./lib && lerna run test --stream",
     "functional-test:web": "./lib/functional_tests/run-web.sh",
     "functional-test:ios": "./lib/functional_tests/run-ios.sh",
     "functional-test:android": "./lib/functional_tests/run-android.sh",


### PR DESCRIPTION
By running the tests with the `since` flag everywhere has two issues:

* The coverage in coveralls is a little misleading for master
* Wider side effects a la babel scripts may break other packages but the PR tests won't fail

If we run all tests on the master branch this should resolve these two