### PR TITLE
Chore/refactor faketimers

### DIFF
--- a/packages/gestures/__tests__/gestures.native.test.js
+++ b/packages/gestures/__tests__/gestures.native.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { Text } from "react-native";
 import { shallow } from "enzyme";
-import Gesture from "../gestures";
 import { delayAndAdvance } from "@times-components/utils/faketime";
+import Gesture from "../gestures";
 
 const mapTouches = ({ x, y }) => ({
   pageX: x,

--- a/packages/gestures/__tests__/gestures.native.test.js
+++ b/packages/gestures/__tests__/gestures.native.test.js
@@ -2,15 +2,7 @@ import React from "react";
 import { Text } from "react-native";
 import { shallow } from "enzyme";
 import Gesture from "../gestures";
-
-jest.useFakeTimers();
-const delay = ms => new Promise(done => setTimeout(done, ms));
-
-const delayAndAdvance = ms => {
-  const timer = delay(ms);
-  jest.runTimersToTime(ms);
-  return timer;
-};
+import { delayAndAdvance } from "@times-components/utils/faketime";
 
 const mapTouches = ({ x, y }) => ({
   pageX: x,

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -36,6 +36,7 @@
     "@times-components/eslint-config-thetimes": "0.1.3",
     "@times-components/jest-configurator": "0.0.23",
     "@times-components/storybook": "0.2.6",
+    "@times-components/utils": "0.3.0",
     "dextrose": "1.3.2",
     "enzyme": "3.3.0",
     "enzyme-to-json": "3.3.0",

--- a/packages/provider/__tests__/provider-state-transition.test.js
+++ b/packages/provider/__tests__/provider-state-transition.test.js
@@ -4,7 +4,8 @@ import {
   providerTester,
   getRenderedQueries
 } from "@times-components/provider-test-tools";
-import { delayAndAdvance } from "@times-components/utils";
+
+import { delayAndAdvance } from "@times-components/utils/faketime";
 import connect from "../connect";
 
 function AuthorQueryResolver({ variables }) {

--- a/packages/provider/__tests__/provider-state-transition.test.js
+++ b/packages/provider/__tests__/provider-state-transition.test.js
@@ -4,7 +4,7 @@ import {
   providerTester,
   getRenderedQueries
 } from "@times-components/provider-test-tools";
-import { delayAndAdvance } "@times-components/utils";
+import { delayAndAdvance } from "@times-components/utils";
 import connect from "../connect";
 
 function AuthorQueryResolver({ variables }) {

--- a/packages/provider/__tests__/provider-state-transition.test.js
+++ b/packages/provider/__tests__/provider-state-transition.test.js
@@ -4,13 +4,8 @@ import {
   providerTester,
   getRenderedQueries
 } from "@times-components/provider-test-tools";
+import { delayAndAdvance } "@times-components/utils";
 import connect from "../connect";
-
-jest.useFakeTimers();
-
-// Alias the confusingly misnamed runTimersToTime to advanceTimersByTime
-// Jest has done this in v22, so this can be removed if we upgrade
-jest.advanceTimersByTime = jest.runTimersToTime;
 
 function AuthorQueryResolver({ variables }) {
   return {
@@ -34,12 +29,6 @@ const query = gql`
 const Connected = connect(query);
 const Debounced = props => <Connected {...props} debounceTimeMs={1000} />;
 
-const wait = ms => {
-  const timer = new Promise(done => setTimeout(done));
-  jest.advanceTimersByTime(ms);
-  return timer;
-};
-
 describe("provider execution order tests", () => {
   it("should resolve in order", async () => {
     const { link, setProps } = providerTester(AuthorQueryResolver, Debounced, {
@@ -47,11 +36,11 @@ describe("provider execution order tests", () => {
     });
 
     await link.findByQuery("AuthorQuery", { slug: "1" }).resolve();
-    await wait(0); // wait for render
+    await delayAndAdvance(0); // wait for render
     await setProps({ slug: "2" });
-    await wait(500);
+    await delayAndAdvance(500);
     await setProps({ slug: "3" });
-    await wait(1000);
+    await delayAndAdvance(1000);
 
     expect(getRenderedQueries(link)).toMatchSnapshot();
   });
@@ -63,7 +52,7 @@ describe("provider execution order tests", () => {
 
     await link.findByQuery("AuthorQuery", { slug: "1" }).resolve();
     await setProps({ slug: "2" });
-    await wait(1000);
+    await delayAndAdvance(1000);
 
     expect(getRenderedQueries(link)).toMatchSnapshot();
   });
@@ -73,11 +62,11 @@ describe("provider execution order tests", () => {
       slug: "1"
     });
 
-    await wait(0);
+    await delayAndAdvance(0);
     await setProps({ slug: "2" });
-    await wait(500);
+    await delayAndAdvance(500);
     await link.findByQuery("AuthorQuery", { slug: "1" }).resolve();
-    await wait(1000);
+    await delayAndAdvance(1000);
 
     expect(getRenderedQueries(link)).toMatchSnapshot();
   });

--- a/packages/utils/__tests__/faketime.test.js
+++ b/packages/utils/__tests__/faketime.test.js
@@ -1,12 +1,12 @@
-import { delayAndAdvance, delay, advance } from '../faketime';
+import { delayAndAdvance, delay, advance } from "../faketime";
 
-describe('faketimer tests', () => {
+describe("faketimer tests", () => {
   it("should advance time instantly", async () => {
     await delayAndAdvance(10 * 60 * 1000);
   });
 
   it("should advance time in steps", async () => {
-    let events = [];
+    const events = [];
     delay(1000).then(() => events.push(2));
     delay(500).then(() => events.push(1));
 
@@ -14,5 +14,5 @@ describe('faketimer tests', () => {
     expect(events).toEqual([1]);
     await advance(500);
     expect(events).toEqual([1, 2]);
-  })
+  });
 });

--- a/packages/utils/__tests__/faketime.test.js
+++ b/packages/utils/__tests__/faketime.test.js
@@ -1,0 +1,18 @@
+import { delayAndAdvance, delay, advance } from '../faketime';
+
+describe('faketimer tests', () => {
+  it("should advance time instantly", async () => {
+    await delayAndAdvance(24 * 60 * 1000);
+  });
+
+  it("should advance time in steps", async () => {
+    let events = [];
+    delay(1000).then(() => events.push(2));
+    delay(500).then(() => events.push(1);
+
+    await advance(500);
+    expect(events).toEqual([1]);
+    await advance(500);
+    expect(events).toEqual([1, 2]);
+  })
+});

--- a/packages/utils/__tests__/faketime.test.js
+++ b/packages/utils/__tests__/faketime.test.js
@@ -2,13 +2,13 @@ import { delayAndAdvance, delay, advance } from '../faketime';
 
 describe('faketimer tests', () => {
   it("should advance time instantly", async () => {
-    await delayAndAdvance(24 * 60 * 1000);
+    await delayAndAdvance(10 * 60 * 1000);
   });
 
   it("should advance time in steps", async () => {
     let events = [];
     delay(1000).then(() => events.push(2));
-    delay(500).then(() => events.push(1);
+    delay(500).then(() => events.push(1));
 
     await advance(500);
     expect(events).toEqual([1]);

--- a/packages/utils/faketime.js
+++ b/packages/utils/faketime.js
@@ -1,10 +1,9 @@
-
 jest.useFakeTimers();
 
 export const advance = ms => {
   jest.runTimersToTime(ms);
   return Promise.resolve();
-}
+};
 
 export const delay = ms => new Promise(done => setTimeout(done, ms));
 

--- a/packages/utils/faketime.js
+++ b/packages/utils/faketime.js
@@ -1,0 +1,15 @@
+
+jest.useFakeTimers();
+
+export const advance = ms => {
+  jest.runTimersToTime(ms);
+  return Promise.resolve();
+}
+
+export const delay = ms => new Promise(done => setTimeout(done, ms));
+
+export const delayAndAdvance = ms => {
+  const timer = delay(ms);
+  advance(ms);
+  return timer;
+};


### PR DESCRIPTION
refactors commonly used timer related functions into utils.
Once all packges use faketimers we should install faketimers in jest-configurator to make it harder to write non deterministic tests