### PR TITLE
feat: Allowing platform independence in Jest Configurator

### DIFF
--- a/packages/jest-configurator/__tests__/jest-configurator.test.js
+++ b/packages/jest-configurator/__tests__/jest-configurator.test.js
@@ -48,7 +48,6 @@ describe("Jest Configurator Tests", () => {
     });
   });
 
-  // Web specific
   describe("Web specific configuration", () => {
     it("should use the module mapper to match react-native to react-native-web", () => {
       const config = jestConfigurator("web", dir);
@@ -87,6 +86,18 @@ describe("Jest Configurator Tests", () => {
         "js",
         "json"
       ]);
+    });
+  });
+
+  describe("No platform specific config", () => {
+    it("should allow a null platform value", () => {
+      const config = jestConfigurator(null, dir);
+      expect(config.moduleFileExtensions).toEqual(["js", "json"]);
+    });
+
+    it("should allow any other value to be platformless config", () => {
+      const config = jestConfigurator(12345, dir);
+      expect(config.moduleFileExtensions).toEqual(["js", "json"]);
     });
   });
 });

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -72,7 +72,9 @@ export default (
       coverageIgnoreGlobs
     ),
     testMatch: [`${module}/__tests__/${platformPath}*.test.js`],
-    testPathIgnorePatterns: [`${module}/__tests__/${platformPath}jest.config.js`],
+    testPathIgnorePatterns: [
+      `${module}/__tests__/${platformPath}jest.config.js`
+    ],
     snapshotSerializers: ["enzyme-to-json/serializer"],
     setupTestFrameworkScriptFile: path.resolve(__dirname, "../setup-jest.js")
   };

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -36,8 +36,6 @@ const platformCode = platform => {
       return nativeSpecific("ios");
     case "android":
       return nativeSpecific("android");
-    case null:
-      return platformIndependentSpecific;
     default:
       return platformIndependentSpecific;
   }

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -24,6 +24,23 @@ const webSpecific = {
   moduleFileExtensions: ["web.js", "js", "json"]
 };
 
+const platformIndependentSpecific = {
+  moduleFileExtensions: ["js", "json"]
+};
+
+const platformCode = platform => {
+  switch (platform) {
+    case "web":
+      return webSpecific;
+    case "ios":
+      return nativeSpecific("ios");
+    case "android":
+      return nativeSpecific("android");
+    default:
+      return platformIndependentSpecific;
+  }
+};
+
 export default (
   platform: Platform,
   cwd: string,
@@ -38,7 +55,7 @@ export default (
 
   return {
     preset: "react-native",
-    ...(platform === "web" ? webSpecific : nativeSpecific(platform)),
+    ...platformCode(platform),
     rootDir,
     transformIgnorePatterns: [
       "node_modules/(?!(react-native|react-native-linear-gradient|@times-components)/)"

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -36,6 +36,8 @@ const platformCode = platform => {
       return nativeSpecific("ios");
     case "android":
       return nativeSpecific("android");
+    case null:
+      return platformIndependentSpecific;
     default:
       return platformIndependentSpecific;
   }
@@ -53,6 +55,8 @@ export default (
     (global || local).replace("node_modules", "")
   );
 
+  const platformPath = platform ? `${platform}/` : "";
+
   return {
     preset: "react-native",
     ...platformCode(platform),
@@ -60,15 +64,15 @@ export default (
     transformIgnorePatterns: [
       "node_modules/(?!(react-native|react-native-linear-gradient|@times-components)/)"
     ],
-    coverageDirectory: `${module}/coverage/${platform}/`,
+    coverageDirectory: `${module}/coverage/${platformPath}`,
     collectCoverageFrom: getCoveragePaths(
       rootDir,
       module,
       platform,
       coverageIgnoreGlobs
     ),
-    testMatch: [`${module}/__tests__/${platform}/*.test.js`],
-    testPathIgnorePatterns: [`${module}/__tests__/${platform}/jest.config.js`],
+    testMatch: [`${module}/__tests__/${platformPath}*.test.js`],
+    testPathIgnorePatterns: [`${module}/__tests__/${platformPath}jest.config.js`],
     snapshotSerializers: ["enzyme-to-json/serializer"],
     setupTestFrameworkScriptFile: path.resolve(__dirname, "../setup-jest.js")
   };

--- a/packages/utils/__tests__/jest.config.js
+++ b/packages/utils/__tests__/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfigurator = require("@times-components/jest-configurator").default;
+
+module.exports = jestConfigurator("", __dirname);

--- a/packages/utils/__tests__/jest.config.js
+++ b/packages/utils/__tests__/jest.config.js
@@ -1,3 +1,3 @@
 const jestConfigurator = require("@times-components/jest-configurator").default;
 
-module.exports = jestConfigurator("", __dirname);
+module.exports = jestConfigurator(null, __dirname);

--- a/packages/utils/__tests__/jest.config.js
+++ b/packages/utils/__tests__/jest.config.js
@@ -1,3 +1,6 @@
 const jestConfigurator = require("@times-components/jest-configurator").default;
 
-module.exports = jestConfigurator(null, __dirname);
+module.exports = jestConfigurator(null, __dirname, [
+  "graphql.js",
+  "fetch-gql-schema.js"
+]);

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
   "description": "A set of helpers and/or workarounds to be shared across packages",
   "scripts": {
     "make-schema": "node ./scripts/fetch-gql-schema",
-    "test": "jest --config='./__tests__/jest.config.js'",
+    "test": "jest --config='./__tests__/jest.config.js' --bail --ci --coverage",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "fmt": "prettier --write '**/*.*'",
     "lint": "eslint . && yarn prettier:diff"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,26 +4,10 @@
   "description": "A set of helpers and/or workarounds to be shared across packages",
   "scripts": {
     "make-schema": "node ./scripts/fetch-gql-schema",
-    "test": "jest --bail --ci --coverage",
+    "test": "jest --config='./__tests__/jest.config.js'",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "fmt": "prettier --write '**/*.*'",
     "lint": "eslint . && yarn prettier:diff"
-  },
-  "jest": {
-    "preset": "react-native",
-    "rootDir": "../../",
-    "coverageDirectory": "<rootDir>/packages/utils/coverage/",
-    "collectCoverageFrom": [
-      "**/packages/utils/*.js",
-      "!**/packages/utils/*.test.js",
-      "!**/packages/utils/graphql.js"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!(react-native|@times-components)/)"
-    ],
-    "testMatch": [
-      "<rootDir>/packages/utils/__tests__/*.test.js"
-    ]
   },
   "repository": {
     "type": "git",
@@ -50,6 +34,7 @@
     "prettier": "1.8.2"
   },
   "dependencies": {
+    "@times-components/jest-configurator": "0.0.23",
     "apollo-cache-inmemory": "1.1.5",
     "apollo-client": "2.2.0",
     "graphql": "0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3247,9 +3247,9 @@ content-type@~1.0.1, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-conventional-changelog-angular@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.1.tgz#e1434d017c854032b272f690424a8c0ca16dc318"
+conventional-changelog-angular@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.2.tgz#0a811313de46326e5e4e11dac281d61cfe1f00c4"
   dependencies:
     compare-func "^1.3.1"
     q "^1.4.1"
@@ -3276,12 +3276,12 @@ conventional-changelog-codemirror@^0.3.0:
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-core@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.0.tgz#1bdf7d21f3d066427ff9e07db0a2c5dd60015b9f"
+conventional-changelog-core@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.1.tgz#7573de89bde46e0ccf395b4b85a0869aa5388e8d"
   dependencies:
     conventional-changelog-writer "^3.0.0"
-    conventional-commits-parser "^2.1.0"
+    conventional-commits-parser "^2.1.1"
     dateformat "^1.0.12"
     get-pkg-repo "^1.0.0"
     git-raw-commits "^1.3.0"
@@ -3294,9 +3294,9 @@ conventional-changelog-core@^2.0.0:
     read-pkg-up "^1.0.1"
     through2 "^2.0.0"
 
-conventional-changelog-ember@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.1.tgz#bc71dc0a57e5c7ed0bf0538c32e44220691871d1"
+conventional-changelog-ember@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.2.tgz#d3dd89ffe96832384a5d3b60dc63bf5e0142a944"
   dependencies:
     q "^1.4.1"
 
@@ -3331,6 +3331,10 @@ conventional-changelog-jshint@^0.3.0:
     compare-func "^1.3.1"
     q "^1.4.1"
 
+conventional-changelog-preset-loader@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.2.tgz#dfb5877884ef852b648bdef6e69e53e1bda188df"
+
 conventional-changelog-writer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.0.tgz#e106154ed94341e387d717b61be2181ff53254cc"
@@ -3346,21 +3350,21 @@ conventional-changelog-writer@^3.0.0:
     split "^1.0.0"
     through2 "^2.0.0"
 
-conventional-changelog@^1.1.12:
+conventional-changelog@^1.1.10:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.2.0.tgz#74947e73e48b57ceb6859c373f4f9d4fb5e6d4df"
-
   dependencies:
-    conventional-changelog-angular "^1.6.1"
+    conventional-changelog-angular "^1.6.2"
     conventional-changelog-atom "^0.2.0"
     conventional-changelog-codemirror "^0.3.0"
-    conventional-changelog-core "^2.0.0"
-    conventional-changelog-ember "^0.3.1"
+    conventional-changelog-core "^2.0.1"
+    conventional-changelog-ember "^0.3.2"
     conventional-changelog-eslint "^1.0.0"
     conventional-changelog-express "^0.3.0"
     conventional-changelog-jquery "^0.1.0"
     conventional-changelog-jscs "^0.1.0"
     conventional-changelog-jshint "^0.3.0"
+    conventional-changelog-preset-loader "^1.1.2"
 
 conventional-commit-types@^2.0.0:
   version "2.2.0"
@@ -3376,6 +3380,18 @@ conventional-commits-filter@^1.1.1:
 conventional-commits-parser@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz#9b4b7c91124bf2a1a9a2cc1c72760d382cbbb229"
+  dependencies:
+    JSONStream "^1.0.4"
+    is-text-path "^1.0.0"
+    lodash "^4.2.1"
+    meow "^3.3.0"
+    split2 "^2.0.0"
+    through2 "^2.0.0"
+    trim-off-newlines "^1.0.0"
+
+conventional-commits-parser@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.1.tgz#1525a01bdad3349297b4210396e283d8a8ffd044"
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.0"


### PR DESCRIPTION
Some packages do not require platform specific environments for testing. These currently have their own Jest files. In order to use Jest projects as the top level we would want to run a command like `jest --projects */**/jest.config.js`. This means if we have consistent Jest Configs in all packages using the Jest Configurator, we should be able to reach our goal.

Thoughts?