### PR TITLE
Fix: vertically align the ads

### DIFF
--- a/packages/ad/ad-init.js
+++ b/packages/ad/ad-init.js
@@ -47,10 +47,10 @@ const adInit = args => {
         el.innerHTML = `
           <div
             id="${data.pos}"
-            style="display: table-cell; vertical-align: middle"
           ></div>
         `;
-        el.style.display = "table";
+        el.style.display = "flex";
+        el.style.alignItems = "center";
         el.style.margin = "0 auto";
 
         const mapping = googletag.sizeMapping();


### PR DESCRIPTION
This PR vertically aligns the ads. Unable to attach screenshot of native as storybook isn't working for native.

**Before on web**
![screen shot 2018-02-15 at 14 59 41](https://user-images.githubusercontent.com/9569135/36262987-e8dac11e-1260-11e8-9ee1-4386784f9909.png)


**After on Web** 

![screen shot 2018-02-15 at 14 57 37](https://user-images.githubusercontent.com/9569135/36262927-bd78ff7c-1260-11e8-8b93-5bc7c3b934e2.png)
