### PR TITLE
feat: Add Jest Configurator to the Article Byline package

### DIFF
--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -1,0 +1,294 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Article Byline test on android renders correctly with a single author 1`] = `
+<Text
+  accessibilityRole="link"
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  href="/profile/alexandra-frean"
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "textDecorationLine": "underline",
+      },
+      Object {
+        "color": "#069",
+      },
+      undefined,
+    ]
+  }
+>
+  Alexandra Frean
+</Text>
+`;
+
+exports[`Article Byline test on android renders correctly with a single inline element 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+>
+  Lindsay McIntosh Scottish Political Editor
+</Text>
+`;
+
+exports[`Article Byline test on android renders correctly with an empty AST (empty byline on DB) 1`] = `null`;
+
+exports[`Article Byline test on android renders correctly with multiple authors separated by spaces 1`] = `
+Array [
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/camilla-long"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Camilla Long
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+     
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/mike-atherton"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Mike Atherton
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+     
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/alexandra-frean"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Alexandra Frean
+  </Text>,
+]
+`;
+
+exports[`Article Byline test on android renders correctly with multiple authors separated by text with commas 1`] = `
+Array [
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/camilla-long"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Camilla Long
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    , 
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/mike-atherton"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Mike Atherton
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    , 
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/alexandra-frean"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Alexandra Frean
+  </Text>,
+]
+`;
+
+exports[`Article Byline test on android renders correctly with styles 1`] = `
+<Text
+  accessibilityRole="link"
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  href="/profile/alexandra-frean"
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "textDecorationLine": "underline",
+      },
+      Object {
+        "color": "#069",
+      },
+      Object {
+        "color": "red",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Alexandra Frean
+</Text>
+`;
+
+exports[`Article Byline test on android renders correctly with the author at the end 1`] = `
+Array [
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    RBS Six Nations 
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/mike-atherton"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Mike Atherton
+  </Text>,
+]
+`;
+
+exports[`Article Byline test on android renders correctly with the author in the begining 1`] = `
+Array [
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/camilla-long"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Camilla Long
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    , Environment Editor
+  </Text>,
+]
+`;

--- a/packages/article-byline/__tests__/android/article-byline.android.test.js
+++ b/packages/article-byline/__tests__/android/article-byline.android.test.js
@@ -1,0 +1,5 @@
+import shared from "../shared";
+
+describe("Article Byline test on android", () => {
+  shared();
+});

--- a/packages/article-byline/__tests__/android/jest.config.js
+++ b/packages/article-byline/__tests__/android/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfigurator = require("@times-components/jest-configurator").default;
+
+module.exports = jestConfigurator("android", __dirname);

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -1,0 +1,294 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Article Byline test on iOS renders correctly with a single author 1`] = `
+<Text
+  accessibilityRole="link"
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  href="/profile/alexandra-frean"
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "textDecorationLine": "underline",
+      },
+      Object {
+        "color": "#069",
+      },
+      undefined,
+    ]
+  }
+>
+  Alexandra Frean
+</Text>
+`;
+
+exports[`Article Byline test on iOS renders correctly with a single inline element 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+>
+  Lindsay McIntosh Scottish Political Editor
+</Text>
+`;
+
+exports[`Article Byline test on iOS renders correctly with an empty AST (empty byline on DB) 1`] = `null`;
+
+exports[`Article Byline test on iOS renders correctly with multiple authors separated by spaces 1`] = `
+Array [
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/camilla-long"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Camilla Long
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+     
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/mike-atherton"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Mike Atherton
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+     
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/alexandra-frean"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Alexandra Frean
+  </Text>,
+]
+`;
+
+exports[`Article Byline test on iOS renders correctly with multiple authors separated by text with commas 1`] = `
+Array [
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/camilla-long"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Camilla Long
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    , 
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/mike-atherton"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Mike Atherton
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    , 
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/alexandra-frean"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Alexandra Frean
+  </Text>,
+]
+`;
+
+exports[`Article Byline test on iOS renders correctly with styles 1`] = `
+<Text
+  accessibilityRole="link"
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  href="/profile/alexandra-frean"
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "textDecorationLine": "underline",
+      },
+      Object {
+        "color": "#069",
+      },
+      Object {
+        "color": "red",
+        "textDecorationLine": "underline",
+      },
+    ]
+  }
+>
+  Alexandra Frean
+</Text>
+`;
+
+exports[`Article Byline test on iOS renders correctly with the author at the end 1`] = `
+Array [
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    RBS Six Nations 
+  </Text>,
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/mike-atherton"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Mike Atherton
+  </Text>,
+]
+`;
+
+exports[`Article Byline test on iOS renders correctly with the author in the begining 1`] = `
+Array [
+  <Text
+    accessibilityRole="link"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    href="/profile/camilla-long"
+    onPress={[Function]}
+    style={
+      Array [
+        Object {
+          "textDecorationLine": "underline",
+        },
+        Object {
+          "color": "#069",
+        },
+        undefined,
+      ]
+    }
+  >
+    Camilla Long
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
+    , Environment Editor
+  </Text>,
+]
+`;

--- a/packages/article-byline/__tests__/ios/article-byline.ios.test.js
+++ b/packages/article-byline/__tests__/ios/article-byline.ios.test.js
@@ -1,0 +1,5 @@
+import shared from "../shared";
+
+describe("Article Byline test on iOS", () => {
+  shared();
+});

--- a/packages/article-byline/__tests__/ios/jest.config.js
+++ b/packages/article-byline/__tests__/ios/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfigurator = require("@times-components/jest-configurator").default;
+
+module.exports = jestConfigurator("ios", __dirname);

--- a/packages/article-byline/__tests__/shared.js
+++ b/packages/article-byline/__tests__/shared.js
@@ -13,7 +13,7 @@ const bylineStyles = {
   }
 };
 
-describe("Article Byline Tests", () => {
+module.exports = () => {
   it("renders correctly with a single author", () => {
     const tree = renderer
       .create(<ArticleByline ast={authorsAST.singleAuthor} />)
@@ -69,4 +69,4 @@ describe("Article Byline Tests", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
-});
+};

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article Byline Tests renders correctly with a single author 1`] = `
+exports[`Article Byline test on web renders correctly with a single author 1`] = `
 <a
   className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
   dir="auto"
@@ -13,15 +13,15 @@ exports[`Article Byline Tests renders correctly with a single author 1`] = `
 </a>
 `;
 
-exports[`Article Byline Tests renders correctly with a single inline element 1`] = `
+exports[`Article Byline test on web renders correctly with a single inline element 1`] = `
 <span>
   Lindsay McIntosh Scottish Political Editor
 </span>
 `;
 
-exports[`Article Byline Tests renders correctly with an empty AST (empty byline on DB) 1`] = `null`;
+exports[`Article Byline test on web renders correctly with an empty AST (empty byline on DB) 1`] = `null`;
 
-exports[`Article Byline Tests renders correctly with multiple authors separated by spaces 1`] = `
+exports[`Article Byline test on web renders correctly with multiple authors separated by spaces 1`] = `
 Array [
   <a
     className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
@@ -62,7 +62,7 @@ Array [
 ]
 `;
 
-exports[`Article Byline Tests renders correctly with multiple authors separated by text with commas 1`] = `
+exports[`Article Byline test on web renders correctly with multiple authors separated by text with commas 1`] = `
 Array [
   <a
     className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
@@ -103,7 +103,7 @@ Array [
 ]
 `;
 
-exports[`Article Byline Tests renders correctly with styles 1`] = `
+exports[`Article Byline test on web renders correctly with styles 1`] = `
 <a
   className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
   dir="auto"
@@ -121,7 +121,7 @@ exports[`Article Byline Tests renders correctly with styles 1`] = `
 </a>
 `;
 
-exports[`Article Byline Tests renders correctly with the author at the end 1`] = `
+exports[`Article Byline test on web renders correctly with the author at the end 1`] = `
 Array [
   <span>
     RBS Six Nations 
@@ -139,7 +139,7 @@ Array [
 ]
 `;
 
-exports[`Article Byline Tests renders correctly with the author in the begining 1`] = `
+exports[`Article Byline test on web renders correctly with the author in the begining 1`] = `
 Array [
   <a
     className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"

--- a/packages/article-byline/__tests__/web/article-byline.web.test.js
+++ b/packages/article-byline/__tests__/web/article-byline.web.test.js
@@ -1,0 +1,5 @@
+import shared from "../shared";
+
+describe("Article Byline test on web", () => {
+  shared();
+});

--- a/packages/article-byline/__tests__/web/jest.config.js
+++ b/packages/article-byline/__tests__/web/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfigurator = require("@times-components/jest-configurator").default;
+
+module.exports = jestConfigurator("web", __dirname);

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -4,7 +4,10 @@
   "description": "Article byline information",
   "main": "article-byline",
   "scripts": {
-    "test": "jest --config='./jest.config.json' --ci --bail --coverage",
+    "test:android": "jest --config='./__tests__/android/jest.config.js'",
+    "test:ios": "jest --config='./__tests__/ios/jest.config.js'",
+    "test:web": "jest --config='./__tests__/web/jest.config.js'",
+    "test": "yarn test:android --ci --bail --coverage && yarn test:ios --ci --bail --coverage && yarn test:web --ci --bail --coverage",
     "fmt": "prettier --write '**/*.*'",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "lint": "eslint . && yarn prettier:diff",
@@ -31,6 +34,7 @@
   "devDependencies": {
     "@storybook/react-native": "3.3.11",
     "@times-components/eslint-config-thetimes": "0.1.3",
+    "@times-components/jest-configurator": "0.2.0",
     "dextrose": "1.4.5",
     "eslint": "4.9.0",
     "jest": "21.2.1",


### PR DESCRIPTION
Adds Jest Configurator to the Byline package.

N.B. The coverage is not 100%. This is because there is no implementation for onPress yet. This is waiting for a native routing solution.