### PR TITLE
fix: make ids accurate

### DIFF
--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -181,14 +181,17 @@ exports[`AuthorProfile test on android renders profile 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.1",
         "id": 1,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.2",
         "id": 2,
         "isLoading": true,
       },
@@ -1911,7 +1914,7 @@ exports[`AuthorProfile test on android renders profile content component 1`] = `
     Array [
       Object {
         "__typename": "Article",
-        "elementId": "articleList-1-0",
+        "elementId": "d98c257c-cb16-11e7-b529-95e3fc05f40f.0",
         "headline": "Top medal for forces dog who took a bite out of the Taliban",
         "id": "d98c257c-cb16-11e7-b529-95e3fc05f40f",
         "label": "",
@@ -1944,7 +1947,7 @@ exports[`AuthorProfile test on android renders profile content component 1`] = `
       },
       Object {
         "__typename": "Article",
-        "elementId": "articleList-1-1",
+        "elementId": "4e6894ec-cb18-11e7-b529-95e3fc05f40f.1",
         "headline": "Social media must raise game to beat terrorists, says UN chief",
         "id": "4e6894ec-cb18-11e7-b529-95e3fc05f40f",
         "label": "",
@@ -1977,7 +1980,7 @@ exports[`AuthorProfile test on android renders profile content component 1`] = `
       },
       Object {
         "__typename": "Article",
-        "elementId": "articleList-1-2",
+        "elementId": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2",
         "headline": "Cuts have left the army 20 years out of date, says former general",
         "id": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f",
         "label": "",
@@ -3743,6 +3746,7 @@ exports[`AuthorProfile test on android renders profile content loading 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
@@ -4480,14 +4484,17 @@ exports[`AuthorProfile test on android renders profile loading 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.1",
         "id": 1,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.2",
         "id": 2,
         "isLoading": true,
       },
@@ -5977,14 +5984,17 @@ exports[`AuthorProfile test on android renders with no author 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.1",
         "id": 1,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.2",
         "id": 2,
         "isLoading": true,
       },

--- a/packages/author-profile/__tests__/author-profile-content.native.js
+++ b/packages/author-profile/__tests__/author-profile-content.native.js
@@ -107,7 +107,7 @@ export default () => {
           {
             isViewable: true,
             item: {
-              elementId: "articleList-1-2"
+              elementId: "f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2"
             }
           }
         ]

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -181,14 +181,17 @@ exports[`AuthorProfile test on ios renders profile 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.1",
         "id": 1,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.2",
         "id": 2,
         "isLoading": true,
       },
@@ -1782,7 +1785,7 @@ exports[`AuthorProfile test on ios renders profile content component 1`] = `
     Array [
       Object {
         "__typename": "Article",
-        "elementId": "articleList-1-0",
+        "elementId": "d98c257c-cb16-11e7-b529-95e3fc05f40f.0",
         "headline": "Top medal for forces dog who took a bite out of the Taliban",
         "id": "d98c257c-cb16-11e7-b529-95e3fc05f40f",
         "label": "",
@@ -1815,7 +1818,7 @@ exports[`AuthorProfile test on ios renders profile content component 1`] = `
       },
       Object {
         "__typename": "Article",
-        "elementId": "articleList-1-1",
+        "elementId": "4e6894ec-cb18-11e7-b529-95e3fc05f40f.1",
         "headline": "Social media must raise game to beat terrorists, says UN chief",
         "id": "4e6894ec-cb18-11e7-b529-95e3fc05f40f",
         "label": "",
@@ -1848,7 +1851,7 @@ exports[`AuthorProfile test on ios renders profile content component 1`] = `
       },
       Object {
         "__typename": "Article",
-        "elementId": "articleList-1-2",
+        "elementId": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2",
         "headline": "Cuts have left the army 20 years out of date, says former general",
         "id": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f",
         "label": "",
@@ -3526,6 +3529,7 @@ exports[`AuthorProfile test on ios renders profile content loading 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
@@ -4230,14 +4234,17 @@ exports[`AuthorProfile test on ios renders profile loading 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.1",
         "id": 1,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.2",
         "id": 2,
         "isLoading": true,
       },
@@ -5627,14 +5634,17 @@ exports[`AuthorProfile test on ios renders with no author 1`] = `
   data={
     Array [
       Object {
+        "elementId": "empty.0",
         "id": 0,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.1",
         "id": 1,
         "isLoading": true,
       },
       Object {
+        "elementId": "empty.2",
         "id": 2,
         "isLoading": true,
       },

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-content.web.test.js.snap
@@ -646,9 +646,9 @@ exports[`AuthorProfile test on web renders profile 1`] = `
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-width-13qz1uu rn-zIndex-1lgpqti"
     >
       <div
-        accessibility-label="articleList-1-0"
-        data-testid="articleList-1-0"
-        id="articleList-1-0"
+        accessibility-label="empty.0"
+        data-testid="empty.0"
+        id="empty.0"
       >
         <div
           className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-19yat4t rn-paddingTop-1qxgc49 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -743,9 +743,9 @@ exports[`AuthorProfile test on web renders profile 1`] = `
         </div>
       </div>
       <div
-        accessibility-label="articleList-1-1"
-        data-testid="articleList-1-1"
-        id="articleList-1-1"
+        accessibility-label="empty.1"
+        data-testid="empty.1"
+        id="empty.1"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -843,9 +843,9 @@ exports[`AuthorProfile test on web renders profile 1`] = `
         </div>
       </div>
       <div
-        accessibility-label="articleList-1-2"
-        data-testid="articleList-1-2"
-        id="articleList-1-2"
+        accessibility-label="empty.2"
+        data-testid="empty.2"
+        id="empty.2"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -1136,9 +1136,9 @@ exports[`AuthorProfile test on web renders profile content component 1`] = `
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-width-13qz1uu rn-zIndex-1lgpqti"
     >
       <div
-        accessibility-label="articleList-1-0"
-        data-testid="articleList-1-0"
-        id="articleList-1-0"
+        accessibility-label="d98c257c-cb16-11e7-b529-95e3fc05f40f.0"
+        data-testid="d98c257c-cb16-11e7-b529-95e3fc05f40f.0"
+        id="d98c257c-cb16-11e7-b529-95e3fc05f40f.0"
       >
         <a
           href="https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f"
@@ -1266,9 +1266,9 @@ exports[`AuthorProfile test on web renders profile content component 1`] = `
         </a>
       </div>
       <div
-        accessibility-label="articleList-1-1"
-        data-testid="articleList-1-1"
-        id="articleList-1-1"
+        accessibility-label="4e6894ec-cb18-11e7-b529-95e3fc05f40f.1"
+        data-testid="4e6894ec-cb18-11e7-b529-95e3fc05f40f.1"
+        id="4e6894ec-cb18-11e7-b529-95e3fc05f40f.1"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -1399,9 +1399,9 @@ exports[`AuthorProfile test on web renders profile content component 1`] = `
         </a>
       </div>
       <div
-        accessibility-label="articleList-1-2"
-        data-testid="articleList-1-2"
-        id="articleList-1-2"
+        accessibility-label="f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2"
+        data-testid="f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2"
+        id="f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -2044,9 +2044,9 @@ exports[`AuthorProfile test on web renders profile content loading 1`] = `
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-width-13qz1uu rn-zIndex-1lgpqti"
     >
       <div
-        accessibility-label="articleList-undefined-0"
-        data-testid="articleList-undefined-0"
-        id="articleList-undefined-0"
+        accessibility-label="empty.0"
+        data-testid="empty.0"
+        id="empty.0"
       >
         <div
           className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-19yat4t rn-paddingTop-1qxgc49 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -2486,9 +2486,9 @@ exports[`AuthorProfile test on web renders profile loading 1`] = `
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-width-13qz1uu rn-zIndex-1lgpqti"
     >
       <div
-        accessibility-label="articleList-undefined-0"
-        data-testid="articleList-undefined-0"
-        id="articleList-undefined-0"
+        accessibility-label="empty.0"
+        data-testid="empty.0"
+        id="empty.0"
       >
         <div
           className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-19yat4t rn-paddingTop-1qxgc49 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -2583,9 +2583,9 @@ exports[`AuthorProfile test on web renders profile loading 1`] = `
         </div>
       </div>
       <div
-        accessibility-label="articleList-undefined-1"
-        data-testid="articleList-undefined-1"
-        id="articleList-undefined-1"
+        accessibility-label="empty.1"
+        data-testid="empty.1"
+        id="empty.1"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -2683,9 +2683,9 @@ exports[`AuthorProfile test on web renders profile loading 1`] = `
         </div>
       </div>
       <div
-        accessibility-label="articleList-undefined-2"
-        data-testid="articleList-undefined-2"
-        id="articleList-undefined-2"
+        accessibility-label="empty.2"
+        data-testid="empty.2"
+        id="empty.2"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -2981,9 +2981,9 @@ exports[`AuthorProfile test on web renders with no author 1`] = `
       className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-width-13qz1uu rn-zIndex-1lgpqti"
     >
       <div
-        accessibility-label="articleList-1-0"
-        data-testid="articleList-1-0"
-        id="articleList-1-0"
+        accessibility-label="empty.0"
+        data-testid="empty.0"
+        id="empty.0"
       >
         <div
           className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingRight-9aemit rn-paddingLeft-gy4na3 rn-paddingBottom-19yat4t rn-paddingTop-1qxgc49 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -3035,9 +3035,9 @@ exports[`AuthorProfile test on web renders with no author 1`] = `
         </div>
       </div>
       <div
-        accessibility-label="articleList-1-1"
-        data-testid="articleList-1-1"
-        id="articleList-1-1"
+        accessibility-label="empty.1"
+        data-testid="empty.1"
+        id="empty.1"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -3092,9 +3092,9 @@ exports[`AuthorProfile test on web renders with no author 1`] = `
         </div>
       </div>
       <div
-        accessibility-label="articleList-1-2"
-        data-testid="articleList-1-2"
-        id="articleList-1-2"
+        accessibility-label="empty.2"
+        data-testid="empty.2"
+        id="empty.2"
       >
         <div
           className="rn-alignItems-1oszu61 rn-backgroundColor-7ut9fm rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-height-109y4c4 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"

--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -129,13 +129,14 @@ class AuthorProfileContent extends React.Component {
     const data = articlesLoading
       ? Array(pageSize)
           .fill()
-          .map((number, id) => ({
-            id,
+          .map((number, indx) => ({
+            id: indx,
+            elementId: `empty.${indx}`,
             isLoading: true
           }))
-      : articles.map((article, idx) => ({
+      : articles.map((article, indx) => ({
           ...article,
-          elementId: `articleList-${page}-${idx}`
+          elementId: `${article.id}.${indx}`
         }));
 
     if (!articlesLoading) this.props.receiveChildList(data);

--- a/packages/author-profile/author-profile-content.web.js
+++ b/packages/author-profile/author-profile-content.web.js
@@ -185,32 +185,35 @@ class AuthorProfileContent extends Component {
       </ContentContainer>
     );
 
-    const data = (articlesLoading
+    const data = articlesLoading
       ? Array(pageSize)
           .fill()
-          .map((number, id) => ({ id, isLoading: true }))
-      : articles
-    ).map((article, idx) => ({
-      ...article,
-      elementId: `articleList-${page}-${idx}`
-    }));
+          .map((number, indx) => ({
+            id: indx,
+            elementId: `empty.${indx}`,
+            isLoading: true
+          }))
+      : articles.map((article, indx) => ({
+          ...article,
+          elementId: `${article.id}.${indx}`
+        }));
 
     const Contents = (
       <ContentContainer>
         {paginationComponent({ hideResults: false, autoScroll: false })}
         <View style={styles.container}>
           {data &&
-            data.map((article, key) => {
-              const { id, url } = article;
+            data.map((article, indx) => {
+              const { id, elementId, url } = article;
               const separatorComponent =
-                key > 0 ? <AuthorProfileItemSeparator /> : null;
+                indx > 0 ? <AuthorProfileItemSeparator /> : null;
 
               return (
                 <div
-                  key={id}
-                  id={article.elementId}
-                  accessibility-label={article.elementId}
-                  data-testid={article.elementId}
+                  key={elementId}
+                  id={elementId}
+                  accessibility-label={elementId}
+                  data-testid={elementId}
                   ref={node => this.registerNode(node)}
                 >
                   <ErrorView>
@@ -221,7 +224,7 @@ class AuthorProfileContent extends Component {
                           <AuthorProfileItem
                             {...article}
                             imageRatio={imageRatio}
-                            imageSize={this.getImageSize(article.elementId)}
+                            imageSize={this.getImageSize(elementId)}
                             showImage={showImages}
                             onPress={e => onArticlePress(e, { id, url })}
                           />


### PR DESCRIPTION
Now we have debounced paging it's possible to have new ids for the existing content because they're artificially based on the current page. We do have unique ids for articles though, so this PR uses them instead. Index has also been added for complete defence against any rogue duplicate articles.... 