### PR TITLE
feat: REPLAT-1310 Article Byline Link

### DIFF
--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -14,7 +14,7 @@ exports[`Article Byline test on android renders correctly with a single author 1
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354E",
+        "color": "#006699",
       },
       Object {},
     ]
@@ -75,7 +75,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -103,7 +103,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -131,7 +131,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -157,7 +157,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -185,7 +185,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -213,7 +213,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -238,7 +238,7 @@ exports[`Article Byline test on android renders correctly with styles 1`] = `
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354E",
+        "color": "#006699",
       },
       Object {
         "color": "red",
@@ -273,7 +273,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -299,7 +299,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -14,9 +14,33 @@ exports[`Article Byline test on android renders correctly with a single author 1
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#069",
+        "color": "#13354e",
       },
-      undefined,
+      Object {},
+    ]
+  }
+>
+  Alexandra Frean
+</Text>
+`;
+
+exports[`Article Byline test on android renders correctly with a single author with a section 1`] = `
+<Text
+  accessibilityRole="link"
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  href="/profile/alexandra-frean"
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "textDecorationLine": "underline",
+      },
+      Object {
+        "color": "#008347",
+      },
+      Object {},
     ]
   }
 >
@@ -51,9 +75,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -79,9 +103,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -107,9 +131,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -133,9 +157,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -161,9 +185,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -189,9 +213,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -214,7 +238,7 @@ exports[`Article Byline test on android renders correctly with styles 1`] = `
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#069",
+        "color": "#13354e",
       },
       Object {
         "color": "red",
@@ -249,9 +273,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -275,9 +299,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -14,7 +14,7 @@ exports[`Article Byline test on android renders correctly with a single author 1
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354e",
+        "color": "#13354E",
       },
       Object {},
     ]
@@ -75,7 +75,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -103,7 +103,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -131,7 +131,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -157,7 +157,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -185,7 +185,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -213,7 +213,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -238,7 +238,7 @@ exports[`Article Byline test on android renders correctly with styles 1`] = `
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354e",
+        "color": "#13354E",
       },
       Object {
         "color": "red",
@@ -273,7 +273,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -299,7 +299,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -14,7 +14,7 @@ exports[`Article Byline test on iOS renders correctly with a single author 1`] =
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354E",
+        "color": "#006699",
       },
       Object {},
     ]
@@ -75,7 +75,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -103,7 +103,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -131,7 +131,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -157,7 +157,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -185,7 +185,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -213,7 +213,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -238,7 +238,7 @@ exports[`Article Byline test on iOS renders correctly with styles 1`] = `
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354E",
+        "color": "#006699",
       },
       Object {
         "color": "red",
@@ -273,7 +273,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]
@@ -299,7 +299,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354E",
+          "color": "#006699",
         },
         Object {},
       ]

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -14,9 +14,33 @@ exports[`Article Byline test on iOS renders correctly with a single author 1`] =
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#069",
+        "color": "#13354e",
       },
-      undefined,
+      Object {},
+    ]
+  }
+>
+  Alexandra Frean
+</Text>
+`;
+
+exports[`Article Byline test on iOS renders correctly with a single author with a section 1`] = `
+<Text
+  accessibilityRole="link"
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  href="/profile/alexandra-frean"
+  onPress={[Function]}
+  style={
+    Array [
+      Object {
+        "textDecorationLine": "underline",
+      },
+      Object {
+        "color": "#008347",
+      },
+      Object {},
     ]
   }
 >
@@ -51,9 +75,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -79,9 +103,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -107,9 +131,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -133,9 +157,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -161,9 +185,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -189,9 +213,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -214,7 +238,7 @@ exports[`Article Byline test on iOS renders correctly with styles 1`] = `
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#069",
+        "color": "#13354e",
       },
       Object {
         "color": "red",
@@ -249,9 +273,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >
@@ -275,9 +299,9 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#069",
+          "color": "#13354e",
         },
-        undefined,
+        Object {},
       ]
     }
   >

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -14,7 +14,7 @@ exports[`Article Byline test on iOS renders correctly with a single author 1`] =
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354e",
+        "color": "#13354E",
       },
       Object {},
     ]
@@ -75,7 +75,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -103,7 +103,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -131,7 +131,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -157,7 +157,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -185,7 +185,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -213,7 +213,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -238,7 +238,7 @@ exports[`Article Byline test on iOS renders correctly with styles 1`] = `
         "textDecorationLine": "underline",
       },
       Object {
-        "color": "#13354e",
+        "color": "#13354E",
       },
       Object {
         "color": "red",
@@ -273,7 +273,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]
@@ -299,7 +299,7 @@ Array [
           "textDecorationLine": "underline",
         },
         Object {
-          "color": "#13354e",
+          "color": "#13354E",
         },
         Object {},
       ]

--- a/packages/article-byline/__tests__/shared.js
+++ b/packages/article-byline/__tests__/shared.js
@@ -7,16 +7,21 @@ import ArticleByline from "../article-byline";
 const authorsAST = require("../fixtures/authors.json");
 
 const bylineStyles = {
-  link: {
-    color: "red",
-    textDecorationLine: "underline"
-  }
+  color: "red",
+  textDecorationLine: "underline"
 };
 
 module.exports = () => {
   it("renders correctly with a single author", () => {
     const tree = renderer
       .create(<ArticleByline ast={authorsAST.singleAuthor} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("renders correctly with a single author with a section", () => {
+    const tree = renderer
+      .create(<ArticleByline ast={authorsAST.singleAuthor} section="sport" />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -2,12 +2,35 @@
 
 exports[`Article Byline test on web renders correctly with a single author 1`] = `
 <a
-  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
   dir="auto"
   href="/profile/alexandra-frean"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="link"
+  style={
+    Object {
+      "color": "rgba(19,53,78,1)",
+    }
+  }
+>
+  Alexandra Frean
+</a>
+`;
+
+exports[`Article Byline test on web renders correctly with a single author with a section 1`] = `
+<a
+  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+  dir="auto"
+  href="/profile/alexandra-frean"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="link"
+  style={
+    Object {
+      "color": "rgba(0,131,71,1)",
+    }
+  }
 >
   Alexandra Frean
 </a>
@@ -24,12 +47,17 @@ exports[`Article Byline test on web renders correctly with an empty AST (empty b
 exports[`Article Byline test on web renders correctly with multiple authors separated by spaces 1`] = `
 Array [
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/camilla-long"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Camilla Long
   </a>,
@@ -37,12 +65,17 @@ Array [
      
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/mike-atherton"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Mike Atherton
   </a>,
@@ -50,12 +83,17 @@ Array [
      
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/alexandra-frean"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Alexandra Frean
   </a>,
@@ -65,12 +103,17 @@ Array [
 exports[`Article Byline test on web renders correctly with multiple authors separated by text with commas 1`] = `
 Array [
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/camilla-long"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Camilla Long
   </a>,
@@ -78,12 +121,17 @@ Array [
     , 
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/mike-atherton"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Mike Atherton
   </a>,
@@ -91,12 +139,17 @@ Array [
     , 
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/alexandra-frean"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Alexandra Frean
   </a>,
@@ -127,12 +180,17 @@ Array [
     RBS Six Nations 
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/mike-atherton"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Mike Atherton
   </a>,
@@ -142,12 +200,17 @@ Array [
 exports[`Article Byline test on web renders correctly with the author in the begining 1`] = `
 Array [
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/camilla-long"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
+    style={
+      Object {
+        "color": "rgba(19,53,78,1)",
+      }
+    }
   >
     Camilla Long
   </a>,

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -2,17 +2,12 @@
 
 exports[`Article Byline test on web renders correctly with a single author 1`] = `
 <a
-  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
   dir="auto"
   href="/profile/alexandra-frean"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="link"
-  style={
-    Object {
-      "color": "rgba(19,53,78,1)",
-    }
-  }
 >
   Alexandra Frean
 </a>
@@ -47,17 +42,12 @@ exports[`Article Byline test on web renders correctly with an empty AST (empty b
 exports[`Article Byline test on web renders correctly with multiple authors separated by spaces 1`] = `
 Array [
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/camilla-long"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Camilla Long
   </a>,
@@ -65,17 +55,12 @@ Array [
      
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/mike-atherton"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Mike Atherton
   </a>,
@@ -83,17 +68,12 @@ Array [
      
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/alexandra-frean"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Alexandra Frean
   </a>,
@@ -103,17 +83,12 @@ Array [
 exports[`Article Byline test on web renders correctly with multiple authors separated by text with commas 1`] = `
 Array [
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/camilla-long"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Camilla Long
   </a>,
@@ -121,17 +96,12 @@ Array [
     , 
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/mike-atherton"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Mike Atherton
   </a>,
@@ -139,17 +109,12 @@ Array [
     , 
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/alexandra-frean"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Alexandra Frean
   </a>,
@@ -180,17 +145,12 @@ Array [
     RBS Six Nations 
   </span>,
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/mike-atherton"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Mike Atherton
   </a>,
@@ -200,17 +160,12 @@ Array [
 exports[`Article Byline test on web renders correctly with the author in the begining 1`] = `
 Array [
   <a
-    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
     dir="auto"
     href="/profile/camilla-long"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="link"
-    style={
-      Object {
-        "color": "rgba(19,53,78,1)",
-      }
-    }
   >
     Camilla Long
   </a>,

--- a/packages/article-byline/article-byline-proptypes.js
+++ b/packages/article-byline/article-byline-proptypes.js
@@ -4,6 +4,7 @@ import { treePropType } from "@times-components/markup";
 
 export const articleBylinePropTypes = {
   ast: PropTypes.arrayOf(treePropType).isRequired,
+  section: PropTypes.string,
   style: PropTypes.shape({
     link: Text.propTypes.style
   })
@@ -11,5 +12,6 @@ export const articleBylinePropTypes = {
 
 export const articleBylineDefaultPropTypes = {
   ast: {},
+  section: "news",
   style: {}
 };

--- a/packages/article-byline/article-byline-proptypes.js
+++ b/packages/article-byline/article-byline-proptypes.js
@@ -12,6 +12,6 @@ export const articleBylinePropTypes = {
 
 export const articleBylineDefaultPropTypes = {
   ast: {},
-  section: "news",
+  section: "",
   style: {}
 };

--- a/packages/article-byline/article-byline.js
+++ b/packages/article-byline/article-byline.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { TextLink } from "@times-components/link";
 import { renderTrees } from "@times-components/markup";
-import sectionColours from "@times-components/styleguide";
+import { colours } from "@times-components/styleguide";
 
 import {
   articleBylinePropTypes,
@@ -13,9 +13,12 @@ const ArticleByline = ({ ast, section, style }) =>
   renderTrees(ast, {
     author(key, attributes, children) {
       const url = `/profile/${attributes.slug}`;
+      const linkColour = section
+        ? colours.sectionColours[section]
+        : colours.functionalColours.blue;
       return (
         <TextLink
-          style={[{ color: sectionColours[section] }, style]}
+          style={[{ color: linkColour }, style]}
           key={key}
           url={url}
           onPress={() => {}}

--- a/packages/article-byline/article-byline.js
+++ b/packages/article-byline/article-byline.js
@@ -1,27 +1,21 @@
 /* eslint-disable react/no-array-index-key */
 import React from "react";
-import { StyleSheet } from "react-native";
 import { TextLink } from "@times-components/link";
 import { renderTrees } from "@times-components/markup";
+import sectionColours from "@times-components/styleguide";
 
 import {
   articleBylinePropTypes,
   articleBylineDefaultPropTypes
 } from "./article-byline-proptypes";
 
-const linkStyles = StyleSheet.create({
-  link: {
-    color: "#069"
-  }
-});
-
-const ArticleByline = ({ ast, style }) =>
+const ArticleByline = ({ ast, section, style }) =>
   renderTrees(ast, {
     author(key, attributes, children) {
       const url = `/profile/${attributes.slug}`;
       return (
         <TextLink
-          style={[linkStyles.link, style.link]}
+          style={[{ color: sectionColours[section] }, style]}
           key={key}
           url={url}
           onPress={() => {}}

--- a/packages/article-byline/article-byline.stories.js
+++ b/packages/article-byline/article-byline.stories.js
@@ -14,16 +14,19 @@ const bylineStyles = {
 };
 
 const bylineLinkStyles = {
-  link: {
-    color: "red",
-    textDecorationLine: "none"
-  }
+  color: "red",
+  textDecorationLine: "none"
 };
 
 storiesOf("Primitives/ArticleByline", module)
   .add("ArticleByline with a single author", () => (
     <Text style={bylineStyles}>
       <ArticleByline ast={authorsAST.singleAuthor} />
+    </Text>
+  ))
+  .add("ArticleByline with a single author in sport section", () => (
+    <Text style={bylineStyles}>
+      <ArticleByline ast={authorsAST.singleAuthor} section="sport" />
     </Text>
   ))
   .add("ArticleByline with a text only element", () => (

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@times-components/link": "0.14.1",
     "@times-components/markup": "0.21.1",
+    "@times-components/styleguide": "0.2.1",
     "prop-types": "15.6.0"
   },
   "peerDependencies": {

--- a/packages/article-label/article-label.stories.js
+++ b/packages/article-label/article-label.stories.js
@@ -3,12 +3,12 @@ import React from "react";
 import { storiesOf } from "@storybook/react-native";
 import { select } from "@storybook/addon-knobs/react";
 import invert from "lodash.invert";
-import sectionColours from "@times-components/styleguide";
+import { colours } from "@times-components/styleguide";
 import ArticleLabel from "./article-label";
 
 storiesOf("Primitives/ArticleLabel", module).add("ArticleLabel", () => (
   <ArticleLabel
     title="swimming"
-    color={select("Section", invert(sectionColours), "#333333")}
+    color={select("Section", invert(colours.sectionColours), "#333333")}
   />
 ));

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -127,7 +127,7 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#13354e",
+            "color": "#13354E",
           },
           Object {},
         ]
@@ -345,7 +345,7 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#7b0046",
+            "color": "#7B0046",
           },
           Object {},
         ]
@@ -777,7 +777,7 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#db133b",
+            "color": "#DB133B",
           },
           Object {},
         ]
@@ -973,7 +973,7 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#005b8d",
+            "color": "#005B8D",
           },
           Object {},
         ]
@@ -1165,7 +1165,7 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#13354e",
+            "color": "#13354E",
           },
           Object {},
         ]

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -127,9 +127,9 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#13354e",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -345,9 +345,9 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#7b0046",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -504,9 +504,9 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#008347",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -777,9 +777,9 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#db133b",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -973,9 +973,9 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#005b8d",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -1165,9 +1165,9 @@ exports[`Article Summary test on Android renders an article-summary component wi
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#13354e",
           },
-          undefined,
+          Object {},
         ]
       }
     >

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -125,9 +125,9 @@ exports[`Article Summary test on ios renders an article-summary component with a
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#13354e",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -341,9 +341,9 @@ exports[`Article Summary test on ios renders an article-summary component with c
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#7b0046",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -498,9 +498,9 @@ exports[`Article Summary test on ios renders an article-summary component with e
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#008347",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -767,9 +767,9 @@ exports[`Article Summary test on ios renders an article-summary component with m
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#db133b",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -961,9 +961,9 @@ exports[`Article Summary test on ios renders an article-summary component with n
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#005b8d",
           },
-          undefined,
+          Object {},
         ]
       }
     >
@@ -1151,9 +1151,9 @@ exports[`Article Summary test on ios renders an article-summary component with n
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#069",
+            "color": "#13354e",
           },
-          undefined,
+          Object {},
         ]
       }
     >

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -125,7 +125,7 @@ exports[`Article Summary test on ios renders an article-summary component with a
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#13354e",
+            "color": "#13354E",
           },
           Object {},
         ]
@@ -341,7 +341,7 @@ exports[`Article Summary test on ios renders an article-summary component with c
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#7b0046",
+            "color": "#7B0046",
           },
           Object {},
         ]
@@ -767,7 +767,7 @@ exports[`Article Summary test on ios renders an article-summary component with m
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#db133b",
+            "color": "#DB133B",
           },
           Object {},
         ]
@@ -961,7 +961,7 @@ exports[`Article Summary test on ios renders an article-summary component with n
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#005b8d",
+            "color": "#005B8D",
           },
           Object {},
         ]
@@ -1151,7 +1151,7 @@ exports[`Article Summary test on ios renders an article-summary component with n
             "textDecorationLine": "underline",
           },
           Object {
-            "color": "#13354e",
+            "color": "#13354E",
           },
           Object {},
         ]

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -91,12 +91,17 @@ exports[`Article Summary test on Web renders an article-summary component with a
     }
   >
     <a
-      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
       dir="auto"
       href="/profile/camilla-long"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="link"
+      style={
+        Object {
+          "color": "rgba(19,53,78,1)",
+        }
+      }
     >
       Camilla Long
     </a>
@@ -222,12 +227,17 @@ exports[`Article Summary test on Web renders an article-summary component with c
     }
   >
     <a
-      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
       dir="auto"
       href="/profile/camilla-long"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="link"
+      style={
+        Object {
+          "color": "rgba(123,0,70,1)",
+        }
+      }
     >
       Camilla Long
     </a>
@@ -340,12 +350,17 @@ exports[`Article Summary test on Web renders an article-summary component with e
     }
   >
     <a
-      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
       dir="auto"
       href="/profile/camilla-long"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="link"
+      style={
+        Object {
+          "color": "rgba(0,131,71,1)",
+        }
+      }
     >
       Camilla Long
     </a>
@@ -544,12 +559,17 @@ exports[`Article Summary test on Web renders an article-summary component with m
     }
   >
     <a
-      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
       dir="auto"
       href="/profile/camilla-long"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="link"
+      style={
+        Object {
+          "color": "rgba(219,19,59,1)",
+        }
+      }
     >
       Camilla Long
     </a>
@@ -696,12 +716,17 @@ exports[`Article Summary test on Web renders an article-summary component with n
     }
   >
     <a
-      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
       dir="auto"
       href="/profile/camilla-long"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="link"
+      style={
+        Object {
+          "color": "rgba(0,91,141,1)",
+        }
+      }
     >
       Camilla Long
     </a>
@@ -848,12 +873,17 @@ exports[`Article Summary test on Web renders an article-summary component with n
     }
   >
     <a
-      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1hxpnkq rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+      className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
       dir="auto"
       href="/profile/camilla-long"
       onClick={[Function]}
       onKeyDown={[Function]}
       role="link"
+      style={
+        Object {
+          "color": "rgba(19,53,78,1)",
+        }
+      }
     >
       Camilla Long
     </a>

--- a/packages/article-summary/fixtures/article-empty-paragraph.js
+++ b/packages/article-summary/fixtures/article-empty-paragraph.js
@@ -43,7 +43,8 @@ export default {
           }
         ]
       }
-    ]
+    ],
+    section: "sport"
   },
   content: () => (
     <ArticleSummaryContent

--- a/packages/article-summary/fixtures/article-multi.js
+++ b/packages/article-summary/fixtures/article-multi.js
@@ -39,7 +39,8 @@ export default {
           }
         ]
       }
-    ]
+    ],
+    section: "thedish"
   },
   content: () => (
     <ArticleSummaryContent

--- a/packages/article-summary/fixtures/no-datepublication.js
+++ b/packages/article-summary/fixtures/no-datepublication.js
@@ -39,7 +39,8 @@ export default {
           }
         ]
       }
-    ]
+    ],
+    section: "business"
   },
   content: () => (
     <ArticleSummaryContent

--- a/packages/article-summary/fixtures/review.js
+++ b/packages/article-summary/fixtures/review.js
@@ -43,7 +43,8 @@ export default {
           }
         ]
       }
-    ]
+    ],
+    section: "culture"
   },
   content: () => (
     <ArticleSummaryContent

--- a/packages/article/__tests__/android/__snapshots__/related-article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/related-article.android.test.js.snap
@@ -1587,7 +1587,7 @@ exports[`Related articles test on android Related articles renders three related
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#13354e",
+                        "color": "#db133b",
                       },
                       Object {},
                     ]
@@ -1897,7 +1897,7 @@ exports[`Related articles test on android Related articles renders three related
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#13354e",
+                        "color": "#008347",
                       },
                       Object {},
                     ]
@@ -2207,7 +2207,7 @@ exports[`Related articles test on android Related articles renders three related
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#13354e",
+                        "color": "#6c6c69",
                       },
                       Object {},
                     ]

--- a/packages/article/__tests__/android/__snapshots__/related-article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/related-article.android.test.js.snap
@@ -1575,11 +1575,32 @@ exports[`Related articles test on android Related articles renders three related
                 }
               >
                 <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="/profile/camilla-long"
+                  onPress={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#13354e",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Camilla Long
+                </Text>
+                <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                 >
-                  Camilla Long, Environment Editor
+                  , Environment Editor
                 </Text>
               </Text>
             </View>
@@ -1864,11 +1885,32 @@ exports[`Related articles test on android Related articles renders three related
                 }
               >
                 <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="/profile/camilla-long"
+                  onPress={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#13354e",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Camilla Long
+                </Text>
+                <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                 >
-                  Camilla Long, Environment Editor
+                  , Environment Editor
                 </Text>
               </Text>
             </View>
@@ -2153,11 +2195,32 @@ exports[`Related articles test on android Related articles renders three related
                 }
               >
                 <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="/profile/camilla-long"
+                  onPress={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#13354e",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Camilla Long
+                </Text>
+                <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                 >
-                  Camilla Long, Environment Editor
+                  , Environment Editor
                 </Text>
               </Text>
             </View>

--- a/packages/article/__tests__/android/__snapshots__/related-article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/related-article.android.test.js.snap
@@ -1587,7 +1587,7 @@ exports[`Related articles test on android Related articles renders three related
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#db133b",
+                        "color": "#DB133B",
                       },
                       Object {},
                     ]
@@ -2207,7 +2207,7 @@ exports[`Related articles test on android Related articles renders three related
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#6c6c69",
+                        "color": "#6C6C69",
                       },
                       Object {},
                     ]

--- a/packages/article/__tests__/ios/__snapshots__/related-article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/related-article.ios.test.js.snap
@@ -1457,7 +1457,7 @@ exports[`Related articles test on ios Related articles renders three related art
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#13354e",
+                        "color": "#db133b",
                       },
                       Object {},
                     ]
@@ -1734,7 +1734,7 @@ exports[`Related articles test on ios Related articles renders three related art
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#13354e",
+                        "color": "#008347",
                       },
                       Object {},
                     ]
@@ -2011,7 +2011,7 @@ exports[`Related articles test on ios Related articles renders three related art
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#13354e",
+                        "color": "#6c6c69",
                       },
                       Object {},
                     ]

--- a/packages/article/__tests__/ios/__snapshots__/related-article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/related-article.ios.test.js.snap
@@ -1457,7 +1457,7 @@ exports[`Related articles test on ios Related articles renders three related art
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#db133b",
+                        "color": "#DB133B",
                       },
                       Object {},
                     ]
@@ -2011,7 +2011,7 @@ exports[`Related articles test on ios Related articles renders three related art
                         "textDecorationLine": "underline",
                       },
                       Object {
-                        "color": "#6c6c69",
+                        "color": "#6C6C69",
                       },
                       Object {},
                     ]

--- a/packages/article/__tests__/ios/__snapshots__/related-article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/related-article.ios.test.js.snap
@@ -1445,11 +1445,32 @@ exports[`Related articles test on ios Related articles renders three related art
                 }
               >
                 <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="/profile/camilla-long"
+                  onPress={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#13354e",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Camilla Long
+                </Text>
+                <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                 >
-                  Camilla Long, Environment Editor
+                  , Environment Editor
                 </Text>
               </Text>
             </View>
@@ -1701,11 +1722,32 @@ exports[`Related articles test on ios Related articles renders three related art
                 }
               >
                 <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="/profile/camilla-long"
+                  onPress={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#13354e",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Camilla Long
+                </Text>
+                <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                 >
-                  Camilla Long, Environment Editor
+                  , Environment Editor
                 </Text>
               </Text>
             </View>
@@ -1957,11 +1999,32 @@ exports[`Related articles test on ios Related articles renders three related art
                 }
               >
                 <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="/profile/camilla-long"
+                  onPress={[Function]}
+                  style={
+                    Array [
+                      Object {
+                        "textDecorationLine": "underline",
+                      },
+                      Object {
+                        "color": "#13354e",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Camilla Long
+                </Text>
+                <Text
                   accessible={true}
                   allowFontScaling={true}
                   ellipsizeMode="tail"
                 >
-                  Camilla Long, Environment Editor
+                  , Environment Editor
                 </Text>
               </Text>
             </View>

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -666,7 +666,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -674,7 +674,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -692,7 +692,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -700,7 +700,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -713,7 +713,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -721,7 +721,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -732,7 +732,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -740,7 +740,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -751,7 +751,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -759,7 +759,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -770,7 +770,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -778,7 +778,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -789,7 +789,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -797,7 +797,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -808,7 +808,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -816,7 +816,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -827,7 +827,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -835,7 +835,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -846,7 +846,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -854,7 +854,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -865,7 +865,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -873,7 +873,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -884,7 +884,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -892,7 +892,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -903,7 +903,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -911,7 +911,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1596,7 +1596,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1604,7 +1604,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1622,7 +1622,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1630,7 +1630,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1643,7 +1643,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1651,7 +1651,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1662,7 +1662,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1670,7 +1670,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1681,7 +1681,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1689,7 +1689,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1700,7 +1700,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1708,7 +1708,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1719,7 +1719,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1727,7 +1727,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1738,7 +1738,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1746,7 +1746,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1757,7 +1757,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1765,7 +1765,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1776,7 +1776,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1784,7 +1784,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1795,7 +1795,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1803,7 +1803,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1814,7 +1814,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1822,7 +1822,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -1833,7 +1833,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -1841,7 +1841,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2422,7 +2422,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2430,7 +2430,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2448,7 +2448,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2456,7 +2456,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2469,7 +2469,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2477,7 +2477,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2488,7 +2488,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2496,7 +2496,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2507,7 +2507,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2515,7 +2515,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2526,7 +2526,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2534,7 +2534,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2545,7 +2545,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2553,7 +2553,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2564,7 +2564,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2572,7 +2572,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2583,7 +2583,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2591,7 +2591,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2602,7 +2602,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2610,7 +2610,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2621,7 +2621,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2629,7 +2629,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2640,7 +2640,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2648,7 +2648,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -2659,7 +2659,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -2667,7 +2667,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3240,7 +3240,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3248,7 +3248,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3266,7 +3266,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3274,7 +3274,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3287,7 +3287,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3295,7 +3295,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3306,7 +3306,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3314,7 +3314,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3325,7 +3325,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3333,7 +3333,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3344,7 +3344,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3352,7 +3352,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3363,7 +3363,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3371,7 +3371,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3382,7 +3382,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3390,7 +3390,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3401,7 +3401,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3409,7 +3409,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3420,7 +3420,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3428,7 +3428,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3439,7 +3439,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3447,7 +3447,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3458,7 +3458,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3466,7 +3466,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -3477,7 +3477,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -3485,7 +3485,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4188,7 +4188,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4196,7 +4196,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4214,7 +4214,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4222,7 +4222,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4235,7 +4235,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4243,7 +4243,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4254,7 +4254,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4262,7 +4262,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4273,7 +4273,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4281,7 +4281,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4292,7 +4292,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4300,7 +4300,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4311,7 +4311,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4319,7 +4319,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4330,7 +4330,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4338,7 +4338,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4349,7 +4349,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4357,7 +4357,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4368,7 +4368,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4376,7 +4376,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4387,7 +4387,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4395,7 +4395,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4406,7 +4406,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4414,7 +4414,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -4425,7 +4425,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -4433,7 +4433,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5032,7 +5032,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5040,7 +5040,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5058,7 +5058,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5066,7 +5066,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5079,7 +5079,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5087,7 +5087,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5098,7 +5098,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5106,7 +5106,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5117,7 +5117,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5125,7 +5125,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5136,7 +5136,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5144,7 +5144,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5155,7 +5155,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5163,7 +5163,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5174,7 +5174,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5182,7 +5182,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5193,7 +5193,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5201,7 +5201,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5212,7 +5212,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5220,7 +5220,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5231,7 +5231,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5239,7 +5239,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5250,7 +5250,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5258,7 +5258,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5269,7 +5269,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5277,7 +5277,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5954,7 +5954,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5962,7 +5962,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -5980,7 +5980,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -5988,7 +5988,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6001,7 +6001,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6009,7 +6009,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6020,7 +6020,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6028,7 +6028,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6039,7 +6039,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6047,7 +6047,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6058,7 +6058,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6066,7 +6066,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6077,7 +6077,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6085,7 +6085,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6096,7 +6096,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6104,7 +6104,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6115,7 +6115,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6123,7 +6123,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6134,7 +6134,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6142,7 +6142,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6153,7 +6153,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6161,7 +6161,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6172,7 +6172,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6180,7 +6180,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6191,7 +6191,7 @@ Array [
           className="c12"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6199,7 +6199,7 @@ Array [
             className="c13"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6798,7 +6798,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6806,7 +6806,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6824,7 +6824,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6832,7 +6832,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6920,7 +6920,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6928,7 +6928,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -6939,7 +6939,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -6947,7 +6947,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7029,7 +7029,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7037,7 +7037,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7098,7 +7098,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7106,7 +7106,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7188,7 +7188,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7196,7 +7196,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7278,7 +7278,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7286,7 +7286,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7297,7 +7297,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7305,7 +7305,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7316,7 +7316,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7324,7 +7324,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7335,7 +7335,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7343,7 +7343,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7354,7 +7354,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7362,7 +7362,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -7373,7 +7373,7 @@ Array [
           className="c10"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -7381,7 +7381,7 @@ Array [
             className="c11"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8289,7 +8289,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8297,7 +8297,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8327,7 +8327,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8335,7 +8335,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8423,7 +8423,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8431,7 +8431,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8442,7 +8442,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8450,7 +8450,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8532,7 +8532,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8540,7 +8540,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8601,7 +8601,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8609,7 +8609,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8691,7 +8691,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8699,7 +8699,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8781,7 +8781,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8789,7 +8789,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8865,7 +8865,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8873,7 +8873,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8884,7 +8884,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8892,7 +8892,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8903,7 +8903,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8911,7 +8911,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8922,7 +8922,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8930,7 +8930,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >
@@ -8941,7 +8941,7 @@ Array [
           className="c13"
           style={
             Array [
-              103,
+              102,
             ]
           }
         >
@@ -8949,7 +8949,7 @@ Array [
             className="c14"
             style={
               Array [
-                105,
+                104,
               ]
             }
           >

--- a/packages/article/__tests__/web/__snapshots__/related-articles.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/related-articles.web.test.js.snap
@@ -94,10 +94,11 @@ exports[`Related articles test on web Related articles renders single related ar
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(219,19,59,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -144,7 +145,7 @@ exports[`Related articles test on web Related articles renders single related ar
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -278,10 +279,11 @@ exports[`Related articles test on web Related articles renders single related ar
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(219,19,59,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -328,7 +330,7 @@ exports[`Related articles test on web Related articles renders single related ar
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -491,7 +493,7 @@ exports[`Related articles test on web Related articles renders single related ar
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -572,10 +574,11 @@ exports[`Related articles test on web Related articles renders single related ar
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(219,19,59,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -622,7 +625,7 @@ exports[`Related articles test on web Related articles renders single related ar
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -756,10 +759,11 @@ exports[`Related articles test on web Related articles renders three related art
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(219,19,59,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -806,7 +810,7 @@ exports[`Related articles test on web Related articles renders three related art
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -931,10 +935,11 @@ exports[`Related articles test on web Related articles renders three related art
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(0,131,71,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -981,7 +986,7 @@ exports[`Related articles test on web Related articles renders three related art
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -1106,10 +1111,11 @@ exports[`Related articles test on web Related articles renders three related art
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(108,108,105,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -1156,7 +1162,7 @@ exports[`Related articles test on web Related articles renders three related art
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -1305,10 +1311,11 @@ exports[`Related articles test on web Related articles renders two related artic
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(219,19,59,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -1355,7 +1362,7 @@ exports[`Related articles test on web Related articles renders two related artic
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>
@@ -1465,10 +1472,11 @@ exports[`Related articles test on web Related articles renders two related artic
                 className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
+                      "color": "rgba(0,131,71,1)",
                       "fontSize": "12px",
                       "letterSpacing": "1.2px",
                       "lineHeight": "12px",
@@ -1515,7 +1523,7 @@ exports[`Related articles test on web Related articles renders two related artic
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
                 >
-
+                  
                   Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
                   ...
                 </span>

--- a/packages/article/__tests__/web/__snapshots__/related-articles.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/related-articles.web.test.js.snap
@@ -28,17 +28,17 @@ exports[`Related articles test on web Related articles renders single related ar
         className="sc-bZQynM iXJOBT rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-bxivhb gFxRdZ rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-bxivhb gFxRdZ rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-ifAKCX gOWYOL rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -83,99 +83,103 @@ exports[`Related articles test on web Related articles renders single related ar
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-EHOje gPObpk rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-EHOje gPObpk rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(219,19,59,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Now for a new battle: bringing the fragile masterpiece over safely
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
+                  role="heading"
                 >
-                  Friday March 13 2015, 06:54pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  Now for a new battle: bringing the fragile masterpiece over safely
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
                 >
-                  <span>
-                    Camilla Long, Environment Editor
-                  </span>
-                </div>
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Friday March 13 2015, 06:54pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <span>
+                  Camilla Long, Environment Editor
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
     </div>
   </div>
@@ -208,17 +212,17 @@ exports[`Related articles test on web Related articles renders single related ar
         className="sc-ckVGcZ fijhdO rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-kGXeez dJxalb rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-kGXeez dJxalb rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-kpOJdX rEVmW rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -263,95 +267,99 @@ exports[`Related articles test on web Related articles renders single related ar
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-dxgOiQ oABHY rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-dxgOiQ oABHY rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(219,19,59,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Now for a new battle: bringing the fragile masterpiece over safely
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
-                  dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
-                >
-                  Friday March 13 2015, 06:54pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
-                />
               </div>
+              <a
+                href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  dir="auto"
+                  role="heading"
+                >
+                  Now for a new battle: bringing the fragile masterpiece over safely
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                >
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Friday March 13 2015, 06:54pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              />
             </div>
           </div>
-        </a>
+        </div>
       </article>
     </div>
   </div>
@@ -384,17 +392,17 @@ exports[`Related articles test on web Related articles renders single related ar
         className="sc-kAzzGY jFEYIq rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-fjdhpX bwXXoo rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-fjdhpX bwXXoo rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-jzJRlG jebfCY rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -439,81 +447,86 @@ exports[`Related articles test on web Related articles renders single related ar
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-cSHVUG cvHaWv rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-cSHVUG cvHaWv rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
-              <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              <a
+                href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
               >
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
+                  role="heading"
                 >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Now for a new battle: bringing the fragile masterpiece over safely
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                  style={
-                    Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
-                    }
+                  Now for a new battle: bringing the fragile masterpiece over safely
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
                   }
-                >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
-                </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
                 >
-                  Friday March 13 2015, 06:54pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
                   }
-                >
-                  <span>
-                    Charles Bremner, Paris | Jack Malvern
-                  </span>
-                </div>
+                }
+              >
+                Friday March 13 2015, 06:54pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <span>
+                  Charles Bremner, Paris | Jack Malvern
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
     </div>
   </div>
@@ -546,111 +559,105 @@ exports[`Related articles test on web Related articles renders single related ar
         className="sc-gqjmRU jeLTYx rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-dnqmqq dybbee rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
           <div
-            className="sc-dnqmqq dybbee rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+            className="sc-gZMcBi hFaPpl rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
           >
             <div
-              className="sc-gZMcBi hFaPpl rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(219,19,59,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Now for a new battle: bringing the fragile masterpiece over safely
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
+                  role="heading"
                 >
-                  Friday March 13 2015, 06:54pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  Now for a new battle: bringing the fragile masterpiece over safely
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
                 >
-                  <span>
-                    Charles Bremner, Paris | Jack Malvern
-                  </span>
-                </div>
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Friday March 13 2015, 06:54pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <span>
+                  Charles Bremner, Paris | Jack Malvern
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
     </div>
   </div>
@@ -683,17 +690,17 @@ exports[`Related articles test on web Related articles renders three related art
         className="sc-jAaTju gbtOQC rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-jWBwVP hnLcKH rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-jWBwVP hnLcKH rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-brqgnP fTRqGV rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -738,99 +745,118 @@ exports[`Related articles test on web Related articles renders three related art
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-cMljjf cHuNOs rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-cMljjf cHuNOs rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(219,19,59,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Now for a new battle: bringing the fragile masterpiece over safely
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
+                  role="heading"
+                >
+                  Now for a new battle: bringing the fragile masterpiece over safely
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                >
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Friday March 13 2015, 06:54pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <a
+                  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                  href="/profile/camilla-long"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="link"
                   style={
                     Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
+                      "color": "rgba(19,53,78,1)",
                     }
                   }
                 >
-                  Friday March 13 2015, 06:54pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
-                >
-                  <span>
-                    Camilla Long, Environment Editor
-                  </span>
-                </div>
+                  Camilla Long
+                </a>
+                <span>
+                  , Environment Editor
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
       <div
         className="sc-bwzfXH grYLMM rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -839,17 +865,17 @@ exports[`Related articles test on web Related articles renders three related art
         className="sc-jDwBTQ gNCnLQ rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-jWBwVP hnLcKH rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-jWBwVP hnLcKH rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-brqgnP fTRqGV rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -894,99 +920,118 @@ exports[`Related articles test on web Related articles renders three related art
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-cMljjf cHuNOs rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-cMljjf cHuNOs rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(0,131,71,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Bayeux Tapestry to be displayed in Britain
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
+                  role="heading"
+                >
+                  Bayeux Tapestry to be displayed in Britain
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                >
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Wednesday January 17 2018, 12:00pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <a
+                  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                  href="/profile/camilla-long"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="link"
                   style={
                     Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
+                      "color": "rgba(19,53,78,1)",
                     }
                   }
                 >
-                  Wednesday January 17 2018, 12:00pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
-                >
-                  <span>
-                    Camilla Long, Environment Editor
-                  </span>
-                </div>
+                  Camilla Long
+                </a>
+                <span>
+                  , Environment Editor
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
       <div
         className="sc-bwzfXH grYLMM rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -995,17 +1040,17 @@ exports[`Related articles test on web Related articles renders three related art
         className="sc-gPEVay ePLDTf rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-jWBwVP hnLcKH rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-jWBwVP hnLcKH rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-brqgnP fTRqGV rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -1050,99 +1095,118 @@ exports[`Related articles test on web Related articles renders three related art
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-cMljjf cHuNOs rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-cMljjf cHuNOs rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(108,108,105,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Bayeux Tapestry to be displayed in Britain
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
+                  role="heading"
+                >
+                  Bayeux Tapestry to be displayed in Britain
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                >
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Wednesday January 17 2018, 12:00pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <a
+                  className="rn-backgroundColor-wib322 rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-cursor-1loqt21 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-1ncyl3j rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                  dir="auto"
+                  href="/profile/camilla-long"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="link"
                   style={
                     Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
+                      "color": "rgba(19,53,78,1)",
                     }
                   }
                 >
-                  Wednesday January 17 2018, 12:00pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
-                >
-                  <span>
-                    Camilla Long, Environment Editor
-                  </span>
-                </div>
+                  Camilla Long
+                </a>
+                <span>
+                  , Environment Editor
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
     </div>
   </div>
@@ -1175,17 +1239,17 @@ exports[`Related articles test on web Related articles renders two related artic
         className="sc-iAyFgw iolmBv rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-hMqMXs bxvMJn rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-hMqMXs bxvMJn rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-kEYyzF DSgLu rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -1230,99 +1294,103 @@ exports[`Related articles test on web Related articles renders two related artic
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-kkGfuU bwDHcO rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-kkGfuU bwDHcO rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(219,19,59,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Now for a new battle: bringing the fragile masterpiece over safely
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
+                  role="heading"
                 >
-                  Friday March 13 2015, 06:54pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  Now for a new battle: bringing the fragile masterpiece over safely
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
                 >
-                  <span>
-                    Camilla Long, Environment Editor
-                  </span>
-                </div>
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Friday March 13 2015, 06:54pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <span>
+                  Camilla Long, Environment Editor
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
       <div
         className="sc-bwzfXH grYLMM rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -1331,17 +1399,17 @@ exports[`Related articles test on web Related articles renders two related artic
         className="sc-hSdWYo klSWBr rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         role="article"
       >
-        <a
-          href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
-          onClick={[Function]}
-          style={
-            Object {
-              "textDecoration": "none",
-            }
-          }
+        <div
+          className="sc-hMqMXs bxvMJn rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
         >
-          <div
-            className="sc-hMqMXs bxvMJn rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          <a
+            href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
+            onClick={[Function]}
+            style={
+              Object {
+                "textDecoration": "none",
+              }
+            }
           >
             <div
               className="sc-kEYyzF DSgLu rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
@@ -1386,99 +1454,103 @@ exports[`Related articles test on web Related articles renders two related artic
                 </div>
               </div>
             </div>
+          </a>
+          <div
+            className="sc-kkGfuU bwDHcO rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+          >
             <div
-              className="sc-kkGfuU bwDHcO rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+              className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
             >
               <div
-                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+                className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
               >
                 <div
-                  className="rn-alignItems-1oszu61 rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-eqz5dr rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-p1pxzi rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
-                >
-                  <div
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                    dir="auto"
-                    style={
-                      Object {
-                        "color": "rgba(0,131,71,1)",
-                        "fontSize": "12px",
-                        "letterSpacing": "1.2px",
-                        "lineHeight": "12px",
-                      }
-                    }
-                  >
-                    BAYEUX TAPESTRY
-                  </div>
-                </div>
-                <div
-                  className="sc-htpNat inAOtb rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-10u92zi rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  dir="auto"
-                >
-                  <h3
-                    aria-level="3"
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-7cikom rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                    role="heading"
-                  >
-                    Bayeux Tapestry to be displayed in Britain
-                  </h3>
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
                   style={
                     Object {
-                      "WebkitBoxLines": "multiple",
-                      "WebkitFlexWrap": "wrap",
-                      "color": "rgba(105,105,105,1)",
-                      "flexWrap": "wrap",
-                      "fontFamily": "TimesDigitalW04",
-                      "lineHeight": "20px",
-                      "msFlexWrap": "wrap",
+                      "fontSize": "12px",
+                      "letterSpacing": "1.2px",
+                      "lineHeight": "12px",
                     }
                   }
                 >
-                  <span
-                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
-                    dir="auto"
-                  >
-                    
-                    Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
-                    ...
-                  </span>
+                  BAYEUX TAPESTRY
                 </div>
-                <div
-                  aria-label="datePublication"
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-                  data-testid="datePublication"
+              </div>
+              <a
+                href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "textDecoration": "none",
+                  }
+                }
+              >
+                <h3
+                  aria-level="3"
+                  className="sc-htpNat kwttSF rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-102hald rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-iirzy8 rn-fontSize-1b43r93 rn-fontWeight-16dba41 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
+                  role="heading"
                 >
-                  Wednesday January 17 2018, 12:00pm
-                </div>
-                <div
-                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  Bayeux Tapestry to be displayed in Britain
+                </h3>
+              </a>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "WebkitBoxLines": "multiple",
+                    "WebkitFlexWrap": "wrap",
+                    "color": "rgba(105,105,105,1)",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "lineHeight": "20px",
+                    "msFlexWrap": "wrap",
+                  }
+                }
+              >
+                <span
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
                   dir="auto"
-                  style={
-                    Object {
-                      "color": "rgba(105,105,105,1)",
-                      "lineHeight": "15px",
-                    }
-                  }
                 >
-                  <span>
-                    Camilla Long, Environment Editor
-                  </span>
-                </div>
+
+                  Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab.
+                  ...
+                </span>
+              </div>
+              <div
+                aria-label="datePublication"
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                data-testid="datePublication"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                Wednesday January 17 2018, 12:00pm
+              </div>
+              <div
+                className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-d0pm55 rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                dir="auto"
+                style={
+                  Object {
+                    "color": "rgba(105,105,105,1)",
+                    "lineHeight": "15px",
+                  }
+                }
+              >
+                <span>
+                  Camilla Long, Environment Editor
+                </span>
               </div>
             </div>
           </div>
-        </a>
+        </div>
       </article>
     </div>
   </div>

--- a/packages/article/__tests__/web/__snapshots__/related-articles.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/related-articles.web.test.js.snap
@@ -844,7 +844,7 @@ exports[`Related articles test on web Related articles renders three related art
                   role="link"
                   style={
                     Object {
-                      "color": "rgba(19,53,78,1)",
+                      "color": "rgba(219,19,59,1)",
                     }
                   }
                 >
@@ -1019,7 +1019,7 @@ exports[`Related articles test on web Related articles renders three related art
                   role="link"
                   style={
                     Object {
-                      "color": "rgba(19,53,78,1)",
+                      "color": "rgba(0,131,71,1)",
                     }
                   }
                 >
@@ -1194,7 +1194,7 @@ exports[`Related articles test on web Related articles renders three related art
                   role="link"
                   style={
                     Object {
-                      "color": "rgba(19,53,78,1)",
+                      "color": "rgba(108,108,105,1)",
                     }
                   }
                 >

--- a/packages/article/related-articles/fixtures/three-related-articles.json
+++ b/packages/article/related-articles/fixtures/three-related-articles.json
@@ -32,13 +32,28 @@
           "https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh",
         "byline": [
           {
+            "name": "author",
+            "attributes": {
+              "slug": "camilla-long"
+            },
+            "children": [
+              {
+                "name": "text",
+                "attributes": {
+                  "value": "Camilla Long"
+                },
+                "children": []
+              }
+            ]
+          },
+          {
             "name": "inline",
             "attributes": {},
             "children": [
               {
                 "name": "text",
                 "attributes": {
-                  "value": "Camilla Long, Environment Editor"
+                  "value": ", Environment Editor"
                 },
                 "children": []
               }
@@ -86,13 +101,28 @@
         ],
         "byline": [
           {
+            "name": "author",
+            "attributes": {
+              "slug": "camilla-long"
+            },
+            "children": [
+              {
+                "name": "text",
+                "attributes": {
+                  "value": "Camilla Long"
+                },
+                "children": []
+              }
+            ]
+          },
+          {
             "name": "inline",
             "attributes": {},
             "children": [
               {
                 "name": "text",
                 "attributes": {
-                  "value": "Camilla Long, Environment Editor"
+                  "value": ", Environment Editor"
                 },
                 "children": []
               }
@@ -134,13 +164,28 @@
         ],
         "byline": [
           {
+            "name": "author",
+            "attributes": {
+              "slug": "camilla-long"
+            },
+            "children": [
+              {
+                "name": "text",
+                "attributes": {
+                  "value": "Camilla Long"
+                },
+                "children": []
+              }
+            ]
+          },
+          {
             "name": "inline",
             "attributes": {},
             "children": [
               {
                 "name": "text",
                 "attributes": {
-                  "value": "Camilla Long, Environment Editor"
+                  "value": ", Environment Editor"
                 },
                 "children": []
               }

--- a/packages/article/related-articles/related-article-item.js
+++ b/packages/article/related-articles/related-article-item.js
@@ -7,7 +7,7 @@ import ArticleSummary, {
 } from "@times-components/article-summary";
 import Image from "@times-components/image";
 import Link from "@times-components/link";
-import sectionColours from "@times-components/styleguide";
+import { colours } from "@times-components/styleguide";
 import { relatedArticleItemPropTypes } from "./proptypes";
 import styles from "./styles";
 
@@ -42,7 +42,8 @@ const RelatedArticleItem = ({ article, onPress }) => {
           headline={() => <ArticleSummaryHeadline headline={headline} />}
           labelProps={{
             title: label,
-            color: sectionColours[section] || sectionColours.default
+            color:
+              colours.sectionColours[section] || colours.sectionColours.default
           }}
           content={() => <ArticleSummaryContent ast={summary} />}
         />

--- a/packages/article/related-articles/related-article-item.js
+++ b/packages/article/related-articles/related-article-item.js
@@ -37,7 +37,7 @@ const RelatedArticleItem = ({ article, onPress }) => {
           </View>
         ) : null}
         <ArticleSummary
-          bylineProps={{ ast: byline }}
+          bylineProps={{ ast: byline, section }}
           datePublicationProps={{ date: publishedTime }}
           headline={() => <ArticleSummaryHeadline headline={headline} />}
           labelProps={{

--- a/packages/article/related-articles/related-article-item.web.js
+++ b/packages/article/related-articles/related-article-item.web.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { Text } from "react-native";
 import get from "lodash.get";
 import ArticleSummary, {
   ArticleSummaryContent
@@ -45,7 +44,7 @@ const RelatedArticleItem = ({
       ) : null}
       <StyledSummaryContainer>
         <ArticleSummary
-          bylineProps={{ ast: byline }}
+          bylineProps={{ ast: byline, section }}
           datePublicationProps={{ date: publishedTime }}
           headline={() => (
             <Link url={url} onPress={onPress}>

--- a/packages/article/related-articles/related-article-item.web.js
+++ b/packages/article/related-articles/related-article-item.web.js
@@ -35,37 +35,37 @@ const RelatedArticleItem = ({
   );
 
   return (
-    <Link url={url} onPress={onPress}>
-      <StyledRelatedArticleContainer>
-        {imageUri ? (
+    <StyledRelatedArticleContainer>
+      {imageUri ? (
+        <Link url={url} onPress={onPress}>
           <StyledImageContainer>
             <Image uri={`${imageUri}&resize=996`} aspectRatio={16 / 9} />
           </StyledImageContainer>
-        ) : null}
-        <StyledSummaryContainer>
-          <ArticleSummary
-            bylineProps={{ ast: byline }}
-            datePublicationProps={{ date: publishedTime }}
-            headline={() => (
-              <ResponsiveHeadline>
-                <Text
-                  accessibilityRole="heading"
-                  aria-level="3"
-                  style={styles.headline}
-                >
-                  {headline}
-                </Text>
+        </Link>
+      ) : null}
+      <StyledSummaryContainer>
+        <ArticleSummary
+          bylineProps={{ ast: byline }}
+          datePublicationProps={{ date: publishedTime }}
+          headline={() => (
+            <Link url={url} onPress={onPress}>
+              <ResponsiveHeadline
+                accessibilityRole="heading"
+                aria-level="3"
+                style={styles.headline}
+              >
+                {headline}
               </ResponsiveHeadline>
-            )}
-            labelProps={{
-              title: label,
-              color: sectionColours[section] || sectionColours.default
-            }}
-            content={() => <ArticleSummaryContent ast={summary} />}
-          />
-        </StyledSummaryContainer>
-      </StyledRelatedArticleContainer>
-    </Link>
+            </Link>
+          )}
+          labelProps={{
+            title: label,
+            color: sectionColours[section] || sectionColours.default
+          }}
+          content={() => <ArticleSummaryContent ast={summary} />}
+        />
+      </StyledSummaryContainer>
+    </StyledRelatedArticleContainer>
   );
 };
 

--- a/packages/article/related-articles/related-article-item.web.js
+++ b/packages/article/related-articles/related-article-item.web.js
@@ -5,7 +5,7 @@ import ArticleSummary, {
 } from "@times-components/article-summary";
 import Image from "@times-components/image";
 import Link from "@times-components/link";
-import sectionColours from "@times-components/styleguide";
+import { colours } from "@times-components/styleguide";
 import { relatedArticleItemPropTypes } from "./proptypes";
 import styles from "./styles";
 import { ResponsiveHeadline } from "./styles/responsive";
@@ -59,7 +59,8 @@ const RelatedArticleItem = ({
           )}
           labelProps={{
             title: label,
-            color: sectionColours[section] || sectionColours.default
+            color:
+              colours.sectionColours[section] || colours.sectionColours.default
           }}
           content={() => <ArticleSummaryContent ast={summary} />}
         />

--- a/packages/article/related-articles/styles/responsive.web.js
+++ b/packages/article/related-articles/styles/responsive.web.js
@@ -75,6 +75,9 @@ export const ResponsiveHeadline = withResponsiveStyles(Text, {
     font-size: 22px;
     line-height: 22px;
     margin-bottom: 5px;
+    &:hover {
+      color: #069;
+    }
   `,
   mediumUp: () => `
     font-size: 30px;

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -63,3 +63,4 @@
     "access": "public"
   }
 }
+

--- a/packages/styleguide/__tests__/styleguide.test.js
+++ b/packages/styleguide/__tests__/styleguide.test.js
@@ -1,7 +1,13 @@
-import sectionColours from "../";
+import { colours } from "../";
 
 describe("Styleguide tests", () => {
+  it("should have an object of colours", () => {
+    expect(typeof colours).toBe("object");
+  });
   it("should have an object of section colours", () => {
-    expect(typeof sectionColours).toBe("object");
+    expect(typeof colours.sectionColours).toBe("object");
+  });
+  it("should have an object of functional colours", () => {
+    expect(typeof colours.functionalColours).toBe("object");
   });
 });

--- a/packages/styleguide/colours/functional.js
+++ b/packages/styleguide/colours/functional.js
@@ -1,0 +1,5 @@
+const functionalColours = {
+  blue: "#006699"
+};
+
+export default functionalColours;

--- a/packages/styleguide/styleguide.js
+++ b/packages/styleguide/styleguide.js
@@ -1,1 +1,7 @@
-export { default } from "./colours/section";
+import sectionColours from "./colours/section";
+import functionalColours from "./colours/functional";
+
+export const colours = {
+  sectionColours,
+  functionalColours
+};

--- a/packages/styleguide/styleguide.stories.js
+++ b/packages/styleguide/styleguide.stories.js
@@ -2,7 +2,7 @@ import { Platform, ScrollView, Text, View } from "react-native";
 import React from "react";
 import PropTypes from "prop-types";
 import { storiesOf } from "@storybook/react-native";
-import sectionColours from "./styleguide";
+import { colours } from "./styleguide";
 
 const colourBoxStyles = {
   display: {
@@ -43,11 +43,11 @@ ColourBox.propTypes = {
 };
 
 storiesOf("Helpers/Styleguide", module).add("Section Colours", () => {
-  const colourBoxes = Object.keys(sectionColours).map(colourName => (
+  const colourBoxes = Object.keys(colours.sectionColours).map(colourName => (
     <ColourBox
       key={colourName}
       name={colourName}
-      hex={sectionColours[colourName]}
+      hex={colours.sectionColours[colourName]}
     />
   ));
 


### PR DESCRIPTION
This PR includes:

- Adding section prop to Article Byline which then uses styleguide to determine link colour
- Small refactor of how styles can be injected into the Byline
- Updates to fixture data to show off this new style.
- Removed link from card and applied to headline and image.
- Added rollover state back to Headline
