### PR TITLE
chore: publish once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,3 @@ script:
   - ./lib/run_jobs.sh
 after_success:
   - ./lib/publish.sh
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: lib/publish_storybook.sh
-  on:
-    branch: master

--- a/lib/publish.sh
+++ b/lib/publish.sh
@@ -6,6 +6,12 @@ echo "Running publish script"
 echo $(printf "TRAVIS_BRANCH %s" $TRAVIS_BRANCH)
 echo $(printf "TRAVIS_PULL_REQUEST %s" $TRAVIS_PULL_REQUEST)
 
+if [[ $JOB_TYPE != 'rest' ]]
+then
+  echo "We only publish for the rest job"
+  exit 0
+fi
+
 if [[ $TRAVIS_BRANCH != 'master' ]]
 then
   echo "Not on master"
@@ -60,3 +66,5 @@ lerna publish --conventional-commits --yes --concurrency=1 --exact -m "$MESSAGE"
 # push above changes to git
 echo "Pushing to master"
 git push origin master --tags --quiet > /dev/null 2>&1
+
+./lib/publish_storybook.sh


### PR DESCRIPTION
The deploy script (making components.thetimes.co.uk) runs on every publish commit and every job. This moves the logic to the custom script where it will only publish for a single job when merged to master