### PR TITLE
Refactor: Change article as a standalone prop

### DIFF
--- a/packages/article/article-proptype.js
+++ b/packages/article/article-proptype.js
@@ -2,11 +2,15 @@ import PropTypes from "prop-types";
 import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
 
-const ArticlePrototype = {
+const articlePropTypes = {
   article: PropTypes.shape({
     ...ArticleHeader.propTypes,
     ...ArticleMeta.propTypes
   })
 };
 
-export default ArticlePrototype;
+const articleDefaultProps = {
+  article: null
+};
+
+export { articlePropTypes, articleDefaultProps };

--- a/packages/article/article-prototype.js
+++ b/packages/article/article-prototype.js
@@ -1,0 +1,12 @@
+import PropTypes from "prop-types";
+import ArticleHeader from "./article-header/article-header";
+import ArticleMeta from "./article-meta/article-meta";
+
+const ArticlePrototype = {
+  article: PropTypes.shape({
+    ...ArticleHeader.propTypes,
+    ...ArticleMeta.propTypes
+  })
+};
+
+export default ArticlePrototype;

--- a/packages/article/article.js
+++ b/packages/article/article.js
@@ -7,6 +7,7 @@ import { AdComposer } from "@times-components/ad";
 import ArticleContent from "./article-content";
 import ArticleError from "./article-error";
 import ArticleLoading from "./article-loading";
+import { articlePropTypes, articleDefaultProps } from "./article-proptype";
 
 import listViewDataHelper from "./data-helper";
 import styles from "./styles/article-body";
@@ -15,6 +16,7 @@ import ArticleMeta from "./article-meta/article-meta";
 import ArticleRow from "./article-body/article-body-row";
 
 import articleTrackingContext from "./article-tracking-context";
+import {articlePropTypes} from "./article-proptype";
 
 const listViewPageSize = 1;
 const listViewSize = 10;
@@ -108,10 +110,7 @@ class ArticlePage extends React.Component {
 }
 
 ArticlePage.propTypes = {
-  article: PropTypes.shape({
-    ...ArticleHeader.propTypes,
-    ...ArticleMeta.propTypes
-  }),
+  ...articlePropTypes,
   isLoading: PropTypes.bool,
   error: PropTypes.shape({
     graphQLErrors: PropTypes.array,
@@ -124,7 +123,7 @@ ArticlePage.propTypes = {
 };
 
 ArticlePage.defaultProps = {
-  article: null,
+  ...articleDefaultProps,
   isLoading: false,
   error: null
 };

--- a/packages/article/article.js
+++ b/packages/article/article.js
@@ -16,7 +16,6 @@ import ArticleMeta from "./article-meta/article-meta";
 import ArticleRow from "./article-body/article-body-row";
 
 import articleTrackingContext from "./article-tracking-context";
-import {articlePropTypes} from "./article-proptype";
 
 const listViewPageSize = 1;
 const listViewSize = 10;

--- a/packages/article/article.web.js
+++ b/packages/article/article.web.js
@@ -5,7 +5,7 @@ import Ad, { AdComposer } from "@times-components/ad";
 
 import ArticleError from "./article-error";
 import ArticleLoading from "./article-loading";
-import ArticlePrototype from "./article-prototype";
+import { ArticlePrototype, ArticleDefaultProps } from "./article-prototype";
 import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
 import ArticleBody from "./article-body/article-body";
@@ -104,7 +104,7 @@ ArticlePage.propTypes = {
 };
 
 ArticlePage.defaultProps = {
-  article: null,
+  ...ArticleDefaultProps,
   isLoading: false,
   error: null
 };

--- a/packages/article/article.web.js
+++ b/packages/article/article.web.js
@@ -5,7 +5,7 @@ import Ad, { AdComposer } from "@times-components/ad";
 
 import ArticleError from "./article-error";
 import ArticleLoading from "./article-loading";
-import { ArticlePrototype, ArticleDefaultProps } from "./article-prototype";
+import { articlePropTypes, articleDefaultProps } from "./article-proptype";
 import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
 import ArticleBody from "./article-body/article-body";
@@ -91,7 +91,7 @@ class ArticlePage extends React.Component {
 }
 
 ArticlePage.propTypes = {
-  ...ArticlePrototype,
+  ...articlePropTypes,
   isLoading: PropTypes.bool,
   error: PropTypes.shape({
     graphQLErrors: PropTypes.array,
@@ -104,9 +104,10 @@ ArticlePage.propTypes = {
 };
 
 ArticlePage.defaultProps = {
-  ...ArticleDefaultProps,
+  ...articleDefaultProps,
   isLoading: false,
   error: null
 };
-export { ArticlePrototype };
+
+export { articlePropTypes };
 export default articleTrackingContext(ArticlePage);

--- a/packages/article/article.web.js
+++ b/packages/article/article.web.js
@@ -109,5 +109,4 @@ ArticlePage.defaultProps = {
   error: null
 };
 
-export { articlePropTypes };
 export default articleTrackingContext(ArticlePage);

--- a/packages/article/article.web.js
+++ b/packages/article/article.web.js
@@ -5,6 +5,7 @@ import Ad, { AdComposer } from "@times-components/ad";
 
 import ArticleError from "./article-error";
 import ArticleLoading from "./article-loading";
+import ArticlePrototype from "./article-prototype";
 import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
 import ArticleBody from "./article-body/article-body";
@@ -90,10 +91,7 @@ class ArticlePage extends React.Component {
 }
 
 ArticlePage.propTypes = {
-  article: PropTypes.shape({
-    ...ArticleHeader.propTypes,
-    ...ArticleMeta.propTypes
-  }),
+  ...ArticlePrototype,
   isLoading: PropTypes.bool,
   error: PropTypes.shape({
     graphQLErrors: PropTypes.array,
@@ -110,5 +108,5 @@ ArticlePage.defaultProps = {
   isLoading: false,
   error: null
 };
-
+export { ArticlePrototype };
 export default articleTrackingContext(ArticlePage);

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,19 +338,6 @@
     react-treebeard "^2.1.0"
     redux "^3.7.2"
 
-"@times-components/depend@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@times-components/depend/-/depend-0.1.0.tgz#71031aa7a158f2effb9033956d53cb266d7a4a29"
-  dependencies:
-    babel-plugin-transform-runtime "6.23.0"
-    babel-polyfill "6.26.0"
-    babel-runtime "6.26.0"
-    chalk "2.3.1"
-    commander "2.14.1"
-    fs-extra "5.0.0"
-    glob "7.1.2"
-    semver "5.5.0"
-
 "@times-components/fructose@3.1.14":
   version "3.1.14"
   resolved "https://registry.yarnpkg.com/@times-components/fructose/-/fructose-3.1.14.tgz#a31be85b619132431a46774f970b4146927156c1"


### PR DESCRIPTION
This PR exports article as an independent prop which can be used for validation in the consumers i.e. render