### PR TITLE
Moved dependency to dev dependency

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.1.3",
+    "@times-components/jest-configurator": "0.2.1",
     "eslint": "4.9.0",
     "jest": "21.2.1",
     "mkdirp": "0.5.1",
@@ -34,7 +35,6 @@
     "prettier": "1.8.2"
   },
   "dependencies": {
-    "@times-components/jest-configurator": "0.2.1",
     "apollo-cache-inmemory": "1.1.5",
     "apollo-client": "2.2.0",
     "graphql": "0.12.3",


### PR DESCRIPTION
`@times-components/config` had `@times-components/jest-configurator` as a dependency, it should be a dev dependency. Moved it to the correct section 😄 
