### PR TITLE
fix: pins ART to specific github version that supports ssr

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,5 +154,9 @@
   "dependencies": {
     "babel-preset-env": "1.6.1",
     "babel-preset-stage-2": "6.24.1"
+  },
+  "resolutions": {
+    "art": "git+https://github.com/sebmarkbage/art.git#658d84d424ee0bf385337fdc56d429a74b533b27" 
   }
 }
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,9 +842,9 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-art@^0.10.0, art@^0.10.1:
+art@^0.10.0, art@^0.10.1, "art@git+https://github.com/sebmarkbage/art.git#658d84d424ee0bf385337fdc56d429a74b533b27":
   version "0.10.1"
-  resolved "https://registry.yarnpkg.com/art/-/art-0.10.1.tgz#38541883e399225c5e193ff246e8f157cf7b2146"
+  resolved "git+https://github.com/sebmarkbage/art.git#658d84d424ee0bf385337fdc56d429a74b533b27"
 
 asap@~2.0.3:
   version "2.0.6"


### PR DESCRIPTION
art crashes the server as it does not check whether document exists.
Although it has been fixed upstream it has not been published to npm.
This PR works around this fact by resolving to a particular git commit.