### PR TITLE
fix: Put back the missing summary for Author Profiles with no images

### DIFF
--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -3925,6 +3925,32 @@ exports[`AuthorProfile test on android renders profile content item component wi
               Top medal for forces dog who took a bite out of the Taliban
             </Text>
             <Text
+              accessible={true}
+              allowFontScaling={true}
+              className=""
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#696969",
+                  "flexWrap": "wrap",
+                  "fontFamily": "TimesDigitalW04",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                  "marginBottom": 10,
+                }
+              }
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                
+                The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and
+                ...
+              </Text>
+            </Text>
+            <Text
               accessibilityLabel="datePublication"
               accessible={true}
               allowFontScaling={true}

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -201,6 +201,8 @@ export default AuthorProfileContent => {
   it("renders profile content item component with no image", () => {
     const item = cloneDeep(pagedResult(0, 1).data.author.articles.list[0]);
     set(item, "leadAsset.crop.url", null);
+    set(item, "shortSummary", item.summary)
+    set(item, "longSummary", item.summary)
     const component = renderer.create(
       <AuthorProfileItem {...item} imageRatio={20 / 3} onPress={() => {}} />
     );

--- a/packages/author-profile/__tests__/author-profile-helper.js
+++ b/packages/author-profile/__tests__/author-profile-helper.js
@@ -201,8 +201,8 @@ export default AuthorProfileContent => {
   it("renders profile content item component with no image", () => {
     const item = cloneDeep(pagedResult(0, 1).data.author.articles.list[0]);
     set(item, "leadAsset.crop.url", null);
-    set(item, "shortSummary", item.summary)
-    set(item, "longSummary", item.summary)
+    set(item, "shortSummary", item.summary);
+    set(item, "longSummary", item.summary);
     const component = renderer.create(
       <AuthorProfileItem {...item} imageRatio={20 / 3} onPress={() => {}} />
     );

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -3716,6 +3716,32 @@ exports[`AuthorProfile test on ios renders profile content item component with n
               Top medal for forces dog who took a bite out of the Taliban
             </Text>
             <Text
+              accessible={true}
+              allowFontScaling={true}
+              className=""
+              ellipsizeMode="tail"
+              style={
+                Object {
+                  "color": "#696969",
+                  "flexWrap": "wrap",
+                  "fontFamily": "TimesDigitalW04",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                  "marginBottom": 10,
+                }
+              }
+            >
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+              >
+                
+                The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and
+                ...
+              </Text>
+            </Text>
+            <Text
               accessibilityLabel="datePublication"
               accessible={true}
               allowFontScaling={true}

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-content.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-content.web.test.js.snap
@@ -1969,6 +1969,24 @@ exports[`AuthorProfile test on web renders profile content item component with n
                   Top medal for forces dog who took a bite out of the Taliban
                 </h3>
                 <div
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-flexWrap-1w6e6rj rn-font-1lw9tu2 rn-fontFamily-1feecvn rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  dir="auto"
+                  style={
+                    Object {
+                      "lineHeight": "20px",
+                    }
+                  }
+                >
+                  <span
+                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                    dir="auto"
+                  >
+                    
+                    The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and
+                    ...
+                  </span>
+                </div>
+                <div
                   aria-label="datePublication"
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
                   data-testid="datePublication"
@@ -2007,6 +2025,24 @@ exports[`AuthorProfile test on web renders profile content item component with n
                 >
                   Top medal for forces dog who took a bite out of the Taliban
                 </h3>
+                <div
+                  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-flexWrap-1w6e6rj rn-font-1lw9tu2 rn-fontFamily-1feecvn rn-fontSize-1b43r93 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-marginBottom-15d164r rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+                  dir="auto"
+                  style={
+                    Object {
+                      "lineHeight": "20px",
+                    }
+                  }
+                >
+                  <span
+                    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-irrty rn-wordWrap-qvutc0"
+                    dir="auto"
+                  >
+                    
+                    The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and
+                    ...
+                  </span>
+                </div>
                 <div
                   aria-label="datePublication"
                   className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-color-1x7yru4 rn-display-1471scf rn-font-1lw9tu2 rn-fontFamily-j2s0nr rn-fontSize-n6v787 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"

--- a/packages/author-profile/author-profile-item.web.js
+++ b/packages/author-profile/author-profile-item.web.js
@@ -108,7 +108,7 @@ const AuthorProfileItem = item => {
       <LongText>
         <ArticleSummary
           {...childProps}
-          summaryText={() => <ArticleSummaryContent ast={longSummary} />}
+          content={() => <ArticleSummaryContent ast={longSummary} />}
         />
       </LongText>
       <ShortText>


### PR DESCRIPTION
This is to fix REPLAT-1579 where on Author Profile pages with no images, we lose the summary text.
