### PR TITLE
fix: export article default props

### DIFF
--- a/packages/article/article.js
+++ b/packages/article/article.js
@@ -154,4 +154,5 @@ ArticlePage.defaultProps = {
   onRelatedArticlePress: () => {}
 };
 
+export { articlePropTypes, articleDefaultProps };
 export default articleTrackingContext(ArticlePage);

--- a/packages/article/article.web.js
+++ b/packages/article/article.web.js
@@ -120,4 +120,5 @@ ArticlePage.defaultProps = {
   error: null
 };
 
+export { articlePropTypes, articleDefaultProps };
 export default articleTrackingContext(ArticlePage);


### PR DESCRIPTION
This PR exposes article props which can be used for validation by the clients