### PR TITLE
fix: Fix the warning on Native devices when viewing Author Profile

### DIFF
--- a/packages/author-profile/author-profile-content.js
+++ b/packages/author-profile/author-profile-content.js
@@ -149,7 +149,7 @@ class AuthorProfileContent extends React.Component {
         testID="scroll-view"
         accessibilityID="scroll-view"
         data={data}
-        keyExtractor={item => item.id}
+        keyExtractor={item => `${item.id}`}
         renderItem={({ item, index }) => (
           <ErrorView>
             {({ hasError }) =>


### PR DESCRIPTION
The returned value from `keyExtractor` is expected to be a string. As a result a warning was being shown on Author Profile. This fixes this issue.