### PR TITLE
Add emulator to regex to match connected devices

### DIFF
--- a/lib/setup_device_connections.sh
+++ b/lib/setup_device_connections.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! adb devices -l | grep usb > /dev/null
+if ! adb devices -l | grep 'usb\|emulator' > /dev/null
 then
   echo "No devices connected"
   exit 1


### PR DESCRIPTION
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->

`yarn android:device` was working only with real devices connected via usb. This PR changes the matching pattern to allow also for emulators.