### PR TITLE
REPLAT-1675 - Enable fullscreen button for BrightcoveVideo

### DIFF
--- a/packages/brightcove-video/android/src/main/AndroidManifest.xml
+++ b/packages/brightcove-video/android/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 
     package="uk.co.news.rntbrightcovevideo">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application>
         <activity android:name=".BrightcovePlayerActivity"/>
     </application>
 

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerActivity.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerActivity.java
@@ -11,7 +11,7 @@ import com.brightcove.player.model.Video;
 import com.brightcove.player.view.BrightcovePlayer;
 
 public class BrightcovePlayerActivity extends BrightcovePlayer {
-    private final String TAG = this.getClass().getSimpleName();
+    private final String TAG = getClass().getSimpleName();
 
     private static final String PROP_ACCOUNT_ID = "accountId";
     private static final String PROP_POLICY_KEY = "policyKey";

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerJavaModule.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerJavaModule.java
@@ -7,7 +7,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 
-public class BrightcovePlayerJavaModule extends ReactContextBaseJavaModule {
+class BrightcovePlayerJavaModule extends ReactContextBaseJavaModule {
 
     private static final String PROP_ACCOUNT_ID = "accountId";
     private static final String PROP_POLICY_KEY = "policyKey";
@@ -15,7 +15,7 @@ public class BrightcovePlayerJavaModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext context;
 
-    public BrightcovePlayerJavaModule(ReactApplicationContext reactContext) {
+    BrightcovePlayerJavaModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.context = reactContext;
     }

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerJavaModule.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerJavaModule.java
@@ -7,16 +7,13 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 
-import javax.annotation.Nullable;
-
 public class BrightcovePlayerJavaModule extends ReactContextBaseJavaModule {
-    private final String TAG = this.getClass().getSimpleName();
-
-    private ReactApplicationContext context;
 
     private static final String PROP_ACCOUNT_ID = "accountId";
     private static final String PROP_POLICY_KEY = "policyKey";
     private static final String PROP_VIDEO_ID = "videoId";
+
+    private final ReactApplicationContext context;
 
     public BrightcovePlayerJavaModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -29,13 +26,13 @@ public class BrightcovePlayerJavaModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void playVideo(@Nullable ReadableMap video) {
-        Intent intent = new Intent(this.context, BrightcovePlayerActivity.class);
+    public void playVideo(ReadableMap video) {
+        Intent intent = new Intent(context, BrightcovePlayerActivity.class);
         intent.putExtra(PROP_ACCOUNT_ID, video.getString(PROP_ACCOUNT_ID));
         intent.putExtra(PROP_POLICY_KEY, video.getString(PROP_POLICY_KEY));
         intent.putExtra(PROP_VIDEO_ID, video.getString(PROP_VIDEO_ID));
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        this.context.startActivity(intent);
+        context.startActivity(intent);
     }
 
 }

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
@@ -22,7 +22,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
     private Boolean isFullscreen = false;
     private final float progress = 0;
 
-    public BrightcovePlayerView(final Context context) {
+    public BrightcovePlayerView(Context context) {
         super(context);
         setBackgroundColor(Color.BLACK);
         finishInitialization();
@@ -94,7 +94,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
         }
     }
 
-    public void initVideo(String videoId, String accountId, String policyKey, Boolean autoplay, Boolean isFullscreenButtonHidden) {
+    public void initVideo(String videoId, String accountId, String policyKey, Boolean autoplay) {
         this.autoplay = autoplay;
 
         EventEmitter eventEmitter = setupEventEmitter();

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
@@ -5,7 +5,6 @@ import android.graphics.Color;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.SurfaceView;
-import android.view.View;
 
 import com.brightcove.player.edge.Catalog;
 import com.brightcove.player.edge.VideoListener;
@@ -99,10 +98,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
     }
 
     public void initVideo(String videoId, String accountId, String policyKey, Boolean autoplay, Boolean isFullscreenButtonHidden) {
-            View fullScreenButton = this.findViewById(com.brightcove.player.R.id.full_screen);
-            fullScreenButton.setVisibility(isFullscreenButtonHidden ? View.GONE : View.VISIBLE);
-
-            mAutoplay = autoplay;
+        mAutoplay = autoplay;
 
             EventEmitter eventEmitter = setupEventEmitter();
 

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
@@ -17,10 +17,10 @@ import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 
 public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
 
-    private Boolean mAutoplay;
-    private Boolean mIsPlaying = false;
-    private Boolean mIsFullscreen = false;
-    private final float mProgress = 0;
+    private Boolean autoplay;
+    private Boolean isPlaying = false;
+    private Boolean isFullscreen = false;
+    private final float progress = 0;
 
     public BrightcovePlayerView(final Context context) {
         super(context);
@@ -57,7 +57,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
         eventEmitter.on(EventType.ENTER_FULL_SCREEN, new EventListener() {
             @Override
             public void processEvent(Event e) {
-                mIsFullscreen = true;
+                isFullscreen = true;
                 playerView.bubbleCurrentState();
                 playerView.getEventEmitter().emit(EventType.CONFIGURATION_CHANGED);
             }
@@ -65,7 +65,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
         eventEmitter.on(EventType.EXIT_FULL_SCREEN, new EventListener() {
             @Override
             public void processEvent(Event e) {
-                mIsFullscreen = false;
+                isFullscreen = false;
                 playerView.bubbleCurrentState();
                 playerView.getEventEmitter().emit(EventType.CONFIGURATION_CHANGED);
             }
@@ -84,18 +84,18 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
     }
 
     private void bubbleState(Boolean isPlaying, int headPos) {
-        mIsPlaying = isPlaying;
+        this.isPlaying = isPlaying;
 
         try {
             RNTBrightcoveView parentView = (RNTBrightcoveView) getParent();
-            parentView.emitState(mIsPlaying, headPos);
+            parentView.emitState(this.isPlaying, headPos);
         } catch (ClassCastException exc) {
             // ignore
         }
     }
 
     public void initVideo(String videoId, String accountId, String policyKey, Boolean autoplay, Boolean isFullscreenButtonHidden) {
-        mAutoplay = autoplay;
+        this.autoplay = autoplay;
 
         EventEmitter eventEmitter = setupEventEmitter();
 
@@ -121,12 +121,12 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
             public void onVideo(final Video video) {
                 add(video);
 
-                seekTo((int) mProgress);
+                seekTo((int) progress);
 
                 invalidate();
                 requestLayout();
 
-                if (mAutoplay) {
+                if (autoplay) {
                     start();
                 }
             }
@@ -156,11 +156,11 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
     }
 
     public Boolean getIsPlaying() {
-        return mIsPlaying;
+        return isPlaying;
     }
 
     public Boolean getIsFullscreen() {
-        return mIsFullscreen;
+        return isFullscreen;
     }
 
     public float getPlayheadPosition() {

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/BrightcovePlayerView.java
@@ -3,7 +3,6 @@ package uk.co.news.rntbrightcovevideo;
 import android.content.Context;
 import android.graphics.Color;
 import android.support.annotation.NonNull;
-import android.util.Log;
 import android.view.SurfaceView;
 
 import com.brightcove.player.edge.Catalog;
@@ -18,28 +17,26 @@ import com.brightcove.player.view.BrightcoveExoPlayerVideoView;
 
 public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
 
-    public static final String TAG = BrightcovePlayerView.class.getSimpleName();
-
     private Boolean mAutoplay;
     private Boolean mIsPlaying = false;
     private Boolean mIsFullscreen = false;
-    private float mProgress = 0;
+    private final float mProgress = 0;
 
     public BrightcovePlayerView(final Context context) {
         super(context);
-        this.setBackgroundColor(Color.BLACK);
+        setBackgroundColor(Color.BLACK);
         finishInitialization();
-        this.setMediaController(new BrightcoveMediaController(this));
+        setMediaController(new BrightcoveMediaController(this));
     }
 
     private EventEmitter setupEventEmitter() {
-        final BrightcovePlayerView playerView = BrightcovePlayerView.this;
+        final BrightcovePlayerView playerView = this;
 
-        EventEmitter eventEmitter = this.getEventEmitter();
+        EventEmitter eventEmitter = getEventEmitter();
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
             @Override
             public void processEvent(Event e) {
-               fixVideoLayout();
+                fixVideoLayout();
             }
         });
         eventEmitter.on(EventType.PLAY, onEvent(true));
@@ -90,7 +87,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
         mIsPlaying = isPlaying;
 
         try {
-            RNTBrightcoveView parentView = (RNTBrightcoveView) this.getParent();
+            RNTBrightcoveView parentView = (RNTBrightcoveView) getParent();
             parentView.emitState(mIsPlaying, headPos);
         } catch (ClassCastException exc) {
             // ignore
@@ -100,14 +97,14 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
     public void initVideo(String videoId, String accountId, String policyKey, Boolean autoplay, Boolean isFullscreenButtonHidden) {
         mAutoplay = autoplay;
 
-            EventEmitter eventEmitter = setupEventEmitter();
+        EventEmitter eventEmitter = setupEventEmitter();
 
-            Catalog catalog = new Catalog(eventEmitter, accountId, policyKey);
-            catalog.findVideoByID(videoId, createVideoListener());
+        Catalog catalog = new Catalog(eventEmitter, accountId, policyKey);
+        catalog.findVideoByID(videoId, createVideoListener());
     }
 
     private EventListener onEvent(final Boolean isPlaying) {
-        final BrightcovePlayerView playerView = BrightcovePlayerView.this;
+        final BrightcovePlayerView playerView = this;
 
         return new EventListener() {
             @Override
@@ -122,27 +119,25 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
         return new VideoListener() {
             @Override
             public void onVideo(final Video video) {
-                BrightcovePlayerView.this.add(video);
+                add(video);
 
-                BrightcovePlayerView.this.seekTo((int) mProgress);
+                seekTo((int) mProgress);
 
-                BrightcovePlayerView.this.invalidate();
-                BrightcovePlayerView.this.requestLayout();
+                invalidate();
+                requestLayout();
 
                 if (mAutoplay) {
-                    BrightcovePlayerView.this.start();
+                    start();
                 }
             }
         };
     }
 
     private void fixVideoLayout() {
-        Log.d(TAG, "fixVideoLayout");
+        final int viewW = getMeasuredWidth();
+        final int viewH = getMeasuredHeight();
 
-        final int viewW = this.getMeasuredWidth();
-        final int viewH = this.getMeasuredHeight();
-
-        SurfaceView surfaceView = (SurfaceView) this.getRenderView();
+        SurfaceView surfaceView = (SurfaceView) getRenderView();
 
         surfaceView.measure(viewW, viewH);
 
@@ -163,6 +158,7 @@ public class BrightcovePlayerView extends BrightcoveExoPlayerVideoView {
     public Boolean getIsPlaying() {
         return mIsPlaying;
     }
+
     public Boolean getIsFullscreen() {
         return mIsFullscreen;
     }

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveManager.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveManager.java
@@ -14,8 +14,8 @@ import javax.annotation.Nullable;
 
 public class RNTBrightcoveManager extends SimpleViewManager<RNTBrightcoveView> {
 
-    public static final String TAG = RNTBrightcoveManager.class.getSimpleName();
-    public static final String REACT_CLASS = "RNTBrightcove";
+    private static final String TAG = RNTBrightcoveManager.class.getSimpleName();
+    private static final String REACT_CLASS = "RNTBrightcove";
     private static final String PLAY_KEY = "play";
     private static final String PAUSE_KEY = "pause";
     private static final int PLAY_VALUE = 1;

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
@@ -28,7 +28,7 @@ public class RNTBrightcoveView extends FrameLayout {
 
     public RNTBrightcoveView(final ThemedReactContext context) {
         super(context);
-        this.setBackgroundColor(Color.BLACK);
+        setBackgroundColor(Color.BLACK);
     }
 
     @Override
@@ -101,9 +101,9 @@ public class RNTBrightcoveView extends FrameLayout {
         Context context = getContext();
         while (context instanceof ContextWrapper) {
             if (context instanceof Activity) {
-                return (Activity)context;
+                return (Activity) context;
             }
-            context = ((ContextWrapper)context).getBaseContext();
+            context = ((ContextWrapper) context).getBaseContext();
         }
         return null;
     }

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.util.Log;
 import android.widget.FrameLayout;
 
 import com.brightcove.player.event.Event;
@@ -17,14 +16,12 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class RNTBrightcoveView extends FrameLayout {
-    public static final String TAG = RNTBrightcoveView.class.getSimpleName();
-
-    private String mVideoId;
-    private String mAccountId;
-    private String mPolicyKey;
-    private Boolean mAutoplay;
-    private Boolean mHideFullScreenButton;
-    private BrightcovePlayerView mPlayerView;
+    private String videoId;
+    private String accountId;
+    private String policyKey;
+    private Boolean autoplay;
+    private Boolean hideFullScreenButton;
+    private BrightcovePlayerView playerView;
 
     public RNTBrightcoveView(final ThemedReactContext context) {
         super(context);
@@ -33,66 +30,62 @@ public class RNTBrightcoveView extends FrameLayout {
 
     @Override
     protected void onConfigurationChanged(Configuration newConfig) {
-        Log.d(TAG, "onConfigurationChanged");
-
-        mPlayerView.getEventEmitter().emit(EventType.CONFIGURATION_CHANGED);
+        playerView.getEventEmitter().emit(EventType.CONFIGURATION_CHANGED);
 
         super.onConfigurationChanged(newConfig);
     }
 
     public void play() {
-        mPlayerView.start();
+        playerView.start();
     }
 
     public void pause() {
-        mPlayerView.pause();
+        playerView.pause();
     }
 
     public void setVideoId(final String videoId) {
-        if (mVideoId == null) {
-            mVideoId = videoId;
+        if (this.videoId == null) {
+            this.videoId = videoId;
             initPlayerView();
         }
     }
 
     public void setAccountId(final String accountId) {
-        if (mAccountId == null) {
-            mAccountId = accountId;
+        if (this.accountId == null) {
+            this.accountId = accountId;
             initPlayerView();
         }
     }
 
     public void setPolicyKey(final String policyKey) {
-        if (mPolicyKey == null) {
-            mPolicyKey = policyKey;
+        if (this.policyKey == null) {
+            this.policyKey = policyKey;
             initPlayerView();
         }
     }
 
     public void setAutoplay(final Boolean autoplay) {
-        if (mAutoplay == null) {
-            mAutoplay = autoplay;
+        if (this.autoplay == null) {
+            this.autoplay = autoplay;
             initPlayerView();
         }
     }
 
     public void setHideFullScreenButton(final Boolean hideFullScreenButton) {
-        if (mHideFullScreenButton == null) {
-            mHideFullScreenButton = hideFullScreenButton;
+        if (this.hideFullScreenButton == null) {
+            this.hideFullScreenButton = hideFullScreenButton;
             initPlayerView();
         }
     }
 
     private void initPlayerView() {
         if (parametersSet()) {
-            Log.d(TAG, "adding player view");
+            playerView = new BrightcovePlayerView(getActivity());
 
-            mPlayerView = new BrightcovePlayerView(getActivity());
+            addView(playerView);
 
-            addView(mPlayerView);
-
-            boolean isFullscreenButtonHidden = mHideFullScreenButton != null ? mHideFullScreenButton : false;
-            mPlayerView.initVideo(mVideoId, mAccountId, mPolicyKey, mAutoplay, isFullscreenButtonHidden);
+            boolean isFullscreenButtonHidden = hideFullScreenButton != null ? hideFullScreenButton : false;
+            playerView.initVideo(videoId, accountId, policyKey, autoplay, isFullscreenButtonHidden);
         }
     }
 
@@ -112,10 +105,10 @@ public class RNTBrightcoveView extends FrameLayout {
         WritableMap event = Arguments.createMap();
 
         if (isPlaying != null) {
-            Integer duration = mPlayerView.getDuration();
+            Integer duration = playerView.getDuration();
 
             event.putBoolean("isPlaying", isPlaying);
-            event.putBoolean("isFullscreen", mPlayerView.getIsFullscreen());
+            event.putBoolean("isFullscreen", playerView.getIsFullscreen());
             event.putDouble("progress", progress);
 
             if (duration > 0) {
@@ -137,6 +130,6 @@ public class RNTBrightcoveView extends FrameLayout {
     }
 
     private boolean parametersSet() {
-        return mVideoId != null && mAccountId != null && mPolicyKey != null && mAutoplay != null && mHideFullScreenButton != null;
+        return videoId != null && accountId != null && policyKey != null && autoplay != null && hideFullScreenButton != null;
     }
 }

--- a/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
+++ b/packages/brightcove-video/android/src/main/java/uk/co/news/rntbrightcovevideo/RNTBrightcoveView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.view.ContextThemeWrapper;
 import android.widget.FrameLayout;
 
 import com.brightcove.player.event.Event;
@@ -80,12 +81,15 @@ public class RNTBrightcoveView extends FrameLayout {
 
     private void initPlayerView() {
         if (parametersSet()) {
-            playerView = new BrightcovePlayerView(getActivity());
+            boolean hideFullScreenButton = this.hideFullScreenButton != null ? this.hideFullScreenButton : false;
+            int theme = hideFullScreenButton ? R.style.FullScreenButtonDisabled : R.style.FullScreenButtonEnabled;
+
+            playerView = new BrightcovePlayerView(new ContextThemeWrapper(getActivity(), theme));
+
 
             addView(playerView);
 
-            boolean isFullscreenButtonHidden = hideFullScreenButton != null ? hideFullScreenButton : false;
-            playerView.initVideo(videoId, accountId, policyKey, autoplay, isFullscreenButtonHidden);
+            playerView.initVideo(videoId, accountId, policyKey, autoplay);
         }
     }
 

--- a/packages/brightcove-video/android/src/main/res/values/strings.xml
+++ b/packages/brightcove-video/android/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">RNTBrightcoveVideo</string>
-</resources>

--- a/packages/brightcove-video/android/src/main/res/values/styles.xml
+++ b/packages/brightcove-video/android/src/main/res/values/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BrightcoveControlBar" parent="BrightcoveControlBarDefault">
+        <item name="brightcove_full_screen">?attr/brightcove_full_screen</item>
+    </style>
+    <style name="FullScreenButtonEnabled">
+        <item name="brightcove_full_screen">true</item>
+    </style>
+    <style name="FullScreenButtonDisabled">
+        <item name="brightcove_full_screen">false</item>
+    </style>
+</resources>

--- a/packages/brightcove-video/android/src/main/res/values/styles.xml
+++ b/packages/brightcove-video/android/src/main/res/values/styles.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- This is used to style the buttons on the media controller -->
-    <style name="BrightcoveControlBar" parent="BrightcoveControlBarDefault">
-        <!-- You can override values as shown here. The commented variables have the default values
-             It's recommended to parent BrightcoveControlBarDefault -->
-        <item name="brightcove_full_screen">false</item>
-    </style>
-</resources>


### PR DESCRIPTION
The fullscreen button for `BrightcoveVideo` was disabled. This PR re-enables it.

Done also some code cleanup since I was at it, the main change is 21e49c0

| Before | After |
| --- | --- |
| ![brightcove_before](https://user-images.githubusercontent.com/1263058/37720561-7197e134-2d1f-11e8-95c6-b76e8678b5e0.png) | ![brightcove_after](https://user-images.githubusercontent.com/1263058/37720383-102c0006-2d1f-11e8-8a6e-d4b5decfa622.png) |