### PR TITLE
fix: Remove StyleSheet.hairlineWidth in a styled component

### DIFF
--- a/packages/slice/templates/styles/responsive.web.js
+++ b/packages/slice/templates/styles/responsive.web.js
@@ -7,7 +7,7 @@ export const SliceContainer = withResponsiveStyles(View, {
     align-items: center;
     border-style: solid;
     border-bottom-color: ${colours.functional.keyline};
-    border-bottom-width: ${StyleSheet.hairlineWidth}px;
+    border-bottom-width: 1px;
     flex: 1;
     justify-content: center;
   `


### PR DESCRIPTION
Remove StyleSheet.hairlineWidth in a styled component as it breaks article component in render