### PR TITLE
chore: Clean up press events for articles

### DIFF
--- a/packages/article-byline/article-byline.js
+++ b/packages/article-byline/article-byline.js
@@ -25,7 +25,7 @@ const ArticleByline = ({ ast, style, onAuthorPress }) =>
           style={[linkStyles.link, style.link]}
           key={key}
           url={url}
-          onPress={() => onAuthorPress({ slug: attributes.slug, url })}
+          onPress={e => onAuthorPress(e, { slug: attributes.slug, url })}
         >
           {children}
         </TextLink>

--- a/packages/article-byline/article-byline.stories.js
+++ b/packages/article-byline/article-byline.stories.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Text } from "react-native";
 import { storiesOf } from "@storybook/react-native";
 import { fonts, colours, fontSizes } from "@times-components/styleguide";
+import { decorateAction } from "@storybook/addon-actions";
 import ArticleByline from "./article-byline";
 
 const authorsAST = require("./fixtures/authors.json");
@@ -14,6 +15,13 @@ const bylineStyles = {
   flexDirection: "row"
 };
 
+const preventDefaultedAction = decorateAction([
+  ([e, ...args]) => {
+    e.preventDefault();
+    return ["[SyntheticEvent (storybook prevented default)]", ...args];
+  }
+]);
+
 const bylineLinkStyles = {
   link: {
     color: colours.functional.action,
@@ -24,27 +32,42 @@ const bylineLinkStyles = {
 storiesOf("Primitives/ArticleByline", module)
   .add("ArticleByline with a single author", () => (
     <Text style={bylineStyles}>
-      <ArticleByline ast={authorsAST.singleAuthor} />
+      <ArticleByline
+        ast={authorsAST.singleAuthor}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
+      />
     </Text>
   ))
   .add("ArticleByline with a text only element", () => (
     <Text style={bylineStyles}>
-      <ArticleByline ast={authorsAST.singleInlineElement} />
+      <ArticleByline
+        ast={authorsAST.singleInlineElement}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
+      />
     </Text>
   ))
   .add("ArticleByline with multiple authors", () => (
     <Text style={bylineStyles}>
-      <ArticleByline ast={authorsAST.multipleAuthorsCommaSeparated} />
+      <ArticleByline
+        ast={authorsAST.multipleAuthorsCommaSeparated}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
+      />
     </Text>
   ))
   .add("ArticleByline with author in the beginning", () => (
     <Text style={bylineStyles}>
-      <ArticleByline ast={authorsAST.authorInTheBeginning} />
+      <ArticleByline
+        ast={authorsAST.authorInTheBeginning}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
+      />
     </Text>
   ))
   .add("ArticleByline with author at the end", () => (
     <Text style={bylineStyles}>
-      <ArticleByline ast={authorsAST.authorAtTheEnd} />
+      <ArticleByline
+        ast={authorsAST.authorAtTheEnd}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
+      />
     </Text>
   ))
   .add("ArticleByline with styles", () => (
@@ -52,6 +75,7 @@ storiesOf("Primitives/ArticleByline", module)
       <ArticleByline
         ast={authorsAST.multipleAuthorsCommaSeparated}
         style={bylineLinkStyles}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
       />
     </Text>
   ));

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -32,6 +32,8 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
+    "@storybook/addon-actions": "3.3.15",
+    "@storybook/addons": "3.3.15",
     "@storybook/react-native": "3.3.15",
     "@times-components/eslint-config-thetimes": "0.1.4",
     "@times-components/jest-configurator": "0.2.2",

--- a/packages/article/__tests__/related-articles-shared.js
+++ b/packages/article/__tests__/related-articles-shared.js
@@ -3,8 +3,10 @@ import "react-native";
 import React from "react";
 import renderer from "react-test-renderer";
 import mockDate from "mockdate";
+import { shallow } from "enzyme";
 
 import RelatedArticles from "../related-articles/related-articles";
+import RelatedArticleItem from "../related-articles/related-article-item";
 
 import standard1ArticleFixture from "../related-articles/fixtures/standard/1-article.json";
 import standard2ArticlesFixture from "../related-articles/fixtures/standard/2-articles.json";
@@ -13,7 +15,11 @@ import leadAndTwo1ArticleFixture from "../related-articles/fixtures/leadandtwo/1
 import leadAndTwo2ArticlesFixture from "../related-articles/fixtures/leadandtwo/2-articles.json";
 import leadAndTwo3ArticlesFixture from "../related-articles/fixtures/leadandtwo/3-articles.json";
 
-const createRelatedArticlesProps = (fixtureData, action = () => {}) => ({
+const createRelatedArticlesProps = (
+  fixtureData,
+  action = () => {},
+  onPress = () => {}
+) => ({
   analyticsStream: action,
   articles: fixtureData.relatedArticles,
   template: fixtureData.relatedArticlesLayout.template,
@@ -21,7 +27,7 @@ const createRelatedArticlesProps = (fixtureData, action = () => {}) => ({
     fixtureData.relatedArticlesLayout.lead ||
     fixtureData.relatedArticlesLayout.opinion ||
     "",
-  onPress: () => {}
+  onPress
 });
 
 export default () => {
@@ -170,6 +176,29 @@ export default () => {
       expect(events.mock.calls).toMatchSnapshot(
         "should send analytics for lead and two support related articles"
       );
+    });
+  });
+
+  it("callback triggered on related article press", () => {
+    const onRelatedArticlePress = jest.fn();
+    const article = standard1ArticleFixture.data.relatedArticles[0];
+
+    const component = shallow(
+      <RelatedArticleItem
+        article={article}
+        onPress={onRelatedArticlePress}
+        summaryConfig={{}}
+      />
+    );
+
+    const eventMock = {};
+    component
+      .find("Link")
+      .at(0)
+      .simulate("press", eventMock);
+
+    expect(onRelatedArticlePress).toHaveBeenCalledWith(eventMock, {
+      url: article.url
     });
   });
 };

--- a/packages/article/__tests__/shared.js
+++ b/packages/article/__tests__/shared.js
@@ -74,7 +74,13 @@ export default () => {
   it("renders activity indicator ", () => {
     const tree = renderer
       .create(
-        <Article isLoading analyticsStream={() => {}} adConfig={adConfig} />
+        <Article
+          isLoading
+          analyticsStream={() => {}}
+          adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
+        />
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
@@ -86,7 +92,13 @@ export default () => {
     };
 
     const tree = renderer.create(
-      <Article {...props} analyticsStream={() => {}} adConfig={adConfig} />
+      <Article
+        {...props}
+        analyticsStream={() => {}}
+        adConfig={adConfig}
+        onRelatedArticlePress={() => {}}
+        onAuthorPress={() => {}}
+      />
     );
     expect(tree).toMatchSnapshot();
   });
@@ -98,6 +110,8 @@ export default () => {
           {...fullArticleFixture.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -111,6 +125,8 @@ export default () => {
           {...articleFixtureNoFlags.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -124,6 +140,8 @@ export default () => {
           {...articleFixtureNoLabel.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -137,6 +155,8 @@ export default () => {
           {...articleFixtureNoStandfirst.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -150,6 +170,8 @@ export default () => {
           {...articleFixtureNoStandfirstNoFlags.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -163,6 +185,8 @@ export default () => {
           {...articleFixtureNoStandfirstNoLabel.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -175,6 +199,8 @@ export default () => {
           {...articleFixtureNoLabelNoFlags.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -187,6 +213,8 @@ export default () => {
           {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -200,6 +228,8 @@ export default () => {
           {...articleFixtureWithVideo.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();
@@ -213,6 +243,8 @@ export default () => {
         {...fullArticleFixture.data}
         analyticsStream={stream}
         adConfig={adConfig}
+        onRelatedArticlePress={() => {}}
+        onAuthorPress={() => {}}
       />
     );
     expect(stream).toHaveBeenCalledWith({

--- a/packages/article/__tests__/web/article.web.test.js
+++ b/packages/article/__tests__/web/article.web.test.js
@@ -60,6 +60,8 @@ describe("Article test on web", () => {
           {...articleFixtureNoLeadAsset.data}
           analyticsStream={() => {}}
           adConfig={adConfig}
+          onRelatedArticlePress={() => {}}
+          onAuthorPress={() => {}}
         />
       )
       .toJSON();

--- a/packages/article/article.js
+++ b/packages/article/article.js
@@ -158,16 +158,14 @@ ArticlePage.propTypes = {
     message: PropTypes.string
   }),
   adConfig: PropTypes.shape({}).isRequired,
-  onRelatedArticlePress: PropTypes.func,
-  onAuthorPress: PropTypes.func
+  onRelatedArticlePress: PropTypes.func.isRequired,
+  onAuthorPress: PropTypes.func.isRequired
 };
 
 ArticlePage.defaultProps = {
   ...articleDefaultProps,
   isLoading: false,
-  error: null,
-  onRelatedArticlePress: () => {},
-  onAuthorPress: () => {}
+  error: null
 };
 
 export { articlePropTypes, articleDefaultProps };

--- a/packages/article/article.stories.js
+++ b/packages/article/article.stories.js
@@ -120,7 +120,9 @@ storiesOf("Pages/Article", module)
       ...fullArticleFixture.data,
       isLoading: false,
       analyticsStream: storybookReporter,
-      adConfig
+      adConfig,
+      onRelatedArticlePress: preventDefaultedAction("onRelatedArticlePress"),
+      onAuthorPress: preventDefaultedAction("onAuthorPress")
     };
 
     return <Article {...props} />;
@@ -130,7 +132,9 @@ storiesOf("Pages/Article", module)
       ...articleWithVideoFixture.data,
       isLoading: false,
       analyticsStream: storybookReporter,
-      adConfig
+      adConfig,
+      onRelatedArticlePress: preventDefaultedAction("onRelatedArticlePress"),
+      onAuthorPress: preventDefaultedAction("onAuthorPress")
     };
 
     return <Article {...props} />;
@@ -140,7 +144,9 @@ storiesOf("Pages/Article", module)
       ...fullLongArticleFixture.data,
       isLoading: false,
       analyticsStream: storybookReporter,
-      adConfig
+      adConfig,
+      onRelatedArticlePress: preventDefaultedAction("onRelatedArticlePress"),
+      onAuthorPress: preventDefaultedAction("onAuthorPress")
     };
 
     return <Article {...props} />;
@@ -149,7 +155,9 @@ storiesOf("Pages/Article", module)
     const props = {
       analyticsStream: storybookReporter,
       isLoading: true,
-      adConfig
+      adConfig,
+      onRelatedArticlePress: preventDefaultedAction("onRelatedArticlePress"),
+      onAuthorPress: preventDefaultedAction("onAuthorPress")
     };
 
     return <Article {...props} />;
@@ -175,6 +183,10 @@ storiesOf("Pages/Article", module)
             error={error}
             analyticsStream={storybookReporter}
             adConfig={adConfig}
+            onRelatedArticlePress={preventDefaultedAction(
+              "onRelatedArticlePress"
+            )}
+            onAuthorPress={preventDefaultedAction("onAuthorPress")}
           />
         )}
       </ArticleProvider>
@@ -196,6 +208,10 @@ storiesOf("Pages/Article", module)
             {...fullArticleFixture.data}
             analyticsStream={storybookReporter}
             adConfig={adConfig}
+            onRelatedArticlePress={preventDefaultedAction(
+              "onRelatedArticlePress"
+            )}
+            onAuthorPress={preventDefaultedAction("onAuthorPress")}
           />
         </div>
       );
@@ -206,6 +222,8 @@ storiesOf("Pages/Article", module)
         {...fullArticleFixture.data}
         analyticsStream={storybookReporter}
         adConfig={adConfig}
+        onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+        onAuthorPress={preventDefaultedAction("onAuthorPress")}
       />
     );
   })
@@ -214,6 +232,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoAds.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No standfirst", () => (
@@ -221,6 +241,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoStandfirst.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No label", () => (
@@ -228,6 +250,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoLabel.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No flags", () => (
@@ -235,6 +259,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoFlags.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No standfirst, no label", () => (
@@ -242,6 +268,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoStandfirstNoLabel.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No standfirst, no flags", () => (
@@ -249,6 +277,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoStandfirstNoFlags.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No label, no flags", () => (
@@ -256,6 +286,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoLabelNoFlags.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No label, no flags, no standfirst", () => (
@@ -263,6 +295,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Fixtures - No lead asset", () => (
@@ -270,6 +304,8 @@ storiesOf("Pages/Article", module)
       {...articleFixtureNoLeadAsset.data}
       analyticsStream={storybookReporter}
       adConfig={adConfig}
+      onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
+      onAuthorPress={preventDefaultedAction("onAuthorPress")}
     />
   ))
   .add("Default template with one related article", () => (

--- a/packages/article/article.web.js
+++ b/packages/article/article.web.js
@@ -28,7 +28,7 @@ const adStyle = {
 };
 
 class ArticlePage extends React.Component {
-  static renderArticle(articleData) {
+  static renderArticle(articleData, onRelatedArticlePress, onAuthorPress) {
     const {
       headline,
       flags,
@@ -51,7 +51,7 @@ class ArticlePage extends React.Component {
           analyticsStream={() => {}}
           articles={relatedArticles}
           template={relatedArticlesLayout.template}
-          onPress={() => null}
+          onPress={onRelatedArticlePress}
         />
       ) : null;
 
@@ -75,6 +75,7 @@ class ArticlePage extends React.Component {
               byline={byline}
               publishedTime={publishedTime}
               publicationName={publicationName}
+              onAuthorPress={onAuthorPress}
             />
             <Topics topics={topics} device="DESKTOP" />
           </MetaContainer>
@@ -95,7 +96,12 @@ class ArticlePage extends React.Component {
   }
 
   render() {
-    const { error, isLoading } = this.props;
+    const {
+      error,
+      isLoading,
+      onRelatedArticlePress,
+      onAuthorPress
+    } = this.props;
 
     if (error) {
       return <ArticleError {...error} />;
@@ -107,7 +113,11 @@ class ArticlePage extends React.Component {
 
     return (
       <AdComposer adConfig={this.props.adConfig}>
-        {ArticlePage.renderArticle(this.props.article)}
+        {ArticlePage.renderArticle(
+          this.props.article,
+          onRelatedArticlePress,
+          onAuthorPress
+        )}
       </AdComposer>
     );
   }
@@ -123,7 +133,8 @@ ArticlePage.propTypes = {
     }),
     message: PropTypes.string
   }),
-  adConfig: PropTypes.shape({}).isRequired
+  adConfig: PropTypes.shape({}).isRequired,
+  onRelatedArticlePress: PropTypes.func.isRequired
 };
 
 ArticlePage.defaultProps = {

--- a/packages/article/related-articles/related-article-item.js
+++ b/packages/article/related-articles/related-article-item.js
@@ -34,7 +34,7 @@ const RelatedArticleItem = ({
   );
 
   return (
-    <Link url={url} onPress={onPress}>
+    <Link url={url} onPress={e => onPress(e, { url: article.url })}>
       <Card
         contentContainerClass={contentContainerClass}
         imageContainerClass={imageContainerClass}

--- a/packages/article/related-articles/related-articles.js
+++ b/packages/article/related-articles/related-articles.js
@@ -31,7 +31,7 @@ const RelatedArticles = ({ articles, mainId, onPress, template }) => {
         headlineClass={headlineClass}
         id={article.id}
         imageContainerClass={imageContainerClass}
-        onPress={() => onPress({ url: article.url })}
+        onPress={e => onPress(e, { url: article.url })}
         showImage={showImage}
         showSummary={showSummary}
         summaryConfig={summaryConfig}

--- a/packages/article/related-articles/related-articles.js
+++ b/packages/article/related-articles/related-articles.js
@@ -31,7 +31,7 @@ const RelatedArticles = ({ articles, mainId, onPress, template }) => {
         headlineClass={headlineClass}
         id={article.id}
         imageContainerClass={imageContainerClass}
-        onPress={e => onPress(e, { url: article.url })}
+        onPress={onPress}
         showImage={showImage}
         showSummary={showSummary}
         summaryConfig={summaryConfig}


### PR DESCRIPTION
Standardized onPress events for article-bylines and related articles and added addon-actions for
storybook to prevent default actions and log the event