### PR TITLE
Add filter to depend

### DIFF
--- a/packages/depend/__tests__/__snapshots__/cli.test.js.snap
+++ b/packages/depend/__tests__/__snapshots__/cli.test.js.snap
@@ -79,3 +79,18 @@ Array [
   ],
 ]
 `;
+
+exports[`depend cli tests restricts to only requested packages 1`] = `
+Array [
+  Array [
+    "1",
+    "a",
+    "1.0.1 1.0.0",
+  ],
+  Array [
+    "2",
+    "b",
+    "2.0.0",
+  ],
+]
+`;

--- a/packages/depend/__tests__/cli.test.js
+++ b/packages/depend/__tests__/cli.test.js
@@ -121,4 +121,15 @@ describe("depend cli tests", () => {
     expect(readJson.mock.calls).toEqual([["lerna.json"]]);
     expect(getPackages.mock.calls).toEqual([["*/package.json"]]);
   });
+
+  it("restricts to only requested packages", async () => {
+    const exit = jest.fn();
+    const log = jest.fn();
+    const argv = { list: 1, expr: "*", only: "{a,b}" };
+    const getPackages = () => divergent;
+
+    await main({ log, argv, getPackages, exit });
+    expect(exit.mock.calls).toEqual([]);
+    expect(log.mock.calls).toMatchSnapshot();
+  })
 });

--- a/packages/depend/__tests__/cli.test.js
+++ b/packages/depend/__tests__/cli.test.js
@@ -131,5 +131,5 @@ describe("depend cli tests", () => {
     await main({ log, argv, getPackages, exit });
     expect(exit.mock.calls).toEqual([]);
     expect(log.mock.calls).toMatchSnapshot();
-  })
+  });
 });

--- a/packages/depend/cli-parser.js
+++ b/packages/depend/cli-parser.js
@@ -47,7 +47,10 @@ export default commander
     "how to resolve conflicts. possible strategies: conservative, progressive, majority, majorityConservative, majorityProgressive",
     validateStrategies
   )
-  .option("-on --only", "glob expression that restricts dependencies to process")
+  .option(
+    "-on --only",
+    "glob expression that restricts dependencies to process"
+  )
   .option("-f --fix", "fixed dependencies with wrong versions")
   .option("-sr --show-rules", "prints rules that will be applied")
   .option("-l --list", "prints all dependencies in use")

--- a/packages/depend/cli-parser.js
+++ b/packages/depend/cli-parser.js
@@ -47,6 +47,7 @@ export default commander
     "how to resolve conflicts. possible strategies: conservative, progressive, majority, majorityConservative, majorityProgressive",
     validateStrategies
   )
+  .option("-on --only", "glob expression that restricts dependencies to process")
   .option("-f --fix", "fixed dependencies with wrong versions")
   .option("-sr --show-rules", "prints rules that will be applied")
   .option("-l --list", "prints all dependencies in use")

--- a/packages/depend/depend.js
+++ b/packages/depend/depend.js
@@ -1,4 +1,5 @@
 import "babel-polyfill";
+import minimatch from "minimatch";
 
 const { keys, values, entries } = Object;
 const toObject = (a, b) => ({ ...a, ...b });
@@ -188,11 +189,20 @@ export function applyStrategy(requirements, strategy) {
   };
 }
 
-export default async function compute(packagesList, strategy, overrides = {}) {
+export function restrictRequirements(requirements, expr) {
+  const filter = expr
+    ? name => minimatch(name, expr)
+    : () => true;
+
+  return requirements.filter(requirement => filter(requirement.requires.name));
+}
+
+export default async function compute(packagesList, strategy, filter, overrides = {}) {
   const packages = packagesList.map(p => p[1]);
   const requirements = getAllRequirements(packages);
+  const targetRequirements = restrictRequirements(requirements, filter);
 
-  const { versionSets, resolved } = applyStrategy(requirements, strategy);
+  const { versionSets, resolved } = applyStrategy(targetRequirements, strategy);
 
   const wrong = findWrongVersions(packages);
   const rules = createRules(resolved, wrong);
@@ -205,7 +215,7 @@ export default async function compute(packagesList, strategy, overrides = {}) {
   const suggestions = getSuggestions(todo);
 
   return {
-    requirements,
+    requirements: targetRequirements,
     versionSets,
     wrong,
     rules,

--- a/packages/depend/depend.js
+++ b/packages/depend/depend.js
@@ -190,14 +190,17 @@ export function applyStrategy(requirements, strategy) {
 }
 
 export function restrictRequirements(requirements, expr) {
-  const filter = expr
-    ? name => minimatch(name, expr)
-    : () => true;
+  const filter = expr ? name => minimatch(name, expr) : () => true;
 
   return requirements.filter(requirement => filter(requirement.requires.name));
 }
 
-export default async function compute(packagesList, strategy, filter, overrides = {}) {
+export default async function compute(
+  packagesList,
+  strategy,
+  filter,
+  overrides = {}
+) {
   const packages = packagesList.map(p => p[1]);
   const requirements = getAllRequirements(packages);
   const targetRequirements = restrictRequirements(requirements, filter);

--- a/packages/depend/main.js
+++ b/packages/depend/main.js
@@ -49,6 +49,7 @@ export default async function main({
   return depend(
     packagesList,
     argv.strategy ? strategies[argv.strategy] : null,
+    argv.only,
     pickOverride(argv.pick)
   )
     .then(

--- a/packages/depend/package.json
+++ b/packages/depend/package.json
@@ -66,6 +66,7 @@
     "commander": "2.14.1",
     "fs-extra": "5.0.0",
     "glob": "7.1.2",
+    "minimatch": "3.0.4",
     "semver": "5.5.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8116,7 +8116,7 @@ minimatch@0.3.0:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:


### PR DESCRIPTION
This PR adds an `--only` or `-on` (I went for `-on` instead of `-o` cause `-o` is usually used for output, could also just remove it) flag to restrict the packages on which `depends` act on.

The rationale behind that is that sometimes we're not interested in the whole deps graph, sometimes we are.

Talking to @nikhedonia it seems like in web implementations, for example, we want all the packages to be aligned because some CSS classes will be otherwise referring to different versions (so different styles), in native implementations, we're mostly interested in libraries that have a native library to be included on the project (e.g. `react-native-linear-gradient`), because there's only one entry point for these. The rest is ok because it'll simply be included with different versions in different packages.