### PR TITLE
feat: Inline article link callbacks for native

### DIFF
--- a/packages/article/article.stories.js
+++ b/packages/article/article.stories.js
@@ -135,6 +135,7 @@ const RenderArticle = ({
       onRelatedArticlePress={preventDefaultedAction("onRelatedArticlePress")}
       onAuthorPress={preventDefaultedAction("onAuthorPress")}
       onVideoPress={preventDefaultedAction("onVideoPress")}
+      onLinkPress={preventDefaultedAction("onLinkPress")}
     />
   );
 };
@@ -180,6 +181,7 @@ storiesOf("Pages/Article", module)
                 "onRelatedArticlePress"
               )}
               onAuthorPress={preventDefaultedAction("onAuthorPress")}
+              onLinkPress={preventDefaultedAction("onLinkPress")}
             />
           )}
         </ArticleProvider>

--- a/packages/article/src/__tests__/shared.js
+++ b/packages/article/src/__tests__/shared.js
@@ -81,6 +81,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -100,6 +101,7 @@ export default () => {
         onRelatedArticlePress={() => {}}
         onAuthorPress={() => {}}
         onVideoPress={() => {}}
+        onLinkPress={() => {}}
       />
     );
     expect(tree).toMatchSnapshot();
@@ -115,6 +117,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -131,6 +134,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -147,6 +151,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -163,6 +168,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -179,6 +185,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -195,6 +202,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -210,6 +218,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -225,6 +234,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -241,6 +251,7 @@ export default () => {
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
           onVideoPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();
@@ -257,6 +268,7 @@ export default () => {
         onRelatedArticlePress={() => {}}
         onAuthorPress={() => {}}
         onVideoPress={() => {}}
+        onLinkPress={() => {}}
       />
     );
     expect(stream).toHaveBeenCalledWith({

--- a/packages/article/src/__tests__/web/article.web.test.js
+++ b/packages/article/src/__tests__/web/article.web.test.js
@@ -62,6 +62,7 @@ describe("Article test on web", () => {
           adConfig={adConfig}
           onRelatedArticlePress={() => {}}
           onAuthorPress={() => {}}
+          onLinkPress={() => {}}
         />
       )
       .toJSON();

--- a/packages/article/src/article-body/article-body-row.js
+++ b/packages/article/src/article-body/article-body-row.js
@@ -7,7 +7,7 @@ import PullQuote from "@times-components/pull-quote";
 import BodyParagraph from "./article-body-paragraph";
 import ArticleLink from "./article-link";
 
-const ArticleRow = ({ content: { data, index } }) =>
+const ArticleRow = ({ content: { data, index }, onLinkPress }) =>
   renderTrees([data], {
     paragraph(key, attributes, children) {
       return (
@@ -46,12 +46,14 @@ const ArticleRow = ({ content: { data, index } }) =>
       );
     },
     link(key, attributes, children) {
+      const url = attributes.href;
+
       return (
         <ArticleLink
           key={index}
           uuid={index}
-          onPress={() => {}}
-          url={attributes.href}
+          onPress={e => onLinkPress(e, { url })}
+          url={url}
         >
           {children}
         </ArticleLink>
@@ -67,7 +69,8 @@ ArticleRow.propTypes = {
       name: PropTypes.string
     }),
     index: PropTypes.number
-  }).isRequired
+  }).isRequired,
+  onLinkPress: PropTypes.func.isRequired
 };
 
 export default ArticleRow;

--- a/packages/article/src/article-body/article-body-row.web.js
+++ b/packages/article/src/article-body/article-body-row.web.js
@@ -25,7 +25,7 @@ export const responsiveImageWrapper = imageType => {
   }
 };
 
-const ArticleRow = ({ content: { data, index } }) =>
+const ArticleRow = ({ content: { data, index }, onLinkPress }) =>
   renderTrees([data], {
     paragraph(key, attributes, children) {
       return (
@@ -62,12 +62,14 @@ const ArticleRow = ({ content: { data, index } }) =>
       );
     },
     link(key, attributes, children) {
+      const url = attributes.href;
+
       return (
         <ArticleLink
           key={key}
           uuid={index}
-          onPress={() => {}}
-          url={attributes.href}
+          onPress={e => onLinkPress(e, { url })}
+          url={url}
         >
           {children}
         </ArticleLink>
@@ -83,7 +85,8 @@ ArticleRow.propTypes = {
       name: PropTypes.string
     }),
     index: PropTypes.number
-  }).isRequired
+  }).isRequired,
+  onLinkPress: PropTypes.func.isRequired
 };
 
 export default ArticleRow;

--- a/packages/article/src/article-body/article-body.web.js
+++ b/packages/article/src/article-body/article-body.web.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import ArticleRow from "./article-body-row";
 
 const ArticleBody = props => {
-  const { section, content: bodyContent, contextUrl } = props;
+  const { section, content: bodyContent, contextUrl, onLinkPress } = props;
   const contentArray = bodyContent.map((rowData, index) => {
     const item = {
       data: Object.assign({}, rowData),
@@ -18,7 +18,11 @@ const ArticleBody = props => {
     return item;
   });
   const BodyView = contentArray.map(content => (
-    <ArticleRow key={`cont-${content.index}`} content={content} />
+    <ArticleRow
+      key={`cont-${content.index}`}
+      content={content}
+      onLinkPress={onLinkPress}
+    />
   ));
 
   return BodyView;
@@ -33,7 +37,8 @@ ArticleBody.propTypes = {
     })
   ).isRequired,
   section: PropTypes.string,
-  contextUrl: PropTypes.string.isRequired
+  contextUrl: PropTypes.string.isRequired,
+  onLinkPress: PropTypes.func.isRequired
 };
 
 export default ArticleBody;

--- a/packages/article/src/article-content.js
+++ b/packages/article/src/article-content.js
@@ -7,14 +7,21 @@ const ArticleContent = ({
   renderRow,
   onRelatedArticlePress,
   onAuthorPress,
-  onVideoPress
+  onVideoPress,
+  onLinkPress
 }) => (
   <FlatList
     testID="flat-list-article"
     keyExtractor={item => item.type + item.index || item.type}
     data={data}
     renderItem={({ item }) =>
-      renderRow(item, onRelatedArticlePress, onAuthorPress, onVideoPress)
+      renderRow(
+        item,
+        onRelatedArticlePress,
+        onAuthorPress,
+        onVideoPress,
+        onLinkPress
+      )
     }
   />
 );
@@ -30,7 +37,8 @@ ArticleContent.propTypes = {
   renderRow: PropTypes.func.isRequired,
   onRelatedArticlePress: PropTypes.func.isRequired,
   onAuthorPress: PropTypes.func.isRequired,
-  onVideoPress: PropTypes.func.isRequired
+  onVideoPress: PropTypes.func.isRequired,
+  onLinkPress: PropTypes.func.isRequired
 };
 
 export default ArticleContent;

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -28,7 +28,8 @@ class ArticlePage extends React.Component {
     rowData,
     onRelatedArticlePress,
     onAuthorPress,
-    onVideoPress
+    onVideoPress,
+    onLinkPress
   ) {
     switch (rowData.type) {
       case "leadAsset": {
@@ -71,7 +72,7 @@ class ArticlePage extends React.Component {
       }
 
       case "articleBodyRow": {
-        return <ArticleRow content={rowData} />;
+        return <ArticleRow content={rowData} onLinkPress={onLinkPress} />;
       }
 
       case "relatedArticles": {
@@ -137,6 +138,7 @@ class ArticlePage extends React.Component {
         onRelatedArticlePress={this.props.onRelatedArticlePress}
         onAuthorPress={this.props.onAuthorPress}
         onVideoPress={this.props.onVideoPress}
+        onLinkPress={this.props.onLinkPress}
         scrollRenderAheadDistance={listViewScrollRenderAheadDistance}
         pageSize={listViewPageSize}
       />
@@ -161,7 +163,8 @@ ArticlePage.propTypes = {
   adConfig: PropTypes.shape({}).isRequired,
   onRelatedArticlePress: PropTypes.func.isRequired,
   onAuthorPress: PropTypes.func.isRequired,
-  onVideoPress: PropTypes.func.isRequired
+  onVideoPress: PropTypes.func.isRequired,
+  onLinkPress: PropTypes.func.isRequired
 };
 
 ArticlePage.defaultProps = {

--- a/packages/article/src/article.web.js
+++ b/packages/article/src/article.web.js
@@ -28,7 +28,12 @@ const adStyle = {
 };
 
 class ArticlePage extends React.Component {
-  static renderArticle(articleData, onRelatedArticlePress, onAuthorPress) {
+  static renderArticle(
+    articleData,
+    onRelatedArticlePress,
+    onAuthorPress,
+    onLinkPress
+  ) {
     const {
       headline,
       flags,
@@ -84,7 +89,12 @@ class ArticlePage extends React.Component {
             <LeadAssetComponent {...leadAssetProps} />
           </LeadAssetContainer>
           <BodyContainer>
-            <ArticleBody content={content} section={section} contextUrl={url} />
+            <ArticleBody
+              content={content}
+              section={section}
+              contextUrl={url}
+              onLinkPress={onLinkPress}
+            />
           </BodyContainer>
         </MainContainer>
         <Topics topics={topics} />
@@ -101,7 +111,8 @@ class ArticlePage extends React.Component {
       error,
       isLoading,
       onRelatedArticlePress,
-      onAuthorPress
+      onAuthorPress,
+      onLinkPress
     } = this.props;
 
     if (error) {
@@ -117,7 +128,8 @@ class ArticlePage extends React.Component {
         {ArticlePage.renderArticle(
           this.props.article,
           onRelatedArticlePress,
-          onAuthorPress
+          onAuthorPress,
+          onLinkPress
         )}
       </AdComposer>
     );
@@ -135,7 +147,8 @@ ArticlePage.propTypes = {
     message: PropTypes.string
   }),
   adConfig: PropTypes.shape({}).isRequired,
-  onRelatedArticlePress: PropTypes.func.isRequired
+  onRelatedArticlePress: PropTypes.func.isRequired,
+  onLinkPress: PropTypes.func.isRequired
 };
 
 ArticlePage.defaultProps = {


### PR DESCRIPTION
Added onLinkPress to article body and passed it to article row to enable link click callbacks for native. Native apps will expose a native module to utilize these callbacks.

Paired with: @colincclark 