### PR TITLE
Removes postinstall transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "android:device": "./lib/setup_device_connections.sh && yarn android",
     "prefmt": "prettier --write '**/*.*'",
     "fmt": "lerna run fmt",
+    "postinstall": "lerna run transpile",
     "packages:publish": "lerna publish --conventional-commits --yes --concurrency=1 --exact",
     "packages:publish-dry-run": "yarn packages:publish --skip-git --skip-npm",
     "clean-snaps": "rm -rf dextrose/snappy/*.png",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "android:device": "./lib/setup_device_connections.sh && yarn android",
     "prefmt": "prettier --write '**/*.*'",
     "fmt": "lerna run fmt",
-    "postinstall": "lerna run postinstall",
     "packages:publish": "lerna publish --conventional-commits --yes --concurrency=1 --exact",
     "packages:publish-dry-run": "yarn packages:publish --skip-git --skip-npm",
     "clean-snaps": "rm -rf dextrose/snappy/*.png",

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -12,8 +12,7 @@
     "test": "jest",
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/article-flag/package.json
+++ b/packages/article-flag/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/article-label/package.json
+++ b/packages/article-label/package.json
@@ -13,8 +13,7 @@
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -14,8 +14,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -15,8 +15,7 @@
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/author-head/package.json
+++ b/packages/author-head/package.json
@@ -14,8 +14,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/brightcove-video/package.json
+++ b/packages/brightcove-video/package.json
@@ -11,8 +11,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -14,8 +14,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/date-publication/package.json
+++ b/packages/date-publication/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/depend/package.json
+++ b/packages/depend/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "transpile": "babel . -d dist --ignore dist,node_modules,coverage,__tests__ && cp package.json dist/package.json",
     "prepublishOnly": "yarn transpile",
-    "postinstall": "yarn transpile",
     "fmt": "prettier --write '**/*.*'",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "lint": "eslint . && npm run prettier:diff",

--- a/packages/error-view/package.json
+++ b/packages/error-view/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-thetimes/package.json
+++ b/packages/eslint-config-thetimes/package.json
@@ -9,8 +9,7 @@
     "prettier:diff": "prettier --list-different '**/*.*'",
     "lint": "yarn prettier:diff",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -14,8 +14,7 @@
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -11,8 +11,7 @@
     "lint": "flow && eslint . && yarn prettier:diff",
     "pretest": "./setup.sh",
     "test": "jest",
-    "transpile": "babel src --ignore node_modules,__tests__ -d lib",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d lib"
   },
   "repository": {
     "type": "git",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose gs $(PWD)",
     "dextrose-clean": "dextrose cs $(PWD)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -14,8 +14,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/provider-test-tools/package.json
+++ b/packages/provider-test-tools/package.json
@@ -10,8 +10,7 @@
     "lint": "eslint . && npm run prettier:diff",
     "test": "jest",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -11,8 +11,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "jest": {
     "preset": "react-native",

--- a/packages/pull-quote/package.json
+++ b/packages/pull-quote/package.json
@@ -13,8 +13,7 @@
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/responsive-styles/package.json
+++ b/packages/responsive-styles/package.json
@@ -10,8 +10,7 @@
     "lint": "eslint . && yarn prettier:diff",
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/slice/package.json
+++ b/packages/slice/package.json
@@ -12,8 +12,7 @@
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -13,8 +13,7 @@
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -13,8 +13,7 @@
     "test:ios": "jest --config='./src/__tests__/ios/jest.config.js'",
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -10,8 +10,7 @@
     "lint": "eslint . && yarn prettier:diff",
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/topics/package.json
+++ b/packages/topics/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -14,8 +14,7 @@
     "dextrose-stories": "dextrose generate-stories $(pwd)",
     "dextrose-clean": "dextrose clean-stories $(pwd)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,8 +11,7 @@
     "lint": "eslint . && yarn prettier:diff",
     "test": "jest --config='./src/__tests__/jest.config.js'",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist && cp src/schema.json dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist && cp src/schema.json dist"
   },
   "repository": {
     "type": "git",

--- a/packages/video-label/package.json
+++ b/packages/video-label/package.json
@@ -13,8 +13,7 @@
     "test:web": "jest --config='./src/__tests__/web/jest.config.js'",
     "test:all": "yarn test:android --coverage & yarn test:ios --coverage & yarn test:web --coverage",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -15,8 +15,7 @@
     "dextrose-stories": "dextrose gs $(PWD)",
     "dextrose-clean": "dextrose cs $(PWD)",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist",
-    "postinstall": "yarn transpile"
+    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Removes `postinstall` transpilation of each package, as our dependents should be using the provided, pre-generated transpiled code. We originally included this behaviour to support specific dev setups, but in retrospect this is an edge case.