### PR TITLE
Removes provider fixtures from .npmignore

### DIFF
--- a/packages/provider/.npmignore
+++ b/packages/provider/.npmignore
@@ -2,7 +2,6 @@
 __tests__
 *.fructose.js
 *.test.js
-fixtures
 coverage
 android/**/test
 android/**/androidTest


### PR DESCRIPTION
Removes `fixtures` from the provider package's .npmignore files, so that consumers can use the exposed `fixtureGenerator` member.
