### PR TITLE
refactor: add appropriate newlines for CLI generated files

### DIFF
--- a/lib/cli/templates.js
+++ b/lib/cli/templates.js
@@ -41,7 +41,8 @@ const testEsLintConfigFile = handlebars.compile(`{
   "env": {
     "jest": true
   }
-}`);
+}
+`);
 
 const testFileNative = platform =>
   handlebars.compile(`import shared from "../shared";
@@ -116,7 +117,7 @@ export default webStyles;
 `);
 
 const packageJsonFile = variables =>
-  JSON.stringify(packageJson(variables), null, 2);
+  `${JSON.stringify(packageJson(variables), null, 2)}\n`;
 
 module.exports = variables => [
   [indexFile, `src/${variables.packageName}.js`],


### PR DESCRIPTION
- adds newlines to the ends of CLI-generated package.json and eslintrc files