### PR TITLE
chore: dont export tealium storybook reporter

### DIFF
--- a/packages/article/article.stories.js
+++ b/packages/article/article.stories.js
@@ -8,7 +8,7 @@ import { decorateAction } from "@storybook/addon-actions";
 import { select, text } from "@storybook/addon-knobs/react";
 import { ArticleProvider, articleQuery } from "@times-components/provider";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
-import { storybookReporter } from "@times-components/tealium";
+import storybookReporter from "@times-components/tealium/src/storybook";
 import Article from "./src/article";
 
 import fullArticleTypenameFixture from "./fixtures/full-article-typename.json";

--- a/packages/author-head/author-head.stories.js
+++ b/packages/author-head/author-head.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
 import { decorateAction } from "@storybook/addon-actions";
-import { storybookReporter } from "@times-components/tealium";
+import storybookReporter from "@times-components/tealium/src/storybook";
 import { withTrackingContext } from "@times-components/tracking";
 import { LateralSpacingDecorator } from "@times-components/storybook";
 import AuthorHead from "./src/author-head";

--- a/packages/author-profile/author-profile.stories.js
+++ b/packages/author-profile/author-profile.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react-native";
 import { decorateAction } from "@storybook/addon-actions";
 import { MockedProvider } from "@times-components/utils";
-import { storybookReporter } from "@times-components/tealium";
+import storybookReporter from "@times-components/tealium/src/storybook";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import { AuthorProfileProvider } from "@times-components/provider";

--- a/packages/related-articles/related-articles.stories.js
+++ b/packages/related-articles/related-articles.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/react-native";
 import React from "react";
 import { ScrollView } from "react-native";
 import { decorateAction } from "@storybook/addon-actions";
-import { storybookReporter } from "@times-components/tealium";
+import storybookReporter from "@times-components/tealium/src/storybook";
 import RelatedArticles from "./src/related-articles";
 
 import standard1RelatedArticleFixture from "./fixtures/standard/1-article.json";

--- a/packages/tealium/src/index.js
+++ b/packages/tealium/src/index.js
@@ -1,4 +1,3 @@
 import createTealiumReport from "./tealium";
 
-export { default as storybookReporter } from "./storybook";
 export default createTealiumReport;

--- a/packages/topics/topics.stories.js
+++ b/packages/topics/topics.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { View } from "react-native";
 import { storiesOf } from "@storybook/react-native";
 import { withTrackingContext } from "@times-components/tracking";
-import storybookReporter from "@times-components/tealium/dist/storybook";
+import storybookReporter from "@times-components/tealium/src/storybook";
 import Topic from "./src/topic";
 import Topics from "./src/topics";
 import topicsData from "./fixtures/topics";

--- a/packages/tracking/tracking.stories.js
+++ b/packages/tracking/tracking.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Button, View } from "react-native";
 import { storiesOf } from "@storybook/react-native";
-import { storybookReporter } from "@times-components/tealium";
+import storybookReporter from "@times-components/tealium/src/storybook";
 import {
   withTrackingContext,
   withTrackEvents,


### PR DESCRIPTION
tealium's storybookReporter is a dev-dependency hence exporting in a prod-installation is not possible.
