### PR TITLE
feat: only set video label to "video" if no explicit label is provided (REPLAT-1919)

### DIFF
--- a/packages/video-label/__tests__/android/__snapshots__/video-label.android.test.js.snap
+++ b/packages/video-label/__tests__/android/__snapshots__/video-label.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video Label test on android does not render title if title equals Video 1`] = `
+exports[`Video Label test on android renders VideoLabel with an explicit title 1`] = `
 <View
   style={
     Object {
@@ -54,126 +54,74 @@ exports[`Video Label test on android does not render title if title equals Video
         Object {
           "color": "#008347",
           "marginLeft": 5,
-        },
-      ]
-    }
-  >
-    V I D E O
-  </Text>
-</View>
-`;
-
-exports[`Video Label test on android renders VideoLabel 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-    }
-  }
->
-  <svg
-    height={12}
-    style={Object {}}
-    viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
-    width={20.64}
-  >
-    <rect
-      fill="#1D1D1B"
-      height="13.5721404"
-      style={Object {}}
-      width="15.4550103"
-      x="0.154639175"
-      y="0.139754386"
-    />
-    <polygon
-      fill="#1D1D1B"
-      points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
-      style={Object {}}
-    />
-    <polygon
-      fill="#1D1D1B"
-      points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
-      style={Object {}}
-    />
-  </svg>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "letterSpacing": 1.2,
-          "lineHeight": 12,
-          "margin": 0,
-          "padding": 0,
-          "position": "relative",
-          "top": 2,
-        },
-        Object {
-          "color": "#008347",
-          "marginLeft": 5,
-        },
-      ]
-    }
-  >
-    V I D E O
-  </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "letterSpacing": 1.2,
-          "lineHeight": 12,
-          "margin": 0,
-          "padding": 0,
-          "position": "relative",
-          "top": 1,
-        },
-        Object {
-          "color": "#008347",
-          "marginLeft": 5,
-        },
-      ]
-    }
-  >
-    |
-  </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "letterSpacing": 1.2,
-          "lineHeight": 12,
-          "margin": 0,
-          "padding": 0,
-          "position": "relative",
-          "top": 2,
-        },
-        Object {
-          "color": "#008347",
-          "paddingLeft": 5,
         },
       ]
     }
   >
     S W I M M I N G
+  </Text>
+</View>
+`;
+
+exports[`Video Label test on android renders VideoLabel without an explicit title 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+    }
+  }
+>
+  <svg
+    height={12}
+    style={Object {}}
+    viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
+    width={20.64}
+  >
+    <rect
+      fill="#1D1D1B"
+      height="13.5721404"
+      style={Object {}}
+      width="15.4550103"
+      x="0.154639175"
+      y="0.139754386"
+    />
+    <polygon
+      fill="#1D1D1B"
+      points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
+      style={Object {}}
+    />
+    <polygon
+      fill="#1D1D1B"
+      points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
+      style={Object {}}
+    />
+  </svg>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "letterSpacing": 1.2,
+          "lineHeight": 12,
+          "margin": 0,
+          "padding": 0,
+          "position": "relative",
+          "top": 2,
+        },
+        Object {
+          "color": "#008347",
+          "marginLeft": 5,
+        },
+      ]
+    }
+  >
+    V I D E O
   </Text>
 </View>
 `;

--- a/packages/video-label/__tests__/ios/__snapshots__/video-label.ios.test.js.snap
+++ b/packages/video-label/__tests__/ios/__snapshots__/video-label.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video Label test on ios does not render title if title equals Video 1`] = `
+exports[`Video Label test on ios renders VideoLabel with an explicit title 1`] = `
 <View
   style={
     Object {
@@ -54,126 +54,74 @@ exports[`Video Label test on ios does not render title if title equals Video 1`]
         Object {
           "color": "#008347",
           "marginLeft": 5,
-        },
-      ]
-    }
-  >
-    VIDEO
-  </Text>
-</View>
-`;
-
-exports[`Video Label test on ios renders VideoLabel 1`] = `
-<View
-  style={
-    Object {
-      "alignItems": "center",
-      "flexDirection": "row",
-    }
-  }
->
-  <svg
-    height={12}
-    style={Object {}}
-    viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
-    width={20.64}
-  >
-    <rect
-      fill="#1D1D1B"
-      height="13.5721404"
-      style={Object {}}
-      width="15.4550103"
-      x="0.154639175"
-      y="0.139754386"
-    />
-    <polygon
-      fill="#1D1D1B"
-      points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
-      style={Object {}}
-    />
-    <polygon
-      fill="#1D1D1B"
-      points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
-      style={Object {}}
-    />
-  </svg>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "letterSpacing": 1.2,
-          "lineHeight": 12,
-          "margin": 0,
-          "padding": 0,
-          "position": "relative",
-          "top": 2,
-        },
-        Object {
-          "color": "#008347",
-          "marginLeft": 5,
-        },
-      ]
-    }
-  >
-    VIDEO
-  </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "letterSpacing": 1.2,
-          "lineHeight": 12,
-          "margin": 0,
-          "padding": 0,
-          "position": "relative",
-          "top": 1,
-        },
-        Object {
-          "color": "#008347",
-          "marginLeft": 5,
-        },
-      ]
-    }
-  >
-    |
-  </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 12,
-          "fontWeight": "400",
-          "letterSpacing": 1.2,
-          "lineHeight": 12,
-          "margin": 0,
-          "padding": 0,
-          "position": "relative",
-          "top": 2,
-        },
-        Object {
-          "color": "#008347",
-          "paddingLeft": 5,
         },
       ]
     }
   >
     SWIMMING
+  </Text>
+</View>
+`;
+
+exports[`Video Label test on ios renders VideoLabel without an explicit title 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flexDirection": "row",
+    }
+  }
+>
+  <svg
+    height={12}
+    style={Object {}}
+    viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
+    width={20.64}
+  >
+    <rect
+      fill="#1D1D1B"
+      height="13.5721404"
+      style={Object {}}
+      width="15.4550103"
+      x="0.154639175"
+      y="0.139754386"
+    />
+    <polygon
+      fill="#1D1D1B"
+      points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
+      style={Object {}}
+    />
+    <polygon
+      fill="#1D1D1B"
+      points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
+      style={Object {}}
+    />
+  </svg>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "letterSpacing": 1.2,
+          "lineHeight": 12,
+          "margin": 0,
+          "padding": 0,
+          "position": "relative",
+          "top": 2,
+        },
+        Object {
+          "color": "#008347",
+          "marginLeft": 5,
+        },
+      ]
+    }
+  >
+    VIDEO
   </Text>
 </View>
 `;

--- a/packages/video-label/__tests__/shared.js
+++ b/packages/video-label/__tests__/shared.js
@@ -4,7 +4,7 @@ import renderer from "react-test-renderer";
 import VideoLabel from "../src/video-label";
 
 export default () => {
-  it("renders VideoLabel", () => {
+  it("renders VideoLabel with an explicit title", () => {
     const tree = renderer
       .create(<VideoLabel title="swimming" color="#008347" />)
       .toJSON();
@@ -12,10 +12,8 @@ export default () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("does not render title if title equals Video", () => {
-    const tree = renderer
-      .create(<VideoLabel title="Video" color="#008347" />)
-      .toJSON();
+  it("renders VideoLabel without an explicit title", () => {
+    const tree = renderer.create(<VideoLabel color="#008347" />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/packages/video-label/__tests__/web/__snapshots__/video-label.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video Label test on web does not render title if title equals Video 1`] = `
+exports[`Video Label test on web renders VideoLabel with an explicit title 1`] = `
 <div
   className="rn-alignItems-1awozwy rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-18u37iz rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
 >
@@ -41,97 +41,61 @@ exports[`Video Label test on web does not render title if title equals Video 1`]
         "letterSpacing": "1.2px",
         "lineHeight": "12px",
         "marginLeft": "5px",
-        "top": "2px",
-      }
-    }
-  >
-    VIDEO
-  </div>
-</div>
-`;
-
-exports[`Video Label test on web renders VideoLabel 1`] = `
-<div
-  className="rn-alignItems-1awozwy rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-18u37iz rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
->
-  <svg
-    height={12}
-    style={Object {}}
-    viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
-    width={20.64}
-  >
-    <rect
-      fill="#1D1D1B"
-      height="13.5721404"
-      style={Object {}}
-      width="15.4550103"
-      x="0.154639175"
-      y="0.139754386"
-    />
-    <polygon
-      fill="#1D1D1B"
-      points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
-      style={Object {}}
-    />
-    <polygon
-      fill="#1D1D1B"
-      points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
-      style={Object {}}
-    />
-  </svg>
-  <div
-    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-    dir="auto"
-    style={
-      Object {
-        "color": "rgba(0,131,71,1)",
-        "fontFamily": "GillSansMTStd-Medium",
-        "fontSize": "12px",
-        "fontWeight": "400",
-        "letterSpacing": "1.2px",
-        "lineHeight": "12px",
-        "marginLeft": "5px",
-        "top": "2px",
-      }
-    }
-  >
-    VIDEO
-  </div>
-  <div
-    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-    dir="auto"
-    style={
-      Object {
-        "color": "rgba(0,131,71,1)",
-        "fontFamily": "GillSansMTStd-Medium",
-        "fontSize": "12px",
-        "fontWeight": "400",
-        "letterSpacing": "1.2px",
-        "lineHeight": "12px",
-        "marginLeft": "5px",
-        "top": "1px",
-      }
-    }
-  >
-    |
-  </div>
-  <div
-    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-position-bnwqim rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
-    dir="auto"
-    style={
-      Object {
-        "color": "rgba(0,131,71,1)",
-        "fontFamily": "GillSansMTStd-Medium",
-        "fontSize": "12px",
-        "fontWeight": "400",
-        "letterSpacing": "1.2px",
-        "lineHeight": "12px",
-        "paddingLeft": "5px",
         "top": "2px",
       }
     }
   >
     SWIMMING
+  </div>
+</div>
+`;
+
+exports[`Video Label test on web renders VideoLabel without an explicit title 1`] = `
+<div
+  className="rn-alignItems-1awozwy rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-6koalj rn-flexShrink-1pxmb3b rn-flexBasis-7vfszb rn-flexDirection-18u37iz rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-zIndex-1lgpqti"
+>
+  <svg
+    height={12}
+    style={Object {}}
+    viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
+    width={20.64}
+  >
+    <rect
+      fill="#1D1D1B"
+      height="13.5721404"
+      style={Object {}}
+      width="15.4550103"
+      x="0.154639175"
+      y="0.139754386"
+    />
+    <polygon
+      fill="#1D1D1B"
+      points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
+      style={Object {}}
+    />
+    <polygon
+      fill="#1D1D1B"
+      points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
+      style={Object {}}
+    />
+  </svg>
+  <div
+    className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-boxSizing-deolkf rn-display-1471scf rn-font-1lw9tu2 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-bnwqim rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+    dir="auto"
+    style={
+      Object {
+        "color": "rgba(0,131,71,1)",
+        "fontFamily": "GillSansMTStd-Medium",
+        "fontSize": "12px",
+        "fontWeight": "400",
+        "letterSpacing": "1.2px",
+        "lineHeight": "12px",
+        "marginLeft": "5px",
+        "top": "2px",
+      }
+    }
+  >
+    VIDEO
   </div>
 </div>
 `;

--- a/packages/video-label/src/video-label.js
+++ b/packages/video-label/src/video-label.js
@@ -1,28 +1,21 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { View, Text } from "react-native";
 import { IconVideo } from "@times-components/icons";
 import PropTypes from "prop-types";
 import styles from "./style";
 import beautifyTitle from "./beautify-title";
 
-const showTitle = title => title && title.toLowerCase() !== "video";
-
-const VideoLabel = ({ title, color }) => (
-  <View style={{ flexDirection: "row", alignItems: "center" }}>
-    <IconVideo height={styles.title.fontSize} fillColor={color} />
-    <Text style={[styles.title, { color, marginLeft: 5 }]}>
-      {beautifyTitle("video")}
-    </Text>
-    {showTitle(title) ? (
-      <Fragment>
-        <Text style={[styles.pipe, { color, marginLeft: 5 }]}>|</Text>
-        <Text style={[styles.title, { color, paddingLeft: 5 }]}>
-          {beautifyTitle(title)}
-        </Text>
-      </Fragment>
-    ) : null}
-  </View>
-);
+const VideoLabel = ({ title, color }) => {
+  const displayTitle = title || "VIDEO";
+  return (
+    <View style={{ flexDirection: "row", alignItems: "center" }}>
+      <IconVideo height={styles.title.fontSize} fillColor={color} />
+      <Text style={[styles.title, { color, marginLeft: 5 }]}>
+        {beautifyTitle(displayTitle)}
+      </Text>
+    </View>
+  );
+};
 
 VideoLabel.propTypes = {
   title: PropTypes.string,

--- a/packages/video-label/src/video-label.js
+++ b/packages/video-label/src/video-label.js
@@ -5,17 +5,14 @@ import PropTypes from "prop-types";
 import styles from "./style";
 import beautifyTitle from "./beautify-title";
 
-const VideoLabel = ({ title, color }) => {
-  const displayTitle = title || "VIDEO";
-  return (
-    <View style={{ flexDirection: "row", alignItems: "center" }}>
-      <IconVideo height={styles.title.fontSize} fillColor={color} />
-      <Text style={[styles.title, { color, marginLeft: 5 }]}>
-        {beautifyTitle(displayTitle)}
-      </Text>
-    </View>
-  );
-};
+const VideoLabel = ({ title, color }) => (
+  <View style={{ flexDirection: "row", alignItems: "center" }}>
+    <IconVideo height={styles.title.fontSize} fillColor={color} />
+    <Text style={[styles.title, { color, marginLeft: 5 }]}>
+      {beautifyTitle(title || "VIDEO")}
+    </Text>
+  </View>
+);
 
 VideoLabel.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
Previously, the video label looked like this with no explicit label:

![image](https://user-images.githubusercontent.com/838984/38676278-64c2e8e8-3e52-11e8-8a9d-4ea29e043b68.png)

And like this with an explicit label:

![image](https://user-images.githubusercontent.com/838984/38676291-71578622-3e52-11e8-9304-1e35bd314bca.png)

Unless the label was "VIDEO" in which case it didn't show it, to avoid having the label "VIDEO | VIDEO".

Now the label only ever shows one bit of text, never 2 with a | character. If an explicit label is provided then it is used, otherwise "VIDEO" is shown:

![image](https://user-images.githubusercontent.com/838984/38676387-c9e2f768-3e52-11e8-8951-d888f2141c91.png)

iOS: 
![image](https://user-images.githubusercontent.com/838984/38676405-d3c2481a-3e52-11e8-88e1-4bd776690f06.png)

Android: 
![image](https://user-images.githubusercontent.com/838984/38676421-dca89ac4-3e52-11e8-8d0a-e3906d4fc0a2.png)
