### PR TITLE
fix: swap order of storybook decorators

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -19,8 +19,9 @@ setOptions({
   hierarchySeparator: /\//
 });
 
-addDecorator(withKnobs);
+
 addDecorator((story, context) => withInfo('')(story)(context));
+addDecorator(withKnobs);
 
 const loadStories = () => req.keys().forEach(filename => req(filename));
 


### PR DESCRIPTION
Otherwise we extract info about the knobs HOC instead of our components