### PR TITLE
fix: fix slice stories (knobs)

### DIFF
--- a/packages/slice/leadandtwo.stories.js
+++ b/packages/slice/leadandtwo.stories.js
@@ -6,7 +6,11 @@ import LeadAndTwoSlice from "./src/templates/leadandtwo";
 
 // knobs
 const itemCountLabel = "Number of support items:";
-const itemCount = ["0", "1", "2"];
+const itemCount = {
+  0: "0",
+  1: "1",
+  2: "2"
+};
 const itemCountDefault = "0";
 
 const colours = [

--- a/packages/slice/opinionandtwo.stories.js
+++ b/packages/slice/opinionandtwo.stories.js
@@ -6,7 +6,11 @@ import OpinionAndTwoSlice from "./src/templates/opinionandtwo";
 
 // knobs
 const itemCountLabel = "Number of support items:";
-const itemCount = ["0", "1", "2"];
+const itemCount = {
+  0: "0",
+  1: "1",
+  2: "2"
+};
 const itemCountDefault = "0";
 
 const colours = [

--- a/packages/slice/standard.stories.js
+++ b/packages/slice/standard.stories.js
@@ -6,7 +6,11 @@ import StandardSlice from "./src/templates/standard";
 
 // knobs
 const itemCountLabel = "Number of items:";
-const itemCount = ["1", "2", "3"];
+const itemCount = {
+  1: "1",
+  2: "2",
+  3: "3"
+};
 const itemCountDefault = "1";
 
 const colours = [


### PR DESCRIPTION
- knobs were broken because the `selectV2` options do not accept an array