### PR TITLE
fix: storybook native compilation error

### DIFF
--- a/packages/tealium-utils/package.json
+++ b/packages/tealium-utils/package.json
@@ -9,7 +9,8 @@
     "prettier:diff": "prettier --list-different '**/*.*'",
     "lint": "eslint . && yarn prettier:diff",
     "prepublishOnly": "yarn transpile",
-    "transpile": "babel src --ignore node_modules,__tests__ -d dist"
+    "cleanup-dist": "rm -rf dist",
+    "transpile": "yarn cleanup-dist && babel src --ignore node_modules,__tests__ -d dist"
   },
   "repository": {
     "type": "git",

--- a/packages/tealium-utils/src/storybook.js
+++ b/packages/tealium-utils/src/storybook.js
@@ -1,0 +1,1 @@
+export default () => {};


### PR DESCRIPTION
fixed a bug around tealium-utils. It was lacking a cleanup-dist step in transpile, and this allowed a compilation bug to creep in that was hidden by stale files in the dist folder.