### PR TITLE
fix: warnings in font storybook

### DIFF
--- a/packages/styleguide/styleguide.stories.js
+++ b/packages/styleguide/styleguide.stories.js
@@ -21,7 +21,7 @@ ColourBox.propTypes = {
 
 const fontDisplayer = (fontFamily, phrase) =>
   Object.keys(fontSizes).map(fontSize => (
-    <Fragment>
+    <Fragment key={fontSize}>
       <Text style={styles.subHeadline}>{fontSize}</Text>
       <Text
         style={[

--- a/packages/styleguide/styleguide.stories.styles.js
+++ b/packages/styleguide/styleguide.stories.styles.js
@@ -36,8 +36,7 @@ const styles = {
   headline: {
     fontSize: fontSizes.body,
     fontWeight: "bold",
-    marginBottom: 10,
-    textDecoration: "underline"
+    marginBottom: 10
   },
   subHeadline: {
     fontSize: fontSizes.meta,


### PR DESCRIPTION
- fix warnings about invalid style and missing keys