### PR TITLE
fix: implement link renderer

### DIFF
--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -88,6 +88,113 @@ exports[`Article Summary tests on Android should render an ArticleSummaryHeadlin
 </Text>
 `;
 
+exports[`Article Summary tests on Android should render an article-summary component containing links 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "marginBottom": 5,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "letterSpacing": 1.2,
+          "marginBottom": 0,
+        }
+      }
+    >
+      F R A N C I S   E L L I O T T
+    </Text>
+  </View>
+  <Text
+    accessibilityRole="heading"
+    accessible={true}
+    allowFontScaling={true}
+    aria-level="3"
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 22,
+        "fontWeight": "400",
+        "lineHeight": 22,
+        "marginBottom": 5,
+      }
+    }
+  >
+    Sajid Javid to end hostile era for illegal immigrants
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#696969",
+        "flexWrap": "wrap",
+        "fontFamily": "TimesDigitalW04",
+        "fontSize": 14,
+        "lineHeight": 20,
+        "marginBottom": 10,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        Sajid Javid
+      </Text>
+       has warned the Home Office to expect an overhaul after the 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        Windrush scandal
+      </Text>
+       as he ditches the policy of creating a “hostile
+      ...
+    </Text>
+  </Text>
+  <Text
+    accessibilityLabel="datePublication"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#696969",
+        "fontFamily": "GillSansMTStd-Medium",
+        "fontSize": 13,
+        "lineHeight": 15,
+        "marginBottom": 5,
+      }
+    }
+    testID="datePublication"
+  >
+    Friday November 17 2017, 12:01am, The Times
+  </Text>
+</View>
+`;
+
 exports[`Article Summary tests on Android should render an article-summary component with a single paragraph 1`] = `
 <View>
   <View
@@ -310,7 +417,7 @@ exports[`Article Summary tests on Android should render an article-summary compo
         
 
       </Text>
-      ITV
+       ITV
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -347,7 +454,7 @@ exports[`Article Summary tests on Android should render an article-summary compo
         
 
       </Text>
-      BBC Two
+       BBC Two
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -88,6 +88,113 @@ exports[`Article Summary tests on ios should render an ArticleSummaryHeadline co
 </Text>
 `;
 
+exports[`Article Summary tests on ios should render an article-summary component containing links 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "marginBottom": 0,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 12,
+          "fontWeight": "400",
+          "letterSpacing": 1.2,
+          "marginBottom": 0,
+        }
+      }
+    >
+      FRANCIS ELLIOTT
+    </Text>
+  </View>
+  <Text
+    accessibilityRole="heading"
+    accessible={true}
+    allowFontScaling={true}
+    aria-level="3"
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#333333",
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": 22,
+        "fontWeight": "900",
+        "lineHeight": 22,
+        "marginBottom": 5,
+      }
+    }
+  >
+    Sajid Javid to end hostile era for illegal immigrants
+  </Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#696969",
+        "flexWrap": "wrap",
+        "fontFamily": "TimesDigitalW04",
+        "fontSize": 14,
+        "lineHeight": 20,
+        "marginBottom": 10,
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+    >
+      
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        Sajid Javid
+      </Text>
+       has warned the Home Office to expect an overhaul after the 
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        Windrush scandal
+      </Text>
+       as he ditches the policy of creating a “hostile
+      ...
+    </Text>
+  </Text>
+  <Text
+    accessibilityLabel="datePublication"
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#696969",
+        "fontFamily": "GillSansMTStd-Medium",
+        "fontSize": 13,
+        "lineHeight": 15,
+        "marginBottom": 5,
+      }
+    }
+    testID="datePublication"
+  >
+    Friday November 17 2017, 12:01am, The Times
+  </Text>
+</View>
+`;
+
 exports[`Article Summary tests on ios should render an article-summary component with a single paragraph 1`] = `
 <View>
   <View
@@ -310,7 +417,7 @@ exports[`Article Summary tests on ios should render an article-summary component
         
 
       </Text>
-      ITV
+       ITV
       <Text
         accessible={true}
         allowFontScaling={true}
@@ -347,7 +454,7 @@ exports[`Article Summary tests on ios should render an article-summary component
         
 
       </Text>
-      BBC Two
+       BBC Two
       <Text
         accessible={true}
         allowFontScaling={true}

--- a/packages/article-summary/__tests__/shared.js
+++ b/packages/article-summary/__tests__/shared.js
@@ -6,6 +6,7 @@ import ArticleSummary, {
   renderAst
 } from "../src/article-summary";
 import defaultFixture from "../fixtures/default";
+import withLinksFixture from "../fixtures/with-links";
 import opinionBylineFixture from "../fixtures/opinion-byline";
 import articleMultiFixture from "../fixtures/article-multi";
 import emptyParagraphFixture from "../fixtures/article-empty-paragraph";
@@ -59,6 +60,14 @@ export default () => {
   it("should render an article-summary component with content including line breaks", () => {
     const tree = renderer
       .create(<ArticleSummary {...reviewFixture} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("should render an article-summary component containing links", () => {
+    const tree = renderer
+      .create(<ArticleSummary {...withLinksFixture} />)
       .toJSON();
 
     expect(tree).toMatchSnapshot();

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -79,6 +79,89 @@ exports[`Article Summary tests on Web should render an ArticleSummaryHeadline co
 </h3>
 `;
 
+exports[`Article Summary tests on Web should render an article-summary component containing links 1`] = `
+<div>
+  <div>
+    <div
+      dir="auto"
+      style={
+        Object {
+          "fontSize": "12px",
+          "fontWeight": "400",
+          "letterSpacing": "1.2px",
+        }
+      }
+    >
+      FRANCIS ELLIOTT
+    </div>
+  </div>
+  <h3
+    aria-level="3"
+    dir="auto"
+    role="heading"
+    style={
+      Object {
+        "fontFamily": "TimesModern-Bold",
+        "fontSize": "22px",
+        "fontWeight": "400",
+        "lineHeight": "22px",
+        "marginBottom": "5px",
+      }
+    }
+  >
+    Sajid Javid to end hostile era for illegal immigrants
+  </h3>
+  <div
+    dir="auto"
+    style={
+      Object {
+        "WebkitBoxLines": "multiple",
+        "WebkitFlexWrap": "wrap",
+        "color": "rgba(105,105,105,1)",
+        "flexWrap": "wrap",
+        "fontFamily": "TimesDigitalW04",
+        "lineHeight": "20px",
+        "marginBottom": "10px",
+        "msFlexWrap": "wrap",
+      }
+    }
+  >
+    <span
+      dir="auto"
+    >
+      
+      <span
+        dir="auto"
+      >
+        Sajid Javid
+      </span>
+       has warned the Home Office to expect an overhaul after the 
+      <span
+        dir="auto"
+      >
+        Windrush scandal
+      </span>
+       as he ditches the policy of creating a “hostile
+      ...
+    </span>
+  </div>
+  <div
+    aria-label="datePublication"
+    data-testid="datePublication"
+    dir="auto"
+    style={
+      Object {
+        "color": "rgba(105,105,105,1)",
+        "lineHeight": "15px",
+        "marginBottom": "5px",
+      }
+    }
+  >
+    Friday November 17 2017, 12:01am, The Times
+  </div>
+</div>
+`;
+
 exports[`Article Summary tests on Web should render an article-summary component with a single paragraph 1`] = `
 <div>
   <div>
@@ -231,7 +314,7 @@ exports[`Article Summary tests on Web should render an article-summary component
         Victoria
       </strong>
       <br />
-      ITV
+       ITV
       <br />
       ★★★★☆
     </span>
@@ -243,7 +326,7 @@ exports[`Article Summary tests on Web should render an article-summary component
         Lucy Worsley’s Nights at the Opera
       </strong>
       <br />
-      BBC Two
+       BBC Two
       <br />
       ★★★☆☆
     </span>

--- a/packages/article-summary/article-summary.showcase.js
+++ b/packages/article-summary/article-summary.showcase.js
@@ -3,6 +3,7 @@ import { View } from "react-native";
 import ArticleSummary from "./src/article-summary";
 
 import defaultFixture from "./fixtures/default";
+import withLinksFixture from "./fixtures/with-links";
 import articleMultiFixture from "./fixtures/article-multi";
 import noBylineFixture from "./fixtures/no-byline";
 import noLabelFixture from "./fixtures/no-label";
@@ -17,6 +18,11 @@ export default {
       type: "story",
       name: "Default",
       component: () => story(<ArticleSummary {...defaultFixture} />)
+    },
+    {
+      type: "story",
+      name: "With links",
+      component: () => story(<ArticleSummary {...withLinksFixture} />)
     },
     {
       type: "story",

--- a/packages/article-summary/fixtures/with-links.js
+++ b/packages/article-summary/fixtures/with-links.js
@@ -1,0 +1,80 @@
+import React from "react";
+import { colours } from "@times-components/styleguide";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+
+export default {
+  labelProps: {
+    title: "Francis Elliott",
+    color: colours.functional.primary
+  },
+  datePublicationProps: {
+    date: "2017-11-17T00:01:00.000Z",
+    publication: "TIMES"
+  },
+  headline: () => (
+    <ArticleSummaryHeadline headline="Sajid Javid to end hostile era for illegal immigrants" />
+  ),
+  content: () => (
+    <ArticleSummaryContent
+      ast={[
+        {
+          name: "paragraph",
+          children: [
+            {
+              name: "link",
+              attributes: {
+                href:
+                  "https://www.thetimes.co.uk/edition/news/sajid-javid-son-of-bus-driver-who-rose-from-poverty-to-become-home-secretary-9606jg3h7",
+                type: "article",
+                canonicalId:
+                  "sajid-javid-son-of-bus-driver-who-rose-from-poverty-to-become-home-secretary-9606jg3h7"
+              },
+              children: [
+                {
+                  name: "text",
+                  attributes: {
+                    value: "Sajid Javid"
+                  },
+                  children: []
+                }
+              ]
+            },
+            {
+              name: "text",
+              attributes: {
+                value:
+                  " has warned the Home Office to expect an overhaul after the "
+              },
+              children: []
+            },
+            {
+              name: "link",
+              attributes: {
+                href:
+                  "https://www.thetimes.co.uk/article/timeline-windrush-immigration-scandals-29s3vtp53",
+                type: "article",
+                canonicalId: "timeline-windrush-immigration-scandals-29s3vtp53"
+              },
+              children: [
+                {
+                  name: "text",
+                  attributes: {
+                    value: "Windrush scandal"
+                  },
+                  children: []
+                }
+              ]
+            },
+            {
+              name: "text",
+              attributes: {
+                value: " as he ditches the policy of creating a “hostile"
+              },
+              children: []
+            }
+          ]
+        }
+      ]}
+    />
+  )
+};

--- a/packages/article-summary/src/article-summary-renderer.js
+++ b/packages/article-summary/src/article-summary-renderer.js
@@ -2,6 +2,9 @@ import React from "react";
 import { Text } from "react-native";
 
 export default {
+  link(key, attributes, renderedChildren) {
+    return <Text key={key}>{renderedChildren}</Text>;
+  },
   paragraph(key, attributes, renderedChildren, index) {
     const padding = renderedChildren.length && index !== 0 ? " " : "";
     return (
@@ -10,9 +13,6 @@ export default {
         {renderedChildren}
       </Text>
     );
-  },
-  text(key, { value }) {
-    return value.trim();
   },
   teaser(key, { isSingle }, renderedChildren) {
     const padding = isSingle ? "" : " ";

--- a/packages/markup/src/tree-prop-types.js
+++ b/packages/markup/src/tree-prop-types.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 const nodeShape = {
   name: PropTypes.string.isRequired,
-  attributes: PropTypes.object.isRequired
+  attributes: PropTypes.object
 };
 
 nodeShape.children = PropTypes.arrayOf(PropTypes.shape(nodeShape)).isRequired;

--- a/packages/related-articles/__tests__/android/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/related-articles.test.js.snap
@@ -911,7 +911,7 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                         ellipsizeMode="tail"
                       >
                         
-                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                         <Text
                           accessible={true}
                           allowFontScaling={true}
@@ -1381,7 +1381,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                         ellipsizeMode="tail"
                       >
                         
-                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                         <Text
                           accessible={true}
                           allowFontScaling={true}
@@ -1584,7 +1584,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                         ellipsizeMode="tail"
                       >
                         
-                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                         <Text
                           accessible={true}
                           allowFontScaling={true}

--- a/packages/related-articles/__tests__/ios/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/related-articles.test.js.snap
@@ -908,7 +908,7 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                         ellipsizeMode="tail"
                       >
                         
-                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                         <Text
                           accessible={true}
                           allowFontScaling={true}
@@ -1376,7 +1376,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                         ellipsizeMode="tail"
                       >
                         
-                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                         <Text
                           accessible={true}
                           allowFontScaling={true}
@@ -1578,7 +1578,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                         ellipsizeMode="tail"
                       >
                         
-                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                        The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                         <Text
                           accessible={true}
                           allowFontScaling={true}

--- a/packages/related-articles/__tests__/web/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/related-articles.test.js.snap
@@ -467,7 +467,7 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                           dir="auto"
                         >
                           
-                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                           <em>
                             The Times
                           </em>
@@ -831,7 +831,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                           dir="auto"
                         >
                           
-                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                           <em>
                             The Times
                           </em>
@@ -854,7 +854,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                           dir="auto"
                         >
                           
-                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                           <em>
                             The Times
                           </em>
@@ -1006,7 +1006,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                           dir="auto"
                         >
                           
-                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                           <em>
                             The Times
                           </em>
@@ -1029,7 +1029,7 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                           dir="auto"
                         >
                           
-                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by
+                          The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by 
                           <em>
                             The Times
                           </em>


### PR DESCRIPTION
We're not currently rendering links in the article summary. This renders their content as plain text.

There is a slight breaking change for sanity sake, the TV review data is so badly formatted that we may as well leave it even more broken so that we don't have to determine which text should be trimmed and which shouldn't. I'm still hopeful we can follow up initial work I started with the Methode team to create a known Review element which will resolve these issues.