### PR TITLE
feat: get fixed fonts from s3

### DIFF
--- a/lib/fetch-fixed-fonts.js
+++ b/lib/fetch-fixed-fonts.js
@@ -1,30 +1,28 @@
-
-const fs = require('fs');
-const AWS = require('aws-sdk');
+const fs = require("fs");
+const AWS = require("aws-sdk");
 const { promisify } = require("util");
 const mkdirp = promisify(require("mkdirp"));
 
 const s3 = new AWS.S3();
-AWS.config.update({ region: 'eu-west-1'});
+AWS.config.update({ region: "eu-west-1" });
 
 const fontDir = `${__dirname}/../dist/public/fonts`;
-const bucket = 'nu-tools-fonts';
+const bucket = "nu-tools-fonts";
 
-s3.listObjects({ Bucket: bucket}, (error, bucketObjects) => {
-    if(error) throw error;
+s3.listObjects({ Bucket: bucket }, (error, bucketObjects) => {
+  if (error) throw error;
 
-    mkdirp(fontDir);
+  mkdirp(fontDir);
 
-    const contents = bucketObjects.Contents;
-    contents.forEach(font => {
+  const contents = bucketObjects.Contents;
+  contents.forEach(font => {
+    s3.getObject({ Bucket: bucket, Key: font.Key }, (err, data) => {
+      if (err) throw err;
 
-     s3.getObject({Bucket: bucket, Key: font.Key}, (err, data) => {
-       if (err) throw err;
-
-       fs.writeFile(`${fontDir}/${font.Key}`,  data.Body, (e) => {
-         if (e) throw e
-       });
+      fs.writeFile(`${fontDir}/${font.Key}`, data.Body, e => {
+        if (e) throw e;
       });
     });
-    console.log('Got all fonts'); // eslint-disable-line no-console
+  });
+  console.log("Got all fonts"); // eslint-disable-line no-console
 });

--- a/lib/fetch-fixed-fonts.js
+++ b/lib/fetch-fixed-fonts.js
@@ -1,0 +1,30 @@
+
+const fs = require('fs');
+const AWS = require('aws-sdk');
+const { promisify } = require("util");
+const mkdirp = promisify(require("mkdirp"));
+
+const s3 = new AWS.S3();
+AWS.config.update({ region: 'eu-west-1'});
+
+const fontDir = `${__dirname}/../dist/public/fonts`;
+const bucket = 'nu-tools-fonts';
+
+s3.listObjects({ Bucket: bucket}, (error, bucketObjects) => {
+    if(error) throw error;
+
+    mkdirp(fontDir);
+
+    const contents = bucketObjects.Contents;
+    contents.forEach(font => {
+
+     s3.getObject({Bucket: bucket, Key: font.Key}, (err, data) => {
+       if (err) throw err;
+
+       fs.writeFile(`${fontDir}/${font.Key}`,  data.Body, (e) => {
+         if (e) throw e
+       });
+      });
+    });
+    console.log('Got all fonts'); // eslint-disable-line no-console
+});

--- a/lib/fetch-fixed-fonts.js
+++ b/lib/fetch-fixed-fonts.js
@@ -13,17 +13,18 @@ const bucket = "nu-tools-fonts";
 s3.listObjects({ Bucket: bucket }, (error, bucketObjects) => {
   if (error) throw error;
 
-  mkdirp(fontDir);
+  mkdirp(fontDir).then(() => {
+    const { contents } = bucketObjects;
+    
+    contents.forEach(font => {
+      s3.getObject({ Bucket: bucket, Key: font.Key }, (err, data) => {
+        if (err) throw err;
 
-  const contents = bucketObjects.Contents;
-  contents.forEach(font => {
-    s3.getObject({ Bucket: bucket, Key: font.Key }, (err, data) => {
-      if (err) throw err;
-
-      fs.writeFile(`${fontDir}/${font.Key}`, data.Body, e => {
-        if (e) throw e;
+        fs.writeFile(`${fontDir}/${font.Key}`, data.Body, e => {
+          if (e) throw e;
+        });
       });
     });
-  });
   console.log("Got all fonts"); // eslint-disable-line no-console
+  })
 });

--- a/lib/fetch-fixed-fonts.js
+++ b/lib/fetch-fixed-fonts.js
@@ -15,7 +15,7 @@ s3.listObjects({ Bucket: bucket }, (error, bucketObjects) => {
 
   mkdirp(fontDir).then(() => {
     const { contents } = bucketObjects;
-    
+
     contents.forEach(font => {
       s3.getObject({ Bucket: bucket, Key: font.Key }, (err, data) => {
         if (err) throw err;
@@ -25,6 +25,6 @@ s3.listObjects({ Bucket: bucket }, (error, bucketObjects) => {
         });
       });
     });
-  console.log("Got all fonts"); // eslint-disable-line no-console
-  })
+    console.log("Got all fonts"); // eslint-disable-line no-console
+  });
 });

--- a/lib/fetch-fixed-fonts.js
+++ b/lib/fetch-fixed-fonts.js
@@ -1,12 +1,13 @@
 const fs = require("fs");
 const AWS = require("aws-sdk");
+const path = require("path");
 const { promisify } = require("util");
 const mkdirp = promisify(require("mkdirp"));
 
 const s3 = new AWS.S3();
 AWS.config.update({ region: "eu-west-1" });
 
-const fontDir = `${__dirname}/../dist/public/fonts`;
+const fontDir = path.resolve(`${__dirname}/../dist/public/fonts`);
 const bucket = "nu-tools-fonts";
 
 s3.listObjects({ Bucket: bucket }, (error, bucketObjects) => {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "deps:fix": "lerna run cli -- -- --fix -s majorityProgressive",
     "deps:list": "lerna run cli -- -- --list -s majorityProgressive",
     "fetch-fonts": "node ./lib/fetch-fonts",
+    "fetch-fixed-fonts": "node ./lib/fetch-fixed-fonts",
     "prestorybook": "yarn fetch-fonts && yarn storybook:build-vendor",
     "storybook": "start-storybook -p 9001 -c .storybook -s ./dist/public",
     "storybook:build-vendor": "webpack --config ./.storybook/vendor.webpack.config.js",


### PR DESCRIPTION
we cant fix fonts on bitrise because font forge is not available on linux.

As a result, this PR will allow bitrise to get a set of fonts that have already been fixed from s3.


