### PR TITLE
Chore: Add visual snapshots and generated components file to ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@
 dist
 storybook-static
 packages
+dextrose/snappy
+fructose/components.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,4 @@ packages
 coverage
 settings.gradle
 build.gradle
+dextrose/snappy


### PR DESCRIPTION
- lint and prettier need to ignore visual snapshots dir and fructose generated components file
