### PR TITLE
fix: Missing headline in topics provider

### DIFF
--- a/packages/provider-test-tools/fixtures/topic.json
+++ b/packages/provider-test-tools/fixtures/topic.json
@@ -8,6 +8,7 @@
         "list": [
           {
             "byline": [],
+            "headline": "Dame Daphne Sheldrick obituary",
             "id": "5b48c89c-4a2c-11e8-8db5-58268675bbb1",
             "label": "obituary",
             "leadAsset": {
@@ -57,6 +58,8 @@
                 ]
               }
             ],
+            "headline":
+              "Racing chief Steve Harman’s future on line over new Tote",
             "id": "4034eff2-47cc-11e8-bf76-d5da08923eed",
             "label": "Racing",
             "leadAsset": {
@@ -106,6 +109,7 @@
                 ]
               }
             ],
+            "headline": "Sick horses being dumped and left to die, says RSPCA",
             "id": "fb849670-478d-11e8-8db5-58268675bbb1",
             "label": "",
             "leadAsset": {
@@ -155,6 +159,7 @@
                 ]
               }
             ],
+            "headline": "Development ‘could kill Edinburgh zoo’s pandas’",
             "id": "1cb67448-4668-11e8-bf76-d5da08923eed",
             "label": "",
             "leadAsset": {
@@ -209,6 +214,7 @@
                 ]
               }
             ],
+            "headline": "Channon eyes shot at Guineas",
             "id": "9ef271f0-45aa-11e8-a171-006f480ab6fd",
             "label": "Racing",
             "leadAsset": {
@@ -259,6 +265,7 @@
                 ]
               }
             ],
+            "headline": "RSPB disputes research on turbine threat to seabirds",
             "id": "368f2544-4411-11e8-99ea-a5dd07dd144b",
             "label": "",
             "leadAsset": {
@@ -309,6 +316,7 @@
                 ]
               }
             ],
+            "headline": "Gulls fly away from wind turbines",
             "id": "0b83d692-4353-11e8-9618-96ec7a8a2ce5",
             "label": "",
             "leadAsset": {
@@ -358,6 +366,7 @@
                 ]
               }
             ],
+            "headline": "Opposing factions team up in hunt for missing eagle",
             "id": "28e2d8be-4268-11e8-9618-96ec7a8a2ce5",
             "label": "",
             "leadAsset": {
@@ -408,6 +417,7 @@
                 ]
               }
             ],
+            "headline": "Fixture error angers Richard Johnson",
             "id": "ca2f566c-4262-11e8-99ea-a5dd07dd144b",
             "label": "Racing",
             "leadAsset": {
@@ -457,6 +467,7 @@
                 ]
               }
             ],
+            "headline": "Criminals getting away with attacks on wildlife",
             "id": "3b78a542-41bb-11e8-99ea-a5dd07dd144b",
             "label": "",
             "leadAsset": {

--- a/packages/provider/__tests__/__snapshots__/topic-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/topic-provider.test.js.snap
@@ -10,6 +10,7 @@ Object {
       Object {
         "__typename": "Article",
         "byline": Array [],
+        "headline": "Dame Daphne Sheldrick obituary",
         "id": "5b48c89c-4a2c-11e8-8db5-58268675bbb1",
         "label": "obituary",
         "leadAsset": Object {
@@ -59,6 +60,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Racing chief Steve Harman’s future on line over new Tote",
         "id": "4034eff2-47cc-11e8-bf76-d5da08923eed",
         "label": "Racing",
         "leadAsset": Object {
@@ -108,6 +110,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Sick horses being dumped and left to die, says RSPCA",
         "id": "fb849670-478d-11e8-8db5-58268675bbb1",
         "label": "",
         "leadAsset": Object {
@@ -157,6 +160,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Development ‘could kill Edinburgh zoo’s pandas’",
         "id": "1cb67448-4668-11e8-bf76-d5da08923eed",
         "label": "",
         "leadAsset": Object {
@@ -210,6 +214,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Channon eyes shot at Guineas",
         "id": "9ef271f0-45aa-11e8-a171-006f480ab6fd",
         "label": "Racing",
         "leadAsset": Object {
@@ -259,6 +264,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "RSPB disputes research on turbine threat to seabirds",
         "id": "368f2544-4411-11e8-99ea-a5dd07dd144b",
         "label": "",
         "leadAsset": Object {
@@ -308,6 +314,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Gulls fly away from wind turbines",
         "id": "0b83d692-4353-11e8-9618-96ec7a8a2ce5",
         "label": "",
         "leadAsset": Object {
@@ -357,6 +364,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Opposing factions team up in hunt for missing eagle",
         "id": "28e2d8be-4268-11e8-9618-96ec7a8a2ce5",
         "label": "",
         "leadAsset": Object {
@@ -406,6 +414,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Fixture error angers Richard Johnson",
         "id": "ca2f566c-4262-11e8-99ea-a5dd07dd144b",
         "label": "Racing",
         "leadAsset": Object {
@@ -455,6 +464,7 @@ Object {
             "name": "inline",
           },
         ],
+        "headline": "Criminals getting away with attacks on wildlife",
         "id": "3b78a542-41bb-11e8-99ea-a5dd07dd144b",
         "label": "",
         "leadAsset": Object {

--- a/packages/provider/src/topic-articles.js
+++ b/packages/provider/src/topic-articles.js
@@ -8,6 +8,7 @@ export const query = gql`
         count
         list {
           byline
+          headline
           id
           label
           leadAsset {


### PR DESCRIPTION
The Topics provider was missing a headline in its request. This fixes this and the associated tests
