### PR TITLE
fix: fix the provider test tools, allow consumer to dictate summary l…

### DIFF
--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -1540,381 +1540,1278 @@ exports[`1. Render an author profile page 1`] = `
 `;
 
 exports[`2. Render an author profile page without images 1`] = `
-<View
-  style={
+<RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  ListFooterComponent={
+    <ArticleListPagination
+      count={20}
+      hideResults={true}
+      onNext={[Function]}
+      onPrev={[Function]}
+      page={1}
+      pageSize={3}
+    />
+  }
+  ListHeaderComponent={
+    <View>
+      <WithTrackEvents(AuthorHead)
+        bio={
+          Array [
+            Object {
+              "attributes": Object {
+                "value": "Deborah Haynes is the defence editor at ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "The Times",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": ", covering the most important defence & security news in the UK and around the world.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ]
+        }
+        isLoading={false}
+        name="Deborah Haynes"
+        onTwitterLinkPress={[Function]}
+        title="Defence Editor"
+        twitter="jdoe"
+        uri="//www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg"
+      />
+      <ArticleListPagination
+        count={20}
+        hideResults={false}
+        onNext={[Function]}
+        onPrev={[Function]}
+        page={1}
+        pageSize={3}
+      />
+    </View>
+  }
+  accessibilityID="scroll-view"
+  data={
+    Array [
+      Object {
+        "__typename": "Article",
+        "elementId": "d98c257c-cb16-11e7-b529-95e3fc05f40f.0",
+        "headline": "Top medal for forces dog who took a bite out of the Taliban",
+        "id": "d98c257c-cb16-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "longSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "publicationName": "TIMES",
+        "publishedTime": "2017-11-17T00:01:00.000Z",
+        "shortSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "url": "https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f",
+      },
+      Object {
+        "__typename": "Article",
+        "elementId": "4e6894ec-cb18-11e7-b529-95e3fc05f40f.1",
+        "headline": "Social media must raise game to beat terrorists, says UN chief",
+        "id": "4e6894ec-cb18-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "longSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The head of the United Nations has added his voice to calls for Facebook, YouTube, Microsoft and Twitter to help to stop the spread of terrorist material online.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "António Guterres said last night that Islamic State and other terrorist groups were losing physical ground in Iraq and Syria but were growing their presence in cyberspace. He described terrorism as",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "publicationName": "TIMES",
+        "publishedTime": "2017-11-17T00:01:00.000Z",
+        "shortSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The head of the United Nations has added his voice to calls for Facebook, YouTube, Microsoft and Twitter to help to stop the spread of terrorist material online.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "António Guterres said last night that Islamic State and other terrorist groups were losing physical ground in Iraq and Syria but were growing their presence in cyberspace. He described terrorism as",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "url": "https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0",
+      },
+      Object {
+        "__typename": "Article",
+        "elementId": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2",
+        "headline": "Cuts have left the army 20 years out of date, says former general",
+        "id": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "longSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Britain’s cash-strapped army is 20 years out of date and would be incapable of surviving Russian artillery and air strikes in a conflict, a former military chief said today.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "General Sir Richard Barrons, the commander of Joint Forces Command until last year, warned that the entire armed forces were on the brink of operational or institutional failure unless",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "publicationName": "TIMES",
+        "publishedTime": "2017-11-14T17:00:00.000Z",
+        "shortSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Britain’s cash-strapped army is 20 years out of date and would be incapable of surviving Russian artillery and air strikes in a conflict, a former military chief said today.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "General Sir Richard Barrons, the commander of Joint Forces Command until last year, warned that the entire armed forces were on the brink of operational or institutional failure unless",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "url": "https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  onViewableItemsChanged={[Function]}
+  pageSize={3}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  scrollRenderAheadDistance={2}
+  stickyHeaderIndices={Array []}
+  testID="scroll-view"
+  updateCellsBatchingPeriod={50}
+  viewabilityConfig={
     Object {
-      "flex": 1,
-      "margin": 15,
+      "viewAreaCoveragePercentThreshold": 100,
+      "waitForInteraction": false,
     }
   }
->
-  <View
-    style={
+  viewabilityConfigCallbackPairs={
+    Array [
       Object {
-        "opacity": 1,
-      }
-    }
-  >
+        "onViewableItemsChanged": [Function],
+        "viewabilityConfig": Object {
+          "viewAreaCoveragePercentThreshold": 100,
+          "waitForInteraction": false,
+        },
+      },
+    ]
+  }
+  windowSize={21}
+>
+  <View>
     <View
-      pointerEvents="box-none"
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "transparent",
-        }
-      }
+      onLayout={[Function]}
     >
-      <View
-        accessibilityRole="banner"
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#F9F8F3",
-            "flexDirection": "column",
-            "paddingBottom": 40,
-            "paddingTop": 30,
-            "width": "100%",
-          }
-        }
-      >
+      <View>
         <View
-          aspectRatio={1}
           style={
             Object {
-              "borderColor": "#FFFFFF",
-              "borderRadius": 50,
-              "marginBottom": 20,
-              "marginLeft": "auto",
-              "marginRight": "auto",
-              "overflow": "hidden",
-              "width": 100,
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            pointerEvents="box-none"
+            style={
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "transparent",
+              }
+            }
+          >
+            <View
+              accessibilityRole="banner"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "#F9F8F3",
+                  "flexDirection": "column",
+                  "paddingBottom": 40,
+                  "paddingTop": 30,
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                aspectRatio={1}
+                style={
+                  Object {
+                    "borderColor": "#FFFFFF",
+                    "borderRadius": 50,
+                    "marginBottom": 20,
+                    "marginLeft": "auto",
+                    "marginRight": "auto",
+                    "overflow": "hidden",
+                    "width": 100,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                >
+                  <Image
+                    onLoad={[Function]}
+                    source={
+                      Object {
+                        "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg&resize=1440",
+                      }
+                    }
+                    style={
+                      Object {
+                        "bottom": 0,
+                        "height": "100%",
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                        "width": "100%",
+                      }
+                    }
+                  />
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      onLayout={[Function]}
+                      style={
+                        Object {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <ARTSurfaceView
+                        style={
+                          Object {
+                            "bottom": 0,
+                            "height": 0,
+                            "left": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
+                        }
+                      >
+                        <ARTShape
+                          d={
+                            Array [
+                              2,
+                              0,
+                              0,
+                              2,
+                              0,
+                              0,
+                              2,
+                              0,
+                              0,
+                              2,
+                              0,
+                              0,
+                            ]
+                          }
+                          fill={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              -0,
+                              0,
+                              0.9764705882352941,
+                              0.9764705882352941,
+                              0.9764705882352941,
+                              1,
+                              0.9294117647058824,
+                              0.9294117647058824,
+                              0.9294117647058824,
+                              1,
+                              0,
+                              1,
+                            ]
+                          }
+                          opacity={1}
+                          stroke={null}
+                          strokeCap={1}
+                          strokeDash={null}
+                          strokeJoin={1}
+                          strokeWidth={1}
+                          transform={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              1,
+                              0,
+                              0,
+                            ]
+                          }
+                        />
+                      </ARTSurfaceView>
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <Text
+                accessibilityLabel="author-name"
+                accessibilityRole="heading"
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#1D1D1B",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 30,
+                  }
+                }
+                testID="author-name"
+              >
+                Deborah Haynes
+              </Text>
+              <Text
+                accessibilityRole="heading"
+                accessible={true}
+                allowFontScaling={true}
+                aria-level="2"
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                defence editor
+              </Text>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "paddingBottom": 8,
+                    "paddingTop": 8,
+                  }
+                }
+              >
+                <svg
+                  height={15}
+                  width={15}
+                >
+                  <path
+                    fill="#006699"
+                  />
+                </svg>
+                <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="https://twitter.com/jdoe"
+                  onPress={[Function]}
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "paddingLeft": 5,
+                      "textDecorationLine": "none",
+                    }
+                  }
+                >
+                  @
+                  jdoe
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "paddingBottom": 32,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 16,
+                      "lineHeight": 26,
+                      "textAlign": "center",
+                    }
+                  }
+                  testID="author-bio"
+                >
+                  Deborah Haynes is the defence editor at 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                  , covering the most important defence & security news in the UK and around the world.
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "stretch",
+              "flexDirection": "row",
+              "justifyContent": "center",
             }
           }
         >
           <View
             style={
               Object {
-                "height": "100%",
-                "width": "100%",
+                "flex": 1,
+                "maxWidth": 800,
               }
             }
           >
-            <Image
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg&resize=1440",
-                }
-              }
-              style={
-                Object {
-                  "bottom": 0,
-                  "height": "100%",
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
-                }
-              }
-            />
             <View
-              onLayout={[Function]}
               style={
                 Object {
-                  "flex": 1,
+                  "alignItems": "stretch",
+                  "flexDirection": "column",
                 }
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
-                    "flex": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "height": 50,
+                    "justifyContent": "center",
                   }
                 }
               >
-                <ARTSurfaceView
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
                   style={
                     Object {
-                      "bottom": 0,
-                      "height": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": 0,
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "paddingTop": 4,
                     }
                   }
+                  testID="results-message"
                 >
-                  <ARTShape
-                    d={
-                      Array [
-                        2,
-                        0,
-                        0,
-                        2,
-                        0,
-                        0,
-                        2,
-                        0,
-                        0,
-                        2,
-                        0,
-                        0,
-                      ]
+                  Showing 1 - 3 of 20 results
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "borderBottomColor": "#DBDBDB",
+                    "borderBottomWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "#DBDBDB",
+                    "borderTopWidth": 1,
+                    "flexDirection": "row",
+                    "height": 50,
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <View />
+                <View>
+                  <View
+                    accessible={true}
+                    nativeBackgroundAndroid={
+                      Object {
+                        "attribute": "selectableItemBackground",
+                        "type": "ThemeAttrAndroid",
+                      }
                     }
-                    fill={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        -0,
-                        0,
-                        0.9764705882352941,
-                        0.9764705882352941,
-                        0.9764705882352941,
-                        1,
-                        0.9294117647058824,
-                        0.9294117647058824,
-                        0.9294117647058824,
-                        1,
-                        0,
-                        1,
-                      ]
-                    }
-                    opacity={1}
-                    stroke={null}
-                    strokeCap={1}
-                    strokeDash={null}
-                    strokeJoin={1}
-                    strokeWidth={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  />
-                </ARTSurfaceView>
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    pointerEvents="box-only"
+                  >
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "baseline",
+                          "flexDirection": "row",
+                          "padding": 12,
+                        }
+                      }
+                      testID="pagination-button-next"
+                    >
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Object {
+                            "color": "#006699",
+                            "fontFamily": "GillSansMTStd-Medium",
+                            "fontSize": 15,
+                            "height": 15,
+                            "marginRight": 10,
+                            "textAlign": "right",
+                          }
+                        }
+                      >
+                        <Text
+                          accessible={true}
+                          allowFontScaling={true}
+                          ellipsizeMode="tail"
+                        >
+                          Next
+                        </Text>
+                      </Text>
+                      <svg
+                        height={12}
+                        width={7}
+                      >
+                        <g
+                          fill="#006699"
+                        >
+                          <path />
+                        </g>
+                      </svg>
+                    </View>
+                  </View>
+                </View>
               </View>
             </View>
           </View>
         </View>
-        <Text
-          accessibilityLabel="author-name"
-          accessibilityRole="heading"
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-            }
-          }
-          testID="author-name"
-        >
-          Deborah Haynes
-        </Text>
-        <Text
-          accessibilityRole="heading"
-          accessible={true}
-          allowFontScaling={true}
-          aria-level="2"
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "color": "#696969",
-              "fontFamily": "TimesDigitalW04-RegularSC",
-              "fontSize": 14,
-            }
-          }
-        >
-          defence editor
-        </Text>
-        <View
-          style={
-            Object {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "paddingBottom": 8,
-              "paddingTop": 8,
-            }
-          }
-        >
-          <svg
-            height={15}
-            width={15}
-          >
-            <path
-              fill="#006699"
-            />
-          </svg>
-          <Text
-            accessibilityRole="link"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            href="https://twitter.com/jdoe"
-            onPress={[Function]}
-            style={
-              Object {
-                "color": "#006699",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 15,
-                "paddingLeft": 5,
-                "textDecorationLine": "none",
-              }
-            }
-          >
-            @
-            jdoe
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "paddingBottom": 32,
-              "paddingLeft": 10,
-              "paddingRight": 10,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesDigitalW04",
-                "fontSize": 16,
-                "lineHeight": 26,
-                "textAlign": "center",
-              }
-            }
-            testID="author-bio"
-          >
-            Deborah Haynes is the defence editor at 
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "fontStyle": "italic",
-                }
-              }
-            >
-              The Times
-            </Text>
-            , covering the most important defence & security news in the UK and around the world.
-          </Text>
-        </View>
       </View>
     </View>
-  </View>
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "margin": 15,
-      }
-    }
-  >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Object {
-          "alignSelf": "center",
-          "color": "#1D1D1B",
-          "fontFamily": "TimesModern-Bold",
-          "fontSize": 35,
-          "marginBottom": 10,
-          "marginTop": 20,
-          "textAlign": "center",
-        }
-      }
-    >
-      Something's gone wrong
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Object {
-          "color": "#696969",
-          "fontFamily": "TimesDigitalW04-Regular",
-          "fontSize": 18,
-          "textAlign": "center",
-        }
-      }
-    >
-      We can't load the page you have requested. Please check your network connection and retry to continue
-    </Text>
     <View
-      style={
-        Object {
-          "bottom": 0,
-          "position": "absolute",
-          "width": "100%",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        accessibilityLabel="Retry"
         accessible={true}
-        isTVSelectable={true}
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackground",
+            "type": "ThemeAttrAndroid",
+          }
+        }
         onResponderGrant={[Function]}
         onResponderMove={[Function]}
         onResponderRelease={[Function]}
         onResponderTerminate={[Function]}
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
+        pointerEvents="box-only"
+      >
+        <View
+          style={
+            Object {
+              "paddingBottom": 15,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 15,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": 0,
+                    "minWidth": "100%",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    accessibilityRole="heading"
+                    accessible={true}
+                    allowFontScaling={true}
+                    aria-level="3"
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "400",
+                        "lineHeight": 22,
+                        "marginBottom": 5,
+                      }
+                    }
+                  >
+                    Top medal for forces dog who took a bite out of the Taliban
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                        "marginBottom": 10,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                      
+                      The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
+                    </Text>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                       
+                      Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen
+                      ...
+                    </Text>
+                  </Text>
+                  <Text
+                    accessibilityLabel="datePublication"
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                        "marginBottom": 5,
+                      }
+                    }
+                    testID="datePublication"
+                  >
+                    Friday November 17 2017, 12:01am, The Times
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
         style={
           Object {
-            "opacity": 1,
+            "paddingLeft": 10,
+            "paddingRight": 10,
           }
         }
       >
         <View
           style={
             Object {
-              "alignItems": "center",
-              "backgroundColor": "#006699",
-              "flex": 1,
-              "height": 45,
-              "justifyContent": "center",
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        accessible={true}
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackground",
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        pointerEvents="box-only"
+      >
+        <View
+          style={
+            Object {
+              "paddingBottom": 15,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 15,
             }
           }
         >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
+          <View
             style={
               Object {
-                "color": "#FFF",
-                "fontFamily": "GillSansMTStd-Medium",
+                "opacity": 1,
               }
             }
           >
-            RETRY
-          </Text>
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": 0,
+                    "minWidth": "100%",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    accessibilityRole="heading"
+                    accessible={true}
+                    allowFontScaling={true}
+                    aria-level="3"
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "400",
+                        "lineHeight": 22,
+                        "marginBottom": 5,
+                      }
+                    }
+                  >
+                    Social media must raise game to beat terrorists, says UN chief
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                        "marginBottom": 10,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                      
+                      The head of the United Nations has added his voice to calls for Facebook, YouTube, Microsoft and Twitter to help to stop the spread of terrorist material online.
+                    </Text>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                       
+                      António Guterres said last night that Islamic State and other terrorist groups were losing physical ground in Iraq and Syria but were growing their presence in cyberspace. He described terrorism as
+                      ...
+                    </Text>
+                  </Text>
+                  <Text
+                    accessibilityLabel="datePublication"
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                        "marginBottom": 5,
+                      }
+                    }
+                    testID="datePublication"
+                  >
+                    Friday November 17 2017, 12:01am, The Times
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        accessible={true}
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackground",
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        pointerEvents="box-only"
+      >
+        <View
+          style={
+            Object {
+              "paddingBottom": 15,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 15,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": 0,
+                    "minWidth": "100%",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    accessibilityRole="heading"
+                    accessible={true}
+                    allowFontScaling={true}
+                    aria-level="3"
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "400",
+                        "lineHeight": 22,
+                        "marginBottom": 5,
+                      }
+                    }
+                  >
+                    Cuts have left the army 20 years out of date, says former general
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                        "marginBottom": 10,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                      
+                      Britain’s cash-strapped army is 20 years out of date and would be incapable of surviving Russian artillery and air strikes in a conflict, a former military chief said today.
+                    </Text>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                       
+                      General Sir Richard Barrons, the commander of Joint Forces Command until last year, warned that the entire armed forces were on the brink of operational or institutional failure unless
+                      ...
+                    </Text>
+                  </Text>
+                  <Text
+                    accessibilityLabel="datePublication"
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                        "marginBottom": 5,
+                      }
+                    }
+                    testID="datePublication"
+                  >
+                    Tuesday November 14 2017, 05:00pm, The Times
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "stretch",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "maxWidth": 800,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderStyle": "solid",
+                  "borderTopColor": "#DBDBDB",
+                  "borderTopWidth": 1,
+                  "flexDirection": "row",
+                  "height": 50,
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <View />
+              <View>
+                <View
+                  accessible={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackground",
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  pointerEvents="box-only"
+                >
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "baseline",
+                        "flexDirection": "row",
+                        "padding": 12,
+                      }
+                    }
+                    testID="pagination-button-next"
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "color": "#006699",
+                          "fontFamily": "GillSansMTStd-Medium",
+                          "fontSize": 15,
+                          "height": 15,
+                          "marginRight": 10,
+                          "textAlign": "right",
+                        }
+                      }
+                    >
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                      >
+                        Next
+                      </Text>
+                    </Text>
+                    <svg
+                      height={12}
+                      width={7}
+                    >
+                      <g
+                        fill="#006699"
+                      >
+                        <path />
+                      </g>
+                    </svg>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
         </View>
       </View>
     </View>
   </View>
-</View>
+</RCTScrollView>
 `;
 
 exports[`3. Render an author profile page loading state 1`] = `

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -1534,337 +1534,730 @@ exports[`1. Render an author profile page 1`] = `
 `;
 
 exports[`2. Render an author profile page without images 1`] = `
-<View
-  style={
+<RCTScrollView
+  ItemSeparatorComponent={[Function]}
+  ListFooterComponent={
+    <ArticleListPagination
+      count={20}
+      hideResults={true}
+      onNext={[Function]}
+      onPrev={[Function]}
+      page={1}
+      pageSize={3}
+    />
+  }
+  ListHeaderComponent={
+    <View>
+      <WithTrackEvents(AuthorHead)
+        bio={
+          Array [
+            Object {
+              "attributes": Object {
+                "value": "Deborah Haynes is the defence editor at ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "The Times",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": ", covering the most important defence & security news in the UK and around the world.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ]
+        }
+        isLoading={false}
+        name="Deborah Haynes"
+        onTwitterLinkPress={[Function]}
+        title="Defence Editor"
+        twitter="jdoe"
+        uri="//www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg"
+      />
+      <ArticleListPagination
+        count={20}
+        hideResults={false}
+        onNext={[Function]}
+        onPrev={[Function]}
+        page={1}
+        pageSize={3}
+      />
+    </View>
+  }
+  accessibilityID="scroll-view"
+  data={
+    Array [
+      Object {
+        "__typename": "Article",
+        "elementId": "d98c257c-cb16-11e7-b529-95e3fc05f40f.0",
+        "headline": "Top medal for forces dog who took a bite out of the Taliban",
+        "id": "d98c257c-cb16-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "longSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "publicationName": "TIMES",
+        "publishedTime": "2017-11-17T00:01:00.000Z",
+        "shortSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "url": "https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f",
+      },
+      Object {
+        "__typename": "Article",
+        "elementId": "4e6894ec-cb18-11e7-b529-95e3fc05f40f.1",
+        "headline": "Social media must raise game to beat terrorists, says UN chief",
+        "id": "4e6894ec-cb18-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "longSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The head of the United Nations has added his voice to calls for Facebook, YouTube, Microsoft and Twitter to help to stop the spread of terrorist material online.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "António Guterres said last night that Islamic State and other terrorist groups were losing physical ground in Iraq and Syria but were growing their presence in cyberspace. He described terrorism as",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "publicationName": "TIMES",
+        "publishedTime": "2017-11-17T00:01:00.000Z",
+        "shortSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "The head of the United Nations has added his voice to calls for Facebook, YouTube, Microsoft and Twitter to help to stop the spread of terrorist material online.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "António Guterres said last night that Islamic State and other terrorist groups were losing physical ground in Iraq and Syria but were growing their presence in cyberspace. He described terrorism as",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "url": "https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0",
+      },
+      Object {
+        "__typename": "Article",
+        "elementId": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f.2",
+        "headline": "Cuts have left the army 20 years out of date, says former general",
+        "id": "f79c9d8c-c95c-11e7-b529-95e3fc05f40f",
+        "label": "",
+        "longSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Britain’s cash-strapped army is 20 years out of date and would be incapable of surviving Russian artillery and air strikes in a conflict, a former military chief said today.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "General Sir Richard Barrons, the commander of Joint Forces Command until last year, warned that the entire armed forces were on the brink of operational or institutional failure unless",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "publicationName": "TIMES",
+        "publishedTime": "2017-11-14T17:00:00.000Z",
+        "shortSummary": Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Britain’s cash-strapped army is 20 years out of date and would be incapable of surviving Russian artillery and air strikes in a conflict, a former military chief said today.",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "General Sir Richard Barrons, the commander of Joint Forces Command until last year, warned that the entire armed forces were on the brink of operational or institutional failure unless",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "paragraph",
+          },
+        ],
+        "url": "https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  onViewableItemsChanged={[Function]}
+  pageSize={3}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  scrollRenderAheadDistance={2}
+  stickyHeaderIndices={Array []}
+  testID="scroll-view"
+  updateCellsBatchingPeriod={50}
+  viewabilityConfig={
     Object {
-      "flex": 1,
-      "margin": 15,
+      "viewAreaCoveragePercentThreshold": 100,
+      "waitForInteraction": false,
     }
   }
->
-  <View
-    style={
+  viewabilityConfigCallbackPairs={
+    Array [
       Object {
-        "opacity": 1,
-      }
-    }
-  >
+        "onViewableItemsChanged": [Function],
+        "viewabilityConfig": Object {
+          "viewAreaCoveragePercentThreshold": 100,
+          "waitForInteraction": false,
+        },
+      },
+    ]
+  }
+  windowSize={21}
+>
+  <View>
     <View
-      pointerEvents="box-none"
-      style={
-        Object {
-          "alignItems": "center",
-          "backgroundColor": "transparent",
-        }
-      }
+      onLayout={[Function]}
     >
-      <View
-        accessibilityRole="banner"
-        style={
-          Object {
-            "alignItems": "center",
-            "backgroundColor": "#F9F8F3",
-            "flexDirection": "column",
-            "paddingBottom": 40,
-            "paddingTop": 30,
-            "width": "100%",
-          }
-        }
-      >
+      <View>
         <View
-          aspectRatio={1}
           style={
             Object {
-              "borderColor": "#FFFFFF",
-              "borderRadius": 50,
-              "marginBottom": 20,
-              "marginLeft": "auto",
-              "marginRight": "auto",
-              "overflow": "hidden",
-              "width": 100,
+              "opacity": 1,
+            }
+          }
+        >
+          <View
+            pointerEvents="box-none"
+            style={
+              Object {
+                "alignItems": "center",
+                "backgroundColor": "transparent",
+              }
+            }
+          >
+            <View
+              accessibilityRole="banner"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "#F9F8F3",
+                  "flexDirection": "column",
+                  "paddingBottom": 40,
+                  "paddingTop": 30,
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                aspectRatio={1}
+                style={
+                  Object {
+                    "borderColor": "#FFFFFF",
+                    "borderRadius": 50,
+                    "marginBottom": 20,
+                    "marginLeft": "auto",
+                    "marginRight": "auto",
+                    "overflow": "hidden",
+                    "width": 100,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "height": "100%",
+                      "width": "100%",
+                    }
+                  }
+                >
+                  <Image
+                    onLoad={[Function]}
+                    source={
+                      Object {
+                        "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg&resize=1440",
+                      }
+                    }
+                    style={
+                      Object {
+                        "bottom": 0,
+                        "height": "100%",
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                        "width": "100%",
+                      }
+                    }
+                  />
+                  <View
+                    onLayout={[Function]}
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      onLayout={[Function]}
+                      style={
+                        Object {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <ARTSurfaceView
+                        style={
+                          Object {
+                            "bottom": 0,
+                            "height": 0,
+                            "left": 0,
+                            "position": "absolute",
+                            "right": 0,
+                            "top": 0,
+                            "width": 0,
+                          }
+                        }
+                      >
+                        <ARTShape
+                          d={
+                            Array [
+                              2,
+                              0,
+                              0,
+                              2,
+                              0,
+                              0,
+                              2,
+                              0,
+                              0,
+                              2,
+                              0,
+                              0,
+                            ]
+                          }
+                          fill={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              -0,
+                              0,
+                              0.9764705882352941,
+                              0.9764705882352941,
+                              0.9764705882352941,
+                              1,
+                              0.9294117647058824,
+                              0.9294117647058824,
+                              0.9294117647058824,
+                              1,
+                              0,
+                              1,
+                            ]
+                          }
+                          opacity={1}
+                          stroke={null}
+                          strokeCap={1}
+                          strokeDash={null}
+                          strokeJoin={1}
+                          strokeWidth={1}
+                          transform={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              1,
+                              0,
+                              0,
+                            ]
+                          }
+                        />
+                      </ARTSurfaceView>
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <Text
+                accessibilityLabel="author-name"
+                accessibilityRole="heading"
+                accessible={true}
+                allowFontScaling={true}
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#1D1D1B",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 30,
+                  }
+                }
+                testID="author-name"
+              >
+                Deborah Haynes
+              </Text>
+              <Text
+                accessibilityRole="heading"
+                accessible={true}
+                allowFontScaling={true}
+                aria-level="2"
+                ellipsizeMode="tail"
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "TimesDigitalW04-RegularSC",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                defence editor
+              </Text>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "paddingBottom": 8,
+                    "paddingTop": 8,
+                  }
+                }
+              >
+                <svg
+                  height={15}
+                  width={15}
+                >
+                  <path
+                    fill="#006699"
+                  />
+                </svg>
+                <Text
+                  accessibilityRole="link"
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  href="https://twitter.com/jdoe"
+                  onPress={[Function]}
+                  style={
+                    Object {
+                      "color": "#006699",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "paddingLeft": 5,
+                      "textDecorationLine": "none",
+                    }
+                  }
+                >
+                  @
+                  jdoe
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "paddingBottom": 32,
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                  }
+                }
+              >
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "fontFamily": "TimesDigitalW04",
+                      "fontSize": 16,
+                      "lineHeight": 26,
+                      "textAlign": "center",
+                    }
+                  }
+                  testID="author-bio"
+                >
+                  Deborah Haynes is the defence editor at 
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "fontStyle": "italic",
+                      }
+                    }
+                  >
+                    The Times
+                  </Text>
+                  , covering the most important defence & security news in the UK and around the world.
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignItems": "stretch",
+              "flexDirection": "row",
+              "justifyContent": "center",
             }
           }
         >
           <View
             style={
               Object {
-                "height": "100%",
-                "width": "100%",
+                "flex": 1,
+                "maxWidth": 800,
               }
             }
           >
-            <Image
-              onLoad={[Function]}
-              source={
-                Object {
-                  "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg&resize=1440",
-                }
-              }
-              style={
-                Object {
-                  "bottom": 0,
-                  "height": "100%",
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                  "width": "100%",
-                }
-              }
-            />
             <View
-              onLayout={[Function]}
               style={
                 Object {
-                  "flex": 1,
+                  "alignItems": "stretch",
+                  "flexDirection": "column",
                 }
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
-                    "flex": 1,
+                    "alignItems": "center",
+                    "flexDirection": "row",
+                    "height": 50,
+                    "justifyContent": "center",
                   }
                 }
               >
-                <ARTSurfaceView
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  ellipsizeMode="tail"
                   style={
                     Object {
-                      "bottom": 0,
-                      "height": 0,
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": 0,
+                      "color": "#696969",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 15,
+                      "paddingTop": 4,
                     }
                   }
+                  testID="results-message"
                 >
-                  <ARTShape
-                    d={
-                      Array [
-                        2,
-                        0,
-                        0,
-                        2,
-                        0,
-                        0,
-                        2,
-                        0,
-                        0,
-                        2,
-                        0,
-                        0,
-                      ]
+                  Showing 1 - 3 of 20 results
+                </Text>
+              </View>
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "borderBottomColor": "#DBDBDB",
+                    "borderBottomWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "#DBDBDB",
+                    "borderTopWidth": 1,
+                    "flexDirection": "row",
+                    "height": 50,
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <View />
+                <View>
+                  <View
+                    accessible={true}
+                    isTVSelectable={true}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      Object {
+                        "opacity": 1,
+                      }
                     }
-                    fill={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        -0,
-                        0,
-                        0.9764705882352941,
-                        0.9764705882352941,
-                        0.9764705882352941,
-                        1,
-                        0.9294117647058824,
-                        0.9294117647058824,
-                        0.9294117647058824,
-                        1,
-                        0,
-                        1,
-                      ]
-                    }
-                    opacity={1}
-                    stroke={null}
-                    strokeCap={1}
-                    strokeDash={null}
-                    strokeJoin={1}
-                    strokeWidth={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  />
-                </ARTSurfaceView>
+                  >
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "padding": 12,
+                        }
+                      }
+                      testID="pagination-button-next"
+                    >
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Object {
+                            "color": "#006699",
+                            "fontFamily": "GillSansMTStd-Medium",
+                            "fontSize": 15,
+                            "height": 15,
+                            "marginRight": 10,
+                            "textAlign": "right",
+                          }
+                        }
+                      >
+                        <Text
+                          accessible={true}
+                          allowFontScaling={true}
+                          ellipsizeMode="tail"
+                        >
+                          Next
+                        </Text>
+                      </Text>
+                      <svg
+                        height={12}
+                        width={7}
+                      >
+                        <g
+                          fill="#006699"
+                        >
+                          <path />
+                        </g>
+                      </svg>
+                    </View>
+                  </View>
+                </View>
               </View>
             </View>
           </View>
         </View>
-        <Text
-          accessibilityLabel="author-name"
-          accessibilityRole="heading"
-          accessible={true}
-          allowFontScaling={true}
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-            }
-          }
-          testID="author-name"
-        >
-          Deborah Haynes
-        </Text>
-        <Text
-          accessibilityRole="heading"
-          accessible={true}
-          allowFontScaling={true}
-          aria-level="2"
-          ellipsizeMode="tail"
-          style={
-            Object {
-              "color": "#696969",
-              "fontFamily": "TimesDigitalW04-RegularSC",
-              "fontSize": 14,
-            }
-          }
-        >
-          defence editor
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "paddingBottom": 8,
-              "paddingTop": 8,
-            }
-          }
-        >
-          <svg
-            height={15}
-            width={15}
-          >
-            <path
-              fill="#006699"
-            />
-          </svg>
-          <Text
-            accessibilityRole="link"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            href="https://twitter.com/jdoe"
-            onPress={[Function]}
-            style={
-              Object {
-                "color": "#006699",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 15,
-                "paddingLeft": 5,
-                "textDecorationLine": "none",
-              }
-            }
-          >
-            @
-            jdoe
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "paddingBottom": 32,
-              "paddingLeft": 10,
-              "paddingRight": 10,
-            }
-          }
-        >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "TimesDigitalW04",
-                "fontSize": 16,
-                "lineHeight": 26,
-                "textAlign": "center",
-              }
-            }
-            testID="author-bio"
-          >
-            Deborah Haynes is the defence editor at 
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              style={
-                Object {
-                  "fontStyle": "italic",
-                }
-              }
-            >
-              The Times
-            </Text>
-            , covering the most important defence & security news in the UK and around the world.
-          </Text>
-        </View>
       </View>
     </View>
-  </View>
-  <View
-    style={
-      Object {
-        "flex": 1,
-        "margin": 15,
-      }
-    }
-  >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Object {
-          "alignSelf": "center",
-          "color": "#1D1D1B",
-          "fontFamily": "TimesModern-Bold",
-          "fontSize": 35,
-          "marginBottom": 10,
-          "marginTop": 20,
-          "textAlign": "center",
-        }
-      }
-    >
-      Something's gone wrong
-    </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Object {
-          "color": "#696969",
-          "fontFamily": "TimesDigitalW04-Regular",
-          "fontSize": 18,
-          "textAlign": "center",
-        }
-      }
-    >
-      We can't load the page you have requested. Please check your network connection and retry to continue
-    </Text>
     <View
-      style={
-        Object {
-          "bottom": 0,
-          "position": "absolute",
-          "width": "100%",
-        }
-      }
+      onLayout={[Function]}
     >
       <View
-        accessibilityLabel="Retry"
         accessible={true}
         isTVSelectable={true}
         onResponderGrant={[Function]}
@@ -1882,32 +2275,531 @@ exports[`2. Render an author profile page without images 1`] = `
         <View
           style={
             Object {
-              "alignItems": "center",
-              "backgroundColor": "#006699",
-              "flex": 1,
-              "height": 45,
-              "justifyContent": "center",
+              "paddingBottom": 15,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 15,
             }
           }
         >
-          <Text
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
+          <View
             style={
               Object {
-                "color": "#FFF",
-                "fontFamily": "GillSansMTStd-Medium",
+                "opacity": 1,
               }
             }
           >
-            RETRY
-          </Text>
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": 0,
+                    "minWidth": "100%",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    accessibilityRole="heading"
+                    accessible={true}
+                    allowFontScaling={true}
+                    aria-level="3"
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "900",
+                        "lineHeight": 22,
+                        "marginBottom": 5,
+                      }
+                    }
+                  >
+                    Top medal for forces dog who took a bite out of the Taliban
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                        "marginBottom": 10,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                      
+                      The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
+                    </Text>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                       
+                      Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen
+                      ...
+                    </Text>
+                  </Text>
+                  <Text
+                    accessibilityLabel="datePublication"
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                        "marginBottom": 5,
+                      }
+                    }
+                    testID="datePublication"
+                  >
+                    Friday November 17 2017, 12:01am, The Times
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        accessible={true}
+        isTVSelectable={true}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "paddingBottom": 15,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 15,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": 0,
+                    "minWidth": "100%",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    accessibilityRole="heading"
+                    accessible={true}
+                    allowFontScaling={true}
+                    aria-level="3"
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "900",
+                        "lineHeight": 22,
+                        "marginBottom": 5,
+                      }
+                    }
+                  >
+                    Social media must raise game to beat terrorists, says UN chief
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                        "marginBottom": 10,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                      
+                      The head of the United Nations has added his voice to calls for Facebook, YouTube, Microsoft and Twitter to help to stop the spread of terrorist material online.
+                    </Text>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                       
+                      António Guterres said last night that Islamic State and other terrorist groups were losing physical ground in Iraq and Syria but were growing their presence in cyberspace. He described terrorism as
+                      ...
+                    </Text>
+                  </Text>
+                  <Text
+                    accessibilityLabel="datePublication"
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                        "marginBottom": 5,
+                      }
+                    }
+                    testID="datePublication"
+                  >
+                    Friday November 17 2017, 12:01am, The Times
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "backgroundColor": "#DBDBDB",
+              "height": 1,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        accessible={true}
+        isTVSelectable={true}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "opacity": 1,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "paddingBottom": 15,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "paddingTop": 15,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "flex-start",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "flex-end",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": 0,
+                    "minWidth": "100%",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    accessibilityRole="heading"
+                    accessible={true}
+                    allowFontScaling={true}
+                    aria-level="3"
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "900",
+                        "lineHeight": 22,
+                        "marginBottom": 5,
+                      }
+                    }
+                  >
+                    Cuts have left the army 20 years out of date, says former general
+                  </Text>
+                  <Text
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "flexWrap": "wrap",
+                        "fontFamily": "TimesDigitalW04",
+                        "fontSize": 14,
+                        "lineHeight": 20,
+                        "marginBottom": 10,
+                      }
+                    }
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                      
+                      Britain’s cash-strapped army is 20 years out of date and would be incapable of surviving Russian artillery and air strikes in a conflict, a former military chief said today.
+                    </Text>
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                    >
+                       
+                      General Sir Richard Barrons, the commander of Joint Forces Command until last year, warned that the entire armed forces were on the brink of operational or institutional failure unless
+                      ...
+                    </Text>
+                  </Text>
+                  <Text
+                    accessibilityLabel="datePublication"
+                    accessible={true}
+                    allowFontScaling={true}
+                    ellipsizeMode="tail"
+                    style={
+                      Object {
+                        "color": "#696969",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                        "marginBottom": 5,
+                      }
+                    }
+                    testID="datePublication"
+                  >
+                    Tuesday November 14 2017, 05:00pm, The Times
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "stretch",
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "maxWidth": 800,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "stretch",
+                "flexDirection": "column",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "borderBottomColor": "#DBDBDB",
+                  "borderBottomWidth": 1,
+                  "borderStyle": "solid",
+                  "borderTopColor": "#DBDBDB",
+                  "borderTopWidth": 1,
+                  "flexDirection": "row",
+                  "height": 50,
+                  "justifyContent": "space-between",
+                }
+              }
+            >
+              <View />
+              <View>
+                <View
+                  accessible={true}
+                  isTVSelectable={true}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "opacity": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "padding": 12,
+                      }
+                    }
+                    testID="pagination-button-next"
+                  >
+                    <Text
+                      accessible={true}
+                      allowFontScaling={true}
+                      ellipsizeMode="tail"
+                      style={
+                        Object {
+                          "color": "#006699",
+                          "fontFamily": "GillSansMTStd-Medium",
+                          "fontSize": 15,
+                          "height": 15,
+                          "marginRight": 10,
+                          "textAlign": "right",
+                        }
+                      }
+                    >
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                      >
+                        Next
+                      </Text>
+                    </Text>
+                    <svg
+                      height={12}
+                      width={7}
+                    >
+                      <g
+                        fill="#006699"
+                      >
+                        <path />
+                      </g>
+                    </svg>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
         </View>
       </View>
     </View>
   </View>
-</View>
+</RCTScrollView>
 `;
 
 exports[`3. Render an author profile page loading state 1`] = `

--- a/packages/author-profile/__tests__/shared.js
+++ b/packages/author-profile/__tests__/shared.js
@@ -4,6 +4,7 @@ import renderer from "react-test-renderer";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import { MockedProvider } from "@times-components/utils";
 import AuthorProfile from "../src/author-profile";
+import longSummaryLength from "../author-profile-constants";
 
 export default () => {
   const mockArticles = fixtureGenerator.makeArticleMocks({
@@ -11,6 +12,7 @@ export default () => {
     withImages: true
   });
   const mockArticlesWithoutImages = fixtureGenerator.makeArticleMocks({
+    longSummaryLength,
     pageSize: 3,
     withImages: false
   });

--- a/packages/author-profile/author-profile-constants.js
+++ b/packages/author-profile/author-profile-constants.js
@@ -1,0 +1,3 @@
+const longSummaryLength = 220;
+
+export default longSummaryLength;

--- a/packages/author-profile/author-profile-constants.web.js
+++ b/packages/author-profile/author-profile-constants.web.js
@@ -1,0 +1,3 @@
+const longSummaryLength = 360;
+
+export default longSummaryLength;

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -6,6 +6,7 @@ import StorybookProvider from "@times-components/storybook/storybook-provider";
 import storybookReporter from "@times-components/tealium-utils";
 import { MockedProvider } from "@times-components/utils";
 import AuthorProfile from "./src/author-profile";
+import longSummaryLength from "./author-profile-constants";
 
 const preventDefaultedAction = decorateAction =>
   decorateAction([
@@ -24,6 +25,7 @@ const mockArticles = fixtureGenerator.makeArticleMocks({
   withImages: true
 });
 const mockArticlesWithoutImages = fixtureGenerator.makeArticleMocks({
+  longSummaryLength,
   pageSize,
   slug,
   withImages: false

--- a/packages/provider-test-tools/src/fixture-generator.js
+++ b/packages/provider-test-tools/src/fixture-generator.js
@@ -70,7 +70,14 @@ const query = ({ withImages }) =>
     withImages ? articleListWithImagesQuery : articleListNoImagesQuery
   );
 
-const makeVariables = ({ withImages, skip, pageSize, slug }) => {
+const makeVariables = ({
+  longSummaryLength,
+  pageSize,
+  shortSummaryLength,
+  skip,
+  slug,
+  withImages
+}) => {
   if (withImages) {
     return {
       slug,
@@ -84,18 +91,20 @@ const makeVariables = ({ withImages, skip, pageSize, slug }) => {
     slug,
     first: pageSize,
     skip,
-    shortSummaryLength: 220,
-    longSummaryLength: 360
+    shortSummaryLength,
+    longSummaryLength
   };
 };
 
 const makeArticleMocks = (
   {
     count = 20,
+    delay = 1000,
+    longSummaryLength = 220,
     pageSize = 5,
-    withImages = false,
+    shortSummaryLength = 220,
     slug = "deborah-haynes",
-    delay = 1000
+    withImages = false
   } = {},
   transform
 ) => [
@@ -105,10 +114,12 @@ const makeArticleMocks = (
     request: {
       query: query({ withImages }),
       variables: makeVariables({
-        withImages,
-        skip: indx * pageSize,
+        longSummaryLength,
         pageSize,
-        slug
+        shortSummaryLength,
+        skip: indx * pageSize,
+        slug,
+        withImages
       })
     },
     result: makeArticleList(

--- a/packages/provider/__tests__/author-articles-no-images.test.js
+++ b/packages/provider/__tests__/author-articles-no-images.test.js
@@ -7,7 +7,11 @@ import AuthorArticlesNoImagesProvider from "../src/author-articles-no-images-bas
 const renderComponent = child =>
   renderer.create(
     <MockedProvider
-      mocks={fixtureGenerator.makeArticleMocks({ pageSize: 5, delay: 0 })}
+      mocks={fixtureGenerator.makeArticleMocks({
+        longSummaryLength: 360,
+        pageSize: 5,
+        delay: 0
+      })}
     >
       <AuthorArticlesNoImagesProvider
         slug="deborah-haynes"


### PR DESCRIPTION
- allow `provider-test-tools` package variables to accept `longSummaryLength` and `acceptSummaryLength`
- pass `longSummaryLength` explicitly from `author-profile` to match the web/native gql queries in the `provider` package

This fixes https://nidigitalsolutions.jira.com/browse/REPLAT-2428