### PR TITLE
fix: Get Topic "Viewed" analytics working

### DIFF
--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -201,17 +201,15 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
 `;
 
 exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
-Array [
-  Object {
-    "action": "Viewed",
-    "attrs": Object {
-      "eventTime": null,
-      "page": 1,
-      "pageSize": 3,
-      "topicName": "Chelsea",
-    },
-    "component": "Page",
-    "object": "Topic",
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "page": 1,
+    "pageSize": 3,
+    "topicName": "Chelsea",
   },
-]
+  "component": "Page",
+  "object": "Topic",
+}
 `;

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -200,7 +200,7 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
 />
 `;
 
-exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
+exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -199,3 +199,19 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
   refetch={[Function]}
 />
 `;
+
+exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
+Array [
+  Object {
+    "action": "Viewed",
+    "attrs": Object {
+      "eventTime": null,
+      "page": 1,
+      "pageSize": 3,
+      "topicName": "Chelsea",
+    },
+    "component": "Page",
+    "object": "Topic",
+  },
+]
+`;

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -201,17 +201,15 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
 `;
 
 exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
-Array [
-  Object {
-    "action": "Viewed",
-    "attrs": Object {
-      "eventTime": null,
-      "page": 1,
-      "pageSize": 3,
-      "topicName": "Chelsea",
-    },
-    "component": "Page",
-    "object": "Topic",
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "page": 1,
+    "pageSize": 3,
+    "topicName": "Chelsea",
   },
-]
+  "component": "Page",
+  "object": "Topic",
+}
 `;

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -200,7 +200,7 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
 />
 `;
 
-exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
+exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -199,3 +199,19 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
   refetch={[Function]}
 />
 `;
+
+exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
+Array [
+  Object {
+    "action": "Viewed",
+    "attrs": Object {
+      "eventTime": null,
+      "page": 1,
+      "pageSize": 3,
+      "topicName": "Chelsea",
+    },
+    "component": "Page",
+    "object": "Topic",
+  },
+]
+`;

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -82,17 +82,9 @@ export default () => {
       </MockedProvider>
     );
 
-    expect(reporter).toHaveBeenCalledWith(
-      expect.objectContaining({
-        object: "Topic",
-        component: "Page",
-        action: "Viewed",
-        attrs: expect.objectContaining({
-          topicName: "Chelsea",
-          page: 1,
-          pageSize
-        })
-      })
-    );
+    const call = reporter.mock.calls[0][0];
+    const callWithoutEventTime = call.attrs && call.attrs.eventTime ? [{ ...call, attrs: {...call.attrs, eventTime: null}}] : call;
+
+    expect(callWithoutEventTime).toMatchSnapshot("3. Send analytics when rendering a topics page (with null event time)");
   });
 };

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -2,6 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import { delay, MockedProvider } from "@times-components/utils";
+import mockDate from "mockdate";
 import Topic from "../src/topic";
 
 // This is the only possible way for this to work... :'-(
@@ -39,10 +40,12 @@ export default () => {
         resolvedOptions: () => ({ timeZone: "Europe/London" })
       })
     };
+    mockDate.set(1514764800000, 0);
   });
 
   afterEach(() => {
     global.Intl = realIntl;
+    mockDate.reset();
   });
 
   it("should render correctly", async () => {
@@ -78,13 +81,19 @@ export default () => {
 
     renderer.create(
       <MockedProvider mocks={mockArticles}>
-        <Topic {...props} page={1} pageSize={pageSize} analyticsStream={reporter} />
+        <Topic
+          {...props}
+          page={1}
+          pageSize={pageSize}
+          analyticsStream={reporter}
+        />
       </MockedProvider>
     );
 
     const call = reporter.mock.calls[0][0];
-    const callWithoutEventTime = call.attrs && call.attrs.eventTime ? [{ ...call, attrs: {...call.attrs, eventTime: null}}] : call;
 
-    expect(callWithoutEventTime).toMatchSnapshot("3. Send analytics when rendering a topics page (with null event time)");
+    expect(call).toMatchSnapshot(
+      "3. Send analytics when rendering a topics page (with null event time)"
+    );
   });
 };

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -72,4 +72,27 @@ export default () => {
       "3. Render a topics page error state with an invalid Topic Query"
     );
   });
+
+  it("should send analytics when rendering a topic page", () => {
+    const reporter = jest.fn();
+
+    renderer.create(
+      <MockedProvider mocks={mockArticles}>
+        <Topic {...props} page={1} pageSize={pageSize} analyticsStream={reporter} />
+      </MockedProvider>
+    );
+
+    expect(reporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object: "Topic",
+        component: "Page",
+        action: "Viewed",
+        attrs: expect.objectContaining({
+          topicName: "Chelsea",
+          page: 1,
+          pageSize
+        })
+      })
+    );
+  });
 };

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -1,8 +1,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import mockDate from "mockdate";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import { delay, MockedProvider } from "@times-components/utils";
-import mockDate from "mockdate";
 import Topic from "../src/topic";
 
 // This is the only possible way for this to work... :'-(
@@ -93,7 +93,7 @@ export default () => {
     const call = reporter.mock.calls[0][0];
 
     expect(call).toMatchSnapshot(
-      "3. Send analytics when rendering a topics page (with null event time)"
+      "4. Send analytics when rendering a topics page (with null event time)"
     );
   });
 };

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -201,17 +201,15 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
 `;
 
 exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
-Array [
-  Object {
-    "action": "Viewed",
-    "attrs": Object {
-      "eventTime": null,
-      "page": 1,
-      "pageSize": 3,
-      "topicName": "Chelsea",
-    },
-    "component": "Page",
-    "object": "Topic",
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "page": 1,
+    "pageSize": 3,
+    "topicName": "Chelsea",
   },
-]
+  "component": "Page",
+  "object": "Topic",
+}
 `;

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -200,7 +200,7 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
 />
 `;
 
-exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
+exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -199,3 +199,19 @@ exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
   refetch={[Function]}
 />
 `;
+
+exports[`3. Send analytics when rendering a topics page (with null event time) 1`] = `
+Array [
+  Object {
+    "action": "Viewed",
+    "attrs": Object {
+      "eventTime": null,
+      "page": 1,
+      "pageSize": 3,
+      "topicName": "Chelsea",
+    },
+    "component": "Page",
+    "object": "Topic",
+  },
+]
+`;

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -46,6 +46,7 @@
     "eslint": "4.9.0",
     "jest": "21.2.1",
     "jest-styled-components": "5.0.0",
+    "mockdate": "2.0.2",
     "prettier": "1.8.2",
     "react": "16.3.1",
     "react-dom": "16.3.1",

--- a/packages/topic/src/topic-tracking-context.js
+++ b/packages/topic/src/topic-tracking-context.js
@@ -6,7 +6,6 @@ export default Component =>
     trackingObjectName: "Topic",
     getAttrs: ({ topic, page, pageSize }) => ({
       topicName: topic && topic.name,
-      articlesCount: get(topic, "articles.count", 0),
       page,
       pageSize
     })

--- a/packages/topic/src/topic-tracking-context.js
+++ b/packages/topic/src/topic-tracking-context.js
@@ -1,4 +1,3 @@
-import get from "lodash.get";
 import { withTrackingContext } from "@times-components/tracking";
 
 export default Component =>


### PR DESCRIPTION
REPLAT-2154

Analytics matches that of Author Profile other than:

1. Articles Count has been removed as it seemed unnecessary and wouldn't work correctly. If this is wanted, then I suggest we should put it back in when integrating the Name and Description provider as this will then closer mimic Author Profile. (Awkward in-between phase)
2. Passing in `isLoading: false` to get around the fact that we don't have the name and description provider yet,