### PR TITLE
Disable delta bundling on android for haul

### DIFF
--- a/android/app/src/main/java/com/storybooknative/MainActivity.java
+++ b/android/app/src/main/java/com/storybooknative/MainActivity.java
@@ -1,6 +1,9 @@
 package com.storybooknative;
 
+import android.os.Bundle;
+
 import com.facebook.react.ReactActivity;
+import com.facebook.react.devsupport.DevInternalSettings;
 
 public class MainActivity extends ReactActivity {
 
@@ -11,5 +14,14 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "storybooknative";
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        DevInternalSettings settings = (DevInternalSettings) getReactNativeHost().getReactInstanceManager().getDevSupportManager().getDevSettings();
+        if (settings != null) {
+            settings.setBundleDeltasEnabled(false);
+        }      
     }
 }


### PR DESCRIPTION
Haul does not support delta bundles, so it had to be turned off manually. Found a way to turn it off automatically for android