### PR TITLE
chore: update analytics tests

### DIFF
--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -18407,3 +18407,44 @@ exports[`Article tests on android should render an error 1`] = `
   </Text>
 </View>
 `;
+
+exports[`Send analytics when rendering an Article page 1`] = `
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "byline": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+    "publishedTime": "2015-03-13T18:54:58.000Z",
+    "topics": Array [
+      Object {
+        "id": "football",
+        "name": "Football",
+        "order": 1,
+      },
+      Object {
+        "id": "manchester-united",
+        "name": "Manchester United FC",
+        "order": 4,
+      },
+      Object {
+        "id": "chelsea",
+        "name": "Chelsea FC",
+        "order": 2,
+      },
+      Object {
+        "id": "arsenal",
+        "name": "Arsenal",
+        "order": 3,
+      },
+      Object {
+        "id": "rugby-union",
+        "name": "Rugby Union",
+        "order": 5,
+      },
+    ],
+  },
+  "component": "Page",
+  "object": "Article",
+}
+`;

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -18325,3 +18325,44 @@ exports[`Article tests on ios should render an error 1`] = `
   </Text>
 </View>
 `;
+
+exports[`Send analytics when rendering an Article page 1`] = `
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "byline": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+    "publishedTime": "2015-03-13T18:54:58.000Z",
+    "topics": Array [
+      Object {
+        "id": "football",
+        "name": "Football",
+        "order": 1,
+      },
+      Object {
+        "id": "manchester-united",
+        "name": "Manchester United FC",
+        "order": 4,
+      },
+      Object {
+        "id": "chelsea",
+        "name": "Chelsea FC",
+        "order": 2,
+      },
+      Object {
+        "id": "arsenal",
+        "name": "Arsenal",
+        "order": 3,
+      },
+      Object {
+        "id": "rugby-union",
+        "name": "Rugby Union",
+        "order": 5,
+      },
+    ],
+  },
+  "component": "Page",
+  "object": "Article",
+}
+`;

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -1,16 +1,24 @@
 import "react-native";
 import React from "react";
 import renderer from "react-test-renderer";
+import mockDate from "mockdate";
 import Article from "../src/article";
 import { adConfig } from "./shared";
 
 import fullArticleFixture from "../fixtures/full-article.json";
 
 export default () => {
+  beforeEach(() => {
+    mockDate.set(1514764800000, 0);
+  });
+
+  afterEach(() => {
+    mockDate.reset();
+  });
+
   it("should track page view", () => {
     const stream = jest.fn();
 
-    const { topics } = fullArticleFixture.data.article;
     renderer.create(
       <Article
         {...fullArticleFixture.data}
@@ -22,18 +30,10 @@ export default () => {
         onLinkPress={() => {}}
       />
     );
-    expect(stream).toHaveBeenCalledWith({
-      object: "Article",
-      component: "Page",
-      action: "Viewed",
-      attrs: expect.objectContaining({
-        headline:
-          "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-        byline:
-          "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-        publishedTime: "2015-03-13T18:54:58.000Z",
-        topics
-      })
-    });
+    const call = stream.mock.calls[0][0];
+
+    expect(call).toMatchSnapshot(
+      "Send analytics when rendering an Article page"
+    );
   });
 };

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -16097,3 +16097,44 @@ exports[`Article tests on web should render an error 1`] = `
   </div>
 </div>
 `;
+
+exports[`Send analytics when rendering an Article page 1`] = `
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "byline": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+    "publishedTime": "2015-03-13T18:54:58.000Z",
+    "topics": Array [
+      Object {
+        "id": "football",
+        "name": "Football",
+        "order": 1,
+      },
+      Object {
+        "id": "manchester-united",
+        "name": "Manchester United FC",
+        "order": 4,
+      },
+      Object {
+        "id": "chelsea",
+        "name": "Chelsea FC",
+        "order": 2,
+      },
+      Object {
+        "id": "arsenal",
+        "name": "Arsenal",
+        "order": 3,
+      },
+      Object {
+        "id": "rugby-union",
+        "name": "Rugby Union",
+        "order": 5,
+      },
+    ],
+  },
+  "component": "Page",
+  "object": "Article",
+}
+`;

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -49,6 +49,7 @@
     "eslint": "4.9.0",
     "jest": "21.2.1",
     "jest-styled-components": "5.0.0",
+    "mockdate": "2.0.2",
     "prettier": "1.8.2",
     "react": "16.3.1",
     "react-dom": "16.3.1",

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -4840,7 +4840,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </View>
 `;
 
-exports[`5. Send analytics when rendering an Auhtor Profile page 1`] = `
+exports[`5. Send analytics when rendering an Author Profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -4840,7 +4840,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </View>
 `;
 
-exports[`5. Author profile page analytics 1`] = `
+exports[`5. Send analytics when rendering an Auhtor Profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -106,7 +106,9 @@ export default () => {
 
     const call = reporter.mock.calls[0][0];
 
-    expect(call).toMatchSnapshot("5. Author profile page analytics");
+    expect(call).toMatchSnapshot(
+      "5. Send analytics when rendering an Auhtor Profile page"
+    );
   });
 };
 

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -111,4 +111,3 @@ export default () => {
     );
   });
 };
-

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -109,3 +109,4 @@ export default () => {
     expect(call).toMatchSnapshot("5. Author profile page analytics");
   });
 };
+

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -95,7 +95,7 @@ export default () => {
     );
   });
 
-  it("should send analytics when rendering an author profile page", () => {
+  it("should send analytics when rendering an Author Profile page", () => {
     const reporter = jest.fn();
 
     renderer.create(

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -107,7 +107,7 @@ export default () => {
     const call = reporter.mock.calls[0][0];
 
     expect(call).toMatchSnapshot(
-      "5. Send analytics when rendering an Auhtor Profile page"
+      "5. Send analytics when rendering an Author Profile page"
     );
   });
 };

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -4828,7 +4828,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </View>
 `;
 
-exports[`5. Send analytics when rendering an Auhtor Profile page 1`] = `
+exports[`5. Send analytics when rendering an Author Profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -4828,7 +4828,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </View>
 `;
 
-exports[`5. Author profile page analytics 1`] = `
+exports[`5. Send analytics when rendering an Auhtor Profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -1730,7 +1730,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </div>
 `;
 
-exports[`5. Send analytics when rendering an Auhtor Profile page 1`] = `
+exports[`5. Send analytics when rendering an Author Profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -1730,7 +1730,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </div>
 `;
 
-exports[`5. Author profile page analytics 1`] = `
+exports[`5. Send analytics when rendering an Auhtor Profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {


### PR DESCRIPTION
Following up from #954, this updates the analytics tests in our page components to follow the same pattern.