### PR TITLE
iOS infinite scroll bugfix for end reached calls before load

### DIFF
--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -122,10 +122,10 @@ class ArticleList extends Component {
         onViewableItemsChanged={this.onViewableItemsChanged}
         pageSize={pageSize}
         onEndReachedThreshold={2}
-        onEndReached={() => {
+        onEndReached={() =>
           // Workaround for iOS Flatlist bug (https://github.com/facebook/react-native/issues/16067)
-          if (data.length > 0) fetchMoreOnEndReached();
-        }}
+          data.length > 0 ? fetchMoreOnEndReached() : null
+        }
         renderItem={({ item, index }) => (
           <ErrorView>
             {({ hasError }) =>

--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -122,7 +122,10 @@ class ArticleList extends Component {
         onViewableItemsChanged={this.onViewableItemsChanged}
         pageSize={pageSize}
         onEndReachedThreshold={2}
-        onEndReached={fetchMoreOnEndReached}
+        onEndReached={() => {
+          // Workaround for iOS Flatlist bug (https://github.com/facebook/react-native/issues/16067)
+          if (data.length > 0) fetchMoreOnEndReached();
+        }}
         renderItem={({ item, index }) => (
           <ErrorView>
             {({ hasError }) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,14 +803,6 @@
     webpack-dev-server "^2.9.5"
     webpack-merge "^4.1.1"
 
-"@times-components/link@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@times-components/link/-/link-0.23.0.tgz#94e59bb5bf650d880938e20373cd2ae74d6ec365"
-  dependencies:
-    "@times-components/responsive-styles" "0.9.0"
-    "@times-components/styleguide" "0.9.0"
-    prop-types "15.6.0"
-
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"


### PR DESCRIPTION
React-native iOS has a bug, where onEndReached gets called right after load. Added a check to avoid this.

Bug: https://github.com/facebook/react-native/issues/16067

This workaround should be removed when the issue is resolved