### PR TITLE
refactor: fix the image component prop type warnings

### DIFF
--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -1293,11 +1293,6 @@ exports[`ArticleList tests on android should render an article list item loading
         >
           <Image
             onLoad={[Function]}
-            source={
-              Object {
-                "uri": "",
-              }
-            }
             style={
               Object {
                 "bottom": 0,
@@ -2035,11 +2030,6 @@ exports[`ArticleList tests on android should render an article list that is load
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -1289,11 +1289,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
         >
           <Image
             onLoad={[Function]}
-            source={
-              Object {
-                "uri": "",
-              }
-            }
             style={
               Object {
                 "bottom": 0,
@@ -2030,11 +2025,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -2577,11 +2577,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -3072,11 +3067,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -3567,11 +3557,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -2569,11 +2569,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -3064,11 +3059,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -3559,11 +3549,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -29,11 +29,6 @@ exports[`2. Renders default layout without uri 1`] = `
 >
   <ImageBackground
     onLoad={[Function]}
-    source={
-      Object {
-        "uri": "",
-      }
-    }
     style={
       Object {
         "height": "100%",

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -29,11 +29,6 @@ exports[`2. Renders default layout without uri 1`] = `
 >
   <ImageBackground
     onLoad={[Function]}
-    source={
-      Object {
-        "uri": "",
-      }
-    }
     style={
       Object {
         "height": "100%",

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -35,25 +35,23 @@ class TimesImage extends Component {
       onLoad: this.handleLoad
     };
 
-    const regExImageDataUrl = new RegExp("data:", "gi");
-    const isDataImageUrl = regExImageDataUrl.test(uri);
+    const isDataImageUrl = uri.indexOf("data:") > -1;
 
-    if (cleanUri && width > 0 && !isDataImageUrl) {
+    if (isDataImageUrl) {
+      props.source = {
+        uri: cleanUri
+      };
+    } else if (cleanUri && width > 0) {
       const regExResize = new RegExp("([?&])resize", "gi");
       const hasResizeParameter = regExResize.test(cleanUri);
 
-      const regExQueryString = new RegExp("[?]", "gi");
-      const hasQueryString = regExQueryString.test(cleanUri);
+      const hasQueryString = cleanUri.indexOf("?") > -1;
       const delimiter = hasQueryString ? "&" : "?";
 
       props.source = {
         uri: hasResizeParameter
           ? cleanUri
           : `${cleanUri}${delimiter}resize=${width}`
-      };
-    } else {
-      props.source = {
-        uri: cleanUri
       };
     }
 

--- a/packages/topic/__tests__/android/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-styling.test.js.snap
@@ -196,11 +196,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -691,11 +686,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -1186,11 +1176,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,

--- a/packages/topic/__tests__/ios/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-styling.test.js.snap
@@ -196,11 +196,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -691,11 +686,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,
@@ -1186,11 +1176,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               >
                 <Image
                   onLoad={[Function]}
-                  source={
-                    Object {
-                      "uri": "",
-                    }
-                  }
                   style={
                     Object {
                       "bottom": 0,


### PR DESCRIPTION
 - fix the image component prop type warnings on native for empty `source.uri` props
- replace RegExp with `indexOf` for perf