### PR TITLE
feat: omit function prop values from snapshots

### DIFF
--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -7,7 +7,6 @@ exports[`Article Byline test on android renders correctly with a section colour 
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="/profile/alexandra-frean"
-  onPress={[Function]}
   style={
     Object {
       "color": "blue",
@@ -26,7 +25,6 @@ exports[`Article Byline test on android renders correctly with a single author 1
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="/profile/alexandra-frean"
-  onPress={[Function]}
   style={
     Object {
       "color": "#006699",
@@ -63,7 +61,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/camilla-long"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -91,7 +88,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/mike-atherton"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -119,7 +115,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/alexandra-frean"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -140,7 +135,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/camilla-long"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -168,7 +162,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/mike-atherton"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -196,7 +189,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/alexandra-frean"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -216,7 +208,6 @@ exports[`Article Byline test on android renders correctly with styles 1`] = `
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="/profile/alexandra-frean"
-  onPress={[Function]}
   style={
     Object {
       "color": "red",
@@ -248,7 +239,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/mike-atherton"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -269,7 +259,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/camilla-long"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -7,7 +7,6 @@ exports[`Article Byline test on iOS renders correctly with a section colour 1`] 
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="/profile/alexandra-frean"
-  onPress={[Function]}
   style={
     Object {
       "color": "blue",
@@ -26,7 +25,6 @@ exports[`Article Byline test on iOS renders correctly with a single author 1`] =
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="/profile/alexandra-frean"
-  onPress={[Function]}
   style={
     Object {
       "color": "#006699",
@@ -63,7 +61,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/camilla-long"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -91,7 +88,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/mike-atherton"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -119,7 +115,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/alexandra-frean"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -140,7 +135,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/camilla-long"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -168,7 +162,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/mike-atherton"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -196,7 +189,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/alexandra-frean"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -216,7 +208,6 @@ exports[`Article Byline test on iOS renders correctly with styles 1`] = `
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="/profile/alexandra-frean"
-  onPress={[Function]}
   style={
     Object {
       "color": "red",
@@ -248,7 +239,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/mike-atherton"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",
@@ -269,7 +259,6 @@ Array [
     allowFontScaling={true}
     ellipsizeMode="tail"
     href="/profile/camilla-long"
-    onPress={[Function]}
     style={
       Object {
         "color": "#006699",

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -4,8 +4,6 @@ exports[`Article Byline test on web renders correctly with a section colour 1`] 
 <a
   dir="auto"
   href="/profile/alexandra-frean"
-  onClick={[Function]}
-  onKeyDown={[Function]}
   role="link"
   style={
     Object {
@@ -21,8 +19,6 @@ exports[`Article Byline test on web renders correctly with a single author 1`] =
 <a
   dir="auto"
   href="/profile/alexandra-frean"
-  onClick={[Function]}
-  onKeyDown={[Function]}
   role="link"
 >
   Alexandra Frean
@@ -44,8 +40,6 @@ Array [
   <a
     dir="auto"
     href="/profile/camilla-long"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Camilla Long
@@ -58,8 +52,6 @@ Array [
   <a
     dir="auto"
     href="/profile/mike-atherton"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Mike Atherton
@@ -72,8 +64,6 @@ Array [
   <a
     dir="auto"
     href="/profile/alexandra-frean"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Alexandra Frean
@@ -86,8 +76,6 @@ Array [
   <a
     dir="auto"
     href="/profile/camilla-long"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Camilla Long
@@ -100,8 +88,6 @@ Array [
   <a
     dir="auto"
     href="/profile/mike-atherton"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Mike Atherton
@@ -114,8 +100,6 @@ Array [
   <a
     dir="auto"
     href="/profile/alexandra-frean"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Alexandra Frean
@@ -127,8 +111,6 @@ exports[`Article Byline test on web renders correctly with styles 1`] = `
 <a
   dir="auto"
   href="/profile/alexandra-frean"
-  onClick={[Function]}
-  onKeyDown={[Function]}
   role="link"
   style={
     Object {
@@ -150,8 +132,6 @@ Array [
   <a
     dir="auto"
     href="/profile/mike-atherton"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Mike Atherton
@@ -164,8 +144,6 @@ Array [
   <a
     dir="auto"
     href="/profile/camilla-long"
-    onClick={[Function]}
-    onKeyDown={[Function]}
     role="link"
   >
     Camilla Long

--- a/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
@@ -14,7 +14,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -36,12 +35,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <svg
@@ -59,18 +52,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -79,12 +60,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -127,7 +102,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -146,7 +120,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -154,7 +127,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -245,12 +217,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -265,7 +231,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -284,7 +249,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -292,7 +256,6 @@ exports[`Article Image test on android Renders Article Image with no caption 1`]
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -497,7 +460,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -519,12 +481,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <svg
@@ -542,18 +498,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -562,12 +506,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -610,7 +548,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -629,7 +566,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -637,7 +573,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -728,12 +663,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -748,7 +677,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -767,7 +695,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -775,7 +702,6 @@ exports[`Article Image test on android does not render Caption on Article Image 
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -882,7 +808,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -904,12 +829,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <svg
@@ -927,18 +846,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -947,12 +854,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -995,7 +896,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0&resize=1440",
@@ -1014,7 +914,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1022,7 +921,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1113,12 +1011,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -1133,7 +1025,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0&resize=1440",
@@ -1152,7 +1043,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1160,7 +1050,6 @@ exports[`Article Image test on android renders inline image (landscape) correctl
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1319,7 +1208,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -1341,12 +1229,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <svg
@@ -1364,18 +1246,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -1384,12 +1254,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -1432,7 +1296,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0&resize=1440",
@@ -1451,7 +1314,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1459,7 +1321,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1550,12 +1411,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -1570,7 +1425,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0&resize=1440",
@@ -1589,7 +1443,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1597,7 +1450,6 @@ exports[`Article Image test on android renders inline image (portrait) correctly
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1747,7 +1599,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -1769,12 +1620,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <svg
@@ -1792,18 +1637,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -1812,12 +1645,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -1860,7 +1687,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0&resize=1440",
@@ -1879,7 +1705,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1887,7 +1712,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1978,12 +1802,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -1998,7 +1816,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0&resize=1440",
@@ -2017,7 +1834,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2025,7 +1841,6 @@ exports[`Article Image test on android renders primary image correctly 1`] = `
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -2177,7 +1992,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -2199,12 +2013,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <svg
@@ -2222,18 +2030,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -2242,12 +2038,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -2290,7 +2080,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0&resize=1440",
@@ -2309,7 +2098,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -2317,7 +2105,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -2408,12 +2195,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -2428,7 +2209,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0&resize=1440",
@@ -2447,7 +2227,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2455,7 +2234,6 @@ exports[`Article Image test on android renders secondary image correctly 1`] = `
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
@@ -14,7 +14,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -31,12 +30,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -58,18 +51,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -78,12 +59,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -126,7 +101,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -145,7 +119,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -153,7 +126,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -239,12 +211,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -263,7 +229,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -282,7 +247,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -290,7 +254,6 @@ exports[`Article Image test on ios Renders Article Image with no caption 1`] = `
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -495,7 +458,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -512,12 +474,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -539,18 +495,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -559,12 +503,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -607,7 +545,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -626,7 +563,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -634,7 +570,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -720,12 +655,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -744,7 +673,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F8c029716-97a2-11e7-8c3c-cb45202c3d59.jpg?crop=160%2C90%2C-0%2C-0&resize=1440",
@@ -763,7 +691,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -771,7 +698,6 @@ exports[`Article Image test on ios does not render Caption on Article Image if b
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -878,7 +804,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -895,12 +820,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -922,18 +841,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -942,12 +849,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -990,7 +891,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0&resize=1440",
@@ -1009,7 +909,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1017,7 +916,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1103,12 +1001,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -1127,7 +1019,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0&resize=1440",
@@ -1146,7 +1037,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1154,7 +1044,6 @@ exports[`Article Image test on ios renders inline image (landscape) correctly 1`
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1313,7 +1202,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -1330,12 +1218,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -1357,18 +1239,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -1377,12 +1247,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -1425,7 +1289,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0&resize=1440",
@@ -1444,7 +1307,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1452,7 +1314,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1538,12 +1399,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -1562,7 +1417,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0&resize=1440",
@@ -1581,7 +1435,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1589,7 +1442,6 @@ exports[`Article Image test on ios renders inline image (portrait) correctly 1`]
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1739,7 +1591,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -1756,12 +1607,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -1783,18 +1628,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -1803,12 +1636,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -1851,7 +1678,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0&resize=1440",
@@ -1870,7 +1696,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1878,7 +1703,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1964,12 +1788,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -1988,7 +1806,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0&resize=1440",
@@ -2007,7 +1824,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2015,7 +1831,6 @@ exports[`Article Image test on ios renders primary image correctly 1`] = `
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -2167,7 +1982,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
     <View>
       <Modal
         hardwareAccelerated={false}
-        onRequestClose={[Function]}
         presentationStyle="fullScreen"
         visible={false}
       >
@@ -2184,12 +1998,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -2211,18 +2019,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
             </svg>
           </View>
           <View
-            onMoveShouldSetResponder={[Function]}
-            onMoveShouldSetResponderCapture={[Function]}
-            onResponderEnd={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderReject={[Function]}
-            onResponderRelease={[Function]}
-            onResponderStart={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-            onStartShouldSetResponderCapture={[Function]}
             style={
               Object {
                 "flexGrow": 1,
@@ -2231,12 +2027,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
           >
             <View
               accessible={true}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
               style={
                 Object {
                   "flexGrow": 1,
@@ -2279,7 +2069,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0&resize=1440",
@@ -2298,7 +2087,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -2306,7 +2094,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -2392,12 +2179,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -2416,7 +2197,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
             }
           >
             <Image
-              onLoad={[Function]}
               source={
                 Object {
                   "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0&resize=1440",
@@ -2435,7 +2215,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
               }
             />
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2443,7 +2222,6 @@ exports[`Article Image test on ios renders secondary image correctly 1`] = `
               }
             >
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,

--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -13,7 +13,6 @@ exports[`ArticleList tests on android should display retry button when fetch mor
     }
   >
     <Button
-      onPress={[Function]}
       title="Retry"
     />
   </View>
@@ -22,8 +21,6 @@ exports[`ArticleList tests on android should display retry button when fetch mor
 
 exports[`ArticleList tests on android should render an article list 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={null}
   accessibilityID="scroll-view"
   data={
@@ -130,24 +127,12 @@ exports[`ArticleList tests on android should render an article list 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -172,9 +157,7 @@ exports[`ArticleList tests on android should render an article list 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -183,12 +166,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -240,7 +217,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440",
@@ -259,7 +235,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -267,7 +242,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -442,9 +416,7 @@ exports[`ArticleList tests on android should render an article list 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -453,12 +425,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -510,7 +476,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440",
@@ -529,7 +494,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -537,7 +501,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -712,9 +675,7 @@ exports[`ArticleList tests on android should render an article list 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -723,12 +684,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -780,7 +735,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=1440",
@@ -799,7 +753,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -807,7 +760,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -965,9 +917,7 @@ exports[`ArticleList tests on android should render an article list 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
@@ -981,12 +931,6 @@ exports[`ArticleList tests on android should render an article list item 1`] = `
       "type": "ThemeAttrAndroid",
     }
   }
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   pointerEvents="box-only"
 >
   <View
@@ -1038,7 +982,6 @@ exports[`ArticleList tests on android should render an article list item 1`] = `
               }
             >
               <Image
-                onLoad={[Function]}
                 source={
                   Object {
                     "uri": "/test-item-image-url?resize=1440",
@@ -1057,7 +1000,6 @@ exports[`ArticleList tests on android should render an article list item 1`] = `
                 }
               />
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1065,7 +1007,6 @@ exports[`ArticleList tests on android should render an article list item 1`] = `
                 }
               >
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1292,7 +1233,6 @@ exports[`ArticleList tests on android should render an article list item loading
           }
         >
           <Image
-            onLoad={[Function]}
             style={
               Object {
                 "bottom": 0,
@@ -1306,7 +1246,6 @@ exports[`ArticleList tests on android should render an article list item loading
             }
           />
           <View
-            onLayout={[Function]}
             style={
               Object {
                 "flex": 1,
@@ -1314,7 +1253,6 @@ exports[`ArticleList tests on android should render an article list item loading
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1403,7 +1341,6 @@ exports[`ArticleList tests on android should render an article list item loading
       }
     >
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1482,7 +1419,6 @@ exports[`ArticleList tests on android should render an article list item loading
         </ARTSurfaceView>
       </View>
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1560,7 +1496,6 @@ exports[`ArticleList tests on android should render an article list item loading
         </ARTSurfaceView>
       </View>
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1638,7 +1573,6 @@ exports[`ArticleList tests on android should render an article list item loading
         </ARTSurfaceView>
       </View>
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1730,12 +1664,6 @@ exports[`ArticleList tests on android should render an article list item without
       "type": "ThemeAttrAndroid",
     }
   }
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   pointerEvents="box-only"
 >
   <View
@@ -1915,7 +1843,6 @@ exports[`ArticleList tests on android should render an article list page error c
     We can't load the page you have requested. Please check your network connection and retry to continue
   </Text>
   <Button
-    onPress={[Function]}
     style={
       Object {
         "alignSelf": "center",
@@ -1929,8 +1856,6 @@ exports[`ArticleList tests on android should render an article list page error c
 
 exports[`ArticleList tests on android should render an article list that is loading 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={null}
   accessibilityID="scroll-view"
   data={
@@ -1943,23 +1868,11 @@ exports[`ArticleList tests on android should render an article list that is load
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -1984,9 +1897,7 @@ exports[`ArticleList tests on android should render an article list that is load
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -2029,7 +1940,6 @@ exports[`ArticleList tests on android should render an article list that is load
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -2043,7 +1953,6 @@ exports[`ArticleList tests on android should render an article list that is load
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -2051,7 +1960,6 @@ exports[`ArticleList tests on android should render an article list that is load
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -2140,7 +2048,6 @@ exports[`ArticleList tests on android should render an article list that is load
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2219,7 +2126,6 @@ exports[`ArticleList tests on android should render an article list that is load
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2297,7 +2203,6 @@ exports[`ArticleList tests on android should render an article list that is load
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2375,7 +2280,6 @@ exports[`ArticleList tests on android should render an article list that is load
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2457,9 +2361,7 @@ exports[`ArticleList tests on android should render an article list that is load
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -2533,8 +2435,6 @@ exports[`ArticleList tests on android should render the article list page error 
       }
     />
   </View>
-  <ArticleListError
-    refetch={[Function]}
-  />
+  <ArticleListError />
 </View>
 `;

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -13,7 +13,6 @@ exports[`ArticleList tests on ios should display retry button when fetch more fa
     }
   >
     <Button
-      onPress={[Function]}
       title="Retry"
     />
   </View>
@@ -22,8 +21,6 @@ exports[`ArticleList tests on ios should display retry button when fetch more fa
 
 exports[`ArticleList tests on ios should render an article list 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={null}
   accessibilityID="scroll-view"
   data={
@@ -130,24 +127,12 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -172,18 +157,10 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -239,7 +216,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440",
@@ -258,7 +234,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -266,7 +241,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -441,18 +415,10 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -508,7 +474,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440",
@@ -527,7 +492,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -535,7 +499,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -710,18 +673,10 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -777,7 +732,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=1440",
@@ -796,7 +750,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -804,7 +757,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -962,9 +914,7 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
@@ -973,12 +923,6 @@ exports[`ArticleList tests on ios should render an article list item 1`] = `
 <View
   accessible={true}
   isTVSelectable={true}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "opacity": 1,
@@ -1034,7 +978,6 @@ exports[`ArticleList tests on ios should render an article list item 1`] = `
               }
             >
               <Image
-                onLoad={[Function]}
                 source={
                   Object {
                     "uri": "/test-item-image-url?resize=1440",
@@ -1053,7 +996,6 @@ exports[`ArticleList tests on ios should render an article list item 1`] = `
                 }
               />
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1061,7 +1003,6 @@ exports[`ArticleList tests on ios should render an article list item 1`] = `
                 }
               >
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1288,7 +1229,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
           }
         >
           <Image
-            onLoad={[Function]}
             style={
               Object {
                 "bottom": 0,
@@ -1302,7 +1242,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
             }
           />
           <View
-            onLayout={[Function]}
             style={
               Object {
                 "flex": 1,
@@ -1310,7 +1249,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1399,7 +1337,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
       }
     >
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1478,7 +1415,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
         </ARTSurfaceView>
       </View>
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1556,7 +1492,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
         </ARTSurfaceView>
       </View>
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1634,7 +1569,6 @@ exports[`ArticleList tests on ios should render an article list item loading sta
         </ARTSurfaceView>
       </View>
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -1721,12 +1655,6 @@ exports[`ArticleList tests on ios should render an article list item without ima
 <View
   accessible={true}
   isTVSelectable={true}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "opacity": 1,
@@ -1910,7 +1838,6 @@ exports[`ArticleList tests on ios should render an article list page error corre
     We can't load the page you have requested. Please check your network connection and retry to continue
   </Text>
   <Button
-    onPress={[Function]}
     style={
       Object {
         "alignSelf": "center",
@@ -1924,8 +1851,6 @@ exports[`ArticleList tests on ios should render an article list page error corre
 
 exports[`ArticleList tests on ios should render an article list that is loading 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={null}
   accessibilityID="scroll-view"
   data={
@@ -1938,23 +1863,11 @@ exports[`ArticleList tests on ios should render an article list that is loading 
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -1979,9 +1892,7 @@ exports[`ArticleList tests on ios should render an article list that is loading 
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -2024,7 +1935,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -2038,7 +1948,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -2046,7 +1955,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -2135,7 +2043,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2214,7 +2121,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2292,7 +2198,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2370,7 +2275,6 @@ exports[`ArticleList tests on ios should render an article list that is loading 
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2452,9 +2356,7 @@ exports[`ArticleList tests on ios should render an article list that is loading 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -2528,8 +2430,6 @@ exports[`ArticleList tests on ios should render the article list page error corr
       }
     />
   </View>
-  <ArticleListError
-    refetch={[Function]}
-  />
+  <ArticleListError />
 </View>
 `;

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -37,7 +37,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
       >
         <a
           href="https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -166,7 +165,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
         <div />
         <a
           href="https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -295,7 +293,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
         <div />
         <a
           href="https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -438,7 +435,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
 exports[`ArticleList tests on web should render an article list item 1`] = `
 <a
   href="/test-article-url"
-  onClick={[Function]}
   style={
     Object {
       "textDecoration": "none",
@@ -671,7 +667,6 @@ exports[`ArticleList tests on web should render an article list item loading sta
 exports[`ArticleList tests on web should render an article list item without images 1`] = `
 <a
   href="/test-article-url"
-  onClick={[Function]}
   style={
     Object {
       "textDecoration": "none",
@@ -879,7 +874,6 @@ exports[`ArticleList tests on web should render an article list page error corre
     We can't load the page you have requested. Please check your network connection and retry to continue
   </Text>
   <Button
-    onPress={[Function]}
     style={
       Object {
         "alignSelf": "center",
@@ -1046,9 +1040,7 @@ exports[`ArticleList tests on web should render the article list item separator 
 
 exports[`ArticleList tests on web should render the article list page error correctly 1`] = `
 <PageErrorContainer>
-  <ArticleListError
-    refetch={[Function]}
-  />
+  <ArticleListError />
   <PageErrorImageContainer>
     <TimesImage
       aspectRatio={0.9090909090909091}
@@ -1081,7 +1073,6 @@ exports[`ArticleList tests on web should render the article list pagination corr
         <div>
           <a
             href="?page=2"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",

--- a/packages/article-list/__tests__/web/__snapshots__/helper.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/helper.web.test.js.snap
@@ -121,7 +121,6 @@ Array [
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "bottom": 0,
@@ -218,7 +217,6 @@ Array [
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "bottom": 0,

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -304,7 +304,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -513,7 +512,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -663,7 +661,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -915,7 +912,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -1099,7 +1095,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -1282,7 +1277,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -1354,7 +1348,6 @@ exports[`Article Summary tests on Android should render an article-summary with 
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -304,7 +304,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -513,7 +512,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -663,7 +661,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -915,7 +912,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -1099,7 +1095,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -1282,7 +1277,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",
@@ -1354,7 +1348,6 @@ exports[`Article Summary tests on ios should render an article-summary with opin
       allowFontScaling={true}
       ellipsizeMode="tail"
       href="/profile/camilla-long"
-      onPress={[Function]}
       style={
         Object {
           "color": "#006699",

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -257,8 +257,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long
@@ -385,8 +383,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long
@@ -500,8 +496,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long
@@ -702,8 +696,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long
@@ -851,8 +843,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long
@@ -999,8 +989,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long
@@ -1046,8 +1034,6 @@ exports[`Article Summary tests on Web should render an article-summary with opin
     <a
       dir="auto"
       href="/profile/camilla-long"
-      onClick={[Function]}
-      onKeyDown={[Function]}
       role="link"
     >
       Camilla Long

--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
@@ -12,27 +12,22 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 >
   <WithTrackEvents(ArticleTopic)
     name="Football"
-    onPress={[Function]}
     slug="football"
   />
   <WithTrackEvents(ArticleTopic)
     name="Manchester United FC"
-    onPress={[Function]}
     slug="manchester-united"
   />
   <WithTrackEvents(ArticleTopic)
     name="Chelsea FC"
-    onPress={[Function]}
     slug="chelsea"
   />
   <WithTrackEvents(ArticleTopic)
     name="Arsenal"
-    onPress={[Function]}
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
     name="Rugby Union"
-    onPress={[Function]}
     slug="rugby-union"
   />
 </View>
@@ -40,7 +35,6 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 
 exports[`2. Render a single topic 1`] = `
 <Link
-  onPress={[Function]}
   url="/topic/football"
 >
   <View

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
@@ -12,27 +12,22 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 >
   <WithTrackEvents(ArticleTopic)
     name="Football"
-    onPress={[Function]}
     slug="football"
   />
   <WithTrackEvents(ArticleTopic)
     name="Manchester United FC"
-    onPress={[Function]}
     slug="manchester-united"
   />
   <WithTrackEvents(ArticleTopic)
     name="Chelsea FC"
-    onPress={[Function]}
     slug="chelsea"
   />
   <WithTrackEvents(ArticleTopic)
     name="Arsenal"
-    onPress={[Function]}
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
     name="Rugby Union"
-    onPress={[Function]}
     slug="rugby-union"
   />
 </View>
@@ -40,7 +35,6 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 
 exports[`2. Render a single topic 1`] = `
 <Link
-  onPress={[Function]}
   url="/topic/football"
 >
   <View

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
@@ -12,27 +12,22 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 >
   <WithTrackEvents(ArticleTopic)
     name="Football"
-    onPress={[Function]}
     slug="football"
   />
   <WithTrackEvents(ArticleTopic)
     name="Manchester United FC"
-    onPress={[Function]}
     slug="manchester-united"
   />
   <WithTrackEvents(ArticleTopic)
     name="Chelsea FC"
-    onPress={[Function]}
     slug="chelsea"
   />
   <WithTrackEvents(ArticleTopic)
     name="Arsenal"
-    onPress={[Function]}
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
     name="Rugby Union"
-    onPress={[Function]}
     slug="rugby-union"
   />
 </View>
@@ -41,7 +36,6 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 exports[`2. Render a single topic 1`] = `
 <Link
   index="0"
-  onPress={[Function]}
   responsiveLinkStyles={null}
   target={null}
   url="/topic/football"

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1085,21 +1085,11 @@ exports[`Article tests on android should render a full article 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -1108,16 +1098,13 @@ exports[`Article tests on android should render a full article 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -1139,12 +1126,6 @@ exports[`Article tests on android should render a full article 1`] = `
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -1162,18 +1143,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -1182,12 +1151,6 @@ exports[`Article tests on android should render a full article 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -1230,7 +1193,6 @@ exports[`Article tests on android should render a full article 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -1249,7 +1211,6 @@ exports[`Article tests on android should render a full article 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -1257,7 +1218,6 @@ exports[`Article tests on android should render a full article 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -1348,12 +1308,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -1368,7 +1322,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -1387,7 +1340,6 @@ exports[`Article tests on android should render a full article 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1395,7 +1347,6 @@ exports[`Article tests on android should render a full article 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1477,9 +1428,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1568,9 +1517,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1626,7 +1573,6 @@ exports[`Article tests on android should render a full article 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -1658,9 +1604,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -1693,7 +1637,6 @@ exports[`Article tests on android should render a full article 1`] = `
             allowFontScaling={true}
             ellipsizeMode="tail"
             href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            onPress={[Function]}
             style={
               Object {
                 "color": "#006699",
@@ -1736,9 +1679,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1757,12 +1698,6 @@ exports[`Article tests on android should render a full article 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "height": 421.875,
@@ -1788,7 +1723,6 @@ exports[`Article tests on android should render a full article 1`] = `
               }
             >
               <Image
-                onLoad={[Function]}
                 source={
                   Object {
                     "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
@@ -1807,7 +1741,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 }
               />
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -1815,7 +1748,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 }
               >
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1955,9 +1887,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -1998,9 +1928,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -2019,12 +1947,6 @@ exports[`Article tests on android should render a full article 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "height": 421.875,
@@ -2050,7 +1972,6 @@ exports[`Article tests on android should render a full article 1`] = `
               }
             >
               <Image
-                onLoad={[Function]}
                 source={
                   Object {
                     "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
@@ -2069,7 +1990,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 }
               />
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -2077,7 +1997,6 @@ exports[`Article tests on android should render a full article 1`] = `
                 }
               >
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -2217,9 +2136,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <ArticleImage
           captionOptions={
@@ -2238,9 +2155,7 @@ exports[`Article tests on android should render a full article 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -2270,9 +2185,7 @@ exports[`Article tests on android should render a full article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -3025,21 +2938,11 @@ exports[`Article tests on android should render a smaller article 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -3048,16 +2951,13 @@ exports[`Article tests on android should render a smaller article 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -3079,12 +2979,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -3102,18 +2996,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -3122,12 +3004,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -3170,7 +3046,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -3189,7 +3064,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -3197,7 +3071,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -3288,12 +3161,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -3308,7 +3175,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -3327,7 +3193,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -3335,7 +3200,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -3417,9 +3281,7 @@ exports[`Article tests on android should render a smaller article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3508,9 +3370,7 @@ exports[`Article tests on android should render a smaller article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3566,7 +3426,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -3598,9 +3457,7 @@ exports[`Article tests on android should render a smaller article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -3633,7 +3490,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
             allowFontScaling={true}
             ellipsizeMode="tail"
             href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            onPress={[Function]}
             style={
               Object {
                 "color": "#006699",
@@ -3683,9 +3539,7 @@ exports[`Article tests on android should render a smaller article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3697,7 +3551,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
         }
       >
         <ArticleTopics
-          onPress={[Function]}
           topics={
             Array [
               Object {
@@ -3725,11 +3578,8 @@ exports[`Article tests on android should render a smaller article 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <RelatedArticles
-        analyticsStream={[Function]}
         articles={
           Array [
             Object {
@@ -4277,7 +4127,6 @@ exports[`Article tests on android should render a smaller article 1`] = `
             },
           ]
         }
-        onPress={[Function]}
         template="DEFAULT"
       />
     </View>
@@ -4435,21 +4284,11 @@ exports[`Article tests on android should render an article with a video asset 1`
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -4458,9 +4297,7 @@ exports[`Article tests on android should render an article with a video asset 1`
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
@@ -4473,12 +4310,6 @@ exports[`Article tests on android should render an article with a video asset 1`
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "height": 421.875,
@@ -4504,7 +4335,6 @@ exports[`Article tests on android should render an article with a video asset 1`
               }
             >
               <Image
-                onLoad={[Function]}
                 source={
                   Object {
                     "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
@@ -4523,7 +4353,6 @@ exports[`Article tests on android should render an article with a video asset 1`
                 }
               />
               <View
-                onLayout={[Function]}
                 style={
                   Object {
                     "flex": 1,
@@ -4531,7 +4360,6 @@ exports[`Article tests on android should render an article with a video asset 1`
                 }
               >
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -4645,9 +4473,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -4690,9 +4516,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -4748,7 +4572,6 @@ exports[`Article tests on android should render an article with a video asset 1`
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -4780,9 +4603,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -4812,9 +4633,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -4844,9 +4663,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -4876,9 +4693,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <ArticleImage
           captionOptions={
@@ -4897,9 +4712,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -4929,9 +4742,7 @@ exports[`Article tests on android should render an article with a video asset 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
@@ -5797,21 +5608,11 @@ exports[`Article tests on android should render an article with no byline 1`] = 
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -5820,16 +5621,13 @@ exports[`Article tests on android should render an article with no byline 1`] = 
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -5851,12 +5649,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -5874,18 +5666,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -5894,12 +5674,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -5942,7 +5716,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -5961,7 +5734,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -5969,7 +5741,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -6060,12 +5831,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -6080,7 +5845,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -6099,7 +5863,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -6107,7 +5870,6 @@ exports[`Article tests on android should render an article with no byline 1`] = 
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -6189,9 +5951,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -6280,9 +6040,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -6325,9 +6083,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -6382,9 +6138,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -6425,9 +6179,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -6457,9 +6209,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -6489,9 +6239,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -6521,9 +6269,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -6553,9 +6299,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -7468,21 +7212,11 @@ exports[`Article tests on android should render an article with no flags 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -7491,16 +7225,13 @@ exports[`Article tests on android should render an article with no flags 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -7522,12 +7253,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -7545,18 +7270,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -7565,12 +7278,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -7613,7 +7320,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -7632,7 +7338,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -7640,7 +7345,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -7731,12 +7435,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -7751,7 +7449,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -7770,7 +7467,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -7778,7 +7474,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -7860,9 +7555,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -7924,9 +7617,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -7982,7 +7673,6 @@ exports[`Article tests on android should render an article with no flags 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -8014,9 +7704,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -8071,9 +7759,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -8114,9 +7800,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -8146,9 +7830,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -8178,9 +7860,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -8210,9 +7890,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -8242,9 +7920,7 @@ exports[`Article tests on android should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -9160,21 +8836,11 @@ exports[`Article tests on android should render an article with no label 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -9183,16 +8849,13 @@ exports[`Article tests on android should render an article with no label 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -9214,12 +8877,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -9237,18 +8894,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -9257,12 +8902,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -9305,7 +8944,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -9324,7 +8962,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -9332,7 +8969,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -9423,12 +9059,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -9443,7 +9073,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -9462,7 +9091,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -9470,7 +9098,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -9552,9 +9179,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -9628,9 +9253,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -9686,7 +9309,6 @@ exports[`Article tests on android should render an article with no label 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -9718,9 +9340,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -9775,9 +9395,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -9818,9 +9436,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -9850,9 +9466,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -9882,9 +9496,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -9914,9 +9526,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -9946,9 +9556,7 @@ exports[`Article tests on android should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -10861,21 +10469,11 @@ exports[`Article tests on android should render an article with no label and no 
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -10884,16 +10482,13 @@ exports[`Article tests on android should render an article with no label and no 
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -10915,12 +10510,6 @@ exports[`Article tests on android should render an article with no label and no 
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -10938,18 +10527,6 @@ exports[`Article tests on android should render an article with no label and no 
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -10958,12 +10535,6 @@ exports[`Article tests on android should render an article with no label and no 
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -11006,7 +10577,6 @@ exports[`Article tests on android should render an article with no label and no 
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -11025,7 +10595,6 @@ exports[`Article tests on android should render an article with no label and no 
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -11033,7 +10602,6 @@ exports[`Article tests on android should render an article with no label and no 
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -11124,12 +10692,6 @@ exports[`Article tests on android should render an article with no label and no 
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -11144,7 +10706,6 @@ exports[`Article tests on android should render an article with no label and no 
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -11163,7 +10724,6 @@ exports[`Article tests on android should render an article with no label and no 
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -11171,7 +10731,6 @@ exports[`Article tests on android should render an article with no label and no 
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -11253,9 +10812,7 @@ exports[`Article tests on android should render an article with no label and no 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -11302,9 +10859,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -11360,7 +10915,6 @@ exports[`Article tests on android should render an article with no label and no 
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -11392,9 +10946,7 @@ exports[`Article tests on android should render an article with no label and no 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -11449,9 +11001,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -11492,9 +11042,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -11524,9 +11072,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -11556,9 +11102,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -11588,9 +11132,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -11620,9 +11162,7 @@ exports[`Article tests on android should render an article with no label and no 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -12535,21 +12075,11 @@ exports[`Article tests on android should render an article with no label, no fla
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -12558,16 +12088,13 @@ exports[`Article tests on android should render an article with no label, no fla
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -12589,12 +12116,6 @@ exports[`Article tests on android should render an article with no label, no fla
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -12612,18 +12133,6 @@ exports[`Article tests on android should render an article with no label, no fla
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -12632,12 +12141,6 @@ exports[`Article tests on android should render an article with no label, no fla
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -12680,7 +12183,6 @@ exports[`Article tests on android should render an article with no label, no fla
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -12699,7 +12201,6 @@ exports[`Article tests on android should render an article with no label, no fla
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -12707,7 +12208,6 @@ exports[`Article tests on android should render an article with no label, no fla
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -12798,12 +12298,6 @@ exports[`Article tests on android should render an article with no label, no fla
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -12818,7 +12312,6 @@ exports[`Article tests on android should render an article with no label, no fla
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -12837,7 +12330,6 @@ exports[`Article tests on android should render an article with no label, no fla
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -12845,7 +12337,6 @@ exports[`Article tests on android should render an article with no label, no fla
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -12927,9 +12418,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -12957,9 +12446,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -13015,7 +12502,6 @@ exports[`Article tests on android should render an article with no label, no fla
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -13047,9 +12533,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -13104,9 +12588,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -13147,9 +12629,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -13179,9 +12659,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -13211,9 +12689,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -13243,9 +12719,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -13275,9 +12749,7 @@ exports[`Article tests on android should render an article with no label, no fla
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -14193,21 +13665,11 @@ exports[`Article tests on android should render an article with no standfirst 1`
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -14216,16 +13678,13 @@ exports[`Article tests on android should render an article with no standfirst 1`
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -14247,12 +13706,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -14270,18 +13723,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -14290,12 +13731,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -14338,7 +13773,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -14357,7 +13791,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -14365,7 +13798,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -14456,12 +13888,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -14476,7 +13902,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -14495,7 +13920,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -14503,7 +13927,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -14585,9 +14008,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -14657,9 +14078,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -14715,7 +14134,6 @@ exports[`Article tests on android should render an article with no standfirst 1`
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -14747,9 +14165,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -14804,9 +14220,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -14847,9 +14261,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -14879,9 +14291,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -14911,9 +14321,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -14943,9 +14351,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -14975,9 +14381,7 @@ exports[`Article tests on android should render an article with no standfirst 1`
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -15890,21 +15294,11 @@ exports[`Article tests on android should render an article with no standfirst an
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -15913,16 +15307,13 @@ exports[`Article tests on android should render an article with no standfirst an
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -15944,12 +15335,6 @@ exports[`Article tests on android should render an article with no standfirst an
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -15967,18 +15352,6 @@ exports[`Article tests on android should render an article with no standfirst an
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -15987,12 +15360,6 @@ exports[`Article tests on android should render an article with no standfirst an
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -16035,7 +15402,6 @@ exports[`Article tests on android should render an article with no standfirst an
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -16054,7 +15420,6 @@ exports[`Article tests on android should render an article with no standfirst an
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -16062,7 +15427,6 @@ exports[`Article tests on android should render an article with no standfirst an
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -16153,12 +15517,6 @@ exports[`Article tests on android should render an article with no standfirst an
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -16173,7 +15531,6 @@ exports[`Article tests on android should render an article with no standfirst an
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -16192,7 +15549,6 @@ exports[`Article tests on android should render an article with no standfirst an
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -16200,7 +15556,6 @@ exports[`Article tests on android should render an article with no standfirst an
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -16282,9 +15637,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -16327,9 +15680,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -16385,7 +15736,6 @@ exports[`Article tests on android should render an article with no standfirst an
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -16417,9 +15767,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -16474,9 +15822,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -16517,9 +15863,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -16549,9 +15893,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -16581,9 +15923,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -16613,9 +15953,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -16645,9 +15983,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -17563,21 +16899,11 @@ exports[`Article tests on android should render an article with no standfirst an
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -17586,16 +16912,13 @@ exports[`Article tests on android should render an article with no standfirst an
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -17617,12 +16940,6 @@ exports[`Article tests on android should render an article with no standfirst an
                     "type": "ThemeAttrAndroid",
                   }
                 }
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 pointerEvents="box-only"
               >
                 <svg
@@ -17640,18 +16957,6 @@ exports[`Article tests on android should render an article with no standfirst an
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -17660,12 +16965,6 @@ exports[`Article tests on android should render an article with no standfirst an
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -17708,7 +17007,6 @@ exports[`Article tests on android should render an article with no standfirst an
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -17727,7 +17025,6 @@ exports[`Article tests on android should render an article with no standfirst an
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -17735,7 +17032,6 @@ exports[`Article tests on android should render an article with no standfirst an
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -17826,12 +17122,6 @@ exports[`Article tests on android should render an article with no standfirst an
                 "type": "ThemeAttrAndroid",
               }
             }
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             pointerEvents="box-only"
           >
             <View
@@ -17846,7 +17136,6 @@ exports[`Article tests on android should render an article with no standfirst an
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -17865,7 +17154,6 @@ exports[`Article tests on android should render an article with no standfirst an
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -17873,7 +17161,6 @@ exports[`Article tests on android should render an article with no standfirst an
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -17955,9 +17242,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -18012,9 +17297,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -18070,7 +17353,6 @@ exports[`Article tests on android should render an article with no standfirst an
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -18102,9 +17384,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -18159,9 +17439,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -18202,9 +17480,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -18234,9 +17510,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -18266,9 +17540,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -18298,9 +17570,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -18330,9 +17600,7 @@ exports[`Article tests on android should render an article with no standfirst an
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1085,21 +1085,11 @@ exports[`Article tests on ios should render a full article 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -1108,16 +1098,13 @@ exports[`Article tests on ios should render a full article 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -1134,12 +1121,6 @@ exports[`Article tests on ios should render a full article 1`] = `
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -1161,18 +1142,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -1181,12 +1150,6 @@ exports[`Article tests on ios should render a full article 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -1229,7 +1192,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -1248,7 +1210,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -1256,7 +1217,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -1342,12 +1302,6 @@ exports[`Article tests on ios should render a full article 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -1366,7 +1320,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -1385,7 +1338,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1393,7 +1345,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1475,9 +1426,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1565,9 +1514,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1623,7 +1570,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -1655,9 +1601,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -1689,7 +1633,6 @@ exports[`Article tests on ios should render a full article 1`] = `
             allowFontScaling={true}
             ellipsizeMode="tail"
             href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            onPress={[Function]}
             style={
               Object {
                 "color": "#006699",
@@ -1732,9 +1675,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1748,12 +1689,6 @@ exports[`Article tests on ios should render a full article 1`] = `
           accessibilityLabel="splash-component"
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -1786,7 +1721,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
@@ -1805,7 +1739,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1813,7 +1746,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1954,9 +1886,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -1996,9 +1926,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -2012,12 +1940,6 @@ exports[`Article tests on ios should render a full article 1`] = `
           accessibilityLabel="splash-component"
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -2050,7 +1972,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
@@ -2069,7 +1990,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -2077,7 +1997,6 @@ exports[`Article tests on ios should render a full article 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -2218,9 +2137,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <ArticleImage
           captionOptions={
@@ -2239,9 +2156,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -2270,9 +2185,7 @@ exports[`Article tests on ios should render a full article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -3024,21 +2937,11 @@ exports[`Article tests on ios should render a smaller article 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -3047,16 +2950,13 @@ exports[`Article tests on ios should render a smaller article 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -3073,12 +2973,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -3100,18 +2994,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -3120,12 +3002,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -3168,7 +3044,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -3187,7 +3062,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -3195,7 +3069,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -3281,12 +3154,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -3305,7 +3172,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -3324,7 +3190,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -3332,7 +3197,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -3414,9 +3278,7 @@ exports[`Article tests on ios should render a smaller article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3504,9 +3366,7 @@ exports[`Article tests on ios should render a smaller article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3562,7 +3422,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -3594,9 +3453,7 @@ exports[`Article tests on ios should render a smaller article 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -3628,7 +3485,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
             allowFontScaling={true}
             ellipsizeMode="tail"
             href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            onPress={[Function]}
             style={
               Object {
                 "color": "#006699",
@@ -3678,9 +3534,7 @@ exports[`Article tests on ios should render a smaller article 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3692,7 +3546,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
         }
       >
         <ArticleTopics
-          onPress={[Function]}
           topics={
             Array [
               Object {
@@ -3720,11 +3573,8 @@ exports[`Article tests on ios should render a smaller article 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <RelatedArticles
-        analyticsStream={[Function]}
         articles={
           Array [
             Object {
@@ -4272,7 +4122,6 @@ exports[`Article tests on ios should render a smaller article 1`] = `
             },
           ]
         }
-        onPress={[Function]}
         template="DEFAULT"
       />
     </View>
@@ -4430,21 +4279,11 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -4453,9 +4292,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
@@ -4463,12 +4300,6 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
           accessibilityLabel="splash-component"
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -4501,7 +4332,6 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
@@ -4520,7 +4350,6 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -4528,7 +4357,6 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -4643,9 +4471,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -4688,9 +4514,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -4746,7 +4570,6 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -4778,9 +4601,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -4809,9 +4630,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -4840,9 +4659,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -4871,9 +4688,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <ArticleImage
           captionOptions={
@@ -4892,9 +4707,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -4923,9 +4736,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
@@ -5791,21 +5602,11 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -5814,16 +5615,13 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -5840,12 +5638,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -5867,18 +5659,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -5887,12 +5667,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -5935,7 +5709,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -5954,7 +5727,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -5962,7 +5734,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -6048,12 +5819,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -6072,7 +5837,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -6091,7 +5855,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -6099,7 +5862,6 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -6181,9 +5943,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -6271,9 +6031,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -6316,9 +6074,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -6372,9 +6128,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -6414,9 +6168,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -6445,9 +6197,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -6476,9 +6226,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -6507,9 +6255,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -6538,9 +6284,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -7452,21 +7196,11 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -7475,16 +7209,13 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -7501,12 +7232,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -7528,18 +7253,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -7548,12 +7261,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -7596,7 +7303,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -7615,7 +7321,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -7623,7 +7328,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -7709,12 +7413,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -7733,7 +7431,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -7752,7 +7449,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -7760,7 +7456,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -7842,9 +7537,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -7905,9 +7598,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -7963,7 +7654,6 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -7995,9 +7685,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -8051,9 +7739,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -8093,9 +7779,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -8124,9 +7808,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -8155,9 +7837,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -8186,9 +7866,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -8217,9 +7895,7 @@ exports[`Article tests on ios should render an article with no flags 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -9134,21 +8810,11 @@ exports[`Article tests on ios should render an article with no label 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -9157,16 +8823,13 @@ exports[`Article tests on ios should render an article with no label 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -9183,12 +8846,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -9210,18 +8867,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -9230,12 +8875,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -9278,7 +8917,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -9297,7 +8935,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -9305,7 +8942,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -9391,12 +9027,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -9415,7 +9045,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -9434,7 +9063,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -9442,7 +9070,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -9524,9 +9151,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -9599,9 +9224,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -9657,7 +9280,6 @@ exports[`Article tests on ios should render an article with no label 1`] = `
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -9689,9 +9311,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -9745,9 +9365,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -9787,9 +9405,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -9818,9 +9434,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -9849,9 +9463,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -9880,9 +9492,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -9911,9 +9521,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -10825,21 +10433,11 @@ exports[`Article tests on ios should render an article with no label and no flag
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -10848,16 +10446,13 @@ exports[`Article tests on ios should render an article with no label and no flag
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -10874,12 +10469,6 @@ exports[`Article tests on ios should render an article with no label and no flag
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -10901,18 +10490,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -10921,12 +10498,6 @@ exports[`Article tests on ios should render an article with no label and no flag
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -10969,7 +10540,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -10988,7 +10558,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -10996,7 +10565,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -11082,12 +10650,6 @@ exports[`Article tests on ios should render an article with no label and no flag
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -11106,7 +10668,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -11125,7 +10686,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -11133,7 +10693,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -11215,9 +10774,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -11263,9 +10820,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -11321,7 +10876,6 @@ exports[`Article tests on ios should render an article with no label and no flag
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -11353,9 +10907,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -11409,9 +10961,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -11451,9 +11001,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -11482,9 +11030,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -11513,9 +11059,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -11544,9 +11088,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -11575,9 +11117,7 @@ exports[`Article tests on ios should render an article with no label and no flag
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -12489,21 +12029,11 @@ exports[`Article tests on ios should render an article with no label, no flags a
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -12512,16 +12042,13 @@ exports[`Article tests on ios should render an article with no label, no flags a
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -12538,12 +12065,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -12565,18 +12086,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -12585,12 +12094,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -12633,7 +12136,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -12652,7 +12154,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -12660,7 +12161,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -12746,12 +12246,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -12770,7 +12264,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -12789,7 +12282,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -12797,7 +12289,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -12879,9 +12370,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -12909,9 +12398,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -12967,7 +12454,6 @@ exports[`Article tests on ios should render an article with no label, no flags a
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -12999,9 +12485,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -13055,9 +12539,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -13097,9 +12579,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -13128,9 +12608,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -13159,9 +12637,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -13190,9 +12666,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -13221,9 +12695,7 @@ exports[`Article tests on ios should render an article with no label, no flags a
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -14138,21 +13610,11 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -14161,16 +13623,13 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -14187,12 +13646,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -14214,18 +13667,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -14234,12 +13675,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -14282,7 +13717,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -14301,7 +13735,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -14309,7 +13742,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -14395,12 +13827,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -14419,7 +13845,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -14438,7 +13863,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -14446,7 +13870,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -14528,9 +13951,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -14600,9 +14021,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -14658,7 +14077,6 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -14690,9 +14108,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -14746,9 +14162,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -14788,9 +14202,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -14819,9 +14231,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -14850,9 +14260,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -14881,9 +14289,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -14912,9 +14318,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -15826,21 +15230,11 @@ exports[`Article tests on ios should render an article with no standfirst and no
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -15849,16 +15243,13 @@ exports[`Article tests on ios should render an article with no standfirst and no
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -15875,12 +15266,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -15902,18 +15287,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -15922,12 +15295,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -15970,7 +15337,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -15989,7 +15355,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -15997,7 +15362,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -16083,12 +15447,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -16107,7 +15465,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -16126,7 +15483,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -16134,7 +15490,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -16216,9 +15571,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -16261,9 +15614,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -16319,7 +15670,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -16351,9 +15701,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -16407,9 +15755,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -16449,9 +15795,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -16480,9 +15824,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -16511,9 +15853,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -16542,9 +15882,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -16573,9 +15911,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={
@@ -17490,21 +16826,11 @@ exports[`Article tests on ios should render an article with no standfirst and no
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="flat-list-article"
@@ -17513,16 +16839,13 @@ exports[`Article tests on ios should render an article with no standfirst and no
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         testID="leadAsset"
       >
         <View>
           <Modal
             hardwareAccelerated={false}
-            onRequestClose={[Function]}
             presentationStyle="fullScreen"
             visible={false}
           >
@@ -17539,12 +16862,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
               <View
                 accessible={true}
                 isTVSelectable={true}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
                   Object {
                     "opacity": 1,
@@ -17566,18 +16883,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                 </svg>
               </View>
               <View
-                onMoveShouldSetResponder={[Function]}
-                onMoveShouldSetResponderCapture={[Function]}
-                onResponderEnd={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderReject={[Function]}
-                onResponderRelease={[Function]}
-                onResponderStart={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                onStartShouldSetResponderCapture={[Function]}
                 style={
                   Object {
                     "flexGrow": 1,
@@ -17586,12 +16891,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
               >
                 <View
                   accessible={true}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
                       "flexGrow": 1,
@@ -17634,7 +16933,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                         }
                       >
                         <Image
-                          onLoad={[Function]}
                           source={
                             Object {
                               "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -17653,7 +16951,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                           }
                         />
                         <View
-                          onLayout={[Function]}
                           style={
                             Object {
                               "flex": 1,
@@ -17661,7 +16958,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                           }
                         >
                           <View
-                            onLayout={[Function]}
                             style={
                               Object {
                                 "flex": 1,
@@ -17747,12 +17043,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
           <View
             accessible={true}
             isTVSelectable={true}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
               Object {
                 "opacity": 1,
@@ -17771,7 +17061,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
@@ -17790,7 +17079,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -17798,7 +17086,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -17880,9 +17167,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -17937,9 +17222,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -17995,7 +17278,6 @@ exports[`Article tests on ios should render an article with no standfirst and no
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </Text>
         </View>
@@ -18027,9 +17309,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-0"
         style={
@@ -18083,9 +17363,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-1"
         style={
@@ -18125,9 +17403,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-2"
         style={
@@ -18156,9 +17432,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-3"
         style={
@@ -18187,9 +17461,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-4"
         style={
@@ -18218,9 +17490,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-5"
         style={
@@ -18249,9 +17519,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
         </Text>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityLabel="paragraph-6"
         style={

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -364,7 +364,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -824,7 +823,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -1372,7 +1370,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -1917,7 +1914,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -1936,7 +1932,6 @@ Array [
         className="c7"
       >
         <ArticleTopics
-          onPress={[Function]}
           style={
             Object {
               "justifyContent": "flex-start",
@@ -2079,7 +2074,6 @@ Array [
           <a
             className="c14"
             href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "underline",
@@ -2611,7 +2605,6 @@ Array [
           <a
             className="c14"
             href="https://www.cam.ac.uk/"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "underline",
@@ -2675,7 +2668,6 @@ Array [
     className="c0"
   >
     <ArticleTopics
-      onPress={[Function]}
       style={
         Object {
           "borderTopColor": "#DBDBDB",
@@ -2709,7 +2701,6 @@ Array [
     />
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -3257,7 +3248,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -3714,7 +3704,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -3733,7 +3722,6 @@ Array [
         className="c7"
       >
         <ArticleTopics
-          onPress={[Function]}
           style={
             Object {
               "justifyContent": "flex-start",
@@ -3876,7 +3864,6 @@ Array [
           <a
             className="c14"
             href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "underline",
@@ -3933,7 +3920,6 @@ Array [
     className="c0"
   >
     <ArticleTopics
-      onPress={[Function]}
       style={
         Object {
           "borderTopColor": "#DBDBDB",
@@ -3967,7 +3953,6 @@ Array [
     />
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -4515,7 +4500,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -4915,7 +4899,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -5919,7 +5902,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -6467,7 +6449,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -6853,7 +6834,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -7290,7 +7270,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -7838,7 +7817,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -8216,7 +8194,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -8653,7 +8630,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -9201,7 +9177,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -9571,7 +9546,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -10008,7 +9982,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -10556,7 +10529,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -10919,7 +10891,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -11356,7 +11327,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -11904,7 +11874,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -12291,7 +12260,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -12728,7 +12696,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -13276,7 +13243,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -13655,7 +13621,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -14092,7 +14057,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -14640,7 +14604,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>
@@ -15011,7 +14974,6 @@ Array [
                   },
                 ]
               }
-              onAuthorPress={[Function]}
             />
           </span>
         </div>
@@ -15448,7 +15410,6 @@ Array [
     </div>
   </div>,
   <RelatedArticles
-    analyticsStream={[Function]}
     articles={
       Array [
         Object {
@@ -15996,7 +15957,6 @@ Array [
         },
       ]
     }
-    onPress={[Function]}
     template="DEFAULT"
   />,
   <div>

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile-head.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile-head.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`1. Should not re-render when twitter prop is changed 1`] = `
 <AuthorProfileHeadTwitter
-  onTwitterLinkPress={[Function]}
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
@@ -10,7 +9,6 @@ exports[`1. Should not re-render when twitter prop is changed 1`] = `
 
 exports[`2. Should not re-render when twitter prop is changed 1`] = `
 <AuthorProfileHeadTwitter
-  onTwitterLinkPress={[Function]}
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
@@ -32,7 +30,6 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
       jobTitle="testJobTitle"
     />
     <AuthorProfileHeadTwitter
-      onTwitterLinkPress={[Function]}
       twitter="testTwitterHandle"
       url="https://twitter.com/testTwitterHandle"
     />

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`1. Render an author profile page 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <AuthorProfileHead
       biography={
@@ -40,7 +38,6 @@ exports[`1. Render an author profile page 1`] = `
       isLoading={false}
       jobTitle="Defence Editor"
       name="Deborah Haynes"
-      onTwitterLinkPress={[Function]}
       twitter="jdoe"
       uri="//www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg"
     />
@@ -156,24 +153,12 @@ exports[`1. Render an author profile page 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -198,9 +183,7 @@ exports[`1. Render an author profile page 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityRole="banner"
         style={
@@ -256,7 +239,6 @@ exports[`1. Render an author profile page 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg?resize=1440",
@@ -275,7 +257,6 @@ exports[`1. Render an author profile page 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -283,7 +264,6 @@ exports[`1. Render an author profile page 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -417,7 +397,6 @@ exports[`1. Render an author profile page 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 href="https://twitter.com/jdoe"
-                onPress={[Function]}
                 style={
                   Object {
                     "color": "#006699",
@@ -475,9 +454,7 @@ exports[`1. Render an author profile page 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -486,12 +463,6 @@ exports[`1. Render an author profile page 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -543,7 +514,6 @@ exports[`1. Render an author profile page 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440",
@@ -562,7 +532,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -570,7 +539,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -745,9 +713,7 @@ exports[`1. Render an author profile page 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -756,12 +722,6 @@ exports[`1. Render an author profile page 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -813,7 +773,6 @@ exports[`1. Render an author profile page 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440",
@@ -832,7 +791,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -840,7 +798,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1015,9 +972,7 @@ exports[`1. Render an author profile page 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -1026,12 +981,6 @@ exports[`1. Render an author profile page 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -1083,7 +1032,6 @@ exports[`1. Render an author profile page 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=1440",
@@ -1102,7 +1050,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1110,7 +1057,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1268,9 +1214,7 @@ exports[`1. Render an author profile page 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -1299,8 +1243,6 @@ exports[`1. Render an author profile page 1`] = `
 
 exports[`2. Render an author profile page without images 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <AuthorProfileHead
       biography={
@@ -1337,7 +1279,6 @@ exports[`2. Render an author profile page without images 1`] = `
       isLoading={false}
       jobTitle="Defence Editor"
       name="Deborah Haynes"
-      onTwitterLinkPress={[Function]}
       twitter="jdoe"
       uri="//www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg"
     />
@@ -1546,24 +1487,12 @@ exports[`2. Render an author profile page without images 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -1588,9 +1517,7 @@ exports[`2. Render an author profile page without images 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityRole="banner"
         style={
@@ -1646,7 +1573,6 @@ exports[`2. Render an author profile page without images 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg?resize=1440",
@@ -1665,7 +1591,6 @@ exports[`2. Render an author profile page without images 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1673,7 +1598,6 @@ exports[`2. Render an author profile page without images 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1807,7 +1731,6 @@ exports[`2. Render an author profile page without images 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 href="https://twitter.com/jdoe"
-                onPress={[Function]}
                 style={
                   Object {
                     "color": "#006699",
@@ -1865,9 +1788,7 @@ exports[`2. Render an author profile page without images 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -1876,12 +1797,6 @@ exports[`2. Render an author profile page without images 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -2016,9 +1931,7 @@ exports[`2. Render an author profile page without images 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -2027,12 +1940,6 @@ exports[`2. Render an author profile page without images 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -2167,9 +2074,7 @@ exports[`2. Render an author profile page without images 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         nativeBackgroundAndroid={
@@ -2178,12 +2083,6 @@ exports[`2. Render an author profile page without images 1`] = `
             "type": "ThemeAttrAndroid",
           }
         }
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         pointerEvents="box-only"
       >
         <View
@@ -2301,9 +2200,7 @@ exports[`2. Render an author profile page without images 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -2332,15 +2229,12 @@ exports[`2. Render an author profile page without images 1`] = `
 
 exports[`3. Render an author profile page loading state 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <AuthorProfileHead
       biography={Array []}
       isLoading={true}
       jobTitle=""
       name=""
-      onTwitterLinkPress={[Function]}
       twitter=""
       uri=""
     />
@@ -2366,24 +2260,12 @@ exports[`3. Render an author profile page loading state 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -2408,9 +2290,7 @@ exports[`3. Render an author profile page loading state 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityRole="banner"
         style={
@@ -2452,7 +2332,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2531,9 +2410,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -2576,7 +2453,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -2590,7 +2466,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -2598,7 +2473,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -2687,7 +2561,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2766,7 +2639,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2844,7 +2716,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2922,7 +2793,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3021,9 +2891,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3066,7 +2934,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -3080,7 +2947,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -3088,7 +2954,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -3177,7 +3042,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3256,7 +3120,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3334,7 +3197,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3412,7 +3274,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3511,9 +3372,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3556,7 +3415,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -3570,7 +3428,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -3578,7 +3435,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -3667,7 +3523,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3746,7 +3601,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3824,7 +3678,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3902,7 +3755,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3984,9 +3836,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -4097,12 +3947,6 @@ exports[`4. Render an author profile page error state 1`] = `
       accessibilityTraits="button"
       accessible={true}
       isTVSelectable={true}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Object {
           "alignItems": "center",

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile-head.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile-head.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`1. Should not re-render when twitter prop is changed 1`] = `
 <AuthorProfileHeadTwitter
-  onTwitterLinkPress={[Function]}
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
@@ -10,7 +9,6 @@ exports[`1. Should not re-render when twitter prop is changed 1`] = `
 
 exports[`2. Should not re-render when twitter prop is changed 1`] = `
 <AuthorProfileHeadTwitter
-  onTwitterLinkPress={[Function]}
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
@@ -32,7 +30,6 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
       jobTitle="testJobTitle"
     />
     <AuthorProfileHeadTwitter
-      onTwitterLinkPress={[Function]}
       twitter="testTwitterHandle"
       url="https://twitter.com/testTwitterHandle"
     />

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`1. Render an author profile page 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <AuthorProfileHead
       biography={
@@ -40,7 +38,6 @@ exports[`1. Render an author profile page 1`] = `
       isLoading={false}
       jobTitle="Defence Editor"
       name="Deborah Haynes"
-      onTwitterLinkPress={[Function]}
       twitter="jdoe"
       uri="//www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg"
     />
@@ -156,24 +153,12 @@ exports[`1. Render an author profile page 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -198,9 +183,7 @@ exports[`1. Render an author profile page 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityRole="banner"
         style={
@@ -256,7 +239,6 @@ exports[`1. Render an author profile page 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg?resize=1440",
@@ -275,7 +257,6 @@ exports[`1. Render an author profile page 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -283,7 +264,6 @@ exports[`1. Render an author profile page 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -416,7 +396,6 @@ exports[`1. Render an author profile page 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 href="https://twitter.com/jdoe"
-                onPress={[Function]}
                 style={
                   Object {
                     "color": "#006699",
@@ -474,18 +453,10 @@ exports[`1. Render an author profile page 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -541,7 +512,6 @@ exports[`1. Render an author profile page 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440",
@@ -560,7 +530,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -568,7 +537,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -743,18 +711,10 @@ exports[`1. Render an author profile page 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -810,7 +770,6 @@ exports[`1. Render an author profile page 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440",
@@ -829,7 +788,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -837,7 +795,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1012,18 +969,10 @@ exports[`1. Render an author profile page 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -1079,7 +1028,6 @@ exports[`1. Render an author profile page 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=1440",
@@ -1098,7 +1046,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1106,7 +1053,6 @@ exports[`1. Render an author profile page 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1264,9 +1210,7 @@ exports[`1. Render an author profile page 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -1295,8 +1239,6 @@ exports[`1. Render an author profile page 1`] = `
 
 exports[`2. Render an author profile page without images 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <AuthorProfileHead
       biography={
@@ -1333,7 +1275,6 @@ exports[`2. Render an author profile page without images 1`] = `
       isLoading={false}
       jobTitle="Defence Editor"
       name="Deborah Haynes"
-      onTwitterLinkPress={[Function]}
       twitter="jdoe"
       uri="//www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg"
     />
@@ -1542,24 +1483,12 @@ exports[`2. Render an author profile page without images 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -1584,9 +1513,7 @@ exports[`2. Render an author profile page without images 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityRole="banner"
         style={
@@ -1642,7 +1569,6 @@ exports[`2. Render an author profile page without images 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   source={
                     Object {
                       "uri": "https://www.thetimes.co.uk/d/img/profile/deborah-haynes.jpg?resize=1440",
@@ -1661,7 +1587,6 @@ exports[`2. Render an author profile page without images 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1669,7 +1594,6 @@ exports[`2. Render an author profile page without images 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1802,7 +1726,6 @@ exports[`2. Render an author profile page without images 1`] = `
                 allowFontScaling={true}
                 ellipsizeMode="tail"
                 href="https://twitter.com/jdoe"
-                onPress={[Function]}
                 style={
                   Object {
                     "color": "#006699",
@@ -1860,18 +1783,10 @@ exports[`2. Render an author profile page without images 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -2010,18 +1925,10 @@ exports[`2. Render an author profile page without images 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -2160,18 +2067,10 @@ exports[`2. Render an author profile page without images 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessible={true}
         isTVSelectable={true}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           Object {
             "opacity": 1,
@@ -2293,9 +2192,7 @@ exports[`2. Render an author profile page without images 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -2324,15 +2221,12 @@ exports[`2. Render an author profile page without images 1`] = `
 
 exports[`3. Render an author profile page loading state 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <AuthorProfileHead
       biography={Array []}
       isLoading={true}
       jobTitle=""
       name=""
-      onTwitterLinkPress={[Function]}
       twitter=""
       uri=""
     />
@@ -2358,24 +2252,12 @@ exports[`3. Render an author profile page loading state 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -2400,9 +2282,7 @@ exports[`3. Render an author profile page loading state 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         accessibilityRole="banner"
         style={
@@ -2444,7 +2324,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2523,9 +2402,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -2568,7 +2445,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -2582,7 +2458,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -2590,7 +2465,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -2679,7 +2553,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2758,7 +2631,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2836,7 +2708,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -2914,7 +2785,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3013,9 +2883,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3058,7 +2926,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -3072,7 +2939,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -3080,7 +2946,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -3169,7 +3034,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3248,7 +3112,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3326,7 +3189,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3404,7 +3266,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3503,9 +3364,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -3548,7 +3407,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -3562,7 +3420,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -3570,7 +3427,6 @@ exports[`3. Render an author profile page loading state 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -3659,7 +3515,6 @@ exports[`3. Render an author profile page loading state 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3738,7 +3593,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3816,7 +3670,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3894,7 +3747,6 @@ exports[`3. Render an author profile page loading state 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -3976,9 +3828,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View>
         <View
           style={
@@ -4089,12 +3939,6 @@ exports[`4. Render an author profile page error state 1`] = `
       accessibilityTraits="button"
       accessible={true}
       isTVSelectable={true}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Object {
           "alignItems": "center",

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-head.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-head.web.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`1. Should not re-render when twitter prop is changed 1`] = `
 <AuthorProfileHeadTwitter
-  onTwitterLinkPress={[Function]}
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
@@ -10,7 +9,6 @@ exports[`1. Should not re-render when twitter prop is changed 1`] = `
 
 exports[`2. Should not re-render when twitter prop is changed 1`] = `
 <AuthorProfileHeadTwitter
-  onTwitterLinkPress={[Function]}
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
@@ -32,7 +30,6 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
       jobTitle="testJobTitle"
     />
     <AuthorProfileHeadTwitter
-      onTwitterLinkPress={[Function]}
       twitter="testTwitterHandle"
       url="https://twitter.com/testTwitterHandle"
     />

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -89,8 +89,6 @@ exports[`1. Render an author profile page 1`] = `
           <a
             dir="auto"
             href="https://twitter.com/jdoe"
-            onClick={[Function]}
-            onKeyDown={[Function]}
             role="link"
           >
             @
@@ -139,7 +137,6 @@ exports[`1. Render an author profile page 1`] = `
             <div>
               <a
                 href="?page=2"
-                onClick={[Function]}
                 style={
                   Object {
                     "textDecoration": "none",
@@ -189,7 +186,6 @@ exports[`1. Render an author profile page 1`] = `
       >
         <a
           href="https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -316,7 +312,6 @@ exports[`1. Render an author profile page 1`] = `
         <div />
         <a
           href="https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -443,7 +438,6 @@ exports[`1. Render an author profile page 1`] = `
         <div />
         <a
           href="https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -575,7 +569,6 @@ exports[`1. Render an author profile page 1`] = `
             <div>
               <a
                 href="?page=2"
-                onClick={[Function]}
                 style={
                   Object {
                     "textDecoration": "none",
@@ -710,8 +703,6 @@ exports[`2. Render an author profile page without images 1`] = `
           <a
             dir="auto"
             href="https://twitter.com/jdoe"
-            onClick={[Function]}
-            onKeyDown={[Function]}
             role="link"
           >
             @
@@ -760,7 +751,6 @@ exports[`2. Render an author profile page without images 1`] = `
             <div>
               <a
                 href="?page=2"
-                onClick={[Function]}
                 style={
                   Object {
                     "textDecoration": "none",
@@ -810,7 +800,6 @@ exports[`2. Render an author profile page without images 1`] = `
       >
         <a
           href="https://www.thetimes.co.uk/article/top-medal-for-forces-dog-who-took-a-bite-out-of-the-taliban-vgklxs37f"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -957,7 +946,6 @@ exports[`2. Render an author profile page without images 1`] = `
         <div />
         <a
           href="https://www.thetimes.co.uk/article/social-media-must-raise-game-to-beat-terrorists-says-un-chief-s5w8878f0"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -1104,7 +1092,6 @@ exports[`2. Render an author profile page without images 1`] = `
         <div />
         <a
           href="https://www.thetimes.co.uk/article/cuts-have-left-the-army-20-years-out-of-date-says-former-general-sir-richard-barrons-lg9txzbpn"
-          onClick={[Function]}
           style={
             Object {
               "textDecoration": "none",
@@ -1256,7 +1243,6 @@ exports[`2. Render an author profile page without images 1`] = `
             <div>
               <a
                 href="?page=2"
-                onClick={[Function]}
                 style={
                   Object {
                     "textDecoration": "none",
@@ -1659,15 +1645,6 @@ exports[`4. Render an author profile page error state 1`] = `
     </div>
     <div
       aria-label="Retry"
-      onKeyDown={[Function]}
-      onKeyPress={[Function]}
-      onKeyUp={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       role="button"
       tabIndex="0"
     >

--- a/packages/button/__tests__/android/__snapshots__/button.test.js.snap
+++ b/packages/button/__tests__/android/__snapshots__/button.test.js.snap
@@ -7,7 +7,6 @@ exports[`1. Render the button 1`] = `
   accessibilityRole="button"
   accessibilityTraits="button"
   activeOpacity={0.2}
-  onPress={[Function]}
   style={
     Object {
       "alignItems": "center",

--- a/packages/button/__tests__/ios/__snapshots__/button.test.js.snap
+++ b/packages/button/__tests__/ios/__snapshots__/button.test.js.snap
@@ -7,7 +7,6 @@ exports[`1. Render the button 1`] = `
   accessibilityRole="button"
   accessibilityTraits="button"
   activeOpacity={0.2}
-  onPress={[Function]}
   style={
     Object {
       "alignItems": "center",

--- a/packages/button/__tests__/web/__snapshots__/button.web.test.js.snap
+++ b/packages/button/__tests__/web/__snapshots__/button.web.test.js.snap
@@ -8,7 +8,6 @@ exports[`1. Render the button 1`] = `
   accessibilityTraits="button"
   activeOpacity={0.2}
   focusedOpacity={0.7}
-  onPress={[Function]}
   style={
     Object {
       "alignItems": "center",

--- a/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
@@ -14,7 +14,6 @@ exports[`Caption on Android renders an image with a caption 1`] = `
       }
     >
       <Image
-        onLoad={[Function]}
         source={
           Object {
             "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78&resize=1440",
@@ -33,7 +32,6 @@ exports[`Caption on Android renders an image with a caption 1`] = `
         }
       />
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -41,7 +39,6 @@ exports[`Caption on Android renders an image with a caption 1`] = `
         }
       >
         <View
-          onLayout={[Function]}
           style={
             Object {
               "flex": 1,

--- a/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
@@ -14,7 +14,6 @@ exports[`Caption on Android renders an image with a caption 1`] = `
       }
     >
       <Image
-        onLoad={[Function]}
         source={
           Object {
             "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78&resize=1440",
@@ -33,7 +32,6 @@ exports[`Caption on Android renders an image with a caption 1`] = `
         }
       />
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -41,7 +39,6 @@ exports[`Caption on Android renders an image with a caption 1`] = `
         }
       >
         <View
-          onLayout={[Function]}
           style={
             Object {
               "flex": 1,

--- a/packages/gradient/__tests__/android/__snapshots__/gradient.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient.android.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Gradient tests on android renders a Gradient 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -81,7 +80,6 @@ exports[`Gradient tests on android renders a Gradient 1`] = `
 
 exports[`Gradient tests on android renders a Gradient using array prop styles 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -162,7 +160,6 @@ exports[`Gradient tests on android renders a Gradient using array prop styles 1`
 
 exports[`Gradient tests on android renders a Gradient using prop styles 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -243,7 +240,6 @@ exports[`Gradient tests on android renders a Gradient using prop styles 1`] = `
 
 exports[`Gradient tests on android renders a Gradient using stylesheets 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -325,7 +321,6 @@ exports[`Gradient tests on android renders a Gradient using stylesheets 1`] = `
 
 exports[`Gradient tests on android renders a Gradient with an angle (-45) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -404,7 +399,6 @@ exports[`Gradient tests on android renders a Gradient with an angle (-45) 1`] = 
 
 exports[`Gradient tests on android renders a Gradient with an angle (45) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -483,7 +477,6 @@ exports[`Gradient tests on android renders a Gradient with an angle (45) 1`] = `
 
 exports[`Gradient tests on android renders a Gradient with an angle (90) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -562,7 +555,6 @@ exports[`Gradient tests on android renders a Gradient with an angle (90) 1`] = `
 
 exports[`Gradient tests on android renders a Gradient with an angle (180) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -641,7 +633,6 @@ exports[`Gradient tests on android renders a Gradient with an angle (180) 1`] = 
 
 exports[`Gradient tests on android renders a Gradient with an angle (270) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient.ios.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Gradient tests on iOS renders a Gradient 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -81,7 +80,6 @@ exports[`Gradient tests on iOS renders a Gradient 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient using array prop styles 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -162,7 +160,6 @@ exports[`Gradient tests on iOS renders a Gradient using array prop styles 1`] = 
 
 exports[`Gradient tests on iOS renders a Gradient using prop styles 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -243,7 +240,6 @@ exports[`Gradient tests on iOS renders a Gradient using prop styles 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient using stylesheets 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -325,7 +321,6 @@ exports[`Gradient tests on iOS renders a Gradient using stylesheets 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient with an angle (-45) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -404,7 +399,6 @@ exports[`Gradient tests on iOS renders a Gradient with an angle (-45) 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient with an angle (45) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -483,7 +477,6 @@ exports[`Gradient tests on iOS renders a Gradient with an angle (45) 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient with an angle (90) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -562,7 +555,6 @@ exports[`Gradient tests on iOS renders a Gradient with an angle (90) 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient with an angle (180) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -641,7 +633,6 @@ exports[`Gradient tests on iOS renders a Gradient with an angle (180) 1`] = `
 
 exports[`Gradient tests on iOS renders a Gradient with an angle (270) 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -5,7 +5,6 @@ exports[`1. Renders default layout 1`] = `
   aspectRatio={1.5}
 >
   <ImageBackground
-    onLoad={[Function]}
     source={
       Object {
         "uri": "http://example.com/image.jpg?resize=1440",
@@ -28,7 +27,6 @@ exports[`2. Renders default layout without uri 1`] = `
   aspectRatio={1.5}
 >
   <ImageBackground
-    onLoad={[Function]}
     style={
       Object {
         "height": "100%",
@@ -51,7 +49,6 @@ exports[`3. Renders with a passed style prop 1`] = `
   }
 >
   <ImageBackground
-    onLoad={[Function]}
     source={
       Object {
         "uri": "http://example.com/image.jpg?resize=1440",
@@ -71,7 +68,6 @@ exports[`3. Renders with a passed style prop 1`] = `
 
 exports[`4. Renders a placeholder 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -121,7 +117,6 @@ exports[`5. Renders with prepended https schema 1`] = `
   aspectRatio={1.5}
 >
   <ImageBackground
-    onLoad={[Function]}
     source={
       Object {
         "uri": "https://example.com/image.jpg?resize=1440",

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -5,7 +5,6 @@ exports[`1. Renders default layout 1`] = `
   aspectRatio={1.5}
 >
   <ImageBackground
-    onLoad={[Function]}
     source={
       Object {
         "uri": "http://example.com/image.jpg?resize=1440",
@@ -28,7 +27,6 @@ exports[`2. Renders default layout without uri 1`] = `
   aspectRatio={1.5}
 >
   <ImageBackground
-    onLoad={[Function]}
     style={
       Object {
         "height": "100%",
@@ -51,7 +49,6 @@ exports[`3. Renders with a passed style prop 1`] = `
   }
 >
   <ImageBackground
-    onLoad={[Function]}
     source={
       Object {
         "uri": "http://example.com/image.jpg?resize=1440",
@@ -71,7 +68,6 @@ exports[`3. Renders with a passed style prop 1`] = `
 
 exports[`4. Renders a placeholder 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,
@@ -121,7 +117,6 @@ exports[`5. Renders with prepended https schema 1`] = `
   aspectRatio={1.5}
 >
   <ImageBackground
-    onLoad={[Function]}
     source={
       Object {
         "uri": "https://example.com/image.jpg?resize=1440",

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -128,7 +128,6 @@ exports[`3. Renders with a passed style prop 1`] = `
 
 exports[`4. Renders a placeholder 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,

--- a/packages/jest-serializer/__tests__/__snapshots__/serializer.test.js.snap
+++ b/packages/jest-serializer/__tests__/__snapshots__/serializer.test.js.snap
@@ -16,6 +16,12 @@ exports[`Jest serializer should not remove styles 1`] = `
 
 exports[`Jest serializer should remove d-prop from path 1`] = `<path />`;
 
+exports[`Jest serializer should remove functions as props 1`] = `
+<View>
+  <Dummy />
+</View>
+`;
+
 exports[`Jest serializer should remove rnw-classnames 1`] = `
 <View
   className="rn-notprop main main2"

--- a/packages/jest-serializer/__tests__/serializer.test.js
+++ b/packages/jest-serializer/__tests__/serializer.test.js
@@ -68,4 +68,16 @@ describe("Jest serializer", () => {
     const tree = shallow(<DummyRenderer />);
     expect(tree).toMatchSnapshot();
   });
+
+  it("should remove functions as props", () => {
+    const Dummy = () => null;
+    const DummyRenderer = () => (
+      <View>
+        <Dummy testFunc={() => 42} />
+      </View>
+    );
+
+    const tree = shallow(<DummyRenderer />);
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/jest-serializer/src/jest-serializer.js
+++ b/packages/jest-serializer/src/jest-serializer.js
@@ -3,9 +3,9 @@ import { StyleSheet } from "react-native-web";
 import omit from "lodash.omit";
 import omitBy from "lodash.omitby";
 
-function withoutProps(node) {
-  return { ...node, props: {} };
-}
+const withoutProps = node => ({ ...node, props: {} });
+
+const excludeProps = x => x === undefined || typeof x === "function";
 
 function getType({ type }) {
   if (type instanceof Function) {
@@ -48,11 +48,9 @@ function transformRenderProps(propsToTransform, transformer) {
 function transform(node) {
   if (!node || !node.props) return node;
 
-  const { className, style: styles, ...props } = { ...node.props };
+  const { className, style: styles, ...props } = node.props;
 
-  const children = []
-    .concat(node.children || node.props.children)
-    .map(transform);
+  const children = (node.children || node.props.children || []).map(transform);
 
   const flattened = StyleSheet.flatten(styles);
   const style = Object.keys(flattened || {}).length ? { style: flattened } : {};
@@ -66,18 +64,15 @@ function transform(node) {
         ...cleanClassNames(className),
         ...style
       },
-      x => x === undefined
+      excludeProps
     ),
     ...children
   );
 }
 
-function test(value) {
-  return !!value && value.$$typeof === Symbol.for("react.test.json");
-}
+const test = value =>
+  !!value && value.$$typeof === Symbol.for("react.test.json");
 
-function print(node, serialize) {
-  return serialize(transform(node));
-}
+const print = (node, serialize) => serialize(transform(node));
 
 module.exports = { test, print };

--- a/packages/link/__tests__/android/__snapshots__/link.android.test.js.snap
+++ b/packages/link/__tests__/android/__snapshots__/link.android.test.js.snap
@@ -9,12 +9,6 @@ exports[`Link test on android Link doesnt change inner text styles 1`] = `
       "type": "ThemeAttrAndroid",
     }
   }
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   pointerEvents="box-only"
 >
   <Text
@@ -36,12 +30,6 @@ exports[`Link test on android Link renders correctly 1`] = `
       "type": "ThemeAttrAndroid",
     }
   }
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   pointerEvents="box-only"
 >
   The Times
@@ -55,7 +43,6 @@ exports[`Link test on android TextLink renders correctly with children 1`] = `
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="http://thetimes.co.uk"
-  onPress={[Function]}
   style={
     Object {
       "textDecorationLine": "underline",
@@ -73,7 +60,6 @@ exports[`Link test on android TextLink renders correctly with multiple styles 1`
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="http://thetimes.co.uk"
-  onPress={[Function]}
   style={
     Object {
       "backgroundColor": "blue",
@@ -93,7 +79,6 @@ exports[`Link test on android TextLink renders correctly with specific styles 1`
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="http://thetimes.co.uk"
-  onPress={[Function]}
   style={
     Object {
       "backgroundColor": "blue",

--- a/packages/link/__tests__/ios/__snapshots__/link.ios.test.js.snap
+++ b/packages/link/__tests__/ios/__snapshots__/link.ios.test.js.snap
@@ -4,12 +4,6 @@ exports[`Link test on ios Link doesnt change inner text styles 1`] = `
 <View
   accessible={true}
   isTVSelectable={true}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "opacity": 1,
@@ -30,12 +24,6 @@ exports[`Link test on ios Link renders correctly 1`] = `
 <View
   accessible={true}
   isTVSelectable={true}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "opacity": 1,
@@ -53,7 +41,6 @@ exports[`Link test on ios TextLink renders correctly with children 1`] = `
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="http://thetimes.co.uk"
-  onPress={[Function]}
   style={
     Object {
       "textDecorationLine": "underline",
@@ -71,7 +58,6 @@ exports[`Link test on ios TextLink renders correctly with multiple styles 1`] = 
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="http://thetimes.co.uk"
-  onPress={[Function]}
   style={
     Object {
       "backgroundColor": "blue",
@@ -91,7 +77,6 @@ exports[`Link test on ios TextLink renders correctly with specific styles 1`] = 
   allowFontScaling={true}
   ellipsizeMode="tail"
   href="http://thetimes.co.uk"
-  onPress={[Function]}
   style={
     Object {
       "backgroundColor": "blue",

--- a/packages/link/__tests__/web/__snapshots__/link.web.test.js.snap
+++ b/packages/link/__tests__/web/__snapshots__/link.web.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Link tests on Web Link doesnt change inner text styles 1`] = `
 <a
   href="http://thetimes.co.uk"
-  onClick={[Function]}
   style={
     Object {
       "textDecoration": "none",
@@ -19,7 +18,6 @@ exports[`Link tests on Web Link doesnt change inner text styles 1`] = `
 exports[`Link tests on Web Link renders correctly 1`] = `
 <a
   href="http://thetimes.co.uk"
-  onClick={[Function]}
   style={
     Object {
       "textDecoration": "none",
@@ -34,8 +32,6 @@ exports[`Link tests on Web TextLink renders correctly with children 1`] = `
 <a
   dir="auto"
   href="http://thetimes.co.uk"
-  onClick={[Function]}
-  onKeyDown={[Function]}
   role="link"
 >
   The Times
@@ -46,8 +42,6 @@ exports[`Link tests on Web TextLink renders correctly with multiple styles 1`] =
 <a
   dir="auto"
   href="http://thetimes.co.uk"
-  onClick={[Function]}
-  onKeyDown={[Function]}
   role="link"
   style={
     Object {
@@ -64,8 +58,6 @@ exports[`Link tests on Web TextLink renders correctly with specific styles 1`] =
 <a
   dir="auto"
   href="http://thetimes.co.uk"
-  onClick={[Function]}
-  onKeyDown={[Function]}
   role="link"
   style={
     Object {
@@ -80,7 +72,6 @@ exports[`Link tests on Web TextLink renders correctly with specific styles 1`] =
 exports[`Link tests on Web renders with a target 1`] = `
 <a
   href="http://thetimes.co.uk"
-  onClick={[Function]}
   style={
     Object {
       "textDecoration": "none",

--- a/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
@@ -96,7 +96,6 @@ exports[`Pagination on Web renders correctly 1`] = `
     <div>
       <a
         href="./2"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",
@@ -234,7 +233,6 @@ exports[`Pagination on Web renders next link 1`] = `
     <div>
       <a
         href="./2"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",
@@ -371,7 +369,6 @@ exports[`Pagination on Web renders prev and next link 1`] = `
     <div>
       <a
         href="./1"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",
@@ -412,7 +409,6 @@ exports[`Pagination on Web renders prev and next link 1`] = `
     <div>
       <a
         href="./3"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",
@@ -549,7 +545,6 @@ exports[`Pagination on Web renders prev link 1`] = `
     <div>
       <a
         href="./2"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",
@@ -688,7 +683,6 @@ exports[`Pagination on Web renders results message 1`] = `
     <div>
       <a
         href="./2"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",
@@ -781,7 +775,6 @@ exports[`Pagination on Web renders with hidden results 1`] = `
     <div>
       <a
         href="./2"
-        onClick={[Function]}
         style={
           Object {
             "textDecoration": "none",

--- a/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes.test.js.snap
+++ b/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes.test.js.snap
@@ -243,7 +243,6 @@ exports[`3. Renders with a twitter handle 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         href="https://twitter.com/@henrywinter"
-        onPress={[Function]}
         style={
           Object {
             "color": "#006699",

--- a/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes.test.js.snap
+++ b/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes.test.js.snap
@@ -252,7 +252,6 @@ exports[`3. Renders with a twitter handle 1`] = `
         allowFontScaling={true}
         ellipsizeMode="tail"
         href="https://twitter.com/@henrywinter"
-        onPress={[Function]}
         style={
           Object {
             "color": "#006699",

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes.test.js.snap
@@ -107,8 +107,6 @@ exports[`3. Renders with a twitter handle 1`] = `
       <a
         dir="auto"
         href="https://twitter.com/@henrywinter"
-        onClick={[Function]}
-        onKeyDown={[Function]}
         rel=" noopener noreferrer"
         role="link"
         target="_blank"

--- a/packages/related-articles/__tests__/android/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/related-articles.test.js.snap
@@ -87,12 +87,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -134,7 +128,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104&resize=1440",
@@ -153,7 +146,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -161,7 +153,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -474,12 +465,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -521,7 +506,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104&resize=1440",
@@ -540,7 +524,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -548,7 +531,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -791,12 +773,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -838,7 +814,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F82723c10-fb7f-11e7-a987-7fcf5e9983dc.jpg?crop=4886%2C2748%2C92%2C108&resize=1440",
@@ -857,7 +832,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -865,7 +839,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1198,12 +1171,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -1388,12 +1355,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -1591,12 +1552,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -1878,12 +1833,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -1925,7 +1874,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe42e32fe-d14c-11e7-b1ec-8503a5941b97.jpg?crop=6250%2C3516%2C0%2C326&resize=1440",
@@ -1944,7 +1892,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1952,7 +1899,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -2265,12 +2211,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -2312,7 +2252,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe42e32fe-d14c-11e7-b1ec-8503a5941b97.jpg?crop=6250%2C3516%2C0%2C326&resize=1440",
@@ -2331,7 +2270,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -2339,7 +2277,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -2582,12 +2519,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -2821,12 +2752,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -2868,7 +2793,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe42e32fe-d14c-11e7-b1ec-8503a5941b97.jpg?crop=6250%2C3516%2C0%2C326&resize=1440",
@@ -2887,7 +2811,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -2895,7 +2818,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -3138,12 +3060,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -3300,12 +3216,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -3546,12 +3456,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -3738,7 +3642,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0&resize=1440",
@@ -3757,7 +3660,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -3765,7 +3667,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -3948,12 +3849,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -4140,7 +4035,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0&resize=1440",
@@ -4159,7 +4053,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -4167,7 +4060,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -4280,12 +4172,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -4519,12 +4405,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -4711,7 +4591,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0&resize=1440",
@@ -4730,7 +4609,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -4738,7 +4616,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -4851,12 +4728,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View
@@ -5013,12 +4884,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
               "type": "ThemeAttrAndroid",
             }
           }
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           pointerEvents="box-only"
         >
           <View

--- a/packages/related-articles/__tests__/ios/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/related-articles.test.js.snap
@@ -82,12 +82,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -133,7 +127,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104&resize=1440",
@@ -152,7 +145,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -160,7 +152,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -468,12 +459,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -519,7 +504,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104&resize=1440",
@@ -538,7 +522,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -546,7 +529,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -784,12 +766,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -835,7 +811,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F82723c10-fb7f-11e7-a987-7fcf5e9983dc.jpg?crop=4886%2C2748%2C92%2C108&resize=1440",
@@ -854,7 +829,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -862,7 +836,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -1190,12 +1163,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -1379,12 +1346,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -1581,12 +1542,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -1867,12 +1822,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -1918,7 +1867,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe42e32fe-d14c-11e7-b1ec-8503a5941b97.jpg?crop=6250%2C3516%2C0%2C326&resize=1440",
@@ -1937,7 +1885,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -1945,7 +1892,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -2253,12 +2199,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -2304,7 +2244,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe42e32fe-d14c-11e7-b1ec-8503a5941b97.jpg?crop=6250%2C3516%2C0%2C326&resize=1440",
@@ -2323,7 +2262,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -2331,7 +2269,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -2569,12 +2506,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -2807,12 +2738,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -2858,7 +2783,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fe42e32fe-d14c-11e7-b1ec-8503a5941b97.jpg?crop=6250%2C3516%2C0%2C326&resize=1440",
@@ -2877,7 +2801,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -2885,7 +2808,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -3123,12 +3045,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -3284,12 +3200,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -3529,12 +3439,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -3725,7 +3629,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0&resize=1440",
@@ -3744,7 +3647,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -3752,7 +3654,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -3930,12 +3831,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -4126,7 +4021,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0&resize=1440",
@@ -4145,7 +4039,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -4153,7 +4046,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -4261,12 +4153,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -4499,12 +4385,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -4695,7 +4575,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     }
                   >
                     <Image
-                      onLoad={[Function]}
                       source={
                         Object {
                           "uri": "https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0&resize=1440",
@@ -4714,7 +4593,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       }
                     />
                     <View
-                      onLayout={[Function]}
                       style={
                         Object {
                           "flex": 1,
@@ -4722,7 +4600,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       }
                     >
                       <View
-                        onLayout={[Function]}
                         style={
                           Object {
                             "flex": 1,
@@ -4830,12 +4707,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,
@@ -4991,12 +4862,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
         <View
           accessible={true}
           isTVSelectable={true}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             Object {
               "opacity": 1,

--- a/packages/related-articles/__tests__/web/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/related-articles.test.js.snap
@@ -48,7 +48,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
         >
           <a
             href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -261,7 +260,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
         >
           <a
             href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -419,7 +417,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
         >
           <a
             href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -642,7 +639,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
         >
           <a
             href="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -819,7 +815,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
         >
           <a
             href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -1009,7 +1004,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
         >
           <a
             href="https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -1267,7 +1261,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
         >
           <a
             href="https://www.uat-thetimes.co.uk/article/defence-of-the-realm-282pmmb7t"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -1473,7 +1466,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
         >
           <a
             href="https://www.uat-thetimes.co.uk/article/defence-of-the-realm-282pmmb7t"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -1628,7 +1620,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
           >
             <a
               href="https://www.uat-thetimes.co.uk/article/size-matters-so-ministers-must-prove-they-are-serious-about-defence-bhs0jnw6d"
-              onClick={[Function]}
               style={
                 Object {
                   "textDecoration": "none",
@@ -1821,7 +1812,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
         >
           <a
             href="https://www.uat-thetimes.co.uk/article/defence-of-the-realm-282pmmb7t"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -1995,7 +1985,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
           >
             <a
               href="https://www.uat-thetimes.co.uk/article/take-expensive-trident-out-of-mod-budget-hammond-urged-ztsxlskj2"
-              onClick={[Function]}
               style={
                 Object {
                   "textDecoration": "none",
@@ -2123,7 +2112,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
           >
             <a
               href="https://www.uat-thetimes.co.uk/article/size-matters-so-ministers-must-prove-they-are-serious-about-defence-bhs0jnw6d"
-              onClick={[Function]}
               style={
                 Object {
                   "textDecoration": "none",
@@ -2323,7 +2311,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
         >
           <a
             href="https://www.uat-thetimes.co.uk/article/defence-of-the-realm-282pmmb7t"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -2552,7 +2539,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
         >
           <a
             href="https://www.uat-thetimes.co.uk/article/defence-of-the-realm-282pmmb7t"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -2749,7 +2735,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
           >
             <a
               href="https://www.uat-thetimes.co.uk/article/size-matters-so-ministers-must-prove-they-are-serious-about-defence-bhs0jnw6d"
-              onClick={[Function]}
               style={
                 Object {
                   "textDecoration": "none",
@@ -2942,7 +2927,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
         >
           <a
             href="https://www.uat-thetimes.co.uk/article/defence-of-the-realm-282pmmb7t"
-            onClick={[Function]}
             style={
               Object {
                 "textDecoration": "none",
@@ -3120,7 +3104,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
           >
             <a
               href="https://www.uat-thetimes.co.uk/article/take-expensive-trident-out-of-mod-budget-hammond-urged-ztsxlskj2"
-              onClick={[Function]}
               style={
                 Object {
                   "textDecoration": "none",
@@ -3248,7 +3231,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
           >
             <a
               href="https://www.uat-thetimes.co.uk/article/size-matters-so-ministers-must-prove-they-are-serious-about-defence-bhs0jnw6d"
-              onClick={[Function]}
               style={
                 Object {
                   "textDecoration": "none",

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -165,14 +165,9 @@ exports[`1. Render a Topic page 1`] = `
   }
   articlesLoading={false}
   count={10}
-  fetchMore={[Function]}
   imageRatio={1.5}
-  onArticlePress={[Function]}
-  onNext={[Function]}
-  onPrev={[Function]}
   page={1}
   pageSize={3}
-  refetch={[Function]}
   showImages={true}
 />
 `;
@@ -187,20 +182,14 @@ exports[`2. Render a topics page loading state 1`] = `
     />
   }
   articlesLoading={true}
-  fetchMore={[Function]}
   imageRatio={1.5}
   isLoading={true}
   pageSize={3}
-  refetch={[Function]}
   showImages={true}
 />
 `;
 
-exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
-<ArticleListPageError
-  refetch={[Function]}
-/>
-`;
+exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `<ArticleListPageError />`;
 
 exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
 Object {

--- a/packages/topic/__tests__/android/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-styling.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Topic styling tests on android should render styling correctly 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <TopicHead
       description="A swanky part of town."
@@ -32,24 +30,12 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -74,9 +60,7 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -150,9 +134,7 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -195,7 +177,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -209,7 +190,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -217,7 +197,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -306,7 +285,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -385,7 +363,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -463,7 +440,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -541,7 +517,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -640,9 +615,7 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -685,7 +658,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -699,7 +671,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -707,7 +678,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -796,7 +766,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -875,7 +844,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -953,7 +921,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1031,7 +998,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1130,9 +1096,7 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1175,7 +1139,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -1189,7 +1152,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1197,7 +1159,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1286,7 +1247,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1365,7 +1325,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1443,7 +1402,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1521,7 +1479,6 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1603,9 +1560,7 @@ exports[`Topic styling tests on android should render styling correctly 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -165,14 +165,9 @@ exports[`1. Render a Topic page 1`] = `
   }
   articlesLoading={false}
   count={10}
-  fetchMore={[Function]}
   imageRatio={1.5}
-  onArticlePress={[Function]}
-  onNext={[Function]}
-  onPrev={[Function]}
   page={1}
   pageSize={3}
-  refetch={[Function]}
   showImages={true}
 />
 `;
@@ -187,20 +182,14 @@ exports[`2. Render a topics page loading state 1`] = `
     />
   }
   articlesLoading={true}
-  fetchMore={[Function]}
   imageRatio={1.5}
   isLoading={true}
   pageSize={3}
-  refetch={[Function]}
   showImages={true}
 />
 `;
 
-exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
-<ArticleListPageError
-  refetch={[Function]}
-/>
-`;
+exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `<ArticleListPageError />`;
 
 exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
 Object {

--- a/packages/topic/__tests__/ios/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-styling.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Topic styling tests on ios should render styling correctly 1`] = `
 <RCTScrollView
-  ItemSeparatorComponent={[Function]}
-  ListFooterComponent={[Function]}
   ListHeaderComponent={
     <TopicHead
       description="A swanky part of town."
@@ -32,24 +30,12 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
     ]
   }
   disableVirtualization={false}
-  getItem={[Function]}
-  getItemCount={[Function]}
   horizontal={false}
   initialNumToRender={10}
-  keyExtractor={[Function]}
   maxToRenderPerBatch={10}
   numColumns={1}
-  onContentSizeChange={[Function]}
-  onEndReached={[Function]}
   onEndReachedThreshold={2}
-  onLayout={[Function]}
-  onMomentumScrollEnd={[Function]}
-  onScroll={[Function]}
-  onScrollBeginDrag={[Function]}
-  onScrollEndDrag={[Function]}
-  onViewableItemsChanged={[Function]}
   pageSize={3}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   testID="scroll-view"
@@ -74,9 +60,7 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
   windowSize={21}
 >
   <View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -150,9 +134,7 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -195,7 +177,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -209,7 +190,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -217,7 +197,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -306,7 +285,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -385,7 +363,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -463,7 +440,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -541,7 +517,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -640,9 +615,7 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -685,7 +658,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -699,7 +671,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -707,7 +678,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -796,7 +766,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -875,7 +844,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -953,7 +921,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1031,7 +998,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1130,9 +1096,7 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
         />
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    >
+    <View>
       <View
         style={
           Object {
@@ -1175,7 +1139,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                 }
               >
                 <Image
-                  onLoad={[Function]}
                   style={
                     Object {
                       "bottom": 0,
@@ -1189,7 +1152,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                   }
                 />
                 <View
-                  onLayout={[Function]}
                   style={
                     Object {
                       "flex": 1,
@@ -1197,7 +1159,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
                   }
                 >
                   <View
-                    onLayout={[Function]}
                     style={
                       Object {
                         "flex": 1,
@@ -1286,7 +1247,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
             }
           >
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1365,7 +1325,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1443,7 +1402,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1521,7 +1479,6 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
               </ARTSurfaceView>
             </View>
             <View
-              onLayout={[Function]}
               style={
                 Object {
                   "flex": 1,
@@ -1603,9 +1560,7 @@ exports[`Topic styling tests on ios should render styling correctly 1`] = `
         </View>
       </View>
     </View>
-    <View
-      onLayout={[Function]}
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -165,14 +165,9 @@ exports[`1. Render a Topic page 1`] = `
   }
   articlesLoading={false}
   count={10}
-  fetchMore={[Function]}
   imageRatio={1.5}
-  onArticlePress={[Function]}
-  onNext={[Function]}
-  onPrev={[Function]}
   page={1}
   pageSize={3}
-  refetch={[Function]}
   showImages={true}
 />
 `;
@@ -187,20 +182,14 @@ exports[`2. Render a topics page loading state 1`] = `
     />
   }
   articlesLoading={true}
-  fetchMore={[Function]}
   imageRatio={1.5}
   isLoading={true}
   pageSize={3}
-  refetch={[Function]}
   showImages={true}
 />
 `;
 
-exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `
-<ArticleListPageError
-  refetch={[Function]}
-/>
-`;
+exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `<ArticleListPageError />`;
 
 exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
 Object {

--- a/packages/video/__tests__/android/__snapshots__/video.android.test.js.snap
+++ b/packages/video/__tests__/android/__snapshots__/video.android.test.js.snap
@@ -31,12 +31,6 @@ exports[`Video on native renders correctly 1`] = `
       "type": "ThemeAttrAndroid",
     }
   }
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "height": 200,
@@ -62,7 +56,6 @@ exports[`Video on native renders correctly 1`] = `
       }
     >
       <Image
-        onLoad={[Function]}
         source={
           Object {
             "uri": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
@@ -81,7 +74,6 @@ exports[`Video on native renders correctly 1`] = `
         }
       />
       <View
-        onLayout={[Function]}
         style={
           Object {
             "flex": 1,
@@ -89,7 +81,6 @@ exports[`Video on native renders correctly 1`] = `
         }
       >
         <View
-          onLayout={[Function]}
           style={
             Object {
               "flex": 1,
@@ -213,12 +204,6 @@ exports[`Video on native renders correctly without a poster image 1`] = `
       "type": "ThemeAttrAndroid",
     }
   }
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "height": 200,

--- a/packages/video/__tests__/ios/__snapshots__/video.ios.test.js.snap
+++ b/packages/video/__tests__/ios/__snapshots__/video.ios.test.js.snap
@@ -26,12 +26,6 @@ exports[`Video on native renders correctly 1`] = `
   accessibilityLabel="splash-component"
   accessible={true}
   isTVSelectable={true}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "opacity": 1,
@@ -64,7 +58,6 @@ exports[`Video on native renders correctly 1`] = `
         }
       >
         <Image
-          onLoad={[Function]}
           source={
             Object {
               "uri": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
@@ -83,7 +76,6 @@ exports[`Video on native renders correctly 1`] = `
           }
         />
         <View
-          onLayout={[Function]}
           style={
             Object {
               "flex": 1,
@@ -91,7 +83,6 @@ exports[`Video on native renders correctly 1`] = `
           }
         >
           <View
-            onLayout={[Function]}
             style={
               Object {
                 "flex": 1,
@@ -211,12 +202,6 @@ exports[`Video on native renders correctly without a poster image 1`] = `
   accessibilityLabel="splash-component"
   accessible={true}
   isTVSelectable={true}
-  onResponderGrant={[Function]}
-  onResponderMove={[Function]}
-  onResponderRelease={[Function]}
-  onResponderTerminate={[Function]}
-  onResponderTerminationRequest={[Function]}
-  onStartShouldSetResponder={[Function]}
   style={
     Object {
       "opacity": 1,


### PR DESCRIPTION
test: remove functions from snapshots
refactor: make code terse

I'd like to propose that `[Function]` in a snapshot provides little to no value, is rarely needed for the snapshot used for the test and just creates snapshot noise. This is what our snapshots without them would look like. If there's a particular case you think is missed that would not be covered by a behavioural test/TypeScript please let me know