### PR TITLE
chore: set or fix node version to less than 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A collection of presentational components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {
-    "node": ">=8.9.0",
+    "node": "<10",
     "yarn": "1.7.0"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A collection of presentational components for The Times and Sunday Times",
   "main": "index.js",
   "engines": {
-    "node": "<10",
+    "node": ">=8.9.0 <10",
     "yarn": "1.7.0"
   },
   "bin": {


### PR DESCRIPTION
- fix node version to less than 10, as t-c does not work on 10 yet.

Note: this will only throw a warning not an error if a node version greater than 10 is used