### PR TITLE
fix: lazy loading on safari

### DIFF
--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -66,7 +66,7 @@ exports[`ArticleList tests on web should render an article list 1`] = `
                     >
                       <img
                         alt=""
-                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=100"
+                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440"
                         style={
                           Object {
                             "display": "block",
@@ -194,7 +194,7 @@ exports[`ArticleList tests on web should render an article list 1`] = `
                     >
                       <img
                         alt=""
-                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=100"
+                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440"
                         style={
                           Object {
                             "display": "block",
@@ -322,7 +322,7 @@ exports[`ArticleList tests on web should render an article list 1`] = `
                     >
                       <img
                         alt=""
-                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=100"
+                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=1440"
                         style={
                           Object {
                             "display": "block",

--- a/packages/article-list/__tests__/web/__snapshots__/helper.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/helper.web.test.js.snap
@@ -82,7 +82,7 @@ exports[`Lazy loading and pagination tests on web Lazy loading tests should rend
 Array [
   <TimesImage
     aspectRatio={1.5}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440"
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=660"
   >
     <View>
       <div>
@@ -98,7 +98,7 @@ Array [
         >
           <img
             alt=""
-            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440"
+            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=660"
             style={
               Object {
                 "display": "block",
@@ -178,7 +178,7 @@ Array [
   </TimesImage>,
   <TimesImage
     aspectRatio={1.5}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440"
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=660"
   >
     <View>
       <div>
@@ -194,7 +194,7 @@ Array [
         >
           <img
             alt=""
-            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440"
+            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=660"
             style={
               Object {
                 "display": "block",

--- a/packages/article-list/__tests__/web/__snapshots__/helper.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/helper.web.test.js.snap
@@ -82,7 +82,7 @@ exports[`Lazy loading and pagination tests on web Lazy loading tests should rend
 Array [
   <TimesImage
     aspectRatio={1.5}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=660"
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440"
   >
     <View>
       <div>
@@ -98,7 +98,7 @@ Array [
         >
           <img
             alt=""
-            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=660"
+            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440"
             style={
               Object {
                 "display": "block",
@@ -178,7 +178,7 @@ Array [
   </TimesImage>,
   <TimesImage
     aspectRatio={1.5}
-    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=660"
+    uri="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440"
   >
     <View>
       <div>
@@ -194,7 +194,7 @@ Array [
         >
           <img
             alt=""
-            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=660"
+            src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440"
             style={
               Object {
                 "display": "block",

--- a/packages/article-list/__tests__/web/helper.web.test.js
+++ b/packages/article-list/__tests__/web/helper.web.test.js
@@ -144,6 +144,9 @@ describe("Lazy loading and pagination tests on web", () => {
     });
 
     it("should render good quality images if there is no IntersectionObserver", () => {
+      Object.defineProperty(window, "clientWidth", {
+        value: 600
+      });
       const component = mount(
         <ArticleList
           {...articleListContentProps}
@@ -153,19 +156,6 @@ describe("Lazy loading and pagination tests on web", () => {
           )}
         />
       );
-
-      // not ideal as this relies on the actual implementation but there's no "nice" way of setting clientWidth
-      const authorProfileInstance = component.find("ArticleList").instance();
-      const rn = authorProfileInstance.registerNode;
-      authorProfileInstance.registerNode = node => {
-        if (node) {
-          Object.defineProperty(node, "clientWidth", {
-            value: 600
-          });
-        }
-
-        rn.call(authorProfileInstance, node);
-      };
 
       // we have to force the render lifecycle that the lazy images rely on, in that first the nodes are registered
       // and then when we render again after loading, we show the sized images

--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -166,5 +166,5 @@ class ArticleList extends Component {
 ArticleList.propTypes = propTypes;
 ArticleList.defaultProps = defaultProps;
 
-export default withTrackScrollDepth(ArticleList);
 export { default as ArticleListPageError } from "./article-list-page-error";
+export default withTrackScrollDepth(ArticleList);

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -56,7 +56,7 @@ class ArticleList extends Component {
       return this.state.images.get(nodeId);
     }
 
-    return this.images.get(nodeId);
+    return normaliseWidth(window.clientWidth);
   }
 
   handleObservation(entries) {
@@ -90,15 +90,11 @@ class ArticleList extends Component {
   }
 
   registerNode(node) {
-    if (!node) {
+    if (!node || !this.observer) {
       return;
     }
 
-    if (this.observer) {
-      this.observer.observe(node);
-    } else {
-      this.images.set(node.id, normaliseWidth(node.clientWidth));
-    }
+    this.observer.observe(node);
   }
 
   render() {
@@ -224,5 +220,5 @@ class ArticleList extends Component {
 ArticleList.propTypes = propTypes;
 ArticleList.defaultProps = defaultProps;
 
-export default withTrackScrollDepth(ArticleList);
 export { default as ArticleListPageError } from "./article-list-page-error";
+export default withTrackScrollDepth(ArticleList);

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -21,7 +21,6 @@ class ArticleList extends Component {
 
     this.pending = new Set();
     this.pendingTimer = null;
-    this.images = new Map();
     this.state = {
       images: new Map()
     };
@@ -48,11 +47,10 @@ class ArticleList extends Component {
 
     clearTimeout(this.pendingTimer);
     this.pending.clear();
-    this.images.clear();
   }
 
   getImageSize(nodeId) {
-    if (this.observer) {
+    if (this.observer && nodeId) {
       return this.state.images.get(nodeId);
     }
 

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -215,7 +215,7 @@ exports[`1. Render an author profile page 1`] = `
                     >
                       <img
                         alt=""
-                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=100"
+                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1b5afe88-cb0d-11e7-9ee9-e45ae7e1cdd4.jpg?crop=4252%2C2835%2C0%2C0&resize=1440"
                         style={
                           Object {
                             "display": "block",
@@ -341,7 +341,7 @@ exports[`1. Render an author profile page 1`] = `
                     >
                       <img
                         alt=""
-                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=100"
+                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fd1fe3000-cb0e-11e7-9ee9-e45ae7e1cdd4.jpg?crop=2887%2C1925%2C562%2C745&resize=1440"
                         style={
                           Object {
                             "display": "block",
@@ -467,7 +467,7 @@ exports[`1. Render an author profile page 1`] = `
                     >
                       <img
                         alt=""
-                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=100"
+                        src="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F459f7782-c950-11e7-9ee9-e45ae7e1cdd4.jpg?crop=5448%2C3632%2C0%2C0&resize=1440"
                         style={
                           Object {
                             "display": "block",


### PR DESCRIPTION
- fix lazy loading of `ArticleList` on safari. Safari does not use `IntersectionObserver`. The registration of images was happening _after_ the images were being fetched from the Component Class `images.map()`. Set the image width directly rather than going through the map as it was unnecessary 