### PR TITLE
fix: topic and author profile stories

### DIFF
--- a/packages/article-list/__tests__/shared-web.js
+++ b/packages/article-list/__tests__/shared-web.js
@@ -2,54 +2,14 @@ import "react-native";
 import React from "react";
 import renderer from "react-test-renderer";
 import { mount } from "enzyme";
+import { AdComposer } from "@times-components/ad";
 import ArticleListPagination from "../src/article-list-pagination";
 import ArticleList from "./../src/article-list";
 import ArticleListItem from "./../src/article-list-item";
 import articleListProps from "./default-article-list-props";
 import pagedResult from "./paged-result";
 
-const adConfig = {
-  networkId: "mockNetwork",
-  adUnit: "mockAdUnit",
-  pageTargeting: {
-    title: "Title"
-  },
-  slotTargeting: {
-    path: "/news"
-  },
-  biddersConfig: {
-    timeout: 3000,
-    minPrice: 0.01,
-    maxBid: 15,
-    bucketSize: 0.25,
-    bidders: {
-      appnexus: {
-        placementId: "5823281"
-      },
-      rubicon: {
-        accountId: "14062",
-        siteId: "70608",
-        zoneId: "335918"
-      },
-      amazon: {
-        accountId: "3360"
-      },
-      criteo: {
-        zoneMap: {
-          "120x600": "764877"
-        }
-      },
-      pubmatic: {
-        accountId: "156034",
-        adSlotPrefix: "Thetimes"
-      },
-      indexExchange: {
-        siteId: "188830"
-      }
-    }
-  },
-  bidderSlots: ["ad-header", "ad-article-inline"]
-};
+const { defaultProps: { adConfig } } = AdComposer;
 
 export default () => {
   it("should render the article list pagination correctly", () => {

--- a/packages/article-list/article-list.showcase.js
+++ b/packages/article-list/article-list.showcase.js
@@ -1,5 +1,6 @@
 import { Text, View } from "react-native";
 import React from "react";
+import { AdComposer } from "@times-components/ad";
 import articleListNoImagesFixture from "@times-components/provider-test-tools/fixtures/author-profile/article-list-no-images.json";
 import articleListWithImagesFixture from "@times-components/provider-test-tools/fixtures/author-profile/article-list-with-images.json";
 import storybookReporter from "@times-components/tealium-utils";
@@ -14,53 +15,7 @@ const preventDefaultedAction = decorateAction =>
     }
   ]);
 
-const adConfig = {
-  networkId: "25436805",
-  adUnit: "d.thetimes.co.uk",
-  pageTargeting: {
-    title: "Title",
-    label: "Label"
-  },
-  slotTargeting: {
-    path: "/news",
-    sec_id: "null",
-    section: "news",
-    zone: "current_edition",
-    slot: "news"
-  },
-  biddersConfig: {
-    timeout: 3000,
-    minPrice: 0.01,
-    maxBid: 15,
-    bucketSize: 0.25,
-    bidders: {
-      appnexus: {
-        placementId: "5823281"
-      },
-      rubicon: {
-        accountId: "14062",
-        siteId: "70608",
-        zoneId: "335918"
-      },
-      amazon: {
-        accountId: "3360"
-      },
-      criteo: {
-        zoneMap: {
-          "120x600": "764877"
-        }
-      },
-      pubmatic: {
-        accountId: "156034",
-        adSlotPrefix: "Thetimes"
-      },
-      indexExchange: {
-        siteId: "188830"
-      }
-    }
-  },
-  bidderSlots: ["ad-header", "ad-article-inline"]
-};
+const { defaultProps: { adConfig } } = AdComposer;
 
 const getProps = decorateAction => ({
   adConfig,

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -199,7 +199,9 @@ class ArticleList extends Component {
                       }
                     </ErrorView>
                   </div>
-                  {index === 4 && Object.keys(adConfig).length !== 0 ? (
+                  {!articlesLoading &&
+                  index === 4 &&
+                  Object.keys(adConfig).length !== 0 ? (
                     <AdComposer adConfig={adConfig}>
                       <Ad pos="inline-ad" />
                     </AdComposer>

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -172,6 +172,21 @@ class ArticleList extends Component {
               const separatorComponent =
                 index > 0 ? <ArticleListItemSeparator /> : null;
 
+              const renderArticle = () => {
+                if (
+                  articlesLoading ||
+                  index !== 4 ||
+                  Object.keys(adConfig).length === 0
+                ) {
+                  return null;
+                }
+                return (
+                  <AdComposer adConfig={adConfig}>
+                    <Ad pos="inline-ad" />
+                  </AdComposer>
+                );
+              };
+
               return (
                 <Fragment key={elementId}>
                   <div
@@ -199,13 +214,7 @@ class ArticleList extends Component {
                       }
                     </ErrorView>
                   </div>
-                  {!articlesLoading &&
-                  index === 4 &&
-                  Object.keys(adConfig).length !== 0 ? (
-                    <AdComposer adConfig={adConfig}>
-                      <Ad pos="inline-ad" />
-                    </AdComposer>
-                  ) : null}
+                  {renderArticle()}
                 </Fragment>
               );
             })}

--- a/packages/article/article.showcase.js
+++ b/packages/article/article.showcase.js
@@ -106,6 +106,7 @@ const renderArticle = (
     {...data}
     isLoading={isLoading}
     analyticsStream={analyticsStream}
+    adConfig={adConfig}
     error={error}
     onAuthorPress={preventDefaultedAction(decorateAction)("onAuthorPress")}
     onLinkPress={preventDefaultedAction(decorateAction)("onLinkPress")}
@@ -176,6 +177,7 @@ export default {
             >
               {({ article, isLoading, error }) => (
                 <Article
+                  adConfig={defaultAdConfig}
                   analyticsStream={storybookReporter}
                   article={article}
                   error={error}

--- a/packages/article/article.showcase.js
+++ b/packages/article/article.showcase.js
@@ -106,7 +106,6 @@ const renderArticle = (
     {...data}
     isLoading={isLoading}
     analyticsStream={analyticsStream}
-    adConfig={adConfig}
     error={error}
     onAuthorPress={preventDefaultedAction(decorateAction)("onAuthorPress")}
     onLinkPress={preventDefaultedAction(decorateAction)("onLinkPress")}
@@ -177,7 +176,6 @@ export default {
             >
               {({ article, isLoading, error }) => (
                 <Article
-                  adConfig={defaultAdConfig}
                   analyticsStream={storybookReporter}
                   article={article}
                   error={error}

--- a/packages/author-profile/__tests__/mocks.js
+++ b/packages/author-profile/__tests__/mocks.js
@@ -17,6 +17,7 @@ export const mockAuthorWithoutImages = fixtureGenerator.makeAuthor({
 });
 
 export const props = {
+  adConfig: {},
   analyticsStream: () => {},
   author: mockAuthor,
   fetchMore: () => {},

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -16,6 +16,54 @@ const preventDefaultedAction = decorateAction =>
     }
   ]);
 
+const adConfig = {
+  networkId: "25436805",
+  adUnit: "d.thetimes.co.uk",
+  pageTargeting: {
+    title: "Title",
+    label: "Label"
+  },
+  slotTargeting: {
+    path: "/news",
+    sec_id: "null",
+    section: "news",
+    zone: "current_edition",
+    slot: "news"
+  },
+  biddersConfig: {
+    timeout: 3000,
+    minPrice: 0.01,
+    maxBid: 15,
+    bucketSize: 0.25,
+    bidders: {
+      appnexus: {
+        placementId: "5823281"
+      },
+      rubicon: {
+        accountId: "14062",
+        siteId: "70608",
+        zoneId: "335918"
+      },
+      amazon: {
+        accountId: "3360"
+      },
+      criteo: {
+        zoneMap: {
+          "120x600": "764877"
+        }
+      },
+      pubmatic: {
+        accountId: "156034",
+        adSlotPrefix: "Thetimes"
+      },
+      indexExchange: {
+        siteId: "188830"
+      }
+    }
+  },
+  bidderSlots: ["ad-header", "ad-article-inline"]
+};
+
 const slug = "deborah-haynes";
 const pageSize = 5;
 

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -1,5 +1,6 @@
 import "react-native";
 import React from "react";
+import { AdComposer } from "@times-components/ad";
 import { AuthorProfileProvider } from "@times-components/provider";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
@@ -15,54 +16,6 @@ const preventDefaultedAction = decorateAction =>
       return ["[SyntheticEvent (storybook prevented default)]", ...args];
     }
   ]);
-
-const adConfig = {
-  networkId: "25436805",
-  adUnit: "d.thetimes.co.uk",
-  pageTargeting: {
-    title: "Title",
-    label: "Label"
-  },
-  slotTargeting: {
-    path: "/news",
-    sec_id: "null",
-    section: "news",
-    zone: "current_edition",
-    slot: "news"
-  },
-  biddersConfig: {
-    timeout: 3000,
-    minPrice: 0.01,
-    maxBid: 15,
-    bucketSize: 0.25,
-    bidders: {
-      appnexus: {
-        placementId: "5823281"
-      },
-      rubicon: {
-        accountId: "14062",
-        siteId: "70608",
-        zoneId: "335918"
-      },
-      amazon: {
-        accountId: "3360"
-      },
-      criteo: {
-        zoneMap: {
-          "120x600": "764877"
-        }
-      },
-      pubmatic: {
-        accountId: "156034",
-        adSlotPrefix: "Thetimes"
-      },
-      indexExchange: {
-        siteId: "188830"
-      }
-    }
-  },
-  bidderSlots: ["ad-header", "ad-article-inline"]
-};
 
 const slug = "deborah-haynes";
 const pageSize = 5;
@@ -83,7 +36,10 @@ const mockAuthorWithoutImages = fixtureGenerator.makeAuthor({
   withImages: false
 });
 
+const { defaultProps: { adConfig } } = AdComposer;
+
 const getProps = decorateAction => ({
+  adConfig,
   analyticsStream: storybookReporter,
   articleImageRatio: "3:2",
   author: mockAuthor,

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
+    "@times-components/ad": "0.21.10",
     "@times-components/eslint-config-thetimes": "0.6.1",
     "@times-components/jest-configurator": "0.9.0",
     "@times-components/provider-test-tools": "0.10.8",

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -14,6 +14,7 @@ import { propTypes, defaultProps } from "./author-profile-prop-types";
 import authorProfileTrackingContext from "./author-profile-tracking-context";
 
 const AuthorProfile = ({
+  adConfig,
   author,
   error,
   isLoading,
@@ -33,6 +34,7 @@ const AuthorProfile = ({
   if (isLoading || !author) {
     return (
       <ArticleList
+        adConfig={{}}
         articleListHeader={<AuthorProfileHead isLoading />}
         articlesLoading
         fetchMore={() => Promise.resolve()}
@@ -112,6 +114,7 @@ const AuthorProfile = ({
 
         return (
           <ArticleList
+            adConfig={adConfig}
             articleListHeader={articleListHeader}
             articles={get(data, "articles.list", [])}
             articlesLoading={articlesLoading}

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`1. Render a Topic page 1`] = `
 <ArticleList
+  adConfig={Object {}}
   articleListHeader={
     <TopicHead
       description="Chelsea is known for its affluent residents and the posh shops and restaurants that cater to them. It’s a cultural haven too, with the Royal Court Theatre on Sloane Square and the modern Saatchi Gallery on the Duke of York Square. Close by, busy King’s Road is lined with mid- to high-end stores."
@@ -190,6 +191,7 @@ exports[`1. Render a Topic page 1`] = `
 
 exports[`2. Render a topics page loading state 1`] = `
 <ArticleList
+  adConfig={Object {}}
   articleListHeader={
     <TopicHead
       description=""

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`1. Render a Topic page 1`] = `
 <ArticleList
+  adConfig={Object {}}
   articleListHeader={
     <TopicHead
       description="Chelsea is known for its affluent residents and the posh shops and restaurants that cater to them. It’s a cultural haven too, with the Royal Court Theatre on Sloane Square and the modern Saatchi Gallery on the Duke of York Square. Close by, busy King’s Road is lined with mid- to high-end stores."
@@ -190,6 +191,7 @@ exports[`1. Render a Topic page 1`] = `
 
 exports[`2. Render a topics page loading state 1`] = `
 <ArticleList
+  adConfig={Object {}}
   articleListHeader={
     <TopicHead
       description=""

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -19,6 +19,7 @@ export default () => {
   });
 
   const props = {
+    adConfig: {},
     analyticsStream: () => {},
     isLoading: false,
     onArticlePress: () => {},

--- a/packages/topic/__tests__/topic-styling.js
+++ b/packages/topic/__tests__/topic-styling.js
@@ -7,6 +7,7 @@ import Topic from "../src/topic";
 
 export default () => {
   const props = {
+    adConfig: {},
     analyticsStream: () => {},
     isLoading: false,
     onArticlePress: () => {},

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`1. Render a Topic page 1`] = `
 <ArticleList
+  adConfig={Object {}}
   articleListHeader={
     <TopicHead
       description="Chelsea is known for its affluent residents and the posh shops and restaurants that cater to them. It’s a cultural haven too, with the Royal Court Theatre on Sloane Square and the modern Saatchi Gallery on the Duke of York Square. Close by, busy King’s Road is lined with mid- to high-end stores."
@@ -190,6 +191,7 @@ exports[`1. Render a Topic page 1`] = `
 
 exports[`2. Render a topics page loading state 1`] = `
 <ArticleList
+  adConfig={Object {}}
   articleListHeader={
     <TopicHead
       description=""

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
+    "@times-components/ad": "0.21.10",
     "@times-components/eslint-config-thetimes": "0.6.1",
     "@times-components/jest-configurator": "0.9.0",
     "@times-components/provider-test-tools": "0.10.8",

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -11,6 +11,7 @@ import topicTrackingContext from "./topic-tracking-context";
 import TopicHead from "./topic-head";
 
 const Topic = ({
+  adConfig,
   error,
   isLoading,
   page,
@@ -29,6 +30,7 @@ const Topic = ({
   if (isLoading || !topic) {
     return (
       <ArticleList
+        adConfig={{}}
         articleListHeader={<TopicHead isLoading />}
         articlesLoading
         fetchMore={() => Promise.resolve()}
@@ -88,6 +90,7 @@ const Topic = ({
 
         return (
           <ArticleList
+            adConfig={adConfig}
             articleListHeader={articleListHeader}
             articles={get(data, "articles.list", [])}
             articlesLoading={articlesLoading}

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -2,6 +2,7 @@
 
 import "react-native";
 import React from "react";
+import { AdComposer } from "@times-components/ad";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import storybookReporter from "@times-components/tealium-utils";
@@ -17,56 +18,10 @@ const preventDefaultedAction = decorateAction =>
     }
   ]);
 
-const adConfig = {
-  networkId: "25436805",
-  adUnit: "d.thetimes.co.uk",
-  pageTargeting: {
-    title: "Title",
-    label: "Label"
-  },
-  slotTargeting: {
-    path: "/news",
-    sec_id: "null",
-    section: "news",
-    zone: "current_edition",
-    slot: "news"
-  },
-  biddersConfig: {
-    timeout: 3000,
-    minPrice: 0.01,
-    maxBid: 15,
-    bucketSize: 0.25,
-    bidders: {
-      appnexus: {
-        placementId: "5823281"
-      },
-      rubicon: {
-        accountId: "14062",
-        siteId: "70608",
-        zoneId: "335918"
-      },
-      amazon: {
-        accountId: "3360"
-      },
-      criteo: {
-        zoneMap: {
-          "120x600": "764877"
-        }
-      },
-      pubmatic: {
-        accountId: "156034",
-        adSlotPrefix: "Thetimes"
-      },
-      indexExchange: {
-        siteId: "188830"
-      }
-    }
-  },
-  bidderSlots: ["ad-header", "ad-article-inline"]
-};
-
 const pageSize = 5;
 const slug = "chelsea";
+
+const { defaultProps: { adConfig } } = AdComposer;
 
 const getProps = decorateAction => ({
   adConfig,

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -6,7 +6,6 @@ import { fixtureGenerator } from "@times-components/provider-test-tools";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import storybookReporter from "@times-components/tealium-utils";
 import { MockedProvider } from "@times-components/utils";
-
 import Topic from "./src/topic";
 import TopicProvider from "../provider/src/topic";
 
@@ -18,10 +17,59 @@ const preventDefaultedAction = decorateAction =>
     }
   ]);
 
+const adConfig = {
+  networkId: "25436805",
+  adUnit: "d.thetimes.co.uk",
+  pageTargeting: {
+    title: "Title",
+    label: "Label"
+  },
+  slotTargeting: {
+    path: "/news",
+    sec_id: "null",
+    section: "news",
+    zone: "current_edition",
+    slot: "news"
+  },
+  biddersConfig: {
+    timeout: 3000,
+    minPrice: 0.01,
+    maxBid: 15,
+    bucketSize: 0.25,
+    bidders: {
+      appnexus: {
+        placementId: "5823281"
+      },
+      rubicon: {
+        accountId: "14062",
+        siteId: "70608",
+        zoneId: "335918"
+      },
+      amazon: {
+        accountId: "3360"
+      },
+      criteo: {
+        zoneMap: {
+          "120x600": "764877"
+        }
+      },
+      pubmatic: {
+        accountId: "156034",
+        adSlotPrefix: "Thetimes"
+      },
+      indexExchange: {
+        siteId: "188830"
+      }
+    }
+  },
+  bidderSlots: ["ad-header", "ad-article-inline"]
+};
+
 const pageSize = 5;
 const slug = "chelsea";
 
 const getProps = decorateAction => ({
+  adConfig,
   analyticsStream: storybookReporter,
   onArticlePress: preventDefaultedAction(decorateAction)("onArticlePress"),
   page: 1,


### PR DESCRIPTION
- fixes ArticleList ads by passing the adConfig down through the relevant consumer packages, and limiting ads to only showing when the loading of articles is completed