### PR TITLE
feat: Add Topic page ad config to ad stories

### DIFF
--- a/packages/ad/ad.showcase.js
+++ b/packages/ad/ad.showcase.js
@@ -7,6 +7,7 @@ import Placeholder from "./src/placeholder";
 import NativeDOMContext from "./src/dom-context";
 import WebDOMContext from "./src/dom-context.web";
 import pageTargeting from "./fixtures/page-options.json";
+import topicPageTargeting from "./fixtures/topic-page-options.json";
 import biddersConfig from "./fixtures/bidders-config.json";
 import domContextInit from "./ad.stories-domcontext-init";
 
@@ -29,6 +30,25 @@ const adConfig = () =>
     { biddersConfig },
     { bidderSlots: ["ad-header", "ad-article-inline"] }
   );
+
+const topicAdConfig = () =>
+  Object.assign(
+    {},
+    adConfigBase,
+    { topicPageTargeting },
+    {
+      slotTargeting: {
+        sec_id: "null",
+        section: "topic/chelsea",
+        path: "/topic/chelsea/",
+        zone: "topic",
+        slot: "home"
+      }
+    },
+    { biddersConfig },
+    { bidderSlots: ["ad-inline"] }
+  );
+
 let DOMContext;
 if (window.document) {
   DOMContext = WebDOMContext;
@@ -37,8 +57,9 @@ if (window.document) {
 }
 const articleUrl =
   "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s";
+const topicUrl = "https://www.thetimes.co.uk/topic/chelsea";
 
-const withOpenInNewWindow = children => {
+const withOpenInNewWindow = (children, page) => {
   const link = typeof document === "object" &&
     window !== window.top && (
       <a
@@ -49,8 +70,10 @@ const withOpenInNewWindow = children => {
         Open in new window
       </a>
     );
+
+  const config = page === "topic" ? topicAdConfig : adConfig;
   return (
-    <AdComposer adConfig={adConfig(children.props.pos)}>
+    <AdComposer adConfig={config(children.props.pos)}>
       <View>
         {link}
         {children}
@@ -102,6 +125,17 @@ export default {
             <Ad section="news" pos="header" contextUrl={articleUrl} />
             <Ad section="news" pos="inline-ad" contextUrl={articleUrl} />
           </View>
+        )
+    },
+    {
+      type: "story",
+      name: "render topic ad - inline",
+      component: () =>
+        withOpenInNewWindow(
+          <View>
+            <Ad section="news" pos="inline-ad" contextUrl={topicUrl} />
+          </View>,
+          "topic"
         )
     },
     {

--- a/packages/ad/fixtures/topic-page-options.json
+++ b/packages/ad/fixtures/topic-page-options.json
@@ -1,0 +1,25 @@
+{
+  "testmode": "null",
+  "log": "1",
+  "teaser": false,
+  "pw": "1",
+  "shared": "0",
+  "share_token": "null",
+  "aid": "511f75e4-0096-11e8-a2b0-4e5c7848ab02",
+  "cont": "listing",
+  "kw": "null",
+  "search": "null",
+  "om_v_id": "01602c1f1b6a002b6f76545cb7380407800640700093c",
+  "edition_id": "2018-01-25",
+  "e_uuid": "f2b586a2-f54f-11e7-9cfd-f28094b4d5ce",
+  "ppid": "AAAA016969198",
+  "eid": "AAAA016969198",
+  "kuid": "Li0ACHsr",
+  "ksg":
+    "rzxmnyauv,scdxdxpny,pev88aflc,rpwsw2wub,qlrbrdisn,rqwt3l0vs,rzxit9roh,scd26efxg,scd4rp3dr,rv2hh273q,rzxmboyaj,sat4w5zr7,rs2085or4,rw2q4y17n,rzxih7667,sau87bmgh,scd1httgm,rzxl9c9fc,rzdnqshn3,rz1f4t1af,rs22revlt,rzdn0pkue,rwusiipqe,scdzf5ue6,sat6qec0x,scd561zdz,rwusbvbt6,rzxlxc8x9,rzxlpwpj6,rpwunrlt9,scdye0ajw,rzxl2zwob,scdy6k7fb,pw58k5bt6,rzxj7jvxu,rpwxlidyq,scd5qqxhc,sat55dl3g,rwuslm2uu,rsy610y7q,rwusge2br,scd369xa5,scd078y6q,q46ihbha4,rs2zo0n9z,r6ddwq5od,rwusduoa8,rz1gsevfc,sat4jqdso,rpww778sp,rzxmjser7,rzxl5rcy4,rzxlzfg0s,rpwubont7,scdyr0lr3,scd6cqj7w,rzxmft3c7,rs3ct5unb,rpwrel6lh,scd1rcsns,rwuo9cp64",
+  "cips": null,
+  "breakpoint": "huge",
+  "refresh": "false",
+  "cookie":
+    "ID=cb9a964a8ecc0a17:T=1513593549:S=ALNI_MazhI4VYljtInf_4oIhOeB6YJQH0w"
+}


### PR DESCRIPTION
- Adds topic page ad config to `ad` storybook as per  https://docs.google.com/spreadsheets/d/1_btFh1lBtH2LoEVA0OGZIETLvBv0-ur1mHtJcK66dLE/edit#gid=0