### PR TITLE
Fix: Missing font to fix storybook fonts in IE

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,6 +4,7 @@
     src: url(/fonts/TimesModern-Bold.woff2) format("woff2"),
         url(/fonts/TimesModern-Bold.woff) format("woff"),
         url(/fonts/TimesModern-Bold.ttf) format("ttf"),
+        url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.woff) format("woff"),
         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.eot?iefix) format("eot"),
         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.ttf) format("truetype"),
         url(https://www.thetimes.co.uk/fonts/TimesModern-Bold.svg#webfont) format("svg");


### PR DESCRIPTION
## Before

![screen shot 2018-06-18 at 12 09 23](https://user-images.githubusercontent.com/1736782/41532849-834805dc-72f0-11e8-9ceb-cb5b763a5a59.png)


## After
![screen shot 2018-06-18 at 12 09 30](https://user-images.githubusercontent.com/1736782/41532855-8acf0c7e-72f0-11e8-9465-e9a323f81998.png)
