### PR TITLE
fix: article list ads

### DIFF
--- a/packages/ad/ad.showcase.js
+++ b/packages/ad/ad.showcase.js
@@ -232,7 +232,7 @@ export default {
           </ScrollView>
         )
     },
-    { 
+    {
       type: "story",
       name: "DOMContext",
       platform: "web",

--- a/packages/ad/ad.showcase.js
+++ b/packages/ad/ad.showcase.js
@@ -232,7 +232,7 @@ export default {
           </ScrollView>
         )
     },
-    {
+    { 
       type: "story",
       name: "DOMContext",
       platform: "web",

--- a/packages/ad/src/dom-context.web.js
+++ b/packages/ad/src/dom-context.web.js
@@ -8,6 +8,7 @@ class DOMContext extends Component {
     const { slotSuffix, init, data } = this.props;
 
     this.initExecuting = true;
+    this.hasUnmounted = false;
 
     const adInit = init({
       slotSuffix,
@@ -26,6 +27,11 @@ class DOMContext extends Component {
     this.processEventQueue();
   }
 
+  componentWillUnmount() {
+    this.eventQueue = [];
+    this.hasUnmounted = true;
+  }
+
   eventQueue = [];
 
   eventCallback = (type, detail) => {
@@ -34,13 +40,14 @@ class DOMContext extends Component {
   };
 
   processEventQueue() {
-    if (!this.initExecuting) {
+    if (!this.initExecuting && !this.hasUnmounted) {
       this.eventQueue.forEach(this.processEvent);
       this.eventQueue = [];
     }
   }
 
   processEvent = ({ type, detail }) => {
+    if (this.eventQueue.length === 0) return;
     if (type === "error") {
       throw new Error(`DomContext error: ${detail}`);
     } else if (type === "renderComplete") {

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -1768,44 +1768,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
           </div>
         </a>
       </div>
-      <div>
-        <div
-          style={
-            Object {
-              "height": 0,
-              "overflow": "hidden",
-              "width": 0,
-            }
-          }
-        />
-        <div>
-          <div>
-            <div>
-              <svg
-                height={90}
-                width={728}
-              >
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                  id="Page-1"
-                  opacity="0.07"
-                  stroke="none"
-                  strokeWidth="1"
-                >
-                  <path
-                    fill="#1D1D1B"
-                    id="Shape"
-                  />
-                </g>
-              </svg>
-            </div>
-            <div>
-              ADVERTISEMENT
-            </div>
-          </div>
-        </div>
-      </div>
       <div
         accessibility-label="937bc97c-c597-11e7-92dc-06edfbca4aab.5"
         data-testid="937bc97c-c597-11e7-92dc-06edfbca4aab.5"
@@ -1853,7 +1815,14 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                           }
                         }
                       />
-                      <div>
+                      <div
+                        style={
+                          Object {
+                            "left": "0px",
+                            "top": "0px",
+                          }
+                        }
+                      >
                         <div
                           style={
                             Object {
@@ -1907,6 +1876,7 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                     <div
                       style={
                         Object {
+                          "fontFamily": "TimesDigitalW04",
                           "lineHeight": "20px",
                         }
                       }

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -183,25 +183,20 @@ class ArticleList extends Component {
                   index > 0 ? <ArticleListItemSeparator /> : null;
 
                 const renderAd = () => {
-                  if (index !== this.advertPosition || !hasAdvertConfig) {
+                  if (
+                    index !== this.advertPosition ||
+                    !hasAdvertConfig ||
+                    isLoading ||
+                    articlesLoading
+                  ) {
                     return null;
                   }
-
-                  const renderSlotName = () => {
-                    if (isLoading) {
-                      return "inline-ad-header-loading";
-                    }
-                    if (articlesLoading) {
-                      return "inline-articles-loading";
-                    }
-                    return "inline-ad";
-                  };
 
                   const AdComponent = (
                     <AdComposer adConfig={adConfig}>
                       <Ad
                         slotSuffix={this.advertPositionCounter.toString()}
-                        slotName={renderSlotName()}
+                        slotName="inline-ad"
                       />
                     </AdComposer>
                   );


### PR DESCRIPTION
- this is temporary whilst the PlaceHolder in ads is refactored to be used when an `isLoading` state is passed down to `ad`
- this is to help get ads working on render

Next PR to add further testing for ads and refactor placeholder to be used in ArticleList