### PR TITLE
Add loading state to article-list to avoid duplicate requests

### DIFF
--- a/packages/article-list/__tests__/shared-native.js
+++ b/packages/article-list/__tests__/shared-native.js
@@ -226,4 +226,36 @@ export default () => {
 
     expect(fetchMore).toHaveBeenCalledTimes(1);
   });
+
+  it("should not fetch more if a previous fetch is in progress", async () => {
+    const fetchMore = jest
+      .fn()
+      .mockReturnValue(new Promise(resolve => setTimeout(resolve, 100)));
+    const results = pagedResult(0, 3);
+    const wrapper = shallow(
+      <ArticleList
+        {...articleListProps}
+        articles={results.articles.list}
+        articlesLoading={false}
+        count={10}
+        isLoading={false}
+        page={1}
+        pageSize={3}
+        fetchMore={fetchMore}
+      />
+    ).dive();
+
+    wrapper
+      .find("FlatList")
+      .props()
+      .onEndReached();
+    expect(wrapper.state().loadingMore).toBe(true);
+
+    await wrapper
+      .find("FlatList")
+      .props()
+      .onEndReached();
+
+    expect(fetchMore).toHaveBeenCalledTimes(1);
+  });
 };

--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -20,7 +20,7 @@ class ArticleList extends Component {
   constructor(props) {
     super(props);
     this.onViewableItemsChanged = this.onViewableItemsChanged.bind(this);
-    this.state = { loadMoreError: null };
+    this.state = { loadMoreError: null, loadingMore: false };
   }
 
   componentWillUnmount() {
@@ -82,12 +82,18 @@ class ArticleList extends Component {
 
     if (!articlesLoading) this.props.receiveChildList(data);
 
-    const fetchMoreOnEndReached = () =>
-      this.state.loadMoreError
-        ? null
-        : fetchMore(data.length).catch(loadMoreError =>
-            this.setState({ loadMoreError })
-          );
+    const fetchMoreOnEndReached = () => {
+      if (this.state.loadMoreError || this.state.loadingMore) {
+        return null;
+      }
+
+      this.setState({ loadingMore: true });
+      return fetchMore(data.length)
+        .then(() => this.setState({ loadingMore: false }))
+        .catch(loadMoreError =>
+          this.setState({ loadMoreError, loadingMore: false })
+        );
+    };
 
     const articleListFooter = () => {
       if (data.length >= count) {


### PR DESCRIPTION
React-native flatList has a bug, where certain devices trigger onEndReached multiple times, causing duplicate page loads. (see: https://github.com/facebook/react-native/issues/14015)

This PR aims to add a `loadingMore` state that blocks duplicate requests. 