### PR TITLE
fix: remove redundant slot targetting key-value pair

### DIFF
--- a/packages/topic/fixtures/topic-ad-config.json
+++ b/packages/topic/fixtures/topic-ad-config.json
@@ -28,7 +28,6 @@
   "slotTargeting": {
     "zone": "topic",
     "section": "topic/chelsea",
-    "iuPartsSuffix": "topic",
     "path": "topic/chelsea",
     "slot": "home"
   },


### PR DESCRIPTION
`iuPartsSuffix` is a redundant field so removing from fixture. Confirmed with Dario from ad tech.
