### PR TITLE
chore: Remove accessibilityLabel from date publication

### DIFF
--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -367,7 +367,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -612,7 +611,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -857,7 +855,6 @@ exports[`ArticleList tests on android should render an article list 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1112,7 +1109,6 @@ exports[`ArticleList tests on android should render an article list item 1`] = `
               </Text>
             </Text>
             <Text
-              accessibilityLabel="datePublication"
               style={
                 Object {
                   "color": "#696969",
@@ -1704,7 +1700,6 @@ exports[`ArticleList tests on android should render an article list item without
               </Text>
             </Text>
             <Text
-              accessibilityLabel="datePublication"
               style={
                 Object {
                   "color": "#696969",

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -366,7 +366,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -610,7 +609,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -854,7 +852,6 @@ exports[`ArticleList tests on ios should render an article list 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1108,7 +1105,6 @@ exports[`ArticleList tests on ios should render an article list item 1`] = `
               </Text>
             </Text>
             <Text
-              accessibilityLabel="datePublication"
               style={
                 Object {
                   "color": "#696969",
@@ -1699,7 +1695,6 @@ exports[`ArticleList tests on ios should render an article list item without ima
               </Text>
             </Text>
             <Text
-              accessibilityLabel="datePublication"
               style={
                 Object {
                   "color": "#696969",

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -132,7 +132,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -255,7 +254,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -378,7 +376,6 @@ exports[`ArticleList tests on web should render an article list 1`] = `
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -537,7 +534,6 @@ exports[`ArticleList tests on web should render an article list item 1`] = `
               </span>
             </div>
             <div
-              aria-label="datePublication"
               data-testid="datePublication"
               style={
                 Object {
@@ -724,7 +720,6 @@ exports[`ArticleList tests on web should render an article list item without ima
                 </span>
               </div>
               <div
-                aria-label="datePublication"
                 data-testid="datePublication"
                 style={
                   Object {
@@ -797,7 +792,6 @@ exports[`ArticleList tests on web should render an article list item without ima
                 </span>
               </div>
               <div
-                aria-label="datePublication"
                 data-testid="datePublication"
                 style={
                   Object {
@@ -1269,7 +1263,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1388,7 +1381,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1507,7 +1499,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1626,7 +1617,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1749,7 +1739,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1918,7 +1907,6 @@ exports[`ArticleList tests on web should show an advert after the fifth article 
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -133,7 +133,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -209,7 +208,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -499,7 +497,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -657,7 +654,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -778,7 +774,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -874,7 +869,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -932,7 +926,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -990,7 +983,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -1082,7 +1074,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -1241,7 +1232,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -1295,7 +1285,6 @@ exports[`Article Summary tests on Android should render an article-summary compo
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",
@@ -1446,7 +1435,6 @@ exports[`Article Summary tests on Android should render an article-summary with 
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
     style={
       Object {
         "color": "#696969",

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -2,9 +2,6 @@
 
 exports[`Article Summary tests on ios should render an ArticleSummaryContent component with a AST 1`] = `
 <Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
   style={
     Object {
       "color": "#696969",
@@ -16,11 +13,7 @@ exports[`Article Summary tests on ios should render an ArticleSummaryContent com
     }
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
     
     Victoria
     ...
@@ -32,9 +25,6 @@ exports[`Article Summary tests on ios should render an ArticleSummaryContent com
 
 exports[`Article Summary tests on ios should render an ArticleSummaryContent component with two paragraphs 1`] = `
 <Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
   style={
     Object {
       "color": "#696969",
@@ -46,19 +36,11 @@ exports[`Article Summary tests on ios should render an ArticleSummaryContent com
     }
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
     
     The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
   </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
      
     Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen.
     ...
@@ -69,10 +51,7 @@ exports[`Article Summary tests on ios should render an ArticleSummaryContent com
 exports[`Article Summary tests on ios should render an ArticleSummaryHeadline component with a blank AST 1`] = `
 <Text
   accessibilityRole="heading"
-  accessible={true}
-  allowFontScaling={true}
   aria-level="3"
-  ellipsizeMode="tail"
   style={
     Object {
       "color": "#333333",
@@ -98,9 +77,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -117,10 +93,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -135,9 +108,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Sajid Javid to end hostile era for illegal immigrants
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -149,25 +119,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
+      <Text>
         Sajid Javid
       </Text>
        has warned the Home Office to expect an overhaul after the 
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
+      <Text>
         Windrush scandal
       </Text>
        as he ditches the policy of creating a “hostile
@@ -175,10 +133,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -205,9 +159,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -224,10 +175,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -242,9 +190,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -256,21 +201,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -285,9 +222,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Friday November 17 2017, 12:01am, The Times
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -299,9 +233,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -315,9 +246,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -515,9 +443,6 @@ exports[`Article Summary tests on ios should render an article-summary component
         </ARTSurfaceView>
       </View>
       <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
         style={
           Object {
             "color": "#333333",
@@ -526,7 +451,6 @@ exports[`Article Summary tests on ios should render an article-summary component
             "fontWeight": "400",
             "letterSpacing": 1.2,
             "lineHeight": 12,
-            "margin": 0,
             "marginLeft": 5,
             "padding": 0,
             "position": "relative",
@@ -540,10 +464,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -558,9 +479,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -572,21 +490,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -601,9 +511,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Friday November 17 2017, 12:01am, The Times
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -615,9 +522,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -631,9 +535,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -660,9 +561,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -679,10 +577,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -697,9 +592,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -711,16 +603,9 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
         style={
           Object {
             "fontWeight": "bold",
@@ -729,35 +614,20 @@ exports[`Article Summary tests on ios should render an article-summary component
       >
         Victoria
       </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
+      <Text>
         
 
       </Text>
        ITV
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
+      <Text>
         
 
       </Text>
       ★★★★☆
     </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
        
       <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
         style={
           Object {
             "fontWeight": "bold",
@@ -766,40 +636,24 @@ exports[`Article Summary tests on ios should render an article-summary component
       >
         Lucy Worsley’s Nights at the Opera
       </Text>
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
+      <Text>
         
 
       </Text>
        BBC Two
-      <Text
-        accessible={true}
-        allowFontScaling={true}
-        ellipsizeMode="tail"
-      >
+      <Text>
         
 
       </Text>
       ★★★☆☆
     </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
        
       Poor old Harriet, Duchess of Sutherland. There she was giddily expecting a
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -814,9 +668,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Saturday July 01 2017, 03:32pm, The Sunday Times
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -828,9 +679,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -844,9 +692,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -873,9 +718,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -892,10 +734,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -910,9 +749,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -924,36 +760,20 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       Sally Jones, one of the world’s most wanted terrorists, has been killed in a US drone strike in Syria, it was revealed last night.
     </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
        
       The former punk
     </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
        
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -968,9 +788,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Saturday July 01 2017, 03:32pm, The Sunday Times
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -982,9 +799,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -998,9 +812,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1027,9 +838,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -1046,10 +854,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1064,10 +869,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1094,9 +895,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -1113,10 +911,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1131,10 +926,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1155,10 +946,7 @@ exports[`Article Summary tests on ios should render an article-summary component
 <View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1173,9 +961,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1187,29 +972,17 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
     </Text>
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
        
       Mali sniffed out explosives and insurgents during a gunfight that lasted seven and a half hours to help a team of Special Boat Service (SBS) operators hunt down and kill more than a dozen
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1224,9 +997,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Friday November 17 2017, 12:01am, The Times
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1238,9 +1008,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1254,9 +1021,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1277,10 +1041,7 @@ exports[`Article Summary tests on ios should render an article-summary component
 <View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1295,9 +1056,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1309,21 +1067,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1350,9 +1100,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -1369,10 +1116,7 @@ exports[`Article Summary tests on ios should render an article-summary component
   </View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1387,9 +1131,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1401,20 +1142,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1426,9 +1160,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1442,9 +1173,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1471,9 +1199,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -1489,9 +1214,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     </Text>
   </View>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1503,21 +1225,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1538,10 +1252,7 @@ exports[`Article Summary tests on ios should render an article-summary component
 <View>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1556,9 +1267,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1570,21 +1278,13 @@ exports[`Article Summary tests on ios should render an article-summary component
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1599,9 +1299,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     Friday November 17 2017, 12:01am, The Times
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1613,9 +1310,6 @@ exports[`Article Summary tests on ios should render an article-summary component
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1629,9 +1323,6 @@ exports[`Article Summary tests on ios should render an article-summary component
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1658,9 +1349,6 @@ exports[`Article Summary tests on ios should render an article-summary with opin
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#333333",
@@ -1676,9 +1364,6 @@ exports[`Article Summary tests on ios should render an article-summary with opin
     </Text>
   </View>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#850029",
@@ -1689,9 +1374,6 @@ exports[`Article Summary tests on ios should render an article-summary with opin
     }
   >
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1705,9 +1387,6 @@ exports[`Article Summary tests on ios should render an article-summary with opin
       Camilla Long
     </Text>
     <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
       style={
         Object {
           "color": "#006699",
@@ -1723,10 +1402,7 @@ exports[`Article Summary tests on ios should render an article-summary with opin
   </Text>
   <Text
     accessibilityRole="heading"
-    accessible={true}
-    allowFontScaling={true}
     aria-level="3"
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#333333",
@@ -1741,9 +1417,6 @@ exports[`Article Summary tests on ios should render an article-summary with opin
     Top medal for forces dog who took a bite out of the Taliban
   </Text>
   <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",
@@ -1755,21 +1428,13 @@ exports[`Article Summary tests on ios should render an article-summary with opin
       }
     }
   >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-    >
+    <Text>
       
       The special forces dog fought on under fire, even after shrapnel from Taliban grenades tore into his belly and legs, blew out a front tooth and damaged his right ear.
       ...
     </Text>
   </Text>
   <Text
-    accessibilityLabel="datePublication"
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
     style={
       Object {
         "color": "#696969",

--- a/packages/article-summary/__tests__/ios/jest.config.js
+++ b/packages/article-summary/__tests__/ios/jest.config.js
@@ -1,6 +1,6 @@
 const jestConfigurator = require("@times-components/jest-configurator").default;
 const path = require("path");
 
-module.exports = jestConfigurator("android", __dirname, {
+module.exports = jestConfigurator("ios", __dirname, {
   setupTestFrameworkScriptFile: path.join(__dirname, "./serializers")
 });

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -151,7 +151,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -231,7 +230,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -360,7 +358,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -482,7 +479,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -591,7 +587,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -667,7 +662,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </h3>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -723,7 +717,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     OK, so Putin’s not a lady, but he does have the wildest man‑PMT
   </h3>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -786,7 +779,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -863,7 +855,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -1009,7 +1000,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -1066,7 +1056,6 @@ exports[`Article Summary tests on Web should render an article-summary component
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={
@@ -1186,7 +1175,6 @@ exports[`Article Summary tests on Web should render an article-summary with opin
     </span>
   </div>
   <div
-    aria-label="datePublication"
     data-testid="datePublication"
     dir="auto"
     style={

--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -71,11 +71,7 @@ const ArticleSummary = props => {
       {headline()}
       {content()}
       {datePublicationProps ? (
-        <Text
-          accessibilityLabel="datePublication"
-          style={styles.metaText}
-          testID="datePublication"
-        >
+        <Text style={styles.metaText} testID="datePublication">
           <DatePublication {...datePublicationProps} />
         </Text>
       ) : null}

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -848,7 +848,6 @@ exports[`1. Render an author profile page 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1093,7 +1092,6 @@ exports[`1. Render an author profile page 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1338,7 +1336,6 @@ exports[`1. Render an author profile page 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2444,7 +2441,6 @@ exports[`2. Render an author profile page without images 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2585,7 +2581,6 @@ exports[`2. Render an author profile page without images 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2714,7 +2709,6 @@ exports[`2. Render an author profile page without images 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -846,7 +846,6 @@ exports[`1. Render an author profile page 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1090,7 +1089,6 @@ exports[`1. Render an author profile page 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1334,7 +1332,6 @@ exports[`1. Render an author profile page 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2438,7 +2435,6 @@ exports[`2. Render an author profile page without images 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2578,7 +2574,6 @@ exports[`2. Render an author profile page without images 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2706,7 +2701,6 @@ exports[`2. Render an author profile page without images 1`] = `
                     </Text>
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -272,7 +272,6 @@ exports[`1. Render an author profile page 1`] = `
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -393,7 +392,6 @@ exports[`1. Render an author profile page 1`] = `
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -514,7 +512,6 @@ exports[`1. Render an author profile page 1`] = `
                       </span>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -825,7 +822,6 @@ exports[`2. Render an author profile page without images 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -884,7 +880,6 @@ exports[`2. Render an author profile page without images 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -981,7 +976,6 @@ exports[`2. Render an author profile page without images 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -1048,7 +1042,6 @@ exports[`2. Render an author profile page without images 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -1133,7 +1126,6 @@ exports[`2. Render an author profile page without images 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -1188,7 +1180,6 @@ exports[`2. Render an author profile page without images 1`] = `
                         </span>
                       </div>
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {

--- a/packages/related-articles/__tests__/android/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/related-articles.test.js.snap
@@ -297,7 +297,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -665,7 +664,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -963,7 +961,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1201,7 +1198,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1375,7 +1371,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1549,7 +1544,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1918,7 +1912,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2273,7 +2266,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2417,7 +2409,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                     Size matters, say very tiny ministers Size matters, say very tiny ministers
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2779,7 +2770,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2923,7 +2913,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     Trident gets out of MoD budget, Hammond urged
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3067,7 +3056,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     Size matters, say tiny ministers
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3347,7 +3335,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3717,7 +3704,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3965,7 +3951,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                     An example of a really really really really really really really really really really long headline
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -4238,7 +4223,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -4486,7 +4470,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     Trident out of MoD budget, Hammond urged
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -4630,7 +4613,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     An example of a really really really really really really really really really really really really really really really really really really really really long headline
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",

--- a/packages/related-articles/__tests__/ios/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/related-articles.test.js.snap
@@ -296,7 +296,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -663,7 +662,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -960,7 +958,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1197,7 +1194,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1370,7 +1366,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1543,7 +1538,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -1911,7 +1905,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2265,7 +2258,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2408,7 +2400,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                     Size matters, say very tiny ministers Size matters, say very tiny ministers
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2769,7 +2760,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -2912,7 +2902,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     Trident gets out of MoD budget, Hammond urged
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3055,7 +3044,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                     Size matters, say tiny ministers
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3334,7 +3322,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3703,7 +3690,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -3950,7 +3936,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                     An example of a really really really really really really really really really really long headline
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -4222,7 +4207,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     </Text>
                   </View>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -4469,7 +4453,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     Trident out of MoD budget, Hammond urged
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",
@@ -4612,7 +4595,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                     An example of a really really really really really really really really really really really really really really really really really really really really long headline
                   </Text>
                   <Text
-                    accessibilityLabel="datePublication"
                     style={
                       Object {
                         "color": "#696969",

--- a/packages/related-articles/__tests__/web/__snapshots__/related-articles.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/related-articles.test.js.snap
@@ -156,7 +156,6 @@ exports[`2a. Standard template: Render a single related article 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -365,7 +364,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -510,7 +508,6 @@ exports[`3a. Standard template: Render two related articles 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -726,7 +723,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -893,7 +889,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1060,7 +1055,6 @@ exports[`4a. Standard template: Render three related articles 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1267,7 +1261,6 @@ exports[`5a. Lead and two template: Render one lead related article 1`] = `
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1454,7 +1447,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1574,7 +1566,6 @@ exports[`6a. Lead and two template: Render one lead and one support related arti
                       </h3>
                       <div />
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -1784,7 +1775,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -1904,7 +1894,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       </h3>
                       <div />
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -2018,7 +2007,6 @@ exports[`7a. Lead and two template: Render one lead and two support related arti
                       </h3>
                       <div />
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -2206,7 +2194,6 @@ exports[`8a. Opinion and two template: Render one opinion related article 1`] = 
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -2431,7 +2418,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -2588,7 +2574,6 @@ exports[`9a. Opinion and two template: Render one opinion and one support relate
                       </h3>
                       <div />
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -2769,7 +2754,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       </div>
                     </div>
                     <div
-                      aria-label="datePublication"
                       data-testid="datePublication"
                       style={
                         Object {
@@ -2926,7 +2910,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       </h3>
                       <div />
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {
@@ -3040,7 +3023,6 @@ exports[`10a. Opinion and two template: Render one opinion and two support relat
                       </h3>
                       <div />
                       <div
-                        aria-label="datePublication"
                         data-testid="datePublication"
                         style={
                           Object {


### PR DESCRIPTION
When VoiceOver reads the article summary as a link, it reads "Date Publication" rather than the actual date and publication.