### PR TITLE
Show image loading state instead of hiding it

### DIFF
--- a/packages/article-list/src/article-list-item.js
+++ b/packages/article-list/src/article-list-item.js
@@ -50,7 +50,7 @@ const ArticleListItem = props => {
     <Link onPress={onPress} url={url}>
       <View style={styles.listItemContainer}>
         <Card
-          image={imageUri ? { uri: imageUri } : null}
+          image={{ uri: imageUri }}
           imageRatio={imageRatio}
           showImage={showImage}
         >

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile-head.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile-head.test.js.snap
@@ -33,6 +33,7 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
     }
     testID="author-head"
   >
+    <Image />
     <AuthorProfileHeadJobTitle
       jobTitle="testJobTitle"
     />

--- a/packages/author-profile/__tests__/author-profile-head.js
+++ b/packages/author-profile/__tests__/author-profile-head.js
@@ -9,7 +9,7 @@ export default () => {
     jobTitle: "testJobTitle",
     onTwitterLinkPress: () => null,
     renderBiography: () => null,
-    renderImage: () => null,
+    image: "",
     renderName: () => null,
     twitter: "testTwitterHandle"
   };

--- a/packages/author-profile/__tests__/author-profile-head.js
+++ b/packages/author-profile/__tests__/author-profile-head.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Image } from "react-native";
 import { shallow } from "enzyme";
 import { AuthorProfileHeadBase as AuthorProfileHeadBaseWithoutTracking } from "../src/author-profile-head-base";
 import AuthorProfileHeadTwitter from "../src/author-profile-head-twitter";
@@ -9,7 +10,7 @@ export default () => {
     jobTitle: "testJobTitle",
     onTwitterLinkPress: () => null,
     renderBiography: () => null,
-    image: "",
+    image: <Image />,
     renderName: () => null,
     twitter: "testTwitterHandle"
   };

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile-head.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile-head.test.js.snap
@@ -33,6 +33,7 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
     }
     testID="author-head"
   >
+    <Image />
     <AuthorProfileHeadJobTitle
       jobTitle="testJobTitle"
     />

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-head.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-head.web.test.js.snap
@@ -33,6 +33,7 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
     }
     testID="author-head"
   >
+    <Image />
     <AuthorProfileHeadJobTitle
       jobTitle="testJobTitle"
     />

--- a/packages/author-profile/src/author-profile-head-base.js
+++ b/packages/author-profile/src/author-profile-head-base.js
@@ -19,7 +19,7 @@ export class AuthorProfileHeadBase extends Component {
       jobTitle,
       onTwitterLinkPress,
       renderBiography,
-      renderImage,
+      image,
       renderName,
       twitter
     } = this.props;
@@ -53,7 +53,7 @@ export class AuthorProfileHeadBase extends Component {
           style={styles.authorHeadWrapper}
           testID="author-head"
         >
-          {renderImage()}
+          {image}
           {renderName()}
           {renderJobTitle()}
           {renderTwitterLink()}
@@ -69,7 +69,7 @@ AuthorProfileHeadBase.propTypes = {
   jobTitle: PropTypes.string,
   onTwitterLinkPress: PropTypes.func,
   renderBiography: PropTypes.func.isRequired,
-  renderImage: PropTypes.func.isRequired,
+  image: PropTypes.node.isRequired,
   renderName: PropTypes.func.isRequired,
   twitter: PropTypes.string
 };

--- a/packages/author-profile/src/author-profile-head-image.js
+++ b/packages/author-profile/src/author-profile-head-image.js
@@ -8,7 +8,11 @@ const AuthorProfileHeadImage = ({ uri }) => (
 );
 
 AuthorProfileHeadImage.propTypes = {
-  uri: PropTypes.string.isRequired
+  uri: PropTypes.string
+};
+
+AuthorProfileHeadImage.defaultProps = {
+  uri: ""
 };
 
 export default AuthorProfileHeadImage;

--- a/packages/author-profile/src/author-profile-head.js
+++ b/packages/author-profile/src/author-profile-head.js
@@ -24,7 +24,7 @@ const AuthorProfileHead = ({
     );
   };
 
-  const renderImage = () => <AuthorProfileHeadImage uri={uri} />;
+  const image = <AuthorProfileHeadImage uri={uri} />;
 
   const renderName = () => {
     if (!name) return null;
@@ -49,7 +49,7 @@ const AuthorProfileHead = ({
         jobTitle={jobTitle}
         onTwitterLinkPress={onTwitterLinkPress}
         renderBiography={renderBiography}
-        renderImage={renderImage}
+        image={image}
         renderName={renderName}
         twitter={twitter}
       />

--- a/packages/author-profile/src/author-profile-head.js
+++ b/packages/author-profile/src/author-profile-head.js
@@ -24,10 +24,7 @@ const AuthorProfileHead = ({
     );
   };
 
-  const renderImage = () => {
-    if (!uri) return null;
-    return <AuthorProfileHeadImage uri={uri} />;
-  };
+  const renderImage = () => <AuthorProfileHeadImage uri={uri} />;
 
   const renderName = () => {
     if (!name) return null;

--- a/packages/author-profile/src/author-profile-head.web.js
+++ b/packages/author-profile/src/author-profile-head.web.js
@@ -29,14 +29,11 @@ const AuthorProfileHead = ({
     );
   };
 
-  const renderImage = () => {
-    if (!uri) return null;
-    return (
-      <ImageContainer>
-        <AuthorProfileHeadImage uri={uri} />
-      </ImageContainer>
-    );
-  };
+  const image = (
+    <ImageContainer>
+      <AuthorProfileHeadImage uri={uri} />
+    </ImageContainer>
+  );
 
   const renderName = () => {
     if (!name) return null;
@@ -61,7 +58,7 @@ const AuthorProfileHead = ({
         jobTitle={jobTitle}
         onTwitterLinkPress={onTwitterLinkPress}
         renderBiography={renderBiography}
-        renderImage={renderImage}
+        image={image}
         renderName={renderName}
         twitter={twitter}
       />


### PR DESCRIPTION
Images are flickering on native apps while re-rendering because we are removing the view in loading state, instead of showing the placeholder. Removed the null checks for uri's as the image component itself has a placeholder state