### PR TITLE
chore: Update types to match TPA

### DIFF
--- a/packages/provider/src/author-articles-no-images-base.js
+++ b/packages/provider/src/author-articles-no-images-base.js
@@ -4,8 +4,8 @@ import connectGraphql from "./connect";
 export const query = gql`
   query ArticleListQuery(
     $slug: Slug!
-    $first: Int
-    $skip: Int
+    $first: FirstPagingNumber
+    $skip: SkipPagingNumber
     $shortSummaryLength: Int
     $longSummaryLength: Int
   ) {

--- a/packages/provider/src/author-articles-with-images.js
+++ b/packages/provider/src/author-articles-with-images.js
@@ -4,8 +4,8 @@ import connectGraphql from "./connect";
 export const query = gql`
   query ArticleListQuery(
     $slug: Slug!
-    $first: Int
-    $skip: Int
+    $first: FirstPagingNumber
+    $skip: SkipPagingNumber
     $imageRatio: Ratio!
   ) {
     author(slug: $slug) {

--- a/packages/provider/src/topic-articles.js
+++ b/packages/provider/src/topic-articles.js
@@ -4,8 +4,8 @@ import connectGraphql from "./connect";
 export const query = gql`
   query TopicArticlesQuery(
     $slug: Slug!
-    $first: Int
-    $skip: Int
+    $first: FirstPagingNumer
+    $skip: SkipPagingNumber
     $imageRatio: Ratio!
   ) {
     topic(slug: $slug) {

--- a/packages/provider/src/topic-articles.js
+++ b/packages/provider/src/topic-articles.js
@@ -4,7 +4,7 @@ import connectGraphql from "./connect";
 export const query = gql`
   query TopicArticlesQuery(
     $slug: Slug!
-    $first: FirstPagingNumer
+    $first: FirstPagingNumber
     $skip: SkipPagingNumber
     $imageRatio: Ratio!
   ) {

--- a/packages/utils/src/schema.json
+++ b/packages/utils/src/schema.json
@@ -340,14 +340,22 @@
                   "name": "first",
                   "description":
                     "The maximum number of articles you want to take, defaults to 10",
-                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FirstPagingNumber",
+                    "ofType": null
+                  },
                   "defaultValue": "10"
                 },
                 {
                   "name": "skip",
                   "description":
                     "The number of articles to skip over, useful for paging, defaults to 0",
-                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "SkipPagingNumber",
+                    "ofType": null
+                  },
                   "defaultValue": "0"
                 }
               ],
@@ -378,6 +386,26 @@
           "name": "Int",
           "description":
             "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "FirstPagingNumber",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "SkipPagingNumber",
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -1406,14 +1434,22 @@
                   "name": "first",
                   "description":
                     "The maximum number of articles you want to take, defaults to 10",
-                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FirstPagingNumber",
+                    "ofType": null
+                  },
                   "defaultValue": "10"
                 },
                 {
                   "name": "skip",
                   "description":
                     "The number of articles to skip over, useful for paging, defaults to 0",
-                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "SkipPagingNumber",
+                    "ofType": null
+                  },
                   "defaultValue": "0"
                 }
               ],
@@ -1460,14 +1496,22 @@
                   "name": "first",
                   "description":
                     "The maximum number of articles you want to take, defaults to 10",
-                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "FirstPagingNumber",
+                    "ofType": null
+                  },
                   "defaultValue": "10"
                 },
                 {
                   "name": "skip",
                   "description":
                     "The number of articles to skip over, useful for paging, defaults to 0",
-                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "SkipPagingNumber",
+                    "ofType": null
+                  },
                   "defaultValue": "0"
                 }
               ],


### PR DESCRIPTION
The types have been approved in TPA: https://github.com/newsuk/times-public-api/pull/472

This updates these types in times-components. 

**These two PRs should ship together otherwise there will be errors.**