### PR TITLE
Fix/article list rerender

### DIFF
--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -4361,29 +4361,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         </View>
       </View>
     </View>
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-          style={
-            Object {
-              "paddingVertical": 25,
-            }
-          }
-        />
-      </View>
-    </View>
+    <View />
   </View>
 </RCTScrollView>
 `;

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -55,7 +55,7 @@ export default () => {
 
   it("should render the loading state", () => {
     const tree = renderer.create(
-      <MockedProvider mocks={mockArticles}>
+      <MockedProvider mocks={mockArticles} isLoading>
         <AuthorProfile {...props} isLoading />
       </MockedProvider>
     );

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -4353,29 +4353,7 @@ exports[`3. Render an author profile page loading state 1`] = `
         </View>
       </View>
     </View>
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#DBDBDB",
-              "height": 1,
-            }
-          }
-        />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-          style={
-            Object {
-              "paddingVertical": 25,
-            }
-          }
-        />
-      </View>
-    </View>
+    <View />
   </View>
 </RCTScrollView>
 `;

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -81,7 +81,7 @@ export default {
       type: "story",
       name: "Loading",
       component: (_, { decorateAction }) => (
-        <MockedProvider mocks={mockArticles}>
+        <MockedProvider mocks={mockArticles} isLoading>
           <AuthorProfile {...getProps(decorateAction)} isLoading />
         </MockedProvider>
       )

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -34,23 +34,6 @@ const AuthorProfile = ({
     return <ArticleListPageError refetch={refetch} />;
   }
 
-  if (isLoading || !author) {
-    return (
-      <ArticleList
-        adConfig={adConfig}
-        articleListHeader={<AuthorProfileHead isLoading />}
-        articlesLoading
-        emptyStateMessage={emptyStateMessage}
-        fetchMore={() => Promise.resolve()}
-        imageRatio={ratioTextToFloat("3:2")}
-        isLoading
-        pageSize={initPageSize}
-        refetch={() => {}}
-        showImages
-      />
-    );
-  }
-
   const {
     articles,
     biography,
@@ -59,12 +42,20 @@ const AuthorProfile = ({
     jobTitle,
     name,
     twitter
-  } = author;
+  } = author || {
+    articles: [],
+    biography: "",
+    hasLeadAssets: false,
+    image: "",
+    jobTitle: "",
+    name: "",
+    twitter: ""
+  };
 
   const articleListHeader = (
     <AuthorProfileHead
       biography={biography}
-      isLoading={false}
+      isLoading={isLoading}
       jobTitle={jobTitle}
       name={name}
       onTwitterLinkPress={onTwitterLinkPress}

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -42,15 +42,16 @@ const AuthorProfile = ({
     jobTitle,
     name,
     twitter
-  } = author || {
-    articles: [],
-    biography: "",
-    hasLeadAssets: false,
-    image: "",
-    jobTitle: "",
-    name: "",
-    twitter: ""
-  };
+  } = isLoading
+    ? {
+        articles: [],
+        hasLeadAssets: true,
+        image: "",
+        jobTitle: "",
+        name: "",
+        twitter: ""
+      }
+    : author;
 
   const articleListHeader = (
     <AuthorProfileHead

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -17,7 +17,7 @@ const AuthorProfile = ({
   adConfig,
   author,
   error,
-  isLoading,
+  isLoading: isHeaderLoading,
   onArticlePress,
   onNext,
   onPrev,
@@ -42,7 +42,7 @@ const AuthorProfile = ({
     jobTitle,
     name,
     twitter
-  } = isLoading
+  } = isHeaderLoading
     ? {
         articles: [],
         hasLeadAssets: true,
@@ -56,7 +56,7 @@ const AuthorProfile = ({
   const articleListHeader = (
     <AuthorProfileHead
       biography={biography}
-      isLoading={isLoading}
+      isLoading={isHeaderLoading}
       jobTitle={jobTitle}
       name={name}
       onTwitterLinkPress={onTwitterLinkPress}
@@ -118,7 +118,7 @@ const AuthorProfile = ({
             emptyStateMessage={emptyStateMessage}
             error={articlesError}
             imageRatio={ratioTextToFloat(imageRatio)}
-            isLoading={isLoading}
+            isLoading={isHeaderLoading}
             onArticlePress={onArticlePress}
             onNext={onNext}
             onPrev={onPrev}

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -202,9 +202,11 @@ exports[`2. Render a topics page loading state 1`] = `
     />
   }
   articlesLoading={true}
+  count={0}
   emptyStateMessage="Unfortunately, there are no articles relating to this topic"
   imageRatio={1.5}
   isLoading={true}
+  page={1}
   pageSize={3}
   showImages={true}
 />

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -202,9 +202,11 @@ exports[`2. Render a topics page loading state 1`] = `
     />
   }
   articlesLoading={true}
+  count={0}
   emptyStateMessage="Unfortunately, there are no articles relating to this topic"
   imageRatio={1.5}
   isLoading={true}
+  page={1}
   pageSize={3}
   showImages={true}
 />

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -63,7 +63,11 @@ export default () => {
   });
 
   it("should render the loading state", () => {
-    const tree = renderer.create(<Topic {...props} isLoading />);
+    const tree = renderer.create(
+      <MockedProvider mocks={mockArticles} isLoading>
+        <Topic {...props} topic={{}} isLoading />
+      </MockedProvider>
+    );
 
     expect(tree).toMatchSnapshot("2. Render a topics page loading state");
   });

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -202,9 +202,11 @@ exports[`2. Render a topics page loading state 1`] = `
     />
   }
   articlesLoading={true}
+  count={0}
   emptyStateMessage="Unfortunately, there are no articles relating to this topic"
   imageRatio={1.5}
   isLoading={true}
+  page={1}
   pageSize={3}
   showImages={true}
 />

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -30,10 +30,12 @@ const Topic = ({
     return <ArticleListPageError refetch={refetch} />;
   }
 
-  const { name, description } = topic || { name: "", description: "" };
+  const { name, description } = isLoading
+    ? { name: "", description: "" }
+    : topic;
 
   const articleListHeader = (
-    <TopicHead name={name} description={description} isLoading={false} />
+    <TopicHead name={name} description={description} isLoading={isLoading} />
   );
 
   return (

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -30,24 +30,7 @@ const Topic = ({
     return <ArticleListPageError refetch={refetch} />;
   }
 
-  if (isLoading || !topic) {
-    return (
-      <ArticleList
-        adConfig={adConfig}
-        articleListHeader={<TopicHead isLoading />}
-        articlesLoading
-        emptyStateMessage={emptyStateMessage}
-        fetchMore={() => Promise.resolve()}
-        imageRatio={ratioTextToFloat("3:2")}
-        isLoading
-        pageSize={initPageSize}
-        refetch={() => {}}
-        showImages
-      />
-    );
-  }
-
-  const { name, description } = topic;
+  const { name, description } = topic || { name: "", description: "" };
 
   const articleListHeader = (
     <TopicHead name={name} description={description} isLoading={false} />

--- a/packages/topic/src/topic.js
+++ b/packages/topic/src/topic.js
@@ -13,7 +13,7 @@ import TopicHead from "./topic-head";
 const Topic = ({
   adConfig,
   error,
-  isLoading,
+  isLoading: isHeaderLoading,
   page,
   pageSize: initPageSize,
   onArticlePress,
@@ -30,12 +30,16 @@ const Topic = ({
     return <ArticleListPageError refetch={refetch} />;
   }
 
-  const { name, description } = isLoading
+  const { name, description } = isHeaderLoading
     ? { name: "", description: "" }
     : topic;
 
   const articleListHeader = (
-    <TopicHead name={name} description={description} isLoading={isLoading} />
+    <TopicHead
+      name={name}
+      description={description}
+      isLoading={isHeaderLoading}
+    />
   );
 
   return (
@@ -88,7 +92,7 @@ const Topic = ({
             error={articlesError}
             fetchMore={fetchMoreArticles}
             imageRatio={ratioTextToFloat(imageRatio)}
-            isLoading={isLoading}
+            isLoading={isHeaderLoading}
             onArticlePress={onArticlePress}
             onNext={onNext}
             onPrev={onPrev}

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -58,7 +58,7 @@ export default {
       type: "story",
       name: "Loading",
       component: (_, { decorateAction }) => (
-        <MockedProvider mocks={mocks}>
+        <MockedProvider mocks={mocks} isLoading>
           <Topic {...getProps(decorateAction)} isLoading />
         </MockedProvider>
       )

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,11 +52,13 @@
   "dependencies": {
     "apollo-cache-inmemory": "1.1.10",
     "apollo-client": "2.3.2",
+    "apollo-link": "1.2.2",
     "graphql": "0.13.1",
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.0",
     "react": "16.3.1",
-    "react-apollo": "2.1.4"
+    "react-apollo": "2.1.4",
+    "zen-observable": "0.8.8"
   },
   "peerDependencies": {
     "react": ">=16.2",

--- a/packages/utils/src/graphql.js
+++ b/packages/utils/src/graphql.js
@@ -3,12 +3,14 @@
 import React, { Component } from "react";
 import ApolloClient from "apollo-client";
 import { ApolloProvider } from "react-apollo";
+import { ApolloLink } from "apollo-link";
 import { MockLink } from "react-apollo/test-utils";
 import {
   InMemoryCache as Cache,
   IntrospectionFragmentMatcher
 } from "apollo-cache-inmemory";
 import PropTypes from "prop-types";
+import Observable from "zen-observable";
 import introspectionResult from "./schema.json";
 
 const filteredTypes = introspectionResult.data.__schema.types.filter(
@@ -29,8 +31,12 @@ class MockedProvider extends Component {
   constructor(props, context) {
     super(props, context);
 
+    const link = this.props.isLoading
+      ? new ApolloLink(() => Observable.of())
+      : new MockLink(props.mocks);
+
     this.client = new ApolloClient({
-      link: new MockLink(props.mocks),
+      link,
       cache: new Cache({ addTypename: !props.removeTypename, fragmentMatcher })
     });
   }
@@ -63,11 +69,13 @@ MockedProvider.propTypes = {
     })
   ).isRequired,
   children: PropTypes.node.isRequired,
-  removeTypename: PropTypes.bool
+  removeTypename: PropTypes.bool,
+  isLoading: PropTypes.bool
 };
 
 MockedProvider.defaultProps = {
-  removeTypename: false
+  removeTypename: false,
+  isLoading: false
 };
 
 export { MockedProvider };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14389,7 +14389,7 @@ zen-observable-ts@^0.8.9:
   dependencies:
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable@0.8.8, zen-observable@^0.8.0:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.8.tgz#1ea93995bf098754a58215a1e0a7309e5749ec42"
 


### PR DESCRIPTION
We were rendering separate ArticleLists in loading states and loaded states, which was causing a complete re-render of the page. This is causing glitchy ux in the mobile apps.

- Now we are using the same article list with a loading state.
- Added a isLoading prop to MockedProvider that doesn't return anything by using an empty ApolloLink