### PR TITLE
chore: Move MockedProvider to provider-test-tools

### DIFF
--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -1,7 +1,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import mockDate from "mockdate";
-import { delay, MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
+import { delay } from "@times-components/utils";
 import AuthorProfile from "../src/author-profile";
 import {
   mockArticles,

--- a/packages/author-profile/__tests__/shared-native.js
+++ b/packages/author-profile/__tests__/shared-native.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { FlatList } from "react-native";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
 import AuthorProfile from "../src/author-profile";
 import { mockArticles, pageSize, props } from "./mocks";
 

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -2,10 +2,12 @@ import "react-native";
 import React from "react";
 import { AdComposer } from "@times-components/ad";
 import { AuthorProfileProvider } from "@times-components/provider";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import storybookReporter from "@times-components/tealium-utils";
-import { MockedProvider } from "@times-components/provider-test-tools";
 import AuthorProfile from "./src/author-profile";
 import longSummaryLength from "./author-profile-constants";
 

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -5,7 +5,7 @@ import { AuthorProfileProvider } from "@times-components/provider";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import storybookReporter from "@times-components/tealium-utils";
-import { MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
 import AuthorProfile from "./src/author-profile";
 import longSummaryLength from "./author-profile-constants";
 

--- a/packages/provider-test-tools/package.json
+++ b/packages/provider-test-tools/package.json
@@ -48,7 +48,6 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.6.1",
-    "@times-components/utils": "1.1.4",
     "@times-components/webpack-configurator": "1.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -66,6 +65,7 @@
   },
   "dependencies": {
     "@times-components/provider": "0.36.6",
+    "@times-components/utils": "1.1.4",
     "apollo-cache-inmemory": "1.1.10",
     "apollo-client": "2.3.2",
     "apollo-link": "1.2.2",

--- a/packages/provider-test-tools/src/index.js
+++ b/packages/provider-test-tools/src/index.js
@@ -1,6 +1,7 @@
 import clientTester from "./client-tester";
 import providerTester from "./provider-tester";
 import fixtureGenerator from "./fixture-generator";
+import MockedProvider from "./mocked-provider";
 
 export * from "./helpers";
-export { clientTester, providerTester, fixtureGenerator };
+export { clientTester, fixtureGenerator, MockedProvider, providerTester };

--- a/packages/provider-test-tools/src/mocked-provider.js
+++ b/packages/provider-test-tools/src/mocked-provider.js
@@ -4,7 +4,6 @@ import { ApolloProvider } from "react-apollo";
 import { MockLink } from "react-apollo/test-utils";
 import { InMemoryCache as Cache } from "apollo-cache-inmemory";
 import PropTypes from "prop-types";
-import { IntrospectionFragmentMatcher } from "apollo-cache-inmemory";
 import { fragmentMatcher } from "@times-components/utils";
 
 class MockedProvider extends Component {

--- a/packages/provider-test-tools/src/mocked-provider.js
+++ b/packages/provider-test-tools/src/mocked-provider.js
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import ApolloClient from "apollo-client";
+import { ApolloProvider } from "react-apollo";
+import { MockLink } from "react-apollo/test-utils";
+import { InMemoryCache as Cache } from "apollo-cache-inmemory";
+import PropTypes from "prop-types";
+import { IntrospectionFragmentMatcher } from "apollo-cache-inmemory";
+import { fragmentMatcher } from "@times-components/utils";
+
+class MockedProvider extends Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.client = new ApolloClient({
+      link: new MockLink(props.mocks),
+      cache: new Cache({ addTypename: !props.removeTypename, fragmentMatcher })
+    });
+  }
+
+  render() {
+    return (
+      <ApolloProvider client={this.client}>
+        {this.props.children}
+      </ApolloProvider>
+    );
+  }
+}
+
+const GraphQLRequest = PropTypes.shape({
+  query: PropTypes.object.isRequired,
+  variables: PropTypes.object,
+  operationName: PropTypes.string,
+  context: PropTypes.object,
+  extensions: PropTypes.object
+});
+
+MockedProvider.propTypes = {
+  mocks: PropTypes.arrayOf(
+    PropTypes.shape({
+      request: GraphQLRequest.isRequired,
+      result: PropTypes.object,
+      error: PropTypes.object,
+      delay: PropTypes.number,
+      newData: PropTypes.func
+    })
+  ).isRequired,
+  children: PropTypes.node.isRequired,
+  removeTypename: PropTypes.bool
+};
+
+MockedProvider.defaultProps = {
+  removeTypename: false
+};
+
+export default MockedProvider;

--- a/packages/provider/__tests__/article-provider.test.js
+++ b/packages/provider/__tests__/article-provider.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
 import { addTypenameToDocument } from "apollo-utilities";
 import fixture from "@times-components/provider-test-tools/fixtures/article.json";
 import { ArticleProvider } from "../src/provider";

--- a/packages/provider/__tests__/author-articles-no-images.test.js
+++ b/packages/provider/__tests__/author-articles-no-images.test.js
@@ -1,7 +1,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import AuthorArticlesNoImagesProvider from "../src/author-articles-no-images-base";
 
 const renderComponent = child =>

--- a/packages/provider/__tests__/author-articles-with-images.test.js
+++ b/packages/provider/__tests__/author-articles-with-images.test.js
@@ -1,7 +1,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import { AuthorArticlesWithImagesProvider } from "../src/provider";
 
 const renderComponent = child =>

--- a/packages/provider/__tests__/author-profile-provider.test.js
+++ b/packages/provider/__tests__/author-profile-provider.test.js
@@ -1,7 +1,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import { AuthorProfileProvider } from "../src/provider";
 
 const renderComponent = child =>

--- a/packages/provider/__tests__/provider.test.js
+++ b/packages/provider/__tests__/provider.test.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import renderer from "react-test-renderer";
 import gql from "graphql-tag";
-import { MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
 import connectGraphql from "../src/provider";
 
 const query = gql`

--- a/packages/provider/__tests__/topic-articles-provider.test.js
+++ b/packages/provider/__tests__/topic-articles-provider.test.js
@@ -1,7 +1,9 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import { TopicArticlesProvider } from "../src/provider";
 
 const pageSize = 5;

--- a/packages/provider/__tests__/topic-provider.test.js
+++ b/packages/provider/__tests__/topic-provider.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import renderer from "react-test-renderer";
-import { MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
 import { addTypenameToDocument } from "apollo-utilities";
 import fixture from "@times-components/provider-test-tools/fixtures/topic.json";
 import { TopicProvider } from "../src/provider";

--- a/packages/provider/provider.showcase.js
+++ b/packages/provider/provider.showcase.js
@@ -5,7 +5,7 @@ import topicFixture from "@times-components/provider-test-tools/fixtures/topic.j
 import articleFixture from "@times-components/provider-test-tools/fixtures/article.json";
 import { addTypenameToDocument } from "apollo-utilities";
 import gql from "graphql-tag";
-import { MockedProvider } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
 import { fixtureGenerator } from "@times-components/provider-test-tools";
 import connectGraphql, {
   ArticleProvider,

--- a/packages/provider/provider.showcase.js
+++ b/packages/provider/provider.showcase.js
@@ -5,8 +5,10 @@ import topicFixture from "@times-components/provider-test-tools/fixtures/topic.j
 import articleFixture from "@times-components/provider-test-tools/fixtures/article.json";
 import { addTypenameToDocument } from "apollo-utilities";
 import gql from "graphql-tag";
-import { MockedProvider } from "@times-components/provider-test-tools";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import connectGraphql, {
   ArticleProvider,
   AuthorProfileProvider,

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -48,6 +48,7 @@
     "@storybook/addons": "3.4.1",
     "@storybook/react-native": "3.4.1",
     "@times-components/jest-configurator": "1.0.3",
+    "@times-components/provider-test-tools": "0.12.5",
     "@times-components/utils": "1.1.4",
     "apollo-cache-inmemory": "1.1.10",
     "apollo-client": "2.3.2",

--- a/packages/storybook/storybook-provider.js
+++ b/packages/storybook/storybook-provider.js
@@ -4,7 +4,8 @@ import { ApolloProvider } from "react-apollo";
 import { ApolloClient } from "apollo-client";
 import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
-import { MockedProvider, fragmentMatcher } from "@times-components/utils";
+import { MockedProvider } from "@times-components/provider-test-tools";
+import { fragmentMatcher } from "@times-components/utils";
 import { text } from "@storybook/addon-knobs/react";
 
 const StorybookProvider = props => {

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -1,8 +1,11 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import mockDate from "mockdate";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
-import { delay, MockedProvider } from "@times-components/utils";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
+import { delay } from "@times-components/utils";
 import Topic from "../src/topic";
 
 // This is the only possible way for this to work... :'-(

--- a/packages/topic/__tests__/topic-styling.js
+++ b/packages/topic/__tests__/topic-styling.js
@@ -1,8 +1,10 @@
 import "jest-styled-components";
 import React from "react";
 import renderer from "react-test-renderer";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
-import { MockedProvider } from "@times-components/utils";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import Topic from "../src/topic";
 
 export default () => {

--- a/packages/topic/topic.showcase.js
+++ b/packages/topic/topic.showcase.js
@@ -1,9 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import { fixtureGenerator } from "@times-components/provider-test-tools";
+import {
+  fixtureGenerator,
+  MockedProvider
+} from "@times-components/provider-test-tools";
 import StorybookProvider from "@times-components/storybook/storybook-provider";
 import storybookReporter from "@times-components/tealium-utils";
-import { MockedProvider } from "@times-components/utils";
 import Topic from "./src/topic";
 import TopicProvider from "../provider/src/topic";
 import adConfig from "./fixtures/topic-ad-config.json";

--- a/packages/utils/src/fragmentMatcher.js
+++ b/packages/utils/src/fragmentMatcher.js
@@ -13,6 +13,8 @@ const introspectionQueryResultData = {
   }
 };
 
-export const fragmentMatcher = new IntrospectionFragmentMatcher({
+const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData
 });
+
+export default fragmentMatcher;

--- a/packages/utils/src/graphql.js
+++ b/packages/utils/src/graphql.js
@@ -1,16 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-import React, { Component } from "react";
-import ApolloClient from "apollo-client";
-import { ApolloProvider } from "react-apollo";
-import { ApolloLink } from "apollo-link";
-import { MockLink } from "react-apollo/test-utils";
-import {
-  InMemoryCache as Cache,
-  IntrospectionFragmentMatcher
-} from "apollo-cache-inmemory";
-import PropTypes from "prop-types";
-import Observable from "zen-observable";
+import { IntrospectionFragmentMatcher } from "apollo-cache-inmemory";
 import introspectionResult from "./schema.json";
 
 const filteredTypes = introspectionResult.data.__schema.types.filter(
@@ -26,56 +16,3 @@ const introspectionQueryResultData = {
 export const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData
 });
-
-class MockedProvider extends Component {
-  constructor(props, context) {
-    super(props, context);
-
-    const link = this.props.isLoading
-      ? new ApolloLink(() => Observable.of())
-      : new MockLink(props.mocks);
-
-    this.client = new ApolloClient({
-      link,
-      cache: new Cache({ addTypename: !props.removeTypename, fragmentMatcher })
-    });
-  }
-
-  render() {
-    return (
-      <ApolloProvider client={this.client}>
-        {this.props.children}
-      </ApolloProvider>
-    );
-  }
-}
-
-const GraphQLRequest = PropTypes.shape({
-  query: PropTypes.object.isRequired,
-  variables: PropTypes.object,
-  operationName: PropTypes.string,
-  context: PropTypes.object,
-  extensions: PropTypes.object
-});
-
-MockedProvider.propTypes = {
-  mocks: PropTypes.arrayOf(
-    PropTypes.shape({
-      request: GraphQLRequest.isRequired,
-      result: PropTypes.object,
-      error: PropTypes.object,
-      delay: PropTypes.number,
-      newData: PropTypes.func
-    })
-  ).isRequired,
-  children: PropTypes.node.isRequired,
-  removeTypename: PropTypes.bool,
-  isLoading: PropTypes.bool
-};
-
-MockedProvider.defaultProps = {
-  removeTypename: false,
-  isLoading: false
-};
-
-export { MockedProvider };

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,8 +1,8 @@
 export * from "./faketime";
-export * from "./graphql";
 export * from "./screen";
 export * from "./strings";
 
 export { default as clean } from "./props";
 export { default as addMissingProtocol } from "./add-missing-protocol";
 export { default as schema } from "./schema.json";
+export { default as fragmentMatcher } from "./fragmentMatcher";


### PR DESCRIPTION
As part of the provider refactor, we agreed to move the `MockedProvider` to the `provider-test-tools` package.