### PR TITLE
fix: video label and article topic design tweaks

### DIFF
--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
@@ -41,7 +41,7 @@ exports[`2. Render a single topic 1`] = `
     style={
       Object {
         "borderColor": "#DBDBDB",
-        "borderRadius": 1,
+        "borderRadius": 2,
         "borderWidth": 1,
         "marginRight": 10,
         "marginTop": 10,

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
@@ -41,7 +41,7 @@ exports[`2. Render a single topic 1`] = `
     style={
       Object {
         "borderColor": "#DBDBDB",
-        "borderRadius": 1,
+        "borderRadius": 2,
         "borderWidth": 1,
         "marginRight": 10,
         "marginTop": 10,

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
@@ -44,7 +44,7 @@ exports[`2. Render a single topic 1`] = `
     style={
       Object {
         "borderColor": "#DBDBDB",
-        "borderRadius": 1,
+        "borderRadius": 2,
         "borderWidth": 1,
         "marginRight": "10px",
         "marginTop": "10px",

--- a/packages/article-topics/src/styles/index.js
+++ b/packages/article-topics/src/styles/index.js
@@ -3,7 +3,7 @@ import { colours, fonts, spacing } from "@times-components/styleguide";
 const styles = {
   container: {
     borderColor: colours.functional.keyline,
-    borderRadius: 1,
+    borderRadius: 2,
     borderWidth: 1,
     paddingBottom: 12,
     paddingLeft: spacing(3),

--- a/packages/video-label/src/style/index.web.js
+++ b/packages/video-label/src/style/index.web.js
@@ -3,13 +3,17 @@ import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
   ...sharedStyles,
+  container: {
+    ...sharedStyles.container,
+    marginBottom: 3
+  },
   title: {
     ...sharedStyles.title,
     lineHeight: 11
   },
   iconContainer: {
     ...sharedStyles.iconContainer,
-    paddingBottom: 1
+    paddingBottom: 3
   }
 });
 


### PR DESCRIPTION
- [x] Video icon displaying 2px too low
- [x] We have different spacing below the labels when a video icon is showing
- [x] Tags on article pages should have a 2px border radius (currently 1px)

as part of https://github.com/newsuk/times-components/issues/1069