### PR TITLE
chore: Put back the loading changes

### DIFF
--- a/packages/provider-test-tools/package.json
+++ b/packages/provider-test-tools/package.json
@@ -76,7 +76,8 @@
     "prop-types": "15.6.0",
     "react": "16.3.1",
     "react-apollo": "2.1.4",
-    "react-test-renderer": "16.3.1"
+    "react-test-renderer": "16.3.1",
+    "zen-observable": "0.8.8"
   },
   "peerDependencies": {
     "react": ">=16.2",

--- a/packages/provider-test-tools/src/mocked-provider.js
+++ b/packages/provider-test-tools/src/mocked-provider.js
@@ -1,17 +1,23 @@
 import React, { Component } from "react";
 import ApolloClient from "apollo-client";
+import { ApolloLink } from "apollo-link";
 import { ApolloProvider } from "react-apollo";
 import { MockLink } from "react-apollo/test-utils";
 import { InMemoryCache as Cache } from "apollo-cache-inmemory";
 import PropTypes from "prop-types";
+import Observable from "zen-observable";
 import { fragmentMatcher } from "@times-components/utils";
 
 class MockedProvider extends Component {
   constructor(props, context) {
     super(props, context);
 
+    const link = this.props.isLoading
+      ? new ApolloLink(() => Observable.of())
+      : new MockLink(props.mocks);
+
     this.client = new ApolloClient({
-      link: new MockLink(props.mocks),
+      link,
       cache: new Cache({ addTypename: !props.removeTypename, fragmentMatcher })
     });
   }
@@ -44,11 +50,13 @@ MockedProvider.propTypes = {
     })
   ).isRequired,
   children: PropTypes.node.isRequired,
-  removeTypename: PropTypes.bool
+  removeTypename: PropTypes.bool,
+  isLoading: PropTypes.bool
 };
 
 MockedProvider.defaultProps = {
-  removeTypename: false
+  removeTypename: false,
+  isLoading: false
 };
 
 export default MockedProvider;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,8 +57,7 @@
     "lodash.omitby": "4.6.0",
     "prop-types": "15.6.0",
     "react": "16.3.1",
-    "react-apollo": "2.1.4",
-    "zen-observable": "0.8.8"
+    "react-apollo": "2.1.4"
   },
   "peerDependencies": {
     "react": ">=16.2",


### PR DESCRIPTION
As a result of a PR crossover, @tuncaulubilge code was accidentally removed from the Mocked Provider. This puts it back.

More information here: https://github.com/newsuk/times-components/commit/4ee2fbdc782bcd948f980003edec6b48da688c08#diff-f5bb9753b579b9d5c62e2b72f1b171bfR13
