### PR TITLE
chore: Max number of Article Topics to 5

### DIFF
--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a group of topics in the correct order 1`] = `
+exports[`1. Render a group of topics in the correct order and only 5 1`] = `
 <View
   style={
     Object {
@@ -27,8 +27,8 @@ exports[`1. Render a group of topics in the correct order 1`] = `
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
-    name="Rugby Union"
-    slug="rugby-union"
+    name="Luton Town"
+    slug="luton-town"
   />
 </View>
 `;

--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
@@ -27,8 +27,8 @@ exports[`1. Render a group of topics in the correct order and only 5 1`] = `
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
-    name="Luton Town"
-    slug="luton-town"
+    name="Rugby Union"
+    slug="rugby-union"
   />
 </View>
 `;

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a group of topics in the correct order 1`] = `
+exports[`1. Render a group of topics in the correct order and only 5 1`] = `
 <View
   style={
     Object {
@@ -27,8 +27,8 @@ exports[`1. Render a group of topics in the correct order 1`] = `
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
-    name="Rugby Union"
-    slug="rugby-union"
+    name="Luton Town"
+    slug="luton-town"
   />
 </View>
 `;

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
@@ -27,8 +27,8 @@ exports[`1. Render a group of topics in the correct order and only 5 1`] = `
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
-    name="Luton Town"
-    slug="luton-town"
+    name="Rugby Union"
+    slug="rugby-union"
   />
 </View>
 `;

--- a/packages/article-topics/__tests__/shared.js
+++ b/packages/article-topics/__tests__/shared.js
@@ -15,13 +15,13 @@ module.exports = () => {
     mockDate.reset();
   });
 
-  it("renders a group of topics in the correct order", () => {
+  it("renders a group of topics in the correct order and only 5", () => {
     const wrapper = shallow(
       <ArticleTopics topics={topicData} onPress={() => {}} />
     );
 
     expect(wrapper).toMatchSnapshot(
-      "1. Render a group of topics in the correct order"
+      "1. Render a group of topics in the correct order and only 5"
     );
   });
 

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a group of topics in the correct order 1`] = `
+exports[`1. Render a group of topics in the correct order and only 5 1`] = `
 <View
   style={
     Object {
@@ -27,8 +27,8 @@ exports[`1. Render a group of topics in the correct order 1`] = `
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
-    name="Rugby Union"
-    slug="rugby-union"
+    name="Luton Town"
+    slug="luton-town"
   />
 </View>
 `;

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
@@ -27,8 +27,8 @@ exports[`1. Render a group of topics in the correct order and only 5 1`] = `
     slug="arsenal"
   />
   <WithTrackEvents(ArticleTopic)
-    name="Luton Town"
-    slug="luton-town"
+    name="Rugby Union"
+    slug="rugby-union"
   />
 </View>
 `;

--- a/packages/article-topics/fixtures/topics.js
+++ b/packages/article-topics/fixtures/topics.js
@@ -16,12 +16,12 @@ const topicsData = [
     name: "Arsenal"
   },
   {
-    slug: "luton-town",
-    name: "Luton Town"
-  },
-  {
     slug: "rugby-union",
     name: "Rugby Union"
+  },
+  {
+    slug: "luton-town",
+    name: "Luton Town"
   }
 ];
 

--- a/packages/article-topics/fixtures/topics.js
+++ b/packages/article-topics/fixtures/topics.js
@@ -16,6 +16,10 @@ const topicsData = [
     name: "Arsenal"
   },
   {
+    slug: "luton-town",
+    name: "Luton Town"
+  },
+  {
     slug: "rugby-union",
     name: "Rugby Union"
   }

--- a/packages/article-topics/src/article-topics.js
+++ b/packages/article-topics/src/article-topics.js
@@ -5,12 +5,15 @@ import ArticleTopic from "./article-topic";
 import styles from "./styles";
 
 const { style: ViewPropTypesStyle } = ViewPropTypes;
+const MAX_TOPICS = 5;
 
 const ArticleTopics = ({ topics, style, onPress }) => (
   <View style={[styles.topicGroup, style]}>
-    {topics.map(({ name, slug }) => (
-      <ArticleTopic key={slug} slug={slug} name={name} onPress={onPress} />
-    ))}
+    {topics
+      .slice(0, MAX_TOPICS)
+      .map(({ name, slug }) => (
+        <ArticleTopic key={slug} slug={slug} name={name} onPress={onPress} />
+      ))}
   </View>
 );
 


### PR DESCRIPTION
On an article, the maximum number of Article Topics shown can be 5. This enforces this.