### PR TITLE
Fix apollo-client import for storybooks

### DIFF
--- a/packages/provider-test-tools/src/mocked-provider.js
+++ b/packages/provider-test-tools/src/mocked-provider.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import ApolloClient from "apollo-client";
+import { ApolloClient } from "apollo-client";
 import { ApolloLink } from "apollo-link";
 import { ApolloProvider } from "react-apollo";
 import { MockLink } from "react-apollo/test-utils";


### PR DESCRIPTION
Storybooks are broken due to an import issue with MockedProviders.