### PR TITLE
Fix webpack version in test utils

### DIFF
--- a/packages/test-utils/.eslintignore
+++ b/packages/test-utils/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 **/coverage/*
 dist
+rnw.js

--- a/packages/test-utils/.prettierignore
+++ b/packages/test-utils/.prettierignore
@@ -11,3 +11,4 @@ CHANGELOG.md
 LICENSE
 yarn.lock
 *.log
+rnw.js

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -44,7 +44,9 @@
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.4.0",
     "jest": "21.2.1",
-    "prettier": "1.8.2"
+    "prettier": "1.8.2",
+    "webpack": "4.6.0",
+    "webpack-cli": "2.1.4"
   },
   "dependencies": {
     "@times-components/jest-configurator": "1.0.8",


### PR DESCRIPTION
CI is broken right now due to a webpack version ambiguity. Added webpack and webpack-cli to test-utils package, and updated lint ignore files