### PR TITLE
Set native packages as private and exclude assets from linting

### DIFF
--- a/android-app/.prettierignore
+++ b/android-app/.prettierignore
@@ -21,3 +21,4 @@ settings.gradle
 publish.sh
 gradle.properties
 build.gradle
+build/

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -25,5 +25,6 @@
     "haul": "1.0.0-rc.4",
     "prettier": "1.8.2",
     "webpack": "4.6.0"
-  }
+  },
+  "private": true
 }

--- a/ios-app/.prettierignore
+++ b/ios-app/.prettierignore
@@ -13,3 +13,4 @@ yarn.lock
 *.log
 rnw.js
 haul.config.js
+assets/

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -22,5 +22,6 @@
     "haul": "1.0.0-rc.4",
     "prettier": "1.8.2",
     "webpack": "4.6.0"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
CI is failing trying to publish android-app and ios-app packages. I've set them to private as they don't need to be published to npm.

Also added build and assets to prettierignore to exclude build artifacts from linting