### PR TITLE
refactor: markup renderer

### DIFF
--- a/packages/markup/README.md
+++ b/packages/markup/README.md
@@ -1,6 +1,52 @@
-# Markup Component
+# Markup
 
-This component renders out markup trees into react components.
+This component renders out markup Abstrat Syntax Trees (AST) into components.
+The `renderTree` method takes AST data as the first argument, and an override
+renderer object as the second argument. Markup has a set of default renderers it
+uses for common AST nodes such as `paragraph`, `text` or `link`. In the override
+renderer that a consumer would set, the consumer dictates how these nodes are
+handled. Each renderer method should return an object with an `element` property
+(that returns the component to be rendered), and a optional
+`shouldIgnoreChildren` boolean that can ensure the renderer does not render
+certain node's children.
+
+## Contributing
+
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before contributing to this
+package
+
+## Running the code
+
+Please see our main [README.md](../README.md) to get the project running locally
+
+## Development
+
+The code can be formatted and linted in accordance with the agreed standards.
+
+```
+yarn fmt
+yarn lint
+```
+
+## Testing
+
+Testing can be done on each platform individually
+
+```
+yarn test:android
+yarn test:ios
+yarn test:web
+```
+
+Or the tests for all platforms can be run
+
+```
+yarn test:all
+```
+
+Visit the official
+[storybook](http://components.thetimes.co.uk/?knob-Size%20of%20ad%20placeholder%3A=default&selectedKind=Composed%2FMarkup&selectedStory=Multiple%20paragraphs&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
+to see our available markup templates.
 
 ## How to use
 
@@ -54,13 +100,15 @@ const tree = {
 
 const renderers = {
   fancyThing(key, attributes, renderedChildren) {
-    return (
-      <View key={key} style={{ backgroundColor: attributes.backgroundColor }}>
-        <Text style={{ color: "green" }}>
-          {renderedChildren}
-        </Text>
-      </View>
-    );
+    return {
+      element: (
+        <View key={key} style={{ backgroundColor: attributes.backgroundColor }}>
+          <Text style={{ color: "green" }}>
+            {renderedChildren}
+          </Text>
+        </View>
+      )
+    };
   }
 }
 
@@ -77,7 +125,7 @@ const element = renderTree(tree, renderers)
 an array of trees into an array of react elements.
 
 ```js
-import { renderTree } from "@times-components/markup";
+import { renderTrees } from "@times-components/markup";
 
 const trees = [
   {

--- a/packages/markup/README.md
+++ b/packages/markup/README.md
@@ -1,13 +1,6 @@
 # Markup
 
-This component renders out markup Abstrat Syntax Trees (AST) into components.
-The `renderTree` method takes AST data as the first argument, and an override
-renderer object as the second argument. Markup has a set of default renderers it
-uses for common AST nodes such as `paragraph`, `text` or `link`. In the override
-renderer that a consumer would set, the consumer dictates how these nodes are
-handled. Each renderer method should return an object with an `element` property
-(the component to be rendered), and a optional `shouldRenderChildren` boolean
-that can ensure the renderer does not render that node's children.
+This package is for core rendering of components such `paragraph`, `text` or `link`. Consumers provide Abstrat Syntax Tree (AST) data which `markup` iterates over and renders with default `renderer` functions that dictate how the nodes of the AST are rendered. Consumers can override these default `renderers` by providing their own.
 
 ## Contributing
 
@@ -48,6 +41,9 @@ Visit the official
 to see our available markup templates.
 
 ## How to use
+
+The exported `renderTree` and `renderTrees` methods take AST data as the first argument, and an optional overriding renderer object as the second argument. The provided `renderer` methods should follow the pattern set out in the default `renderers`. Each method should return an object with an `element` property (the component to be rendered), and a optional `shouldRenderChildren` boolean
+that can ensure the renderer does not render that node's children.
 
 ```js
 import { renderTree } from "@times-components/markup";

--- a/packages/markup/README.md
+++ b/packages/markup/README.md
@@ -6,9 +6,8 @@ renderer object as the second argument. Markup has a set of default renderers it
 uses for common AST nodes such as `paragraph`, `text` or `link`. In the override
 renderer that a consumer would set, the consumer dictates how these nodes are
 handled. Each renderer method should return an object with an `element` property
-(that returns the component to be rendered), and a optional
-`shouldRenderChildren` boolean that can ensure the renderer does not render
-certain node's children.
+(the component to be rendered), and a optional `shouldRenderChildren` boolean
+that can ensure the renderer does not render that node's children.
 
 ## Contributing
 

--- a/packages/markup/README.md
+++ b/packages/markup/README.md
@@ -7,7 +7,7 @@ uses for common AST nodes such as `paragraph`, `text` or `link`. In the override
 renderer that a consumer would set, the consumer dictates how these nodes are
 handled. Each renderer method should return an object with an `element` property
 (that returns the component to be rendered), and a optional
-`shouldIgnoreChildren` boolean that can ensure the renderer does not render
+`shouldRenderChildren` boolean that can ensure the renderer does not render
 certain node's children.
 
 ## Contributing

--- a/packages/markup/README.md
+++ b/packages/markup/README.md
@@ -1,6 +1,10 @@
 # Markup
 
-This package is for core rendering of components such `paragraph`, `text` or `link`. Consumers provide Abstrat Syntax Tree (AST) data which `markup` iterates over and renders with default `renderer` functions that dictate how the nodes of the AST are rendered. Consumers can override these default `renderers` by providing their own.
+This package is for core rendering of components such `paragraph`, `text` or
+`link`. Consumers provide Abstrat Syntax Tree (AST) data which `markup` iterates
+over and renders with default `renderer` functions that dictate how the nodes of
+the AST are rendered. Consumers can override these default `renderers` by
+providing their own.
 
 ## Contributing
 
@@ -42,8 +46,12 @@ to see our available markup templates.
 
 ## How to use
 
-The exported `renderTree` and `renderTrees` methods take AST data as the first argument, and an optional overriding renderer object as the second argument. The provided `renderer` methods should follow the pattern set out in the default `renderers`. Each method should return an object with an `element` property (the component to be rendered), and a optional `shouldRenderChildren` boolean
-that can ensure the renderer does not render that node's children.
+The exported `renderTree` and `renderTrees` methods take AST data as the first
+argument, and an optional overriding renderer object as the second argument. The
+provided `renderer` methods should follow the pattern set out in the default
+`renderers`. Each method should return an object with an `element` property (the
+component to be rendered), and a optional `shouldRenderChildren` boolean that
+can ensure the renderer does not render that node's children.
 
 ```js
 import { renderTree } from "@times-components/markup";

--- a/packages/markup/__tests__/android/__snapshots__/markup-ad.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup-ad.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders multiple paragraphs with ads 1`] = `
+exports[`multiple paragraphs with ads 1`] = `
 <View>
   <Text>
     This is the text for paragraph one

--- a/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders a single paragraph 1`] = `
+exports[`1. single paragraph 1`] = `
 <Text>
   This is the text for paragraph one
 </Text>
 `;
 
-exports[`2. renders multiple paragraphs 1`] = `
+exports[`2. multiple paragraphs 1`] = `
 <View>
   <Text>
     This is the text for paragraph one
@@ -17,7 +17,7 @@ exports[`2. renders multiple paragraphs 1`] = `
 </View>
 `;
 
-exports[`3. renders multiple paragraphs with a pull quote 1`] = `
+exports[`3. multiple paragraphs with a pull quote 1`] = `
 <View>
   <Text>
     This is the text for paragraph one
@@ -53,7 +53,7 @@ exports[`3. renders multiple paragraphs with a pull quote 1`] = `
 </View>
 `;
 
-exports[`4. renders the bold tag 1`] = `
+exports[`4. bold tag 1`] = `
 <Text
   style={
     Object {
@@ -65,7 +65,7 @@ exports[`4. renders the bold tag 1`] = `
 </Text>
 `;
 
-exports[`5. renders the italic tag 1`] = `
+exports[`5. italic tag 1`] = `
 <Text
   style={
     Object {
@@ -77,20 +77,20 @@ exports[`5. renders the italic tag 1`] = `
 </Text>
 `;
 
-exports[`6. renders the span tag 1`] = `
+exports[`6. span tag 1`] = `
 <Text>
   some other text here
 </Text>
 `;
 
-exports[`7. renders the line break tag 1`] = `
+exports[`7. line break tag 1`] = `
 <Text>
   
 
 </Text>
 `;
 
-exports[`8. renders a mixture of tags 1`] = `
+exports[`8. mixture of tags 1`] = `
 <View>
   <View>
     <Text>
@@ -127,7 +127,7 @@ exports[`8. renders a mixture of tags 1`] = `
 </View>
 `;
 
-exports[`9. renders tags nested 1`] = `
+exports[`9. nested tags 1`] = `
 <Text>
   Some text is here 
   <Text>
@@ -144,7 +144,7 @@ exports[`9. renders tags nested 1`] = `
 </Text>
 `;
 
-exports[`10. renders wrapped tags 1`] = `
+exports[`10. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -170,18 +170,29 @@ exports[`10. renders wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`11. renders multiple children 1`] = `
+exports[`11. multiple children 1`] = `
 <Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
   style={
     Object {
       "color": "red",
     }
   }
 >
-  <Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
     This is the text for paragraph one
   </Text>
-  <Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
     This is the text for paragraph two
   </Text>
 </Text>
@@ -189,4 +200,4 @@ exports[`11. renders multiple children 1`] = `
 
 exports[`12. does not render a script tag 1`] = `<View />`;
 
-exports[`13. does not render an image tag 1`] = `<View />`;
+exports[`13. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
@@ -211,7 +211,36 @@ exports[`12. provide ast of node for child 1`] = `
 </View>
 `;
 
-exports[`13. wrapped tags 1`] = `
+exports[`13. provide empty children 1`] = `
+<View>
+  <Text>
+    0
+  </Text>
+  <View>
+    <Text>
+      0
+    </Text>
+    <View>
+      <Text>
+        0
+      </Text>
+      <Text>
+        <Text>
+          0
+        </Text>
+      </Text>
+    </View>
+    <Text>
+      0
+    </Text>
+  </View>
+  <Text>
+    0
+  </Text>
+</View>
+`;
+
+exports[`14. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -237,7 +266,7 @@ exports[`13. wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`14. multiple children 1`] = `
+exports[`15. multiple children 1`] = `
 <Text
   style={
     Object {
@@ -254,6 +283,6 @@ exports[`14. multiple children 1`] = `
 </Text>
 `;
 
-exports[`15. does not render a script tag 1`] = `<View />`;
+exports[`16. does not render a script tag 1`] = `<View />`;
 
-exports[`16. image tag 1`] = `<View />`;
+exports[`17. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
@@ -144,9 +144,74 @@ exports[`9. nested tags 1`] = `
 </Text>
 `;
 
-exports[`10. ignore children of nested tags 1`] = `<Text />`;
+exports[`10. ignore children of nested tags 1`] = `
+<View>
+  Some text is here 
+  <View>
+    and there is some 
+    <View>
+      more text 
+      <Text>
+        and in here
+      </Text>
+    </View>
+    <Text />
+     after it too
+  </View>
+   and here
+</View>
+`;
 
-exports[`11. wrapped tags 1`] = `
+exports[`11. provide ast of node 1`] = `
+<View>
+  Some text is here 
+  <View>
+    and there is some 
+    <View>
+      more text 
+      <Text>
+        and in here
+      </Text>
+    </View>
+    <Text>
+      special: {"name":"specialElement","attributes":{},"children":[{"name":"text","attributes":{"value":"text of a special element"},"children":[]},{"name":"inline","attributes":{},"children":[{"name":"text","attributes":{"value":"inline text of a special element"},"children":[]}]}]}
+    </Text>
+     after it too
+  </View>
+   and here
+</View>
+`;
+
+exports[`12. provide ast of node for child 1`] = `
+<View>
+  <Text>
+    special: {"name":"text","attributes":{"value":"Some text is here "},"children":[]}
+  </Text>
+  <View>
+    <Text>
+      special: {"name":"text","attributes":{"value":"and there is some "},"children":[]}
+    </Text>
+    <View>
+      <Text>
+        special: {"name":"text","attributes":{"value":"more text "},"children":[]}
+      </Text>
+      <Text>
+        <Text>
+          special: {"name":"text","attributes":{"value":"and in here"},"children":[]}
+        </Text>
+      </Text>
+    </View>
+    <Text>
+      special: {"name":"text","attributes":{"value":" after it too"},"children":[]}
+    </Text>
+  </View>
+  <Text>
+    special: {"name":"text","attributes":{"value":" and here"},"children":[]}
+  </Text>
+</View>
+`;
+
+exports[`13. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -172,7 +237,7 @@ exports[`11. wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`12. multiple children 1`] = `
+exports[`14. multiple children 1`] = `
 <Text
   style={
     Object {
@@ -189,6 +254,6 @@ exports[`12. multiple children 1`] = `
 </Text>
 `;
 
-exports[`13. does not render a script tag 1`] = `<View />`;
+exports[`15. does not render a script tag 1`] = `<View />`;
 
-exports[`14. image tag 1`] = `<View />`;
+exports[`16. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
@@ -144,7 +144,9 @@ exports[`9. nested tags 1`] = `
 </Text>
 `;
 
-exports[`10. wrapped tags 1`] = `
+exports[`10. ignore children of nested tags 1`] = `<Text />`;
+
+exports[`11. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -170,34 +172,23 @@ exports[`10. wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`11. multiple children 1`] = `
+exports[`12. multiple children 1`] = `
 <Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
   style={
     Object {
       "color": "red",
     }
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
     This is the text for paragraph one
   </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
     This is the text for paragraph two
   </Text>
 </Text>
 `;
 
-exports[`12. does not render a script tag 1`] = `<View />`;
+exports[`13. does not render a script tag 1`] = `<View />`;
 
-exports[`13. image tag 1`] = `<View />`;
+exports[`14. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/android/markup-ad.android.test.js
+++ b/packages/markup/__tests__/android/markup-ad.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-ad.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/markup/__tests__/android/markup.android.test.js
+++ b/packages/markup/__tests__/android/markup.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/markup/__tests__/ios/__snapshots__/markup-ad.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup-ad.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders multiple paragraphs with ads 1`] = `
+exports[`multiple paragraphs with ads 1`] = `
 <View>
   <Text>
     This is the text for paragraph one

--- a/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders a single paragraph 1`] = `
+exports[`1. single paragraph 1`] = `
 <Text>
   This is the text for paragraph one
 </Text>
 `;
 
-exports[`2. renders multiple paragraphs 1`] = `
+exports[`2. multiple paragraphs 1`] = `
 <View>
   <Text>
     This is the text for paragraph one
@@ -17,7 +17,7 @@ exports[`2. renders multiple paragraphs 1`] = `
 </View>
 `;
 
-exports[`3. renders multiple paragraphs with a pull quote 1`] = `
+exports[`3. multiple paragraphs with a pull quote 1`] = `
 <View>
   <Text>
     This is the text for paragraph one
@@ -53,7 +53,7 @@ exports[`3. renders multiple paragraphs with a pull quote 1`] = `
 </View>
 `;
 
-exports[`4. renders the bold tag 1`] = `
+exports[`4. bold tag 1`] = `
 <Text
   style={
     Object {
@@ -65,7 +65,7 @@ exports[`4. renders the bold tag 1`] = `
 </Text>
 `;
 
-exports[`5. renders the italic tag 1`] = `
+exports[`5. italic tag 1`] = `
 <Text
   style={
     Object {
@@ -77,20 +77,20 @@ exports[`5. renders the italic tag 1`] = `
 </Text>
 `;
 
-exports[`6. renders the span tag 1`] = `
+exports[`6. span tag 1`] = `
 <Text>
   some other text here
 </Text>
 `;
 
-exports[`7. renders the line break tag 1`] = `
+exports[`7. line break tag 1`] = `
 <Text>
   
 
 </Text>
 `;
 
-exports[`8. renders a mixture of tags 1`] = `
+exports[`8. mixture of tags 1`] = `
 <View>
   <View>
     <Text>
@@ -127,7 +127,7 @@ exports[`8. renders a mixture of tags 1`] = `
 </View>
 `;
 
-exports[`9. renders tags nested 1`] = `
+exports[`9. nested tags 1`] = `
 <Text>
   Some text is here 
   <Text>
@@ -144,7 +144,7 @@ exports[`9. renders tags nested 1`] = `
 </Text>
 `;
 
-exports[`10. renders wrapped tags 1`] = `
+exports[`10. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -170,18 +170,29 @@ exports[`10. renders wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`11. renders multiple children 1`] = `
+exports[`11. multiple children 1`] = `
 <Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
   style={
     Object {
       "color": "red",
     }
   }
 >
-  <Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
     This is the text for paragraph one
   </Text>
-  <Text>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+  >
     This is the text for paragraph two
   </Text>
 </Text>
@@ -189,4 +200,4 @@ exports[`11. renders multiple children 1`] = `
 
 exports[`12. does not render a script tag 1`] = `<View />`;
 
-exports[`13. does not render an image tag 1`] = `<View />`;
+exports[`13. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
@@ -211,7 +211,36 @@ exports[`12. provide ast of node for child 1`] = `
 </View>
 `;
 
-exports[`13. wrapped tags 1`] = `
+exports[`13. provide empty children 1`] = `
+<View>
+  <Text>
+    0
+  </Text>
+  <View>
+    <Text>
+      0
+    </Text>
+    <View>
+      <Text>
+        0
+      </Text>
+      <Text>
+        <Text>
+          0
+        </Text>
+      </Text>
+    </View>
+    <Text>
+      0
+    </Text>
+  </View>
+  <Text>
+    0
+  </Text>
+</View>
+`;
+
+exports[`14. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -237,7 +266,7 @@ exports[`13. wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`14. multiple children 1`] = `
+exports[`15. multiple children 1`] = `
 <Text
   style={
     Object {
@@ -254,6 +283,6 @@ exports[`14. multiple children 1`] = `
 </Text>
 `;
 
-exports[`15. does not render a script tag 1`] = `<View />`;
+exports[`16. does not render a script tag 1`] = `<View />`;
 
-exports[`16. image tag 1`] = `<View />`;
+exports[`17. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
@@ -144,9 +144,74 @@ exports[`9. nested tags 1`] = `
 </Text>
 `;
 
-exports[`10. ignore children of nested tags 1`] = `<Text />`;
+exports[`10. ignore children of nested tags 1`] = `
+<View>
+  Some text is here 
+  <View>
+    and there is some 
+    <View>
+      more text 
+      <Text>
+        and in here
+      </Text>
+    </View>
+    <Text />
+     after it too
+  </View>
+   and here
+</View>
+`;
 
-exports[`11. wrapped tags 1`] = `
+exports[`11. provide ast of node 1`] = `
+<View>
+  Some text is here 
+  <View>
+    and there is some 
+    <View>
+      more text 
+      <Text>
+        and in here
+      </Text>
+    </View>
+    <Text>
+      special: {"name":"specialElement","attributes":{},"children":[{"name":"text","attributes":{"value":"text of a special element"},"children":[]},{"name":"inline","attributes":{},"children":[{"name":"text","attributes":{"value":"inline text of a special element"},"children":[]}]}]}
+    </Text>
+     after it too
+  </View>
+   and here
+</View>
+`;
+
+exports[`12. provide ast of node for child 1`] = `
+<View>
+  <Text>
+    special: {"name":"text","attributes":{"value":"Some text is here "},"children":[]}
+  </Text>
+  <View>
+    <Text>
+      special: {"name":"text","attributes":{"value":"and there is some "},"children":[]}
+    </Text>
+    <View>
+      <Text>
+        special: {"name":"text","attributes":{"value":"more text "},"children":[]}
+      </Text>
+      <Text>
+        <Text>
+          special: {"name":"text","attributes":{"value":"and in here"},"children":[]}
+        </Text>
+      </Text>
+    </View>
+    <Text>
+      special: {"name":"text","attributes":{"value":" after it too"},"children":[]}
+    </Text>
+  </View>
+  <Text>
+    special: {"name":"text","attributes":{"value":" and here"},"children":[]}
+  </Text>
+</View>
+`;
+
+exports[`13. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -172,7 +237,7 @@ exports[`11. wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`12. multiple children 1`] = `
+exports[`14. multiple children 1`] = `
 <Text
   style={
     Object {
@@ -189,6 +254,6 @@ exports[`12. multiple children 1`] = `
 </Text>
 `;
 
-exports[`13. does not render a script tag 1`] = `<View />`;
+exports[`15. does not render a script tag 1`] = `<View />`;
 
-exports[`14. image tag 1`] = `<View />`;
+exports[`16. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
@@ -144,7 +144,9 @@ exports[`9. nested tags 1`] = `
 </Text>
 `;
 
-exports[`10. wrapped tags 1`] = `
+exports[`10. ignore children of nested tags 1`] = `<Text />`;
+
+exports[`11. wrapped tags 1`] = `
 <Text>
   Camilla Long is 
   <Text
@@ -170,34 +172,23 @@ exports[`10. wrapped tags 1`] = `
 </Text>
 `;
 
-exports[`11. multiple children 1`] = `
+exports[`12. multiple children 1`] = `
 <Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
   style={
     Object {
       "color": "red",
     }
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
     This is the text for paragraph one
   </Text>
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-  >
+  <Text>
     This is the text for paragraph two
   </Text>
 </Text>
 `;
 
-exports[`12. does not render a script tag 1`] = `<View />`;
+exports[`13. does not render a script tag 1`] = `<View />`;
 
-exports[`13. image tag 1`] = `<View />`;
+exports[`14. image tag 1`] = `<View />`;

--- a/packages/markup/__tests__/ios/markup-ad.ios.test.js
+++ b/packages/markup/__tests__/ios/markup-ad.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-ad.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/markup/__tests__/ios/markup.ios.test.js
+++ b/packages/markup/__tests__/ios/markup.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/markup/__tests__/shared-ad.base.js
+++ b/packages/markup/__tests__/shared-ad.base.js
@@ -5,13 +5,11 @@ import { renderTrees } from "../src/markup";
 const multiParagraphWithAds = require("../fixtures/multi-paragraph-with-ads.json");
 
 export default renderComponent => {
-  it("renders multiple paragraphs with ads", () => {
+  it("multiple paragraphs with ads", () => {
     const testInstance = renderComponent(
       <View>{renderTrees(multiParagraphWithAds)}</View>
     );
 
-    expect(testInstance).toMatchSnapshot(
-      "1. renders multiple paragraphs with ads"
-    );
+    expect(testInstance).toMatchSnapshot();
   });
 };

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -184,9 +184,7 @@ export default renderComponent => {
           renderTree(nested, {
             text(key, attributes, renderedChildren) {
               return {
-                element: (
-                  <Text key={key}>{renderedChildren.length}</Text>
-                )
+                element: <Text key={key}>{renderedChildren.length}</Text>
               };
             }
           })

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -128,10 +128,47 @@ export default renderComponent => {
       test: () => {
         const output = renderComponent(
           renderTree(nested, {
-            block(key, attributes, renderedChildren) {
+            specialElement(key, attributes, renderedChildren) {
               return {
                 element: <Text key={key}>{renderedChildren}</Text>,
                 shouldRenderChildren: false
+              };
+            }
+          })
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "provide AST of node",
+      test: () => {
+        const output = renderComponent(
+          renderTree(nested, {
+            specialElement(key, attributes, renderedChildren, indx, node) {
+              return {
+                element: (
+                  <Text key={key}>{`special: ${JSON.stringify(node)}`}</Text>
+                ),
+                shouldRenderChildren: false
+              };
+            }
+          })
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "provide AST of node for child",
+      test: () => {
+        const output = renderComponent(
+          renderTree(nested, {
+            text(key, attributes, renderedChildren, indx, node) {
+              return {
+                element: (
+                  <Text key={key}>{`special: ${JSON.stringify(node)}`}</Text>
+                )
               };
             }
           })

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Text, View } from "react-native";
+import { iterator } from "@times-components/test-utils";
 import { renderTree, renderTrees } from "../src/markup";
 import multiParagraphWithPullQuote from "../fixtures/multi-paragraph-with-pullquote";
 
@@ -16,116 +17,147 @@ const script = require("../fixtures/script.json");
 const image = require("../fixtures/image.json");
 
 export default renderComponent => {
-  it("renders a single paragraph", () => {
-    const output = renderComponent(renderTree(singleParagraph));
+  const tests = [
+    {
+      name: "single paragraph",
+      test: () => {
+        const output = renderComponent(renderTree(singleParagraph));
 
-    expect(output).toMatchSnapshot("1. renders a single paragraph");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "multiple paragraphs",
+      test: () => {
+        const output = renderComponent(
+          <View>{renderTrees(multiParagraph)}</View>
+        );
 
-  it("renders multiple paragraphs", () => {
-    const output = renderComponent(<View>{renderTrees(multiParagraph)}</View>);
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "multiple paragraphs with a pull quote",
+      test: () => {
+        const output = renderComponent(
+          <View>
+            {renderTrees(
+              multiParagraphWithPullQuote({ pullQuote: "Some pull quote" })
+            )}
+          </View>
+        );
 
-    expect(output).toMatchSnapshot("2. renders multiple paragraphs");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "bold tag",
+      test: () => {
+        const output = renderComponent(renderTree(bold));
 
-  it("renders multiple paragraphs with a pull quote", () => {
-    const output = renderComponent(
-      <View>
-        {renderTrees(
-          multiParagraphWithPullQuote({ pullQuote: "Some pull quote" })
-        )}
-      </View>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "italic tag",
+      test: () => {
+        const output = renderComponent(renderTree(italic));
 
-    expect(output).toMatchSnapshot(
-      "3. renders multiple paragraphs with a pull quote"
-    );
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "span tag",
+      test: () => {
+        const output = renderComponent(renderTree(span));
 
-  it("renders the bold tag", () => {
-    const output = renderComponent(renderTree(bold));
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "line break tag",
+      test: () => {
+        const output = renderComponent(renderTree(lineBreak));
 
-    expect(output).toMatchSnapshot("4. renders the bold tag");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "mixture of tags",
+      test: () => {
+        const output = renderComponent(
+          renderTree(mixture, {
+            block(key, attributes, renderedChildren) {
+              return {
+                element: <View key={key}>{renderedChildren}</View>
+              };
+            },
+            link(key, attributes, renderedChildren) {
+              return {
+                element: (
+                  <Text href={attributes.href} key={key}>
+                    {renderedChildren}
+                  </Text>
+                )
+              };
+            }
+          })
+        );
 
-  it("renders the italic tag", () => {
-    const output = renderComponent(renderTree(italic));
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "nested tags",
+      test: () => {
+        const output = renderComponent(
+          renderTree(nested, {
+            block(key, attributes, renderedChildren) {
+              return {
+                element: <Text key={key}>{renderedChildren}</Text>
+              };
+            }
+          })
+        );
 
-    expect(output).toMatchSnapshot("5. renders the italic tag");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "wrapped tags",
+      test: () => {
+        const output = renderComponent(<Text>{renderTrees(bio)}</Text>);
 
-  it("renders the span tag", () => {
-    const output = renderComponent(renderTree(span));
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "multiple children",
+      test: () => {
+        const output = (
+          <Text style={{ color: "red" }}>{renderTrees(multiParagraph)}</Text>
+        );
 
-    expect(output).toMatchSnapshot("6. renders the span tag");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "does not render a script tag",
+      test: () => {
+        const output = renderComponent(<View>{renderTrees(script)}</View>);
 
-  it("renders the line break tag", () => {
-    const output = renderComponent(renderTree(lineBreak));
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "image tag",
+      test: () => {
+        const output = renderComponent(<View>{renderTrees(image)}</View>);
 
-    expect(output).toMatchSnapshot("7. renders the line break tag");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    }
+  ];
 
-  it("renders a mixture of tags", () => {
-    const output = renderComponent(
-      renderTree(mixture, {
-        block(key, attributes, renderedChildren) {
-          return {
-            element: <View key={key}>{renderedChildren}</View>
-          };
-        },
-        link(key, attributes, renderedChildren) {
-          return {
-            element: (
-              <Text href={attributes.href} key={key}>
-                {renderedChildren}
-              </Text>
-            )
-          };
-        }
-      })
-    );
-
-    expect(output).toMatchSnapshot("8. renders a mixture of tags");
-  });
-
-  it("renders tags nested", () => {
-    const output = renderComponent(
-      renderTree(nested, {
-        block(key, attributes, renderedChildren) {
-          return {
-            element: <Text key={key}>{renderedChildren}</Text>
-          };
-        }
-      })
-    );
-
-    expect(output).toMatchSnapshot("9. renders tags nested");
-  });
-
-  it("renders wrapped tags", () => {
-    const output = renderComponent(<Text>{renderTrees(bio)}</Text>);
-
-    expect(output).toMatchSnapshot("10. renders wrapped tags");
-  });
-
-  it("renders multiple children", () => {
-    const output = renderComponent(
-      <Text style={{ color: "red" }}>{renderTrees(multiParagraph)}</Text>
-    );
-
-    expect(output).toMatchSnapshot("11. renders multiple children");
-  });
-
-  it("does not render a script tag", () => {
-    const output = renderComponent(<View>{renderTrees(script)}</View>);
-
-    expect(output).toMatchSnapshot("12. does not render a script tag");
-  });
-
-  it("does not render an image tag", () => {
-    const output = renderComponent(<View>{renderTrees(image)}</View>);
-
-    expect(output).toMatchSnapshot("13. does not render an image tag");
-  });
+  iterator(tests);
 };

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -131,7 +131,7 @@ export default renderComponent => {
             block(key, attributes, renderedChildren) {
               return {
                 element: <Text key={key}>{renderedChildren}</Text>,
-                shouldIgnoreChildren: true
+                shouldRenderChildren: false
               };
             }
           })

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -178,6 +178,24 @@ export default renderComponent => {
       }
     },
     {
+      name: "provide empty children",
+      test: () => {
+        const output = renderComponent(
+          renderTree(nested, {
+            text(key, attributes, renderedChildren) {
+              return {
+                element: (
+                  <Text key={key}>{renderedChildren.length}</Text>
+                )
+              };
+            }
+          })
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
       name: "wrapped tags",
       test: () => {
         const output = renderComponent(<Text>{renderTrees(bio)}</Text>);

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -124,6 +124,23 @@ export default renderComponent => {
       }
     },
     {
+      name: "ignore children of nested tags",
+      test: () => {
+        const output = renderComponent(
+          renderTree(nested, {
+            block(key, attributes, renderedChildren) {
+              return {
+                element: <Text key={key}>{renderedChildren}</Text>,
+                shouldIgnoreChildren: true
+              };
+            }
+          })
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
       name: "wrapped tags",
       test: () => {
         const output = renderComponent(<Text>{renderTrees(bio)}</Text>);
@@ -134,7 +151,7 @@ export default renderComponent => {
     {
       name: "multiple children",
       test: () => {
-        const output = (
+        const output = renderComponent(
           <Text style={{ color: "red" }}>{renderTrees(multiParagraph)}</Text>
         );
 

--- a/packages/markup/__tests__/web/__snapshots__/markup-ad.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup-ad.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders multiple paragraphs with ads 1`] = `
+exports[`multiple paragraphs with ads 1`] = `
 <div>
   <p>
     This is the text for paragraph one

--- a/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
@@ -131,7 +131,9 @@ exports[`9. nested tags 1`] = `
 </div>
 `;
 
-exports[`10. wrapped tags 1`] = `
+exports[`10. ignore children of nested tags 1`] = `<div />`;
+
+exports[`11. wrapped tags 1`] = `
 <div>
   Camilla Long is 
   <em>
@@ -145,13 +147,17 @@ exports[`10. wrapped tags 1`] = `
 </div>
 `;
 
-exports[`11. multiple children 1`] = `
-<Text
-  style={
-    Object {
-      "color": "red",
-    }
-  }
+exports[`12. multiple children 1`] = `
+<style>
+{
+  "IS1": {
+    "color": "red",
+  },
+}
+</style>
+
+<div
+  className="IS1"
 >
   <p>
     This is the text for paragraph one
@@ -159,9 +165,9 @@ exports[`11. multiple children 1`] = `
   <p>
     This is the text for paragraph two
   </p>
-</Text>
+</div>
 `;
 
-exports[`12. does not render a script tag 1`] = `<div />`;
+exports[`13. does not render a script tag 1`] = `<div />`;
 
-exports[`13. image tag 1`] = `<div />`;
+exports[`14. image tag 1`] = `<div />`;

--- a/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
@@ -131,9 +131,74 @@ exports[`9. nested tags 1`] = `
 </div>
 `;
 
-exports[`10. ignore children of nested tags 1`] = `<div />`;
+exports[`10. ignore children of nested tags 1`] = `
+<div>
+  Some text is here 
+  <div>
+    and there is some 
+    <div>
+      more text 
+      <span>
+        and in here
+      </span>
+    </div>
+    <div />
+     after it too
+  </div>
+   and here
+</div>
+`;
 
-exports[`11. wrapped tags 1`] = `
+exports[`11. provide ast of node 1`] = `
+<div>
+  Some text is here 
+  <div>
+    and there is some 
+    <div>
+      more text 
+      <span>
+        and in here
+      </span>
+    </div>
+    <div>
+      special: {"name":"specialElement","attributes":{},"children":[{"name":"text","attributes":{"value":"text of a special element"},"children":[]},{"name":"inline","attributes":{},"children":[{"name":"text","attributes":{"value":"inline text of a special element"},"children":[]}]}]}
+    </div>
+     after it too
+  </div>
+   and here
+</div>
+`;
+
+exports[`12. provide ast of node for child 1`] = `
+<div>
+  <div>
+    special: {"name":"text","attributes":{"value":"Some text is here "},"children":[]}
+  </div>
+  <div>
+    <div>
+      special: {"name":"text","attributes":{"value":"and there is some "},"children":[]}
+    </div>
+    <div>
+      <div>
+        special: {"name":"text","attributes":{"value":"more text "},"children":[]}
+      </div>
+      <span>
+        <div>
+          special: {"name":"text","attributes":{"value":"and in here"},"children":[]}
+        </div>
+      </span>
+    </div>
+    <div>
+      special: {"name":"text","attributes":{"value":" after it too"},"children":[]}
+    </div>
+  </div>
+  <div>
+    special: {"name":"text","attributes":{"value":" and here"},"children":[]}
+  </div>
+</div>
+`;
+
+exports[`13. wrapped tags 1`] = `
 <div>
   Camilla Long is 
   <em>
@@ -147,7 +212,7 @@ exports[`11. wrapped tags 1`] = `
 </div>
 `;
 
-exports[`12. multiple children 1`] = `
+exports[`14. multiple children 1`] = `
 <style>
 {
   "IS1": {
@@ -168,6 +233,6 @@ exports[`12. multiple children 1`] = `
 </div>
 `;
 
-exports[`13. does not render a script tag 1`] = `<div />`;
+exports[`15. does not render a script tag 1`] = `<div />`;
 
-exports[`14. image tag 1`] = `<div />`;
+exports[`16. image tag 1`] = `<div />`;

--- a/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders a single paragraph 1`] = `
+exports[`1. single paragraph 1`] = `
 <p>
   This is the text for paragraph one
 </p>
 `;
 
-exports[`2. renders multiple paragraphs 1`] = `
+exports[`2. multiple paragraphs 1`] = `
 <div>
   <p>
     This is the text for paragraph one
@@ -17,7 +17,7 @@ exports[`2. renders multiple paragraphs 1`] = `
 </div>
 `;
 
-exports[`3. renders multiple paragraphs with a pull quote 1`] = `
+exports[`3. multiple paragraphs with a pull quote 1`] = `
 <style>
 {
   "IS1": {
@@ -67,27 +67,27 @@ exports[`3. renders multiple paragraphs with a pull quote 1`] = `
 </div>
 `;
 
-exports[`4. renders the bold tag 1`] = `
+exports[`4. bold tag 1`] = `
 <strong>
   some text here
 </strong>
 `;
 
-exports[`5. renders the italic tag 1`] = `
+exports[`5. italic tag 1`] = `
 <em>
    some more text here
 </em>
 `;
 
-exports[`6. renders the span tag 1`] = `
+exports[`6. span tag 1`] = `
 <span>
   some other text here
 </span>
 `;
 
-exports[`7. renders the line break tag 1`] = `<br />`;
+exports[`7. line break tag 1`] = `<br />`;
 
-exports[`8. renders a mixture of tags 1`] = `
+exports[`8. mixture of tags 1`] = `
 <div>
   <div>
     <div
@@ -114,7 +114,7 @@ exports[`8. renders a mixture of tags 1`] = `
 </div>
 `;
 
-exports[`9. renders tags nested 1`] = `
+exports[`9. nested tags 1`] = `
 <div>
   Some text is here 
   <span>
@@ -131,7 +131,7 @@ exports[`9. renders tags nested 1`] = `
 </div>
 `;
 
-exports[`10. renders wrapped tags 1`] = `
+exports[`10. wrapped tags 1`] = `
 <div>
   Camilla Long is 
   <em>
@@ -145,17 +145,13 @@ exports[`10. renders wrapped tags 1`] = `
 </div>
 `;
 
-exports[`11. renders multiple children 1`] = `
-<style>
-{
-  "IS1": {
-    "color": "red",
-  },
-}
-</style>
-
-<div
-  className="IS1"
+exports[`11. multiple children 1`] = `
+<Text
+  style={
+    Object {
+      "color": "red",
+    }
+  }
 >
   <p>
     This is the text for paragraph one
@@ -163,9 +159,9 @@ exports[`11. renders multiple children 1`] = `
   <p>
     This is the text for paragraph two
   </p>
-</div>
+</Text>
 `;
 
 exports[`12. does not render a script tag 1`] = `<div />`;
 
-exports[`13. does not render an image tag 1`] = `<div />`;
+exports[`13. image tag 1`] = `<div />`;

--- a/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
@@ -198,7 +198,36 @@ exports[`12. provide ast of node for child 1`] = `
 </div>
 `;
 
-exports[`13. wrapped tags 1`] = `
+exports[`13. provide empty children 1`] = `
+<div>
+  <div>
+    0
+  </div>
+  <div>
+    <div>
+      0
+    </div>
+    <div>
+      <div>
+        0
+      </div>
+      <span>
+        <div>
+          0
+        </div>
+      </span>
+    </div>
+    <div>
+      0
+    </div>
+  </div>
+  <div>
+    0
+  </div>
+</div>
+`;
+
+exports[`14. wrapped tags 1`] = `
 <div>
   Camilla Long is 
   <em>
@@ -212,7 +241,7 @@ exports[`13. wrapped tags 1`] = `
 </div>
 `;
 
-exports[`14. multiple children 1`] = `
+exports[`15. multiple children 1`] = `
 <style>
 {
   "IS1": {
@@ -233,6 +262,6 @@ exports[`14. multiple children 1`] = `
 </div>
 `;
 
-exports[`15. does not render a script tag 1`] = `<div />`;
+exports[`16. does not render a script tag 1`] = `<div />`;
 
-exports[`16. image tag 1`] = `<div />`;
+exports[`17. image tag 1`] = `<div />`;

--- a/packages/markup/__tests__/web/markup-ad.web.test.js
+++ b/packages/markup/__tests__/web/markup-ad.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-ad.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/markup/__tests__/web/markup.web.test.js
+++ b/packages/markup/__tests__/web/markup.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/markup/fixtures/nested.json
+++ b/packages/markup/fixtures/nested.json
@@ -47,6 +47,32 @@
           ]
         },
         {
+          "name": "specialElement",
+          "attributes": {},
+          "children": [
+            {
+              "name": "text",
+              "attributes": {
+                "value": "text of a special element"
+              },
+              "children": []
+            },
+            {
+              "name": "inline",
+              "attributes": {},
+              "children": [
+                {
+                  "name": "text",
+                  "attributes": {
+                    "value": "inline text of a special element"
+                  },
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "text",
           "attributes": {
             "value": " after it too"

--- a/packages/markup/package.json
+++ b/packages/markup/package.json
@@ -39,6 +39,7 @@
     "@times-components/jest-configurator": "1.0.9",
     "@times-components/jest-serializer": "1.0.9",
     "@times-components/storybook": "1.1.6",
+    "@times-components/test-utils": "0.1.2",
     "@times-components/webpack-configurator": "1.0.1",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/markup/src/markup.js
+++ b/packages/markup/src/markup.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, StyleSheet } from "react-native";
+import { Text, StyleSheet, View } from "react-native";
 import Ad from "@times-components/ad";
 import PullQuote from "@times-components/pull-quote";
 import { colours } from "@times-components/styleguide";
@@ -23,14 +23,11 @@ const styles = StyleSheet.create({
 });
 
 const defaultRenderers = {
-  paragraph(key, attributes, renderedChildren) {
+  ad(key, attributes) {
     return {
-      element: <Text key={key}>{renderedChildren}</Text>
-    };
-  },
-  text(key, { value }) {
-    return {
-      element: value
+      element: (
+        <Ad key={key} slotName="inline-ad" style={styles.ad} {...attributes} />
+      )
     };
   },
   bold(key, attributes, renderedChildren) {
@@ -42,6 +39,21 @@ const defaultRenderers = {
       )
     };
   },
+  block(key, attributes, renderedChildren) {
+    return {
+      element: <View key={key}>{renderedChildren}</View>
+    };
+  },
+  break(key) {
+    return {
+      element: <Text key={key}>{"\n"}</Text>
+    };
+  },
+  inline(key, attributes, renderedChildren) {
+    return {
+      element: <Text key={key}>{renderedChildren}</Text>
+    };
+  },
   italic(key, attributes, renderedChildren) {
     return {
       element: (
@@ -51,21 +63,9 @@ const defaultRenderers = {
       )
     };
   },
-  inline(key, attributes, renderedChildren) {
+  paragraph(key, attributes, renderedChildren) {
     return {
       element: <Text key={key}>{renderedChildren}</Text>
-    };
-  },
-  ad(key, attributes) {
-    return {
-      element: (
-        <Ad key={key} slotName="inline-ad" style={styles.ad} {...attributes} />
-      )
-    };
-  },
-  break(key) {
-    return {
-      element: <Text key={key}>{"\n"}</Text>
     };
   },
   pullQuote(key, attributes) {
@@ -78,6 +78,11 @@ const defaultRenderers = {
         />
       )
     };
+  },
+  text(key, { value }) {
+    return {
+      element: value
+    };
   }
 };
 
@@ -85,7 +90,7 @@ export const renderTree = (tree, renderers, index = 0) =>
   renderTreeWithoutDefaults(
     tree,
     Object.assign({}, defaultRenderers, renderers),
-    index ? `${index}` : "",
+    `${index}`,
     index
   );
 

--- a/packages/markup/src/markup.web.js
+++ b/packages/markup/src/markup.web.js
@@ -18,19 +18,26 @@ const styles = StyleSheet.create({
   }
 });
 const defaultRenderers = {
-  paragraph(key, attributes, renderedChildren) {
+  ad(key, attributes) {
     return {
-      element: <p key={key}>{renderedChildren}</p>
+      element: (
+        <Ad key={key} slotName="inline-ad" style={styles.ad} {...attributes} />
+      )
     };
   },
-  text(key, { value }) {
+  block(key, attributes, renderedChildren) {
     return {
-      element: value
+      element: <div key={key}>{renderedChildren}</div>
     };
   },
   bold(key, attributes, renderedChildren) {
     return {
       element: <strong key={key}>{renderedChildren}</strong>
+    };
+  },
+  break(key) {
+    return {
+      element: <br key={key} />
     };
   },
   italic(key, attributes, renderedChildren) {
@@ -43,16 +50,9 @@ const defaultRenderers = {
       element: <span key={key}>{renderedChildren}</span>
     };
   },
-  ad(key, attributes) {
+  paragraph(key, attributes, renderedChildren) {
     return {
-      element: (
-        <Ad key={key} slotName="inline-ad" style={styles.ad} {...attributes} />
-      )
-    };
-  },
-  break(key) {
-    return {
-      element: <br key={key} />
+      element: <p key={key}>{renderedChildren}</p>
     };
   },
   pullQuote(key, attributes) {
@@ -64,6 +64,11 @@ const defaultRenderers = {
           key={key}
         />
       )
+    };
+  },
+  text(key, { value }) {
+    return {
+      element: value
     };
   }
 };

--- a/packages/markup/src/render-tree-without-defaults.js
+++ b/packages/markup/src/render-tree-without-defaults.js
@@ -6,8 +6,9 @@ const renderTree = (tree, renderers, key, indx) => {
   if (!renderer) return null;
 
   const initialResult = renderer(key, attributes);
+  const { element, shouldRenderChildren = true } = initialResult;
 
-  if (initialResult.shouldIgnoreChildren) return initialResult.element;
+  if (!shouldRenderChildren) return element;
 
   const renderedChildren = children.map((child, index) =>
     renderTree(child, renderers, `${key}.${index}`, index)

--- a/packages/markup/src/render-tree-without-defaults.js
+++ b/packages/markup/src/render-tree-without-defaults.js
@@ -5,6 +5,10 @@ const renderTree = (tree, renderers, key, indx) => {
 
   if (!renderer) return null;
 
+  const initialResult = renderer(key, attributes);
+
+  if (initialResult.shouldIgnoreChildren) return initialResult.element;
+
   const renderedChildren = children.map((child, index) =>
     renderTree(child, renderers, `${key}.${index}`, index)
   );

--- a/packages/markup/src/render-tree-without-defaults.js
+++ b/packages/markup/src/render-tree-without-defaults.js
@@ -5,7 +5,7 @@ const renderTree = (tree, renderers, key, indx) => {
 
   if (!renderer) return null;
 
-  const initialResult = renderer(key, attributes);
+  const initialResult = renderer(key, attributes, null, indx, tree);
   const { element, shouldRenderChildren = true } = initialResult;
 
   if (!shouldRenderChildren) return element;
@@ -13,7 +13,9 @@ const renderTree = (tree, renderers, key, indx) => {
   const renderedChildren = children.map((child, index) =>
     renderTree(child, renderers, `${key}.${index}`, index)
   );
-  const result = renderer(key, attributes, renderedChildren, indx);
+  const result = renderer(key, attributes, renderedChildren, indx, tree);
+
   return result.element;
 };
+
 export default renderTree;

--- a/packages/markup/src/render-tree-without-defaults.js
+++ b/packages/markup/src/render-tree-without-defaults.js
@@ -5,7 +5,7 @@ const renderTree = (tree, renderers, key, indx) => {
 
   if (!renderer) return null;
 
-  const initialResult = renderer(key, attributes, null, indx, tree);
+  const initialResult = renderer(key, attributes, [], indx, tree);
   const { element, shouldRenderChildren = true } = initialResult;
 
   if (!shouldRenderChildren) return element;


### PR DESCRIPTION
- extend the `markup` package to ignore child nodes of an AST with a `shouldIgnoreChildren` property - added `ignore children of nested tags` test for this
- add iterator to tests
- amend README