### PR TITLE
fix: replacing react apollo umd due to their issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,12 @@
 {
   "presets": ["react-native"],
   "plugins": [
-    ["flow-react-proptypes", { "ignoreNodeModules": true }],
-    "styled-components",
-    "add-react-displayname"
-  ]
+    [
+      "module-resolver",
+      {
+        "alias": {
+          "react-dom/server": "./node_modules/react-apollo/react-apollo.browser.umd.js"
+        }
+      }
+    ]]
 }


### PR DESCRIPTION
Applying the babel alias to the root level of the project for the fructose app to work (expo and dextrose etc)

