### PR TITLE
test: prepare tests for Jest bump

### DIFF
--- a/packages/ad/__tests__/ad-placeholder-config.shared.js
+++ b/packages/ad/__tests__/ad-placeholder-config.shared.js
@@ -1,27 +1,33 @@
+import { iterator } from "@times-components/test-utils";
 import { calculateViewBox } from "../src/styles";
 
 export default () => {
-  it("should return a small viewBox config", () => {
-    const height = 90;
-    const width = 728;
-    expect(calculateViewBox({ height, width })).toMatchSnapshot(
-      "1. small viewBox config"
-    );
-  });
+  const tests = [
+    {
+      name: "small config",
+      test: () => {
+        const height = 90;
+        const width = 728;
+        expect(calculateViewBox({ height, width })).toMatchSnapshot();
+      }
+    },
+    {
+      name: "mpu config",
+      test: () => {
+        const height = 250;
+        const width = 300;
+        expect(calculateViewBox({ height, width })).toMatchSnapshot();
+      }
+    },
+    {
+      name: "default config",
+      test: () => {
+        const height = 50;
+        const width = 700;
+        expect(calculateViewBox({ height, width })).toMatchSnapshot();
+      }
+    }
+  ];
 
-  it("should return a mpu viewBox config", () => {
-    const height = 250;
-    const width = 300;
-    expect(calculateViewBox({ height, width })).toMatchSnapshot(
-      "2. mpu viewBox config"
-    );
-  });
-
-  it("should return a default viewBox config", () => {
-    const height = 50;
-    const width = 700;
-    expect(calculateViewBox({ height, width })).toMatchSnapshot(
-      "3. default viewBox config"
-    );
-  });
+  iterator(tests);
 };

--- a/packages/ad/__tests__/ad-placeholder-with-style.native.js
+++ b/packages/ad/__tests__/ad-placeholder-with-style.native.js
@@ -17,9 +17,9 @@ export default () => {
     compose(print, minimalNativeTransform, flattenStyleTransform)
   );
 
-  it("should render an advert placeholder", () => {
+  it("advert placeholder", () => {
     const wrapper = shallow(<AdPlaceholder height={300} width={970} />);
 
-    expect(wrapper).toMatchSnapshot("1. advert placeholder");
+    expect(wrapper).toMatchSnapshot();
   });
 };

--- a/packages/ad/__tests__/ad-placeholder.shared.js
+++ b/packages/ad/__tests__/ad-placeholder.shared.js
@@ -21,9 +21,9 @@ export default () => {
     )
   );
 
-  it("should render the advert placeholder", () => {
+  it("advert placeholder", () => {
     const wrapper = shallow(<AdPlaceholder height={300} width={970} />);
 
-    expect(wrapper).toMatchSnapshot("1. advert placeholder");
+    expect(wrapper).toMatchSnapshot();
   });
 };

--- a/packages/ad/__tests__/ad-with-style.native.js
+++ b/packages/ad/__tests__/ad-with-style.native.js
@@ -9,6 +9,7 @@ import {
   minimalNativeTransform,
   print
 } from "@times-components/jest-serializer";
+import { iterator } from "@times-components/test-utils";
 import adInit from "../src/utils/ad-init";
 import adConfig from "../fixtures/article-ad-config.json";
 import Ad, { AdComposer } from "../src/ad";
@@ -43,51 +44,58 @@ export default () => {
     )
   );
 
-  it("should render multiple ad slots", () => {
-    const testInstance = TestRenderer.create(
-      <AdComposer adConfig={adConfig}>
-        <Fragment>
-          <Ad {...props} slotName="header" />
-          <Ad {...props} slotName="pixel" />
-        </Fragment>
-      </AdComposer>
-    );
+  const tests = [
+    {
+      name: "multiple ad slots",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <AdComposer adConfig={adConfig}>
+            <Fragment>
+              <Ad {...props} slotName="header" />
+              <Ad {...props} slotName="pixel" />
+            </Fragment>
+          </AdComposer>
+        );
 
-    const AdComponent = testInstance.root.findAllByType(Ad);
-    AdComponent[0].instance.setAdReady();
-    AdComponent[1].instance.setAdReady();
+        const AdComponent = testInstance.root.findAllByType(Ad);
+        AdComponent[0].instance.setAdReady();
+        AdComponent[1].instance.setAdReady();
 
-    expect(testInstance).toMatchSnapshot("1. multiple adverts");
-  });
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "placeholder when isLoading",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <AdComposer adConfig={adConfig}>
+            <Fragment>
+              <Ad {...props} isLoading slotName="header" />
+            </Fragment>
+          </AdComposer>
+        );
 
-  it("should render only the placeholder when isLoading", () => {
-    const testInstance = TestRenderer.create(
-      <AdComposer adConfig={adConfig}>
-        <Fragment>
-          <Ad {...props} isLoading slotName="header" />
-        </Fragment>
-      </AdComposer>
-    );
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "return null if there is an error in the loading of scripts",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <AdComposer adConfig={adConfig}>
+            <Fragment>
+              <Ad {...props} slotName="header" />
+            </Fragment>
+          </AdComposer>
+        );
 
-    expect(testInstance).toMatchSnapshot(
-      "2. loading state advert shows placeholder only"
-    );
-  });
+        const AdComponent = testInstance.root.findByType(Ad);
+        AdComponent.instance.setAdError();
 
-  it("should return null if there is an error in the loading of scripts", () => {
-    const testInstance = TestRenderer.create(
-      <AdComposer adConfig={adConfig}>
-        <Fragment>
-          <Ad {...props} slotName="header" />
-        </Fragment>
-      </AdComposer>
-    );
+        expect(testInstance).toMatchSnapshot();
+      }
+    }
+  ];
 
-    const AdComponent = testInstance.root.findByType(Ad);
-    AdComponent.instance.setAdError();
-
-    expect(testInstance).toMatchSnapshot(
-      "3. should not show when loading scripts errored"
-    );
-  });
+  iterator(tests);
 };

--- a/packages/ad/__tests__/ad.native.js
+++ b/packages/ad/__tests__/ad.native.js
@@ -8,6 +8,7 @@ import {
   minimalNativeTransform,
   print
 } from "@times-components/jest-serializer";
+import { iterator } from "@times-components/test-utils";
 import adConfig from "../fixtures/article-ad-config.json";
 import Ad, { AdComposer } from "../src/ad";
 
@@ -25,45 +26,64 @@ export default () => {
   const articleContextURL =
     "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s";
 
-  it("one ad slot", () => {
-    const testInstance = TestRenderer.create(
-      <AdComposer adConfig={adConfig}>
-        <Ad contextUrl={articleContextURL} section="news" slotName="header" />
-      </AdComposer>
-    );
+  const tests = [
+    {
+      name: "one ad slot",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <AdComposer adConfig={adConfig}>
+            <Ad
+              contextUrl={articleContextURL}
+              section="news"
+              slotName="header"
+            />
+          </AdComposer>
+        );
 
-    expect(testInstance).toMatchSnapshot("1. Advert");
-  });
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "two ad slots",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <AdComposer adConfig={adConfig}>
+            <Fragment>
+              <Ad
+                contextUrl={articleContextURL}
+                section="news"
+                slotName="header"
+              />
+              <Ad
+                contextUrl={articleContextURL}
+                section="news"
+                slotName="intervention"
+              />
+            </Fragment>
+          </AdComposer>
+        );
 
-  it("two ad slots", () => {
-    const testInstance = TestRenderer.create(
-      <AdComposer adConfig={adConfig}>
-        <Fragment>
-          <Ad contextUrl={articleContextURL} section="news" slotName="header" />
-          <Ad
-            contextUrl={articleContextURL}
-            section="news"
-            slotName="intervention"
-          />
-        </Fragment>
-      </AdComposer>
-    );
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "ad placeholder when isLoading prop is true",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <AdComposer adConfig={adConfig}>
+            <Ad
+              contextUrl={articleContextURL}
+              isLoading
+              section="news"
+              slotName="header"
+            />
+          </AdComposer>
+        );
 
-    expect(testInstance).toMatchSnapshot("2. Two adverts");
-  });
+        expect(testInstance).toMatchSnapshot();
+      }
+    }
+  ];
 
-  it("ad placeholder when isLoading prop is true", () => {
-    const testInstance = TestRenderer.create(
-      <AdComposer adConfig={adConfig}>
-        <Ad
-          contextUrl={articleContextURL}
-          isLoading
-          section="news"
-          slotName="header"
-        />
-      </AdComposer>
-    );
-
-    expect(testInstance).toMatchSnapshot("3. Advert loading state placeholder");
-  });
+  iterator(tests);
 };

--- a/packages/ad/__tests__/ad.shared.js
+++ b/packages/ad/__tests__/ad.shared.js
@@ -28,7 +28,7 @@ export default () => {
     )
   );
 
-  it("should render an advert", () => {
+  it("advert", () => {
     const wrapper = shallow(
       <AdComposer adConfig={adConfig}>
         <Fragment>
@@ -37,6 +37,6 @@ export default () => {
       </AdComposer>
     );
 
-    expect(wrapper).toMatchSnapshot("1. advert");
+    expect(wrapper).toMatchSnapshot();
   });
 };

--- a/packages/ad/__tests__/android/__snapshots__/ad-placeholder-config.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-placeholder-config.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. small viewBox config 1`] = `
+exports[`1. small config 1`] = `
 Object {
   "marginLeft": 630,
   "marginTop": -120,
@@ -9,7 +9,7 @@ Object {
 }
 `;
 
-exports[`2. mpu viewBox config 1`] = `
+exports[`2. mpu config 1`] = `
 Object {
   "marginLeft": 15,
   "marginTop": 0,
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`3. default viewBox config 1`] = `
+exports[`3. default config 1`] = `
 Object {
   "marginLeft": 50,
   "marginTop": 0,

--- a/packages/ad/__tests__/android/__snapshots__/ad-placeholder-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-placeholder-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert placeholder 1`] = `
+exports[`android advert placeholder 1`] = `
 <View
   style={
     Object {

--- a/packages/ad/__tests__/android/__snapshots__/ad-placeholder-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-placeholder-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android advert placeholder 1`] = `
+exports[`advert placeholder 1`] = `
 <View
   style={
     Object {

--- a/packages/ad/__tests__/android/__snapshots__/ad-placeholder.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-placeholder.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert placeholder 1`] = `
+exports[`android advert placeholder 1`] = `
 <View>
   <View>
     <View>

--- a/packages/ad/__tests__/android/__snapshots__/ad-placeholder.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-placeholder.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android advert placeholder 1`] = `
+exports[`advert placeholder 1`] = `
 <View>
   <View>
     <View>

--- a/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. multiple adverts 1`] = `
+exports[`android 1. multiple ad slots 1`] = `
 Array [
   <View
     className="IS4"
@@ -45,7 +45,7 @@ Array [
 ]
 `;
 
-exports[`2. loading state advert shows placeholder only 1`] = `
+exports[`android 2. placeholder when isloading 1`] = `
 <View
   className="IS2"
 >
@@ -57,4 +57,4 @@ exports[`2. loading state advert shows placeholder only 1`] = `
 </View>
 `;
 
-exports[`3. should not show when loading scripts errored 1`] = `null`;
+exports[`android 3. return null if there is an error in the loading of scripts 1`] = `null`;

--- a/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. multiple ad slots 1`] = `
+exports[`1. multiple ad slots 1`] = `
 Array [
   <View
     className="IS4"
@@ -45,7 +45,7 @@ Array [
 ]
 `;
 
-exports[`android 2. placeholder when isloading 1`] = `
+exports[`2. placeholder when isloading 1`] = `
 <View
   className="IS2"
 >
@@ -57,4 +57,4 @@ exports[`android 2. placeholder when isloading 1`] = `
 </View>
 `;
 
-exports[`android 3. return null if there is an error in the loading of scripts 1`] = `null`;
+exports[`3. return null if there is an error in the loading of scripts 1`] = `null`;

--- a/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert 1`] = `
+exports[`android advert 1`] = `
 <Broadcast
   channel="adConfig"
 >

--- a/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
+++ b/packages/ad/__tests__/android/__snapshots__/ad.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android advert 1`] = `
+exports[`advert 1`] = `
 <Broadcast
   channel="adConfig"
 >

--- a/packages/ad/__tests__/android/ad-placeholder-config.android.test.js
+++ b/packages/ad/__tests__/android/ad-placeholder-config.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder-config.shared";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/android/ad-placeholder-with-style.android.test.js
+++ b/packages/ad/__tests__/android/ad-placeholder-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/android/ad-placeholder.android.test.js
+++ b/packages/ad/__tests__/android/ad-placeholder.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder.shared";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/android/ad-with-style.android.test.js
+++ b/packages/ad/__tests__/android/ad-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/android/ad.android.test.js
+++ b/packages/ad/__tests__/android/ad.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad.shared";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/android/dom-context.android.test.js
+++ b/packages/ad/__tests__/android/dom-context.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../dom-context.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/android/utils.android.test.js
+++ b/packages/ad/__tests__/android/utils.android.test.js
@@ -5,11 +5,9 @@ import sharedAdInitUtils from "../utils/ad-init-utils";
 import sharedGenerateConfig from "../utils/generate-config.shared";
 import sharedPrebidConfig from "../utils/prebid-config";
 
-describe("android", () => {
-  sharedAdInit();
-  sharedAdInitGPT();
-  sharedAdInitPrebid();
-  sharedAdInitUtils();
-  sharedGenerateConfig();
-  sharedPrebidConfig();
-});
+sharedAdInit();
+sharedAdInitGPT();
+sharedAdInitPrebid();
+sharedAdInitUtils();
+sharedGenerateConfig();
+sharedPrebidConfig();

--- a/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-config.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-config.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. small viewBox config 1`] = `
+exports[`1. small config 1`] = `
 Object {
   "marginLeft": 630,
   "marginTop": -120,
@@ -9,7 +9,7 @@ Object {
 }
 `;
 
-exports[`2. mpu viewBox config 1`] = `
+exports[`2. mpu config 1`] = `
 Object {
   "marginLeft": 15,
   "marginTop": 0,
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`3. default viewBox config 1`] = `
+exports[`3. default config 1`] = `
 Object {
   "marginLeft": 50,
   "marginTop": 0,

--- a/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios advert placeholder 1`] = `
+exports[`advert placeholder 1`] = `
 <View
   style={
     Object {

--- a/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-placeholder-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert placeholder 1`] = `
+exports[`ios advert placeholder 1`] = `
 <View
   style={
     Object {

--- a/packages/ad/__tests__/ios/__snapshots__/ad-placeholder.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-placeholder.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert placeholder 1`] = `
+exports[`ios advert placeholder 1`] = `
 <View>
   <View>
     <View>

--- a/packages/ad/__tests__/ios/__snapshots__/ad-placeholder.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-placeholder.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios advert placeholder 1`] = `
+exports[`advert placeholder 1`] = `
 <View>
   <View>
     <View>

--- a/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. multiple ad slots 1`] = `
+exports[`1. multiple ad slots 1`] = `
 Array [
   <View
     className="IS4"
@@ -39,7 +39,7 @@ Array [
 ]
 `;
 
-exports[`ios 2. placeholder when isloading 1`] = `
+exports[`2. placeholder when isloading 1`] = `
 <View
   className="IS2"
 >
@@ -51,4 +51,4 @@ exports[`ios 2. placeholder when isloading 1`] = `
 </View>
 `;
 
-exports[`ios 3. return null if there is an error in the loading of scripts 1`] = `null`;
+exports[`3. return null if there is an error in the loading of scripts 1`] = `null`;

--- a/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. multiple adverts 1`] = `
+exports[`ios 1. multiple ad slots 1`] = `
 Array [
   <View
     className="IS4"
@@ -39,7 +39,7 @@ Array [
 ]
 `;
 
-exports[`2. loading state advert shows placeholder only 1`] = `
+exports[`ios 2. placeholder when isloading 1`] = `
 <View
   className="IS2"
 >
@@ -51,4 +51,4 @@ exports[`2. loading state advert shows placeholder only 1`] = `
 </View>
 `;
 
-exports[`3. should not show when loading scripts errored 1`] = `null`;
+exports[`ios 3. return null if there is an error in the loading of scripts 1`] = `null`;

--- a/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios advert 1`] = `
+exports[`advert 1`] = `
 <Broadcast
   channel="adConfig"
 >

--- a/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
+++ b/packages/ad/__tests__/ios/__snapshots__/ad.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert 1`] = `
+exports[`ios advert 1`] = `
 <Broadcast
   channel="adConfig"
 >

--- a/packages/ad/__tests__/ios/ad-placeholder-config.ios.test.js
+++ b/packages/ad/__tests__/ios/ad-placeholder-config.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder-config.shared";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/ios/ad-placeholder-with-style.ios.test.js
+++ b/packages/ad/__tests__/ios/ad-placeholder-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/ios/ad-placeholder.ios.test.js
+++ b/packages/ad/__tests__/ios/ad-placeholder.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder.shared";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/ios/ad-with-style.ios.test.js
+++ b/packages/ad/__tests__/ios/ad-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/ios/ad.ios.test.js
+++ b/packages/ad/__tests__/ios/ad.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad.shared";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/ios/dom-context.ios.test.js
+++ b/packages/ad/__tests__/ios/dom-context.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../dom-context.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/ios/utils.ios.test.js
+++ b/packages/ad/__tests__/ios/utils.ios.test.js
@@ -5,11 +5,9 @@ import sharedAdInitUtils from "../utils/ad-init-utils";
 import sharedGenerateConfig from "../utils/generate-config.shared";
 import sharedPrebidConfig from "../utils/prebid-config";
 
-describe("ios", () => {
-  sharedAdInit();
-  sharedAdInitGPT();
-  sharedAdInitPrebid();
-  sharedAdInitUtils();
-  sharedGenerateConfig();
-  sharedPrebidConfig();
-});
+sharedAdInit();
+sharedAdInitGPT();
+sharedAdInitPrebid();
+sharedAdInitUtils();
+sharedGenerateConfig();
+sharedPrebidConfig();

--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder-config.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder-config.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. small viewBox config 1`] = `
+exports[`1. small config 1`] = `
 Object {
   "marginLeft": 630,
   "marginTop": -120,
@@ -9,7 +9,7 @@ Object {
 }
 `;
 
-exports[`2. mpu viewBox config 1`] = `
+exports[`2. mpu config 1`] = `
 Object {
   "marginLeft": 15,
   "marginTop": 0,
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`3. default viewBox config 1`] = `
+exports[`3. default config 1`] = `
 Object {
   "marginLeft": 50,
   "marginTop": 0,

--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Advert placeholder 1`] = `
+exports[`advert placeholder 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web advert placeholder 1`] = `
+exports[`advert placeholder 1`] = `
 <View>
   <View>
     <View>

--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert placeholder 1`] = `
+exports[`web advert placeholder 1`] = `
 <View>
   <View>
     <View>

--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. multiple adverts 1`] = `
+exports[`1. multiple ad slots 1`] = `
 <style>
 {
   "IS1": {
@@ -88,7 +88,7 @@ exports[`1. multiple adverts 1`] = `
 </AdComposer>
 `;
 
-exports[`2. loading state advert shows placeholder only 1`] = `
+exports[`2. placeholder when isloading 1`] = `
 <style>
 {
   "IS1": {
@@ -189,7 +189,7 @@ exports[`2. loading state advert shows placeholder only 1`] = `
 </Ad>
 `;
 
-exports[`3. should not show when loading scripts errored 1`] = `
+exports[`3. nothing if there is an error in the loading of scripts 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/ad/__tests__/web/__snapshots__/ad.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web advert 1`] = `
+exports[`advert 1`] = `
 <Broadcast
   channel="adConfig"
 >

--- a/packages/ad/__tests__/web/__snapshots__/ad.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. advert 1`] = `
+exports[`web advert 1`] = `
 <Broadcast
   channel="adConfig"
 >

--- a/packages/ad/__tests__/web/ad-placeholder-config.web.test.js
+++ b/packages/ad/__tests__/web/ad-placeholder-config.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder-config.shared";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/web/ad-placeholder-with-style.web.test.js
+++ b/packages/ad/__tests__/web/ad-placeholder-with-style.web.test.js
@@ -41,27 +41,25 @@ const styles = [
   "zIndex"
 ];
 
-describe("web", () => {
-  addSerializers(
-    expect,
-    enzymeTreeSerializer(),
-    compose(
-      stylePrinter,
-      flattenStyleTransform,
-      hoistStyleTransform,
-      minimalWebTransform,
-      replaceTransform({
-        Watermark: propsNoChildren
-      }),
-      rnwTransform(styles)
-    )
+addSerializers(
+  expect,
+  enzymeTreeSerializer(),
+  compose(
+    stylePrinter,
+    flattenStyleTransform,
+    hoistStyleTransform,
+    minimalWebTransform,
+    replaceTransform({
+      Watermark: propsNoChildren
+    }),
+    rnwTransform(styles)
+  )
+);
+
+it("advert placeholder", () => {
+  const wrapper = mount(
+    <AdPlaceholder height={300} style={style} width={970} />
   );
 
-  it("should render an advert placeholder", () => {
-    const wrapper = mount(
-      <AdPlaceholder height={300} style={style} width={970} />
-    );
-
-    expect(wrapper).toMatchSnapshot("1. Advert placeholder");
-  });
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/ad/__tests__/web/ad-placeholder.web.test.js
+++ b/packages/ad/__tests__/web/ad-placeholder.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad-placeholder.shared";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/ad/__tests__/web/ad.web.test.js
+++ b/packages/ad/__tests__/web/ad.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../ad.shared";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -35,6 +35,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/ad/package.json
+++ b/packages/ad/package.json
@@ -35,7 +35,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-style.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a single author 1`] = `
+exports[`ArticleByline tests on android 1. with a single author 1`] = `
 <View>
   <Text
     style={
@@ -18,7 +18,7 @@ exports[`1. Render a single author 1`] = `
 </View>
 `;
 
-exports[`2. Render a given section colour 1`] = `
+exports[`ArticleByline tests on android 2. with a given section colour 1`] = `
 <View>
   <Text
     style={
@@ -36,7 +36,7 @@ exports[`2. Render a given section colour 1`] = `
 </View>
 `;
 
-exports[`3. Render an author with given styles 1`] = `
+exports[`ArticleByline tests on android 3. with given styles 1`] = `
 <View>
   <Text
     style={

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-style.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleByline tests on android 1. with a single author 1`] = `
+exports[`1. with a single author 1`] = `
 <View>
   <Text
     style={
@@ -18,7 +18,7 @@ exports[`ArticleByline tests on android 1. with a single author 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on android 2. with a given section colour 1`] = `
+exports[`2. with a given section colour 1`] = `
 <View>
   <Text
     style={
@@ -36,7 +36,7 @@ exports[`ArticleByline tests on android 2. with a given section colour 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on android 3. with given styles 1`] = `
+exports[`3. with given styles 1`] = `
 <View>
   <Text
     style={

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a single author 1`] = `
+exports[`ArticleBylineWithLinks tests on android 1. with a single author 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -20,7 +20,7 @@ exports[`1. Render a single author 1`] = `
 </View>
 `;
 
-exports[`2. Render a given section colour 1`] = `
+exports[`ArticleBylineWithLinks tests on android 2. with a given section colour 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -40,7 +40,7 @@ exports[`2. Render a given section colour 1`] = `
 </View>
 `;
 
-exports[`3. Render an author with given styles 1`] = `
+exports[`ArticleBylineWithLinks tests on android 3. with given styles 1`] = `
 <View>
   <Text
     accessibilityRole="link"

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleBylineWithLinks tests on android 1. with a single author 1`] = `
+exports[`1. with a single author 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -20,7 +20,7 @@ exports[`ArticleBylineWithLinks tests on android 1. with a single author 1`] = `
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 2. with a given section colour 1`] = `
+exports[`2. with a given section colour 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -40,7 +40,7 @@ exports[`ArticleBylineWithLinks tests on android 2. with a given section colour 
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 3. with given styles 1`] = `
+exports[`3. with given styles 1`] = `
 <View>
   <Text
     accessibilityRole="link"

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleBylineWithLinks tests on android 1. single inline element 1`] = `
+exports[`1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`ArticleBylineWithLinks tests on android 1. single inline element 1`] = 
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 2. with the author in the begining 1`] = `
+exports[`2. with the author in the begining 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -21,7 +21,7 @@ exports[`ArticleBylineWithLinks tests on android 2. with the author in the begin
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 3. with the author at the end 1`] = `
+exports[`3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -34,7 +34,7 @@ exports[`ArticleBylineWithLinks tests on android 3. with the author at the end 1
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 4. with multiple authors separated by text with commas 1`] = `
+exports[`4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -60,7 +60,7 @@ exports[`ArticleBylineWithLinks tests on android 4. with multiple authors separa
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 5. with multiple authors separated by spaces 1`] = `
+exports[`5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -86,4 +86,4 @@ exports[`ArticleBylineWithLinks tests on android 5. with multiple authors separa
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on android 6. null with an empty ast 1`] = `null`;
+exports[`6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline-with-links.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an inline element 1`] = `
+exports[`ArticleBylineWithLinks tests on android 1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`1. Render an inline element 1`] = `
 </View>
 `;
 
-exports[`2. Render an author first 1`] = `
+exports[`ArticleBylineWithLinks tests on android 2. with the author in the begining 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -21,7 +21,7 @@ exports[`2. Render an author first 1`] = `
 </View>
 `;
 
-exports[`3. Render an author last 1`] = `
+exports[`ArticleBylineWithLinks tests on android 3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -34,7 +34,7 @@ exports[`3. Render an author last 1`] = `
 </View>
 `;
 
-exports[`4. Render multiple authors separated by commas 1`] = `
+exports[`ArticleBylineWithLinks tests on android 4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -60,7 +60,7 @@ exports[`4. Render multiple authors separated by commas 1`] = `
 </View>
 `;
 
-exports[`5. Render multiple authors separated by spaces 1`] = `
+exports[`ArticleBylineWithLinks tests on android 5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -86,4 +86,4 @@ exports[`5. Render multiple authors separated by spaces 1`] = `
 </View>
 `;
 
-exports[`6. Render null when AST is empty 1`] = `null`;
+exports[`ArticleBylineWithLinks tests on android 6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleByline tests on android 1. single inline element 1`] = `
+exports[`1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`ArticleByline tests on android 1. single inline element 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on android 2. with the author in the begining 1`] = `
+exports[`2. with the author in the begining 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -19,7 +19,7 @@ exports[`ArticleByline tests on android 2. with the author in the begining 1`] =
 </View>
 `;
 
-exports[`ArticleByline tests on android 3. with the author at the end 1`] = `
+exports[`3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -30,7 +30,7 @@ exports[`ArticleByline tests on android 3. with the author at the end 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on android 4. with multiple authors separated by text with commas 1`] = `
+exports[`4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -50,7 +50,7 @@ exports[`ArticleByline tests on android 4. with multiple authors separated by te
 </View>
 `;
 
-exports[`ArticleByline tests on android 5. with multiple authors separated by spaces 1`] = `
+exports[`5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -70,4 +70,4 @@ exports[`ArticleByline tests on android 5. with multiple authors separated by sp
 </View>
 `;
 
-exports[`ArticleByline tests on android 6. null with an empty ast 1`] = `null`;
+exports[`6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
+++ b/packages/article-byline/__tests__/android/__snapshots__/article-byline.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an inline element 1`] = `
+exports[`ArticleByline tests on android 1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`1. Render an inline element 1`] = `
 </View>
 `;
 
-exports[`2. Render an author first 1`] = `
+exports[`ArticleByline tests on android 2. with the author in the begining 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -19,7 +19,7 @@ exports[`2. Render an author first 1`] = `
 </View>
 `;
 
-exports[`3. Render an author last 1`] = `
+exports[`ArticleByline tests on android 3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -30,7 +30,7 @@ exports[`3. Render an author last 1`] = `
 </View>
 `;
 
-exports[`4. Render multiple authors separated by commas 1`] = `
+exports[`ArticleByline tests on android 4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -50,7 +50,7 @@ exports[`4. Render multiple authors separated by commas 1`] = `
 </View>
 `;
 
-exports[`5. Render multiple authors separated by spaces 1`] = `
+exports[`ArticleByline tests on android 5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -70,4 +70,4 @@ exports[`5. Render multiple authors separated by spaces 1`] = `
 </View>
 `;
 
-exports[`6. Render null when AST is empty 1`] = `null`;
+exports[`ArticleByline tests on android 6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/android/article-byline-style.android.test.js
+++ b/packages/article-byline/__tests__/android/article-byline-style.android.test.js
@@ -1,6 +1,4 @@
 import ArticleByline from "../../src/article-byline";
 import shared from "../shared-with-styles.native";
 
-describe("ArticleByline tests on android", () => {
-  shared(ArticleByline);
-});
+shared(ArticleByline);

--- a/packages/article-byline/__tests__/android/article-byline-with-links-style.android.test.js
+++ b/packages/article-byline/__tests__/android/article-byline-with-links-style.android.test.js
@@ -1,6 +1,4 @@
 import { ArticleBylineWithLinks } from "../../src/article-byline";
 import shared from "../shared-with-styles.native";
 
-describe("ArticleBylineWithLinks tests on android", () => {
-  shared(ArticleBylineWithLinks);
-});
+shared(ArticleBylineWithLinks);

--- a/packages/article-byline/__tests__/android/article-byline-with-links.android.test.js
+++ b/packages/article-byline/__tests__/android/article-byline-with-links.android.test.js
@@ -1,6 +1,4 @@
 import { ArticleBylineWithLinks } from "../../src/article-byline";
 import shared from "../shared.native";
 
-describe("ArticleBylineWithLinks tests on android", () => {
-  shared(ArticleBylineWithLinks);
-});
+shared(ArticleBylineWithLinks);

--- a/packages/article-byline/__tests__/android/article-byline.android.test.js
+++ b/packages/article-byline/__tests__/android/article-byline.android.test.js
@@ -1,6 +1,4 @@
 import ArticleByline from "../../src/article-byline";
 import shared from "../shared.native";
 
-describe("ArticleByline tests on android", () => {
-  shared(ArticleByline);
-});
+shared(ArticleByline);

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-style.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleByline tests on iOS 1. with a single author 1`] = `
+exports[`1. with a single author 1`] = `
 <View>
   <Text
     style={
@@ -18,7 +18,7 @@ exports[`ArticleByline tests on iOS 1. with a single author 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 2. with a given section colour 1`] = `
+exports[`2. with a given section colour 1`] = `
 <View>
   <Text
     style={
@@ -36,7 +36,7 @@ exports[`ArticleByline tests on iOS 2. with a given section colour 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 3. with given styles 1`] = `
+exports[`3. with given styles 1`] = `
 <View>
   <Text
     style={

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-style.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a single author 1`] = `
+exports[`ArticleByline tests on iOS 1. with a single author 1`] = `
 <View>
   <Text
     style={
@@ -18,7 +18,7 @@ exports[`1. Render a single author 1`] = `
 </View>
 `;
 
-exports[`2. Render a given section colour 1`] = `
+exports[`ArticleByline tests on iOS 2. with a given section colour 1`] = `
 <View>
   <Text
     style={
@@ -36,7 +36,7 @@ exports[`2. Render a given section colour 1`] = `
 </View>
 `;
 
-exports[`3. Render an author with given styles 1`] = `
+exports[`ArticleByline tests on iOS 3. with given styles 1`] = `
 <View>
   <Text
     style={

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a single author 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 1. with a single author 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -20,7 +20,7 @@ exports[`1. Render a single author 1`] = `
 </View>
 `;
 
-exports[`2. Render a given section colour 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 2. with a given section colour 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -40,7 +40,7 @@ exports[`2. Render a given section colour 1`] = `
 </View>
 `;
 
-exports[`3. Render an author with given styles 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 3. with given styles 1`] = `
 <View>
   <Text
     accessibilityRole="link"

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleBylineWithLinks tests on iOS 1. with a single author 1`] = `
+exports[`1. with a single author 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -20,7 +20,7 @@ exports[`ArticleBylineWithLinks tests on iOS 1. with a single author 1`] = `
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 2. with a given section colour 1`] = `
+exports[`2. with a given section colour 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -40,7 +40,7 @@ exports[`ArticleBylineWithLinks tests on iOS 2. with a given section colour 1`] 
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 3. with given styles 1`] = `
+exports[`3. with given styles 1`] = `
 <View>
   <Text
     accessibilityRole="link"

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an inline element 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`1. Render an inline element 1`] = `
 </View>
 `;
 
-exports[`2. Render an author first 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 2. with the author in the begining 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -21,7 +21,7 @@ exports[`2. Render an author first 1`] = `
 </View>
 `;
 
-exports[`3. Render an author last 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -34,7 +34,7 @@ exports[`3. Render an author last 1`] = `
 </View>
 `;
 
-exports[`4. Render multiple authors separated by commas 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -60,7 +60,7 @@ exports[`4. Render multiple authors separated by commas 1`] = `
 </View>
 `;
 
-exports[`5. Render multiple authors separated by spaces 1`] = `
+exports[`ArticleBylineWithLinks tests on iOS 5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -86,4 +86,4 @@ exports[`5. Render multiple authors separated by spaces 1`] = `
 </View>
 `;
 
-exports[`6. Render null when AST is empty 1`] = `null`;
+exports[`ArticleBylineWithLinks tests on iOS 6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline-with-links.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleBylineWithLinks tests on iOS 1. single inline element 1`] = `
+exports[`1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`ArticleBylineWithLinks tests on iOS 1. single inline element 1`] = `
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 2. with the author in the begining 1`] = `
+exports[`2. with the author in the begining 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -21,7 +21,7 @@ exports[`ArticleBylineWithLinks tests on iOS 2. with the author in the begining 
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 3. with the author at the end 1`] = `
+exports[`3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -34,7 +34,7 @@ exports[`ArticleBylineWithLinks tests on iOS 3. with the author at the end 1`] =
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 4. with multiple authors separated by text with commas 1`] = `
+exports[`4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -60,7 +60,7 @@ exports[`ArticleBylineWithLinks tests on iOS 4. with multiple authors separated 
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 5. with multiple authors separated by spaces 1`] = `
+exports[`5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text
     accessibilityRole="link"
@@ -86,4 +86,4 @@ exports[`ArticleBylineWithLinks tests on iOS 5. with multiple authors separated 
 </View>
 `;
 
-exports[`ArticleBylineWithLinks tests on iOS 6. null with an empty ast 1`] = `null`;
+exports[`6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an inline element 1`] = `
+exports[`ArticleByline tests on iOS 1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`1. Render an inline element 1`] = `
 </View>
 `;
 
-exports[`2. Render an author first 1`] = `
+exports[`ArticleByline tests on iOS 2. with the author in the begining 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -19,7 +19,7 @@ exports[`2. Render an author first 1`] = `
 </View>
 `;
 
-exports[`3. Render an author last 1`] = `
+exports[`ArticleByline tests on iOS 3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -30,7 +30,7 @@ exports[`3. Render an author last 1`] = `
 </View>
 `;
 
-exports[`4. Render multiple authors separated by commas 1`] = `
+exports[`ArticleByline tests on iOS 4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -50,7 +50,7 @@ exports[`4. Render multiple authors separated by commas 1`] = `
 </View>
 `;
 
-exports[`5. Render multiple authors separated by spaces 1`] = `
+exports[`ArticleByline tests on iOS 5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -70,4 +70,4 @@ exports[`5. Render multiple authors separated by spaces 1`] = `
 </View>
 `;
 
-exports[`6. Render null when AST is empty 1`] = `null`;
+exports[`ArticleByline tests on iOS 6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
+++ b/packages/article-byline/__tests__/ios/__snapshots__/article-byline.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleByline tests on iOS 1. single inline element 1`] = `
+exports[`1. single inline element 1`] = `
 <View>
   <Text>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`ArticleByline tests on iOS 1. single inline element 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 2. with the author in the begining 1`] = `
+exports[`2. with the author in the begining 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -19,7 +19,7 @@ exports[`ArticleByline tests on iOS 2. with the author in the begining 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 3. with the author at the end 1`] = `
+exports[`3. with the author at the end 1`] = `
 <View>
   <Text>
     RBS Six Nations 
@@ -30,7 +30,7 @@ exports[`ArticleByline tests on iOS 3. with the author at the end 1`] = `
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 4. with multiple authors separated by text with commas 1`] = `
+exports[`4. with multiple authors separated by text with commas 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -50,7 +50,7 @@ exports[`ArticleByline tests on iOS 4. with multiple authors separated by text w
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 5. with multiple authors separated by spaces 1`] = `
+exports[`5. with multiple authors separated by spaces 1`] = `
 <View>
   <Text>
     Camilla Long
@@ -70,4 +70,4 @@ exports[`ArticleByline tests on iOS 5. with multiple authors separated by spaces
 </View>
 `;
 
-exports[`ArticleByline tests on iOS 6. null with an empty ast 1`] = `null`;
+exports[`6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/ios/article-byline-style.ios.test.js
+++ b/packages/article-byline/__tests__/ios/article-byline-style.ios.test.js
@@ -1,6 +1,4 @@
 import ArticleByline from "../../src/article-byline";
 import shared from "../shared-with-styles.native";
 
-describe("ArticleByline tests on iOS", () => {
-  shared(ArticleByline);
-});
+shared(ArticleByline);

--- a/packages/article-byline/__tests__/ios/article-byline-with-links-style.ios.test.js
+++ b/packages/article-byline/__tests__/ios/article-byline-with-links-style.ios.test.js
@@ -1,6 +1,4 @@
 import { ArticleBylineWithLinks } from "../../src/article-byline";
 import shared from "../shared-with-styles.native";
 
-describe("ArticleBylineWithLinks tests on iOS", () => {
-  shared(ArticleBylineWithLinks);
-});
+shared(ArticleBylineWithLinks);

--- a/packages/article-byline/__tests__/ios/article-byline-with-links.ios.test.js
+++ b/packages/article-byline/__tests__/ios/article-byline-with-links.ios.test.js
@@ -1,6 +1,4 @@
 import { ArticleBylineWithLinks } from "../../src/article-byline";
 import shared from "../shared.native";
 
-describe("ArticleBylineWithLinks tests on iOS", () => {
-  shared(ArticleBylineWithLinks);
-});
+shared(ArticleBylineWithLinks);

--- a/packages/article-byline/__tests__/ios/article-byline.ios.test.js
+++ b/packages/article-byline/__tests__/ios/article-byline.ios.test.js
@@ -1,6 +1,4 @@
 import ArticleByline from "../../src/article-byline";
 import shared from "../shared.native";
 
-describe("ArticleByline tests on iOS", () => {
-  shared(ArticleByline);
-});
+shared(ArticleByline);

--- a/packages/article-byline/__tests__/shared-with-styles.base.js
+++ b/packages/article-byline/__tests__/shared-with-styles.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { View } from "react-native";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
 import authorsFixture from "../fixtures/authors.json";
 
@@ -13,7 +13,7 @@ const styles = {
 
 export default Component => {
   const renderArticleByline = props =>
-    renderer.create(
+    TestRenderer.create(
       <View>
         <Component {...props} />
       </View>
@@ -23,33 +23,33 @@ export default Component => {
     {
       name: "with a single author",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.singleAuthor
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "with a given section colour",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.singleAuthor,
           color: "blue"
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "with given styles",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.singleAuthor,
           style: styles
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     }
   ];

--- a/packages/article-byline/__tests__/shared-with-styles.base.js
+++ b/packages/article-byline/__tests__/shared-with-styles.base.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import renderer from "react-test-renderer";
+import { iterator } from "@times-components/test-utils";
 import authorsFixture from "../fixtures/authors.json";
 
 const styles = {
@@ -18,28 +19,40 @@ export default Component => {
       </View>
     );
 
-  it("should render with a single author", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.singleAuthor
-    });
-    expect(tree).toMatchSnapshot("1. Render a single author");
-  });
+  const tests = [
+    {
+      name: "with a single author",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.singleAuthor
+        });
 
-  it("should render with a given section colour", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.singleAuthor,
-      color: "blue"
-    });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with a given section colour",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.singleAuthor,
+          color: "blue"
+        });
 
-    expect(tree).toMatchSnapshot("2. Render a given section colour");
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with given styles",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.singleAuthor,
+          style: styles
+        });
 
-  it("should render with given styles", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.singleAuthor,
-      style: styles
-    });
+        expect(tree).toMatchSnapshot();
+      }
+    }
+  ];
 
-    expect(tree).toMatchSnapshot("3. Render an author with given styles");
-  });
+  iterator(tests);
 };

--- a/packages/article-byline/__tests__/shared.base.js
+++ b/packages/article-byline/__tests__/shared.base.js
@@ -2,6 +2,7 @@ import React from "react";
 import { View } from "react-native";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import ArticleByline from "../src/article-byline";
 import authorsFixture from "../fixtures/authors.json";
 
@@ -13,85 +14,107 @@ export default Component => {
       </View>
     );
 
+  const tests = [
+    {
+      name: "single inline element",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.singleInlineElement
+        });
+
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with the author in the begining",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.authorInTheBeginning
+        });
+
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with the author at the end",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.authorAtTheEnd
+        });
+
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with multiple authors separated by text with commas",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.multipleAuthorsCommaSeparated
+        });
+
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with multiple authors separated by spaces",
+      test: () => {
+        const tree = renderArticleByline({
+          ast: authorsFixture.multipleAuthorsSpaceSeparated
+        });
+
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "null with an empty AST",
+      test: () => {
+        const tree = renderer.create(<ArticleByline ast={[]} />);
+
+        expect(tree).toMatchSnapshot();
+      }
+    }
+  ];
+
   if (Component.displayName === "ArticleBylineWithLinks") {
-    it("should handle the onPress event", () => {
-      const onAuthorPressMock = jest.fn();
-      const wrapper = shallow(
-        <Component
-          ast={authorsFixture.singleAuthor}
-          onAuthorPress={onAuthorPressMock}
-        />
-      );
+    tests.push(
+      {
+        name: "handle the onPress event",
+        test: () => {
+          const onAuthorPressMock = jest.fn();
+          const wrapper = shallow(
+            <Component
+              ast={authorsFixture.singleAuthor}
+              onAuthorPress={onAuthorPressMock}
+            />
+          );
 
-      wrapper
-        .at(0)
-        .dive()
-        .find("Text")
-        .simulate("press");
+          wrapper
+            .at(0)
+            .dive()
+            .find("Text")
+            .simulate("press");
 
-      expect(onAuthorPressMock).toHaveBeenCalled();
-    });
+          expect(onAuthorPressMock).toHaveBeenCalled();
+        }
+      },
+      {
+        name: "handle an empty onPress event",
+        test: () => {
+          const wrapper = shallow(
+            <Component ast={authorsFixture.singleAuthor} />
+          );
 
-    it("should handle an empty onPress event", () => {
-      const wrapper = shallow(<Component ast={authorsFixture.singleAuthor} />);
-
-      expect(() =>
-        wrapper
-          .at(0)
-          .dive()
-          .find("Text")
-          .simulate("press")
-      ).not.toThrow();
-    });
+          expect(() =>
+            wrapper
+              .at(0)
+              .dive()
+              .find("Text")
+              .simulate("press")
+          ).not.toThrow();
+        }
+      }
+    );
   }
 
-  it("should render with a single inline element", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.singleInlineElement
-    });
-
-    expect(tree).toMatchSnapshot("1. Render an inline element");
-  });
-
-  it("should render with the author in the begining", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.authorInTheBeginning
-    });
-
-    expect(tree).toMatchSnapshot("2. Render an author first");
-  });
-
-  it("should render with the author at the end", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.authorAtTheEnd
-    });
-
-    expect(tree).toMatchSnapshot("3. Render an author last");
-  });
-
-  it("should render with multiple authors separated by text with commas", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.multipleAuthorsCommaSeparated
-    });
-
-    expect(tree).toMatchSnapshot(
-      "4. Render multiple authors separated by commas"
-    );
-  });
-
-  it("should render with multiple authors separated by spaces", () => {
-    const tree = renderArticleByline({
-      ast: authorsFixture.multipleAuthorsSpaceSeparated
-    });
-
-    expect(tree).toMatchSnapshot(
-      "5. Render multiple authors separated by spaces"
-    );
-  });
-
-  it("should render null with an empty AST", () => {
-    const tree = renderer.create(<ArticleByline ast={[]} />);
-
-    expect(tree).toMatchSnapshot("6. Render null when AST is empty");
-  });
+  iterator(tests);
 };

--- a/packages/article-byline/__tests__/shared.base.js
+++ b/packages/article-byline/__tests__/shared.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { View } from "react-native";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import { iterator } from "@times-components/test-utils";
 import ArticleByline from "../src/article-byline";
@@ -8,7 +8,7 @@ import authorsFixture from "../fixtures/authors.json";
 
 export default Component => {
   const renderArticleByline = props =>
-    renderer.create(
+    TestRenderer.create(
       <View>
         <Component {...props} />
       </View>
@@ -18,59 +18,59 @@ export default Component => {
     {
       name: "single inline element",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.singleInlineElement
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "with the author in the begining",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.authorInTheBeginning
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "with the author at the end",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.authorAtTheEnd
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "with multiple authors separated by text with commas",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.multipleAuthorsCommaSeparated
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "with multiple authors separated by spaces",
       test: () => {
-        const tree = renderArticleByline({
+        const testInstance = renderArticleByline({
           ast: authorsFixture.multipleAuthorsSpaceSeparated
         });
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "null with an empty AST",
       test: () => {
-        const tree = renderer.create(<ArticleByline ast={[]} />);
+        const testInstance = TestRenderer.create(<ArticleByline ast={[]} />);
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     }
   ];

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleByline tests on web 1. with a single author 1`] = `
+exports[`1. with a single author 1`] = `
 <style>
 {
   "S1": {
@@ -35,7 +35,7 @@ exports[`ArticleByline tests on web 1. with a single author 1`] = `
 </div>
 `;
 
-exports[`ArticleByline tests on web 2. with a given section colour 1`] = `
+exports[`2. with a given section colour 1`] = `
 <style>
 {
   "IS1": {
@@ -72,7 +72,7 @@ exports[`ArticleByline tests on web 2. with a given section colour 1`] = `
 </div>
 `;
 
-exports[`ArticleByline tests on web 3. with given styles 1`] = `
+exports[`3. with given styles 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a single author 1`] = `
+exports[`ArticleByline tests on web 1. with a single author 1`] = `
 <style>
 {
   "S1": {
@@ -35,7 +35,7 @@ exports[`1. Render a single author 1`] = `
 </div>
 `;
 
-exports[`2. Render a given section colour 1`] = `
+exports[`ArticleByline tests on web 2. with a given section colour 1`] = `
 <style>
 {
   "IS1": {
@@ -72,7 +72,7 @@ exports[`2. Render a given section colour 1`] = `
 </div>
 `;
 
-exports[`3. Render an author with given styles 1`] = `
+exports[`ArticleByline tests on web 3. with given styles 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a single author 1`] = `
+exports[`ArticleBylineWithLinks tests on web 1. with a single author 1`] = `
 <style>
 {
   "S1": {
@@ -37,7 +37,7 @@ exports[`1. Render a single author 1`] = `
 </div>
 `;
 
-exports[`2. Render a given section colour 1`] = `
+exports[`ArticleBylineWithLinks tests on web 2. with a given section colour 1`] = `
 <style>
 {
   "IS1": {
@@ -76,7 +76,7 @@ exports[`2. Render a given section colour 1`] = `
 </div>
 `;
 
-exports[`3. Render an author with given styles 1`] = `
+exports[`ArticleBylineWithLinks tests on web 3. with given styles 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleBylineWithLinks tests on web 1. with a single author 1`] = `
+exports[`1. with a single author 1`] = `
 <style>
 {
   "S1": {
@@ -37,7 +37,7 @@ exports[`ArticleBylineWithLinks tests on web 1. with a single author 1`] = `
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 2. with a given section colour 1`] = `
+exports[`2. with a given section colour 1`] = `
 <style>
 {
   "IS1": {
@@ -76,7 +76,7 @@ exports[`ArticleBylineWithLinks tests on web 2. with a given section colour 1`] 
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 3. with given styles 1`] = `
+exports[`3. with given styles 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleBylineWithLinks tests on web 1. single inline element 1`] = `
+exports[`1. single inline element 1`] = `
 <div>
   <div>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`ArticleBylineWithLinks tests on web 1. single inline element 1`] = `
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 2. with the author in the begining 1`] = `
+exports[`2. with the author in the begining 1`] = `
 <div>
   <a
     href="/profile/camilla-long"
@@ -22,7 +22,7 @@ exports[`ArticleBylineWithLinks tests on web 2. with the author in the begining 
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 3. with the author at the end 1`] = `
+exports[`3. with the author at the end 1`] = `
 <div>
   <div>
     RBS Six Nations 
@@ -36,7 +36,7 @@ exports[`ArticleBylineWithLinks tests on web 3. with the author at the end 1`] =
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 4. with multiple authors separated by text with commas 1`] = `
+exports[`4. with multiple authors separated by text with commas 1`] = `
 <div>
   <a
     href="/profile/camilla-long"
@@ -65,7 +65,7 @@ exports[`ArticleBylineWithLinks tests on web 4. with multiple authors separated 
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 5. with multiple authors separated by spaces 1`] = `
+exports[`5. with multiple authors separated by spaces 1`] = `
 <div>
   <a
     href="/profile/camilla-long"
@@ -94,4 +94,4 @@ exports[`ArticleBylineWithLinks tests on web 5. with multiple authors separated 
 </div>
 `;
 
-exports[`ArticleBylineWithLinks tests on web 6. null with an empty ast 1`] = `null`;
+exports[`6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an inline element 1`] = `
+exports[`ArticleBylineWithLinks tests on web 1. single inline element 1`] = `
 <div>
   <div>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`1. Render an inline element 1`] = `
 </div>
 `;
 
-exports[`2. Render an author first 1`] = `
+exports[`ArticleBylineWithLinks tests on web 2. with the author in the begining 1`] = `
 <div>
   <a
     href="/profile/camilla-long"
@@ -22,7 +22,7 @@ exports[`2. Render an author first 1`] = `
 </div>
 `;
 
-exports[`3. Render an author last 1`] = `
+exports[`ArticleBylineWithLinks tests on web 3. with the author at the end 1`] = `
 <div>
   <div>
     RBS Six Nations 
@@ -36,7 +36,7 @@ exports[`3. Render an author last 1`] = `
 </div>
 `;
 
-exports[`4. Render multiple authors separated by commas 1`] = `
+exports[`ArticleBylineWithLinks tests on web 4. with multiple authors separated by text with commas 1`] = `
 <div>
   <a
     href="/profile/camilla-long"
@@ -65,7 +65,7 @@ exports[`4. Render multiple authors separated by commas 1`] = `
 </div>
 `;
 
-exports[`5. Render multiple authors separated by spaces 1`] = `
+exports[`ArticleBylineWithLinks tests on web 5. with multiple authors separated by spaces 1`] = `
 <div>
   <a
     href="/profile/camilla-long"
@@ -94,4 +94,4 @@ exports[`5. Render multiple authors separated by spaces 1`] = `
 </div>
 `;
 
-exports[`6. Render null when AST is empty 1`] = `null`;
+exports[`ArticleBylineWithLinks tests on web 6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an inline element 1`] = `
+exports[`ArticleByline tests on web 1. single inline element 1`] = `
 <div>
   <div>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`1. Render an inline element 1`] = `
 </div>
 `;
 
-exports[`2. Render an author first 1`] = `
+exports[`ArticleByline tests on web 2. with the author in the begining 1`] = `
 <div>
   <div>
     Camilla Long
@@ -19,7 +19,7 @@ exports[`2. Render an author first 1`] = `
 </div>
 `;
 
-exports[`3. Render an author last 1`] = `
+exports[`ArticleByline tests on web 3. with the author at the end 1`] = `
 <div>
   <div>
     RBS Six Nations 
@@ -30,7 +30,7 @@ exports[`3. Render an author last 1`] = `
 </div>
 `;
 
-exports[`4. Render multiple authors separated by commas 1`] = `
+exports[`ArticleByline tests on web 4. with multiple authors separated by text with commas 1`] = `
 <div>
   <div>
     Camilla Long
@@ -50,7 +50,7 @@ exports[`4. Render multiple authors separated by commas 1`] = `
 </div>
 `;
 
-exports[`5. Render multiple authors separated by spaces 1`] = `
+exports[`ArticleByline tests on web 5. with multiple authors separated by spaces 1`] = `
 <div>
   <div>
     Camilla Long
@@ -70,4 +70,4 @@ exports[`5. Render multiple authors separated by spaces 1`] = `
 </div>
 `;
 
-exports[`6. Render null when AST is empty 1`] = `null`;
+exports[`ArticleByline tests on web 6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ArticleByline tests on web 1. single inline element 1`] = `
+exports[`1. single inline element 1`] = `
 <div>
   <div>
     Lindsay McIntosh Scottish Political Editor
@@ -8,7 +8,7 @@ exports[`ArticleByline tests on web 1. single inline element 1`] = `
 </div>
 `;
 
-exports[`ArticleByline tests on web 2. with the author in the begining 1`] = `
+exports[`2. with the author in the begining 1`] = `
 <div>
   <div>
     Camilla Long
@@ -19,7 +19,7 @@ exports[`ArticleByline tests on web 2. with the author in the begining 1`] = `
 </div>
 `;
 
-exports[`ArticleByline tests on web 3. with the author at the end 1`] = `
+exports[`3. with the author at the end 1`] = `
 <div>
   <div>
     RBS Six Nations 
@@ -30,7 +30,7 @@ exports[`ArticleByline tests on web 3. with the author at the end 1`] = `
 </div>
 `;
 
-exports[`ArticleByline tests on web 4. with multiple authors separated by text with commas 1`] = `
+exports[`4. with multiple authors separated by text with commas 1`] = `
 <div>
   <div>
     Camilla Long
@@ -50,7 +50,7 @@ exports[`ArticleByline tests on web 4. with multiple authors separated by text w
 </div>
 `;
 
-exports[`ArticleByline tests on web 5. with multiple authors separated by spaces 1`] = `
+exports[`5. with multiple authors separated by spaces 1`] = `
 <div>
   <div>
     Camilla Long
@@ -70,4 +70,4 @@ exports[`ArticleByline tests on web 5. with multiple authors separated by spaces
 </div>
 `;
 
-exports[`ArticleByline tests on web 6. null with an empty ast 1`] = `null`;
+exports[`6. null with an empty ast 1`] = `null`;

--- a/packages/article-byline/__tests__/web/article-byline-style.web.test.js
+++ b/packages/article-byline/__tests__/web/article-byline-style.web.test.js
@@ -1,6 +1,4 @@
 import ArticleByline from "../../src/article-byline";
 import shared from "../shared-with-styles.web";
 
-describe("ArticleByline tests on web", () => {
-  shared(ArticleByline);
-});
+shared(ArticleByline);

--- a/packages/article-byline/__tests__/web/article-byline-with-links-style.web.test.js
+++ b/packages/article-byline/__tests__/web/article-byline-with-links-style.web.test.js
@@ -1,6 +1,4 @@
 import { ArticleBylineWithLinks } from "../../src/article-byline";
 import shared from "../shared-with-styles.web";
 
-describe("ArticleBylineWithLinks tests on web", () => {
-  shared(ArticleBylineWithLinks);
-});
+shared(ArticleBylineWithLinks);

--- a/packages/article-byline/__tests__/web/article-byline-with-links.web.test.js
+++ b/packages/article-byline/__tests__/web/article-byline-with-links.web.test.js
@@ -1,6 +1,4 @@
 import { ArticleBylineWithLinks } from "../../src/article-byline";
 import shared from "../shared.web";
 
-describe("ArticleBylineWithLinks tests on web", () => {
-  shared(ArticleBylineWithLinks);
-});
+shared(ArticleBylineWithLinks);

--- a/packages/article-byline/__tests__/web/article-byline.web.test.js
+++ b/packages/article-byline/__tests__/web/article-byline.web.test.js
@@ -1,6 +1,4 @@
 import ArticleByline from "../../src/article-byline";
 import shared from "../shared.web";
 
-describe("ArticleByline tests on web", () => {
-  shared(ArticleByline);
-});
+shared(ArticleByline);

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -39,6 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article-byline/package.json
+++ b/packages/article-byline/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article-flag/article-flag.showcase.js
+++ b/packages/article-flag/article-flag.showcase.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import {
   NewArticleFlag,

--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders primary image with caption and credits 1`] = `
+exports[`android 1. primary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -58,7 +58,7 @@ exports[`1. renders primary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`2. renders secondary image with caption and credits 1`] = `
+exports[`android 2. secondary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -132,7 +132,7 @@ exports[`2. renders secondary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`3. renders inline image (landscape) with caption and credits 1`] = `
+exports[`android 3. inline image (landscape) with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -206,7 +206,7 @@ exports[`3. renders inline image (landscape) with caption and credits 1`] = `
 </View>
 `;
 
-exports[`4. renders inline image (portrait) with caption and credits 1`] = `
+exports[`android 4. inline image (portrait) with caption and credits 1`] = `
 <View
   style={
     Object {

--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. primary image with caption and credits 1`] = `
+exports[`1. primary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -58,7 +58,7 @@ exports[`android 1. primary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`android 2. secondary image with caption and credits 1`] = `
+exports[`2. secondary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -132,7 +132,7 @@ exports[`android 2. secondary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`android 3. inline image (landscape) with caption and credits 1`] = `
+exports[`3. inline image (landscape) with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -206,7 +206,7 @@ exports[`android 3. inline image (landscape) with caption and credits 1`] = `
 </View>
 `;
 
-exports[`android 4. inline image (portrait) with caption and credits 1`] = `
+exports[`4. inline image (portrait) with caption and credits 1`] = `
 <View
   style={
     Object {

--- a/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. does not render an image if display is not received 1`] = `<View />`;
+exports[`android 1. does not render an image if display is not received 1`] = `<View />`;
 
-exports[`2. does not render an image if ratio is not received 1`] = `<View />`;
+exports[`android 2. does not render an image if ratio is not received 1`] = `<View />`;
 
-exports[`3. renders an image with no caption 1`] = `
+exports[`android 3. image with no caption 1`] = `
 <View>
   <View>
     <ModalImage
@@ -15,7 +15,7 @@ exports[`3. renders an image with no caption 1`] = `
 </View>
 `;
 
-exports[`4. renders a caption if received 1`] = `
+exports[`android 4. image with caption 1`] = `
 <View>
   <View>
     <View>
@@ -29,7 +29,7 @@ exports[`4. renders a caption if received 1`] = `
 </View>
 `;
 
-exports[`5. renders a credit if received 1`] = `
+exports[`android 5. image with credit 1`] = `
 <View>
   <View>
     <View>

--- a/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. does not render an image if display is not received 1`] = `<View />`;
+exports[`1. does not render an image if display is not received 1`] = `<View />`;
 
-exports[`android 2. does not render an image if ratio is not received 1`] = `<View />`;
+exports[`2. does not render an image if ratio is not received 1`] = `<View />`;
 
-exports[`android 3. image with no caption 1`] = `
+exports[`3. image with no caption 1`] = `
 <View>
   <View>
     <ModalImage
@@ -15,7 +15,7 @@ exports[`android 3. image with no caption 1`] = `
 </View>
 `;
 
-exports[`android 4. image with caption 1`] = `
+exports[`4. image with caption 1`] = `
 <View>
   <View>
     <View>
@@ -29,7 +29,7 @@ exports[`android 4. image with caption 1`] = `
 </View>
 `;
 
-exports[`android 5. image with credit 1`] = `
+exports[`5. image with credit 1`] = `
 <View>
   <View>
     <View>

--- a/packages/article-image/__tests__/android/article-image-with-style.android.test.js
+++ b/packages/article-image/__tests__/android/article-image-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/article-image/__tests__/android/article-image.android.test.js
+++ b/packages/article-image/__tests__/android/article-image.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders primary image with caption and credits 1`] = `
+exports[`ios 1. primary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -58,7 +58,7 @@ exports[`1. renders primary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`2. renders secondary image with caption and credits 1`] = `
+exports[`ios 2. secondary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -132,7 +132,7 @@ exports[`2. renders secondary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`3. renders inline image (landscape) with caption and credits 1`] = `
+exports[`ios 3. inline image (landscape) with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -206,7 +206,7 @@ exports[`3. renders inline image (landscape) with caption and credits 1`] = `
 </View>
 `;
 
-exports[`4. renders inline image (portrait) with caption and credits 1`] = `
+exports[`ios 4. inline image (portrait) with caption and credits 1`] = `
 <View
   style={
     Object {

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. primary image with caption and credits 1`] = `
+exports[`1. primary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -58,7 +58,7 @@ exports[`ios 1. primary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`ios 2. secondary image with caption and credits 1`] = `
+exports[`2. secondary image with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -132,7 +132,7 @@ exports[`ios 2. secondary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`ios 3. inline image (landscape) with caption and credits 1`] = `
+exports[`3. inline image (landscape) with caption and credits 1`] = `
 <View
   style={
     Object {
@@ -206,7 +206,7 @@ exports[`ios 3. inline image (landscape) with caption and credits 1`] = `
 </View>
 `;
 
-exports[`ios 4. inline image (portrait) with caption and credits 1`] = `
+exports[`4. inline image (portrait) with caption and credits 1`] = `
 <View
   style={
     Object {

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. does not render an image if display is not received 1`] = `<View />`;
+exports[`ios 1. does not render an image if display is not received 1`] = `<View />`;
 
-exports[`2. does not render an image if ratio is not received 1`] = `<View />`;
+exports[`ios 2. does not render an image if ratio is not received 1`] = `<View />`;
 
-exports[`3. renders an image with no caption 1`] = `
+exports[`ios 3. image with no caption 1`] = `
 <View>
   <View>
     <ModalImage
@@ -15,7 +15,7 @@ exports[`3. renders an image with no caption 1`] = `
 </View>
 `;
 
-exports[`4. renders a caption if received 1`] = `
+exports[`ios 4. image with caption 1`] = `
 <View>
   <View>
     <View>
@@ -29,7 +29,7 @@ exports[`4. renders a caption if received 1`] = `
 </View>
 `;
 
-exports[`5. renders a credit if received 1`] = `
+exports[`ios 5. image with credit 1`] = `
 <View>
   <View>
     <View>

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. does not render an image if display is not received 1`] = `<View />`;
+exports[`1. does not render an image if display is not received 1`] = `<View />`;
 
-exports[`ios 2. does not render an image if ratio is not received 1`] = `<View />`;
+exports[`2. does not render an image if ratio is not received 1`] = `<View />`;
 
-exports[`ios 3. image with no caption 1`] = `
+exports[`3. image with no caption 1`] = `
 <View>
   <View>
     <ModalImage
@@ -15,7 +15,7 @@ exports[`ios 3. image with no caption 1`] = `
 </View>
 `;
 
-exports[`ios 4. image with caption 1`] = `
+exports[`4. image with caption 1`] = `
 <View>
   <View>
     <View>
@@ -29,7 +29,7 @@ exports[`ios 4. image with caption 1`] = `
 </View>
 `;
 
-exports[`ios 5. image with credit 1`] = `
+exports[`5. image with credit 1`] = `
 <View>
   <View>
     <View>

--- a/packages/article-image/__tests__/ios/article-image-with-style.ios.test.js
+++ b/packages/article-image/__tests__/ios/article-image-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/article-image/__tests__/ios/article-image.ios.test.js
+++ b/packages/article-image/__tests__/ios/article-image.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/article-image/__tests__/shared-with-style.base.js
+++ b/packages/article-image/__tests__/shared-with-style.base.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { iterator } from "@times-components/test-utils";
 import ArticleImage from "../src/article-image";
 import primaryImageFixture from "../fixtures/primary-image";
 import secondaryImageFixture from "../fixtures/secondary-image";
@@ -28,47 +29,60 @@ const portraitInlineImage = portraitInlineImageFixture(
 );
 
 export default makeTest => {
-  it("renders primary image with caption and credits", () =>
-    expect(
-      makeTest(
-        <ArticleImage
-          captionOptions={primaryImage.captionOptions}
-          imageOptions={primaryImage.imageOptions}
-        />
-      )
-    ).toMatchSnapshot("1. renders primary image with caption and credits"));
+  const tests = [
+    {
+      name: "primary image with caption and credits",
+      test: () => {
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={primaryImage.captionOptions}
+              imageOptions={primaryImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    },
+    {
+      name: "secondary image with caption and credits",
+      test: () => {
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={secondaryImage.captionOptions}
+              imageOptions={secondaryImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    },
+    {
+      name: "inline image (landscape) with caption and credits",
+      test: () => {
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={landscapeInlineImage.captionOptions}
+              imageOptions={landscapeInlineImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    },
+    {
+      name: "inline image (portrait) with caption and credits",
+      test: () => {
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={portraitInlineImage.captionOptions}
+              imageOptions={portraitInlineImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    }
+  ];
 
-  it("renders secondary image with caption and credits", () =>
-    expect(
-      makeTest(
-        <ArticleImage
-          captionOptions={secondaryImage.captionOptions}
-          imageOptions={secondaryImage.imageOptions}
-        />
-      )
-    ).toMatchSnapshot("2. renders secondary image with caption and credits"));
-
-  it("renders inline image (landscape) with caption and credits", () =>
-    expect(
-      makeTest(
-        <ArticleImage
-          captionOptions={landscapeInlineImage.captionOptions}
-          imageOptions={landscapeInlineImage.imageOptions}
-        />
-      )
-    ).toMatchSnapshot(
-      "3. renders inline image (landscape) with caption and credits"
-    ));
-
-  it("renders inline image (portrait) with caption and credits", () =>
-    expect(
-      makeTest(
-        <ArticleImage
-          captionOptions={portraitInlineImage.captionOptions}
-          imageOptions={portraitInlineImage.imageOptions}
-        />
-      )
-    ).toMatchSnapshot(
-      "4. renders inline image (portrait) with caption and credits"
-    ));
+  iterator(tests);
 };

--- a/packages/article-image/__tests__/shared.base.js
+++ b/packages/article-image/__tests__/shared.base.js
@@ -1,97 +1,114 @@
-import "react-native";
 import React from "react";
+import { iterator } from "@times-components/test-utils";
 import ArticleImage from "../src/article-image";
 
 const testImageUrl = "https://imageserver/someImage";
 
 export default makeTest => {
-  it("does not render an image if display is not received", () => {
-    const noDisplay = {
-      imageOptions: {
-        display: null,
-        ratio: "16:9",
-        url: testImageUrl
+  const tests = [
+    {
+      name: "does not render an image if display is not received",
+      test: () => {
+        const noDisplay = {
+          imageOptions: {
+            display: null,
+            ratio: "16:9",
+            url: testImageUrl
+          }
+        };
+
+        expect(
+          makeTest(<ArticleImage imageOptions={noDisplay.imageOptions} />)
+        ).toMatchSnapshot();
       }
-    };
+    },
+    {
+      name: "does not render an image if ratio is not received",
+      test: () => {
+        const noRatio = {
+          imageOptions: {
+            display: "primary",
+            ratio: null,
+            url: testImageUrl
+          }
+        };
 
-    expect(
-      makeTest(<ArticleImage imageOptions={noDisplay.imageOptions} />)
-    ).toMatchSnapshot("1. does not render an image if display is not received");
-  });
-
-  it("does not render an image if ratio is not received", () => {
-    const noRatio = {
-      imageOptions: {
-        display: "primary",
-        ratio: null,
-        url: testImageUrl
+        expect(
+          makeTest(<ArticleImage imageOptions={noRatio.imageOptions} />)
+        ).toMatchSnapshot();
       }
-    };
+    },
+    {
+      name: "image with no caption",
+      test: () => {
+        const primaryImageNoCaptionProps = {
+          imageOptions: {
+            display: "primary",
+            ratio: "16:9",
+            url: testImageUrl
+          }
+        };
 
-    expect(
-      makeTest(<ArticleImage imageOptions={noRatio.imageOptions} />)
-    ).toMatchSnapshot("2. does not render an image if ratio is not received");
-  });
-
-  it("renders an image with no caption", () => {
-    const primaryImageNoCaptionProps = {
-      imageOptions: {
-        display: "primary",
-        ratio: "16:9",
-        url: testImageUrl
+        expect(
+          makeTest(
+            <ArticleImage
+              imageOptions={primaryImageNoCaptionProps.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
       }
-    };
+    },
+    {
+      name: "image with caption",
+      test: () => {
+        const noCredits = {
+          imageOptions: {
+            display: null,
+            ratio: "16:9",
+            url: testImageUrl
+          },
+          captionOptions: {
+            caption: "Some caption",
+            credits: null
+          }
+        };
 
-    expect(
-      makeTest(
-        <ArticleImage imageOptions={primaryImageNoCaptionProps.imageOptions} />
-      )
-    ).toMatchSnapshot("3. renders an image with no caption");
-  });
-
-  it("renders a caption if received", () => {
-    const noCredits = {
-      imageOptions: {
-        display: null,
-        ratio: "16:9",
-        url: testImageUrl
-      },
-      captionOptions: {
-        caption: "Some caption",
-        credits: null
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={noCredits.captionOptions}
+              imageOptions={noCredits.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
       }
-    };
+    },
+    {
+      name: "image with credit",
+      test: () => {
+        const noCredits = {
+          imageOptions: {
+            display: null,
+            ratio: "16:9",
+            url: testImageUrl
+          },
+          captionOptions: {
+            caption: null,
+            credits: "Some credit"
+          }
+        };
 
-    expect(
-      makeTest(
-        <ArticleImage
-          captionOptions={noCredits.captionOptions}
-          imageOptions={noCredits.imageOptions}
-        />
-      )
-    ).toMatchSnapshot("4. renders a caption if received");
-  });
-
-  it("renders a credit if received", () => {
-    const noCredits = {
-      imageOptions: {
-        display: null,
-        ratio: "16:9",
-        url: testImageUrl
-      },
-      captionOptions: {
-        caption: null,
-        credits: "Some credit"
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={noCredits.captionOptions}
+              imageOptions={noCredits.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
       }
-    };
+    }
+  ];
 
-    expect(
-      makeTest(
-        <ArticleImage
-          captionOptions={noCredits.captionOptions}
-          imageOptions={noCredits.imageOptions}
-        />
-      )
-    ).toMatchSnapshot("5. renders a credit if received");
-  });
+  iterator(tests);
 };

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. primary image with caption and credits 1`] = `
+exports[`1. primary image with caption and credits 1`] = `
 .c0 {
   padding-left: 10px;
 }
@@ -37,7 +37,7 @@ Array [
 ]
 `;
 
-exports[`web 2. secondary image with caption and credits 1`] = `
+exports[`2. secondary image with caption and credits 1`] = `
 Array [
   <div>
     <TimesImage
@@ -60,7 +60,7 @@ Array [
 ]
 `;
 
-exports[`web 3. inline image (landscape) with caption and credits 1`] = `
+exports[`3. inline image (landscape) with caption and credits 1`] = `
 .c0 {
   width: 50%;
   padding-bottom: 20px;
@@ -143,7 +143,7 @@ Array [
 ]
 `;
 
-exports[`web 4. inline image (portrait) with caption and credits 1`] = `
+exports[`4. inline image (portrait) with caption and credits 1`] = `
 .c0 {
   width: 50%;
   padding-bottom: 20px;

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders primary image with caption and credits 1`] = `
+exports[`web 1. primary image with caption and credits 1`] = `
 .c0 {
   padding-left: 10px;
 }
@@ -37,7 +37,7 @@ Array [
 ]
 `;
 
-exports[`2. renders secondary image with caption and credits 1`] = `
+exports[`web 2. secondary image with caption and credits 1`] = `
 Array [
   <div>
     <TimesImage
@@ -60,7 +60,7 @@ Array [
 ]
 `;
 
-exports[`3. renders inline image (landscape) with caption and credits 1`] = `
+exports[`web 3. inline image (landscape) with caption and credits 1`] = `
 .c0 {
   width: 50%;
   padding-bottom: 20px;
@@ -143,7 +143,7 @@ Array [
 ]
 `;
 
-exports[`4. renders inline image (portrait) with caption and credits 1`] = `
+exports[`web 4. inline image (portrait) with caption and credits 1`] = `
 .c0 {
   width: 50%;
   padding-bottom: 20px;

--- a/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. does not render an image if display is not received 1`] = `Array []`;
+exports[`web 1. does not render an image if display is not received 1`] = `Array []`;
 
-exports[`2. does not render an image if ratio is not received 1`] = `Array []`;
+exports[`web 2. does not render an image if ratio is not received 1`] = `Array []`;
 
-exports[`3. renders an image with no caption 1`] = `
+exports[`web 3. image with no caption 1`] = `
 <div>
   <TimesImage
     aspectRatio={1.7777777777777777}
@@ -13,7 +13,7 @@ exports[`3. renders an image with no caption 1`] = `
 </div>
 `;
 
-exports[`4. renders a caption if received 1`] = `
+exports[`web 4. image with caption 1`] = `
 <div>
   <div>
     <div>
@@ -25,7 +25,7 @@ exports[`4. renders a caption if received 1`] = `
 </div>
 `;
 
-exports[`5. renders a credit if received 1`] = `
+exports[`web 5. image with credit 1`] = `
 <div>
   <div>
     <div>

--- a/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. does not render an image if display is not received 1`] = `Array []`;
+exports[`1. does not render an image if display is not received 1`] = `Array []`;
 
-exports[`web 2. does not render an image if ratio is not received 1`] = `Array []`;
+exports[`2. does not render an image if ratio is not received 1`] = `Array []`;
 
-exports[`web 3. image with no caption 1`] = `
+exports[`3. image with no caption 1`] = `
 <div>
   <TimesImage
     aspectRatio={1.7777777777777777}
@@ -13,7 +13,7 @@ exports[`web 3. image with no caption 1`] = `
 </div>
 `;
 
-exports[`web 4. image with caption 1`] = `
+exports[`4. image with caption 1`] = `
 <div>
   <div>
     <div>
@@ -25,7 +25,7 @@ exports[`web 4. image with caption 1`] = `
 </div>
 `;
 
-exports[`web 5. image with credit 1`] = `
+exports[`5. image with credit 1`] = `
 <div>
   <div>
     <div>

--- a/packages/article-image/__tests__/web/article-image-with-style.web.test.js
+++ b/packages/article-image/__tests__/web/article-image-with-style.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/article-image/__tests__/web/article-image.web.test.js
+++ b/packages/article-image/__tests__/web/article-image.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/article-image/article-image.showcase.js
+++ b/packages/article-image/article-image.showcase.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import ArticleImage from "./src/article-image";
 import primaryImageFixture from "./fixtures/primary-image";

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/utils": "2.0.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -39,6 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/utils": "2.0.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",

--- a/packages/article-label/__tests__/shared.js
+++ b/packages/article-label/__tests__/shared.js
@@ -1,14 +1,13 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import ArticleLabel from "../src/article-label";
 
 module.exports = () => {
   it("renders ArticleLabel", () => {
-    const tree = renderer
-      .create(<ArticleLabel color="#008347" title="swimming" />)
-      .toJSON();
+    const testInstance = TestRenderer.create(
+      <ArticleLabel color="#008347" title="swimming" />
+    );
 
-    expect(tree).toMatchSnapshot();
+    expect(testInstance.toJSON()).toMatchSnapshot();
   });
 };

--- a/packages/article-label/article-label.showcase.js
+++ b/packages/article-label/article-label.showcase.js
@@ -1,6 +1,4 @@
 /* eslint-disable react/prop-types */
-
-import "react-native";
 import React from "react";
 import invert from "lodash.invert";
 import { colours } from "@times-components/styleguide";

--- a/packages/article-list/__tests__/shared-web.js
+++ b/packages/article-list/__tests__/shared-web.js
@@ -1,6 +1,5 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import { mount, shallow } from "enzyme";
 import { AdComposer } from "@times-components/ad";
 import ArticleListPagination from "../src/article-list-pagination";
@@ -13,11 +12,11 @@ const { defaultProps: { adConfig } } = AdComposer;
 
 export default () => {
   it("should render the article list pagination correctly", () => {
-    const tree = renderer.create(
+    const testInstance = TestRenderer.create(
       <ArticleListPagination count={20} page={1} pageSize={10} />
     );
 
-    expect(tree).toMatchSnapshot();
+    expect(testInstance).toMatchSnapshot();
   });
 
   it("should handle the link to an article from an article list", () => {
@@ -70,7 +69,7 @@ export default () => {
   it("should show an advert after the fifth article", () => {
     const pageSize = 6;
     const results = pagedResult(0, pageSize);
-    const tree = renderer.create(
+    const testInstance = TestRenderer.create(
       <ArticleList
         {...articleListProps}
         adConfig={adConfig}
@@ -80,6 +79,6 @@ export default () => {
       />
     );
 
-    expect(tree).toMatchSnapshot();
+    expect(testInstance).toMatchSnapshot();
   });
 };

--- a/packages/article-list/__tests__/web/responsive.web.test.js
+++ b/packages/article-list/__tests__/web/responsive.web.test.js
@@ -1,6 +1,5 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import {
   ListContentContainer,
   ListItemWrapper,
@@ -15,39 +14,47 @@ import {
 describe("ArticleList responsive tests on web", () => {
   it("should render ListContentContainer correctly", () => {
     expect(
-      renderer.create(<ListContentContainer />).toJSON()
+      TestRenderer.create(<ListContentContainer />).toJSON()
     ).toMatchSnapshot();
   });
 
   it("should render ListItemWrapper correctly", () => {
-    expect(renderer.create(<ListItemWrapper />).toJSON()).toMatchSnapshot();
+    expect(TestRenderer.create(<ListItemWrapper />).toJSON()).toMatchSnapshot();
   });
 
   it("should render ListItemLongText correctly", () => {
-    expect(renderer.create(<ListItemLongText />).toJSON()).toMatchSnapshot();
+    expect(
+      TestRenderer.create(<ListItemLongText />).toJSON()
+    ).toMatchSnapshot();
   });
 
   it("should render ListItemShortText correctly", () => {
-    expect(renderer.create(<ListItemShortText />).toJSON()).toMatchSnapshot();
+    expect(
+      TestRenderer.create(<ListItemShortText />).toJSON()
+    ).toMatchSnapshot();
   });
 
   it("should render ListItemSeparator correctly", () => {
-    expect(renderer.create(<ListItemSeparator />).toJSON()).toMatchSnapshot();
+    expect(
+      TestRenderer.create(<ListItemSeparator />).toJSON()
+    ).toMatchSnapshot();
   });
 
   it("should render PageErrorContainer correctly", () => {
-    expect(renderer.create(<PageErrorContainer />).toJSON()).toMatchSnapshot();
+    expect(
+      TestRenderer.create(<PageErrorContainer />).toJSON()
+    ).toMatchSnapshot();
   });
 
   it("should render PageErrorImageContainer correctly", () => {
     expect(
-      renderer.create(<PageErrorImageContainer />).toJSON()
+      TestRenderer.create(<PageErrorImageContainer />).toJSON()
     ).toMatchSnapshot();
   });
 
   it("should render PageErrorContentContainer correctly", () => {
     expect(
-      renderer.create(<PageErrorContentContainer />).toJSON()
+      TestRenderer.create(<PageErrorContentContainer />).toJSON()
     ).toMatchSnapshot();
   });
 });

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. article summary component with a single paragraph 1`] = `
+exports[`1. article summary component with a single paragraph 1`] = `
 <View>
   <View
     style={
@@ -113,7 +113,7 @@ exports[`android 1. article summary component with a single paragraph 1`] = `
 </View>
 `;
 
-exports[`android 2. article summary content component with the given style 1`] = `
+exports[`2. article summary content component with the given style 1`] = `
 <Text
   style={
     Object {

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render an article summary component with a single paragraph 1`] = `
+exports[`android 1. article summary component with a single paragraph 1`] = `
 <View>
   <View
     style={
@@ -113,7 +113,7 @@ exports[`1. should render an article summary component with a single paragraph 1
 </View>
 `;
 
-exports[`2. should render an article summary content component with the given style 1`] = `
+exports[`android 2. article summary content component with the given style 1`] = `
 <Text
   style={
     Object {

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. article summary component with a single paragraph 1`] = `
+exports[`1. article summary component with a single paragraph 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -66,7 +66,7 @@ exports[`android 1. article summary component with a single paragraph 1`] = `
 </View>
 `;
 
-exports[`android 2. article summary with opinion byline 1`] = `
+exports[`2. article summary with opinion byline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -118,7 +118,7 @@ exports[`android 2. article summary with opinion byline 1`] = `
 </View>
 `;
 
-exports[`android 3. article summary component with multiple paragraphs 1`] = `
+exports[`3. article summary component with multiple paragraphs 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -167,7 +167,7 @@ exports[`android 3. article summary component with multiple paragraphs 1`] = `
 </View>
 `;
 
-exports[`android 4. article summary component with content including line breaks 1`] = `
+exports[`4. article summary component with content including line breaks 1`] = `
 <View>
   <Text>
     <Text>
@@ -211,7 +211,7 @@ exports[`android 4. article summary component with content including line breaks
 </View>
 `;
 
-exports[`android 5. article summary component containing links 1`] = `
+exports[`5. article summary component containing links 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -248,7 +248,7 @@ exports[`android 5. article summary component containing links 1`] = `
 </View>
 `;
 
-exports[`android 6. article summary component with headline and no content 1`] = `
+exports[`6. article summary component with headline and no content 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -271,7 +271,7 @@ exports[`android 6. article summary component with headline and no content 1`] =
 </View>
 `;
 
-exports[`android 7. article summary component with empty content at the end trimmed 1`] = `
+exports[`7. article summary component with empty content at the end trimmed 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -329,7 +329,7 @@ exports[`android 7. article summary component with empty content at the end trim
 </View>
 `;
 
-exports[`android 8. article summary component with no byline 1`] = `
+exports[`8. article summary component with no byline 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -353,7 +353,7 @@ exports[`android 8. article summary component with no byline 1`] = `
 </View>
 `;
 
-exports[`android 9. article summary component with no label 1`] = `
+exports[`9. article summary component with no label 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -398,7 +398,7 @@ exports[`android 9. article summary component with no label 1`] = `
 </View>
 `;
 
-exports[`android 10. article summary component with no headline 1`] = `
+exports[`10. article summary component with no headline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -422,7 +422,7 @@ exports[`android 10. article summary component with no headline 1`] = `
 </View>
 `;
 
-exports[`android 11. article summary component with no date publication 1`] = `
+exports[`11. article summary component with no date publication 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -467,7 +467,7 @@ exports[`android 11. article summary component with no date publication 1`] = `
 </View>
 `;
 
-exports[`android 12. article summary component with a video label 1`] = `
+exports[`12. article summary component with a video label 1`] = `
 <View>
   <View>
     <VideoLabel

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render an article summary component with a single paragraph 1`] = `
+exports[`android 1. article summary component with a single paragraph 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -66,7 +66,7 @@ exports[`1. should render an article summary component with a single paragraph 1
 </View>
 `;
 
-exports[`2. should render an article summary with opinion byline 1`] = `
+exports[`android 2. article summary with opinion byline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -118,7 +118,7 @@ exports[`2. should render an article summary with opinion byline 1`] = `
 </View>
 `;
 
-exports[`3. should render an article summary component with multiple paragraphs 1`] = `
+exports[`android 3. article summary component with multiple paragraphs 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -167,7 +167,7 @@ exports[`3. should render an article summary component with multiple paragraphs 
 </View>
 `;
 
-exports[`4. should render an article summary component with content including line breaks 1`] = `
+exports[`android 4. article summary component with content including line breaks 1`] = `
 <View>
   <Text>
     <Text>
@@ -211,7 +211,7 @@ exports[`4. should render an article summary component with content including li
 </View>
 `;
 
-exports[`5. should render an article summary component containing links 1`] = `
+exports[`android 5. article summary component containing links 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -248,7 +248,7 @@ exports[`5. should render an article summary component containing links 1`] = `
 </View>
 `;
 
-exports[`6. should render an article summary component with headline and blank content 1`] = `
+exports[`android 6. article summary component with headline and no content 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -271,7 +271,7 @@ exports[`6. should render an article summary component with headline and blank c
 </View>
 `;
 
-exports[`7. should render an article summary component with empty content at the end trimmed 1`] = `
+exports[`android 7. article summary component with empty content at the end trimmed 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -329,7 +329,7 @@ exports[`7. should render an article summary component with empty content at the
 </View>
 `;
 
-exports[`8. should render an article summary component with no byline 1`] = `
+exports[`android 8. article summary component with no byline 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -353,7 +353,7 @@ exports[`8. should render an article summary component with no byline 1`] = `
 </View>
 `;
 
-exports[`9. should render an article summary component with no label 1`] = `
+exports[`android 9. article summary component with no label 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -398,7 +398,7 @@ exports[`9. should render an article summary component with no label 1`] = `
 </View>
 `;
 
-exports[`10. should render an article summary component with no headline 1`] = `
+exports[`android 10. article summary component with no headline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -422,7 +422,7 @@ exports[`10. should render an article summary component with no headline 1`] = `
 </View>
 `;
 
-exports[`11. should render an article summary component with no date publication 1`] = `
+exports[`android 11. article summary component with no date publication 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -467,7 +467,7 @@ exports[`11. should render an article summary component with no date publication
 </View>
 `;
 
-exports[`12. should render an article summary component with a video label 1`] = `
+exports[`android 12. article summary component with a video label 1`] = `
 <View>
   <View>
     <VideoLabel

--- a/packages/article-summary/__tests__/android/article-summary-with-style.android.test.js
+++ b/packages/article-summary/__tests__/android/article-summary-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/article-summary/__tests__/android/article-summary.android.test.js
+++ b/packages/article-summary/__tests__/android/article-summary.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render an article summary component with a single paragraph 1`] = `
+exports[`ios 1. article summary component with a single paragraph 1`] = `
 <View>
   <View
     style={
@@ -113,7 +113,7 @@ exports[`1. should render an article summary component with a single paragraph 1
 </View>
 `;
 
-exports[`2. should render an article summary content component with the given style 1`] = `
+exports[`ios 2. article summary content component with the given style 1`] = `
 <Text
   style={
     Object {

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. article summary component with a single paragraph 1`] = `
+exports[`1. article summary component with a single paragraph 1`] = `
 <View>
   <View
     style={
@@ -113,7 +113,7 @@ exports[`ios 1. article summary component with a single paragraph 1`] = `
 </View>
 `;
 
-exports[`ios 2. article summary content component with the given style 1`] = `
+exports[`2. article summary content component with the given style 1`] = `
 <Text
   style={
     Object {

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. article summary component with a single paragraph 1`] = `
+exports[`1. article summary component with a single paragraph 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -66,7 +66,7 @@ exports[`ios 1. article summary component with a single paragraph 1`] = `
 </View>
 `;
 
-exports[`ios 2. article summary with opinion byline 1`] = `
+exports[`2. article summary with opinion byline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -118,7 +118,7 @@ exports[`ios 2. article summary with opinion byline 1`] = `
 </View>
 `;
 
-exports[`ios 3. article summary component with multiple paragraphs 1`] = `
+exports[`3. article summary component with multiple paragraphs 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -167,7 +167,7 @@ exports[`ios 3. article summary component with multiple paragraphs 1`] = `
 </View>
 `;
 
-exports[`ios 4. article summary component with content including line breaks 1`] = `
+exports[`4. article summary component with content including line breaks 1`] = `
 <View>
   <Text>
     <Text>
@@ -211,7 +211,7 @@ exports[`ios 4. article summary component with content including line breaks 1`]
 </View>
 `;
 
-exports[`ios 5. article summary component containing links 1`] = `
+exports[`5. article summary component containing links 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -248,7 +248,7 @@ exports[`ios 5. article summary component containing links 1`] = `
 </View>
 `;
 
-exports[`ios 6. article summary component with headline and no content 1`] = `
+exports[`6. article summary component with headline and no content 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -271,7 +271,7 @@ exports[`ios 6. article summary component with headline and no content 1`] = `
 </View>
 `;
 
-exports[`ios 7. article summary component with empty content at the end trimmed 1`] = `
+exports[`7. article summary component with empty content at the end trimmed 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -329,7 +329,7 @@ exports[`ios 7. article summary component with empty content at the end trimmed 
 </View>
 `;
 
-exports[`ios 8. article summary component with no byline 1`] = `
+exports[`8. article summary component with no byline 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -353,7 +353,7 @@ exports[`ios 8. article summary component with no byline 1`] = `
 </View>
 `;
 
-exports[`ios 9. article summary component with no label 1`] = `
+exports[`9. article summary component with no label 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -398,7 +398,7 @@ exports[`ios 9. article summary component with no label 1`] = `
 </View>
 `;
 
-exports[`ios 10. article summary component with no headline 1`] = `
+exports[`10. article summary component with no headline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -422,7 +422,7 @@ exports[`ios 10. article summary component with no headline 1`] = `
 </View>
 `;
 
-exports[`ios 11. article summary component with no date publication 1`] = `
+exports[`11. article summary component with no date publication 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -467,7 +467,7 @@ exports[`ios 11. article summary component with no date publication 1`] = `
 </View>
 `;
 
-exports[`ios 12. article summary component with a video label 1`] = `
+exports[`12. article summary component with a video label 1`] = `
 <View>
   <View>
     <VideoLabel

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render an article summary component with a single paragraph 1`] = `
+exports[`ios 1. article summary component with a single paragraph 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -66,7 +66,7 @@ exports[`1. should render an article summary component with a single paragraph 1
 </View>
 `;
 
-exports[`2. should render an article summary with opinion byline 1`] = `
+exports[`ios 2. article summary with opinion byline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -118,7 +118,7 @@ exports[`2. should render an article summary with opinion byline 1`] = `
 </View>
 `;
 
-exports[`3. should render an article summary component with multiple paragraphs 1`] = `
+exports[`ios 3. article summary component with multiple paragraphs 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -167,7 +167,7 @@ exports[`3. should render an article summary component with multiple paragraphs 
 </View>
 `;
 
-exports[`4. should render an article summary component with content including line breaks 1`] = `
+exports[`ios 4. article summary component with content including line breaks 1`] = `
 <View>
   <Text>
     <Text>
@@ -211,7 +211,7 @@ exports[`4. should render an article summary component with content including li
 </View>
 `;
 
-exports[`5. should render an article summary component containing links 1`] = `
+exports[`ios 5. article summary component containing links 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -248,7 +248,7 @@ exports[`5. should render an article summary component containing links 1`] = `
 </View>
 `;
 
-exports[`6. should render an article summary component with headline and blank content 1`] = `
+exports[`ios 6. article summary component with headline and no content 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -271,7 +271,7 @@ exports[`6. should render an article summary component with headline and blank c
 </View>
 `;
 
-exports[`7. should render an article summary component with empty content at the end trimmed 1`] = `
+exports[`ios 7. article summary component with empty content at the end trimmed 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -329,7 +329,7 @@ exports[`7. should render an article summary component with empty content at the
 </View>
 `;
 
-exports[`8. should render an article summary component with no byline 1`] = `
+exports[`ios 8. article summary component with no byline 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -353,7 +353,7 @@ exports[`8. should render an article summary component with no byline 1`] = `
 </View>
 `;
 
-exports[`9. should render an article summary component with no label 1`] = `
+exports[`ios 9. article summary component with no label 1`] = `
 <View>
   <Text
     accessibilityRole="heading"
@@ -398,7 +398,7 @@ exports[`9. should render an article summary component with no label 1`] = `
 </View>
 `;
 
-exports[`10. should render an article summary component with no headline 1`] = `
+exports[`ios 10. article summary component with no headline 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -422,7 +422,7 @@ exports[`10. should render an article summary component with no headline 1`] = `
 </View>
 `;
 
-exports[`11. should render an article summary component with no date publication 1`] = `
+exports[`ios 11. article summary component with no date publication 1`] = `
 <View>
   <View>
     <ArticleLabel
@@ -467,7 +467,7 @@ exports[`11. should render an article summary component with no date publication
 </View>
 `;
 
-exports[`12. should render an article summary component with a video label 1`] = `
+exports[`ios 12. article summary component with a video label 1`] = `
 <View>
   <View>
     <VideoLabel

--- a/packages/article-summary/__tests__/ios/article-summary-with-style.ios.test.js
+++ b/packages/article-summary/__tests__/ios/article-summary-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/article-summary/__tests__/ios/article-summary.ios.test.js
+++ b/packages/article-summary/__tests__/ios/article-summary.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/article-summary/__tests__/shared-with-style.base.js
+++ b/packages/article-summary/__tests__/shared-with-style.base.js
@@ -1,5 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
+import { iterator } from "@times-components/test-utils";
 import ArticleSummary, { ArticleSummaryContent } from "../src/article-summary";
 import defaultFixture from "../fixtures/default";
 
@@ -13,45 +14,50 @@ export default () => {
   const label = "Test label";
   const paragraph = "Test paragraph";
 
-  it("should render an article summary component with a single paragraph", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...defaultFixture({
-          headline,
-          label,
-          paragraph
-        })}
-      />
-    );
+  const tests = [
+    {
+      name: "article summary component with a single paragraph",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...defaultFixture({
+              headline,
+              label,
+              paragraph
+            })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "1. should render an article summary component with a single paragraph"
-    );
-  });
-
-  it("should render an article summary content component with the given style", () => {
-    const ast = [
-      {
-        name: "paragraph",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "Test"
-            },
-            children: []
-          }
-        ]
+        expect(testInstance.toJSON()).toMatchSnapshot();
       }
-    ];
+    },
+    {
+      name: "article summary content component with the given style",
+      test: () => {
+        const ast = [
+          {
+            name: "paragraph",
+            attributes: {},
+            children: [
+              {
+                name: "text",
+                attributes: {
+                  value: "Test"
+                },
+                children: []
+              }
+            ]
+          }
+        ];
 
-    const testInstance = TestRenderer.create(
-      <ArticleSummaryContent ast={ast} />
-    );
+        const testInstance = TestRenderer.create(
+          <ArticleSummaryContent ast={ast} />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "2. should render an article summary content component with the given style"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    }
+  ];
+
+  iterator(tests);
 };

--- a/packages/article-summary/__tests__/shared.base.js
+++ b/packages/article-summary/__tests__/shared.base.js
@@ -1,5 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
+import { iterator } from "@times-components/test-utils";
 import ArticleSummary, { renderAst } from "../src/article-summary";
 import defaultFixture from "../fixtures/default";
 import withSummaryLinksFixture from "../fixtures/with-summary-links";
@@ -27,185 +28,192 @@ export default () => {
   const paragraph1 = "Test paragraph 1.";
   const paragraph2 = "Test paragraph 2";
 
-  it("should render an article summary component with a single paragraph", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...defaultFixture({
-          headline,
-          label,
-          paragraph
-        })}
-      />
-    );
+  const tests = [
+    {
+      name: "article summary component with a single paragraph",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...defaultFixture({
+              headline,
+              label,
+              paragraph
+            })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "1. should render an article summary component with a single paragraph"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary with opinion byline",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...opinionBylineFixture({
+              byline,
+              headline,
+              label,
+              paragraph
+            })}
+          />
+        );
 
-  it("should render an article summary with opinion byline", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...opinionBylineFixture({
-          byline,
-          headline,
-          label,
-          paragraph
-        })}
-      />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with multiple paragraphs",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...articleMultiFixture({
+              byline,
+              headline,
+              label,
+              paragraph1,
+              paragraph2
+            })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "2. should render an article summary with opinion byline"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with content including line breaks",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...reviewFixture({
+              headline,
+              label,
+              review1Title: "Review 1",
+              review2Title: "Review 2",
+              paragraph
+            })}
+          />
+        );
 
-  it("should render an article summary component with multiple paragraphs", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...articleMultiFixture({
-          byline,
-          headline,
-          label,
-          paragraph1,
-          paragraph2
-        })}
-      />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component containing links",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...withSummaryLinksFixture({
+              headline,
+              label
+            })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "3. should render an article summary component with multiple paragraphs"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with headline and no content",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...blankFixture({
+              headline,
+              label
+            })}
+          />
+        );
 
-  it("should render an article summary component with content including line breaks", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...reviewFixture({
-          headline,
-          label,
-          review1Title: "Review 1",
-          review2Title: "Review 2",
-          paragraph
-        })}
-      />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with empty content at the end trimmed",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...emptyParagraphFixture({
+              byline,
+              headline,
+              label,
+              paragraph1,
+              paragraph2
+            })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "4. should render an article summary component with content including line breaks"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with no byline",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary {...noBylineFixture({ headline, paragraph })} />
+        );
 
-  it("should render an article summary component containing links", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...withSummaryLinksFixture({
-          headline,
-          label
-        })}
-      />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with no label",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...noLabelFixture({
+              byline,
+              headline,
+              paragraph
+            })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "5. should render an article summary component containing links"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with no headline",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary {...noHeadline({ label, paragraph })} />
+        );
 
-  it("should render an article summary component with headline and no content", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...blankFixture({
-          headline,
-          label
-        })}
-      />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with no date publication",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...noDatePublication({ byline, headline, label, paragraph })}
+          />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "6. should render an article summary component with headline and blank content"
-    );
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article summary component with a video label",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <ArticleSummary
+            {...videoLabelFixture({ byline, headline, label, paragraph })}
+          />
+        );
 
-  it("should render an article summary component with empty content at the end trimmed", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...emptyParagraphFixture({
-          byline,
-          headline,
-          label,
-          paragraph1,
-          paragraph2
-        })}
-      />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "should handle rendering empty or undefined ast",
+      test: () => {
+        expect(renderAst([])).toEqual([]);
+        expect(renderAst()).toEqual([]);
+      }
+    }
+  ];
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "7. should render an article summary component with empty content at the end trimmed"
-    );
-  });
-
-  it("should render an article summary component with no byline", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary {...noBylineFixture({ headline, paragraph })} />
-    );
-
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "8. should render an article summary component with no byline"
-    );
-  });
-
-  it("should render an article summary component with no label", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...noLabelFixture({
-          byline,
-          headline,
-          paragraph
-        })}
-      />
-    );
-
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "9. should render an article summary component with no label"
-    );
-  });
-
-  it("should render an article summary component with no headline", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary {...noHeadline({ label, paragraph })} />
-    );
-
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "10. should render an article summary component with no headline"
-    );
-  });
-
-  it("should render an article summary component with no date publication", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...noDatePublication({ byline, headline, label, paragraph })}
-      />
-    );
-
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "11. should render an article summary component with no date publication"
-    );
-  });
-
-  it("should render an article summary component with a video label", () => {
-    const testInstance = TestRenderer.create(
-      <ArticleSummary
-        {...videoLabelFixture({ byline, headline, label, paragraph })}
-      />
-    );
-
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "12. should render an article summary component with a video label"
-    );
-  });
-
-  it("should handle rendering empty or undefined ast", () => {
-    expect(renderAst([])).toEqual([]);
-    expect(renderAst()).toEqual([]);
-  });
+  iterator(tests);
 };

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render an article summary component with a single paragraph 1`] = `
+exports[`web 1. article summary component with a single paragraph 1`] = `
 <style>
 {
   "IS1": {
@@ -132,7 +132,7 @@ exports[`1. should render an article summary component with a single paragraph 1
 </div>
 `;
 
-exports[`2. should render an article summary content component with the given style 1`] = `
+exports[`web 2. article summary content component with the given style 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. article summary component with a single paragraph 1`] = `
+exports[`1. article summary component with a single paragraph 1`] = `
 <style>
 {
   "IS1": {
@@ -132,7 +132,7 @@ exports[`web 1. article summary component with a single paragraph 1`] = `
 </div>
 `;
 
-exports[`web 2. article summary content component with the given style 1`] = `
+exports[`2. article summary content component with the given style 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. article summary component with a single paragraph 1`] = `
+exports[`1. article summary component with a single paragraph 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -66,7 +66,7 @@ exports[`web 1. article summary component with a single paragraph 1`] = `
 </div>
 `;
 
-exports[`web 2. article summary with opinion byline 1`] = `
+exports[`2. article summary with opinion byline 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -118,7 +118,7 @@ exports[`web 2. article summary with opinion byline 1`] = `
 </div>
 `;
 
-exports[`web 3. article summary component with multiple paragraphs 1`] = `
+exports[`3. article summary component with multiple paragraphs 1`] = `
 <div>
   <h3
     aria-level="3"
@@ -167,7 +167,7 @@ exports[`web 3. article summary component with multiple paragraphs 1`] = `
 </div>
 `;
 
-exports[`web 4. article summary component with content including line breaks 1`] = `
+exports[`4. article summary component with content including line breaks 1`] = `
 <div>
   <div>
     <span>
@@ -199,7 +199,7 @@ exports[`web 4. article summary component with content including line breaks 1`]
 </div>
 `;
 
-exports[`web 5. article summary component containing links 1`] = `
+exports[`5. article summary component containing links 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -236,7 +236,7 @@ exports[`web 5. article summary component containing links 1`] = `
 </div>
 `;
 
-exports[`web 6. article summary component with headline and no content 1`] = `
+exports[`6. article summary component with headline and no content 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -259,7 +259,7 @@ exports[`web 6. article summary component with headline and no content 1`] = `
 </div>
 `;
 
-exports[`web 7. article summary component with empty content at the end trimmed 1`] = `
+exports[`7. article summary component with empty content at the end trimmed 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -317,7 +317,7 @@ exports[`web 7. article summary component with empty content at the end trimmed 
 </div>
 `;
 
-exports[`web 8. article summary component with no byline 1`] = `
+exports[`8. article summary component with no byline 1`] = `
 <div>
   <h3
     aria-level="3"
@@ -341,7 +341,7 @@ exports[`web 8. article summary component with no byline 1`] = `
 </div>
 `;
 
-exports[`web 9. article summary component with no label 1`] = `
+exports[`9. article summary component with no label 1`] = `
 <div>
   <h3
     aria-level="3"
@@ -386,7 +386,7 @@ exports[`web 9. article summary component with no label 1`] = `
 </div>
 `;
 
-exports[`web 10. article summary component with no headline 1`] = `
+exports[`10. article summary component with no headline 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -410,7 +410,7 @@ exports[`web 10. article summary component with no headline 1`] = `
 </div>
 `;
 
-exports[`web 11. article summary component with no date publication 1`] = `
+exports[`11. article summary component with no date publication 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -455,7 +455,7 @@ exports[`web 11. article summary component with no date publication 1`] = `
 </div>
 `;
 
-exports[`web 12. article summary component with a video label 1`] = `
+exports[`12. article summary component with a video label 1`] = `
 <div>
   <div>
     <VideoLabel

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render an article summary component with a single paragraph 1`] = `
+exports[`web 1. article summary component with a single paragraph 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -66,7 +66,7 @@ exports[`1. should render an article summary component with a single paragraph 1
 </div>
 `;
 
-exports[`2. should render an article summary with opinion byline 1`] = `
+exports[`web 2. article summary with opinion byline 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -118,7 +118,7 @@ exports[`2. should render an article summary with opinion byline 1`] = `
 </div>
 `;
 
-exports[`3. should render an article summary component with multiple paragraphs 1`] = `
+exports[`web 3. article summary component with multiple paragraphs 1`] = `
 <div>
   <h3
     aria-level="3"
@@ -167,7 +167,7 @@ exports[`3. should render an article summary component with multiple paragraphs 
 </div>
 `;
 
-exports[`4. should render an article summary component with content including line breaks 1`] = `
+exports[`web 4. article summary component with content including line breaks 1`] = `
 <div>
   <div>
     <span>
@@ -199,7 +199,7 @@ exports[`4. should render an article summary component with content including li
 </div>
 `;
 
-exports[`5. should render an article summary component containing links 1`] = `
+exports[`web 5. article summary component containing links 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -236,7 +236,7 @@ exports[`5. should render an article summary component containing links 1`] = `
 </div>
 `;
 
-exports[`6. should render an article summary component with headline and blank content 1`] = `
+exports[`web 6. article summary component with headline and no content 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -259,7 +259,7 @@ exports[`6. should render an article summary component with headline and blank c
 </div>
 `;
 
-exports[`7. should render an article summary component with empty content at the end trimmed 1`] = `
+exports[`web 7. article summary component with empty content at the end trimmed 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -317,7 +317,7 @@ exports[`7. should render an article summary component with empty content at the
 </div>
 `;
 
-exports[`8. should render an article summary component with no byline 1`] = `
+exports[`web 8. article summary component with no byline 1`] = `
 <div>
   <h3
     aria-level="3"
@@ -341,7 +341,7 @@ exports[`8. should render an article summary component with no byline 1`] = `
 </div>
 `;
 
-exports[`9. should render an article summary component with no label 1`] = `
+exports[`web 9. article summary component with no label 1`] = `
 <div>
   <h3
     aria-level="3"
@@ -386,7 +386,7 @@ exports[`9. should render an article summary component with no label 1`] = `
 </div>
 `;
 
-exports[`10. should render an article summary component with no headline 1`] = `
+exports[`web 10. article summary component with no headline 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -410,7 +410,7 @@ exports[`10. should render an article summary component with no headline 1`] = `
 </div>
 `;
 
-exports[`11. should render an article summary component with no date publication 1`] = `
+exports[`web 11. article summary component with no date publication 1`] = `
 <div>
   <div>
     <ArticleLabel
@@ -455,7 +455,7 @@ exports[`11. should render an article summary component with no date publication
 </div>
 `;
 
-exports[`12. should render an article summary component with a video label 1`] = `
+exports[`web 12. article summary component with a video label 1`] = `
 <div>
   <div>
     <VideoLabel

--- a/packages/article-summary/__tests__/web/article-summary-with-style.web.test.js
+++ b/packages/article-summary/__tests__/web/article-summary-with-style.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/article-summary/__tests__/web/article-summary.web.test.js
+++ b/packages/article-summary/__tests__/web/article-summary.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -38,7 +38,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article-summary/package.json
+++ b/packages/article-summary/package.json
@@ -38,6 +38,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article Topics test on android:  1. group of topics 1`] = `
+exports[`1. group of topics 1`] = `
 <View
   style={
     Object {
@@ -33,7 +33,7 @@ exports[`Article Topics test on android:  1. group of topics 1`] = `
 </View>
 `;
 
-exports[`Article Topics test on android:  2. single topic 1`] = `
+exports[`2. single topic 1`] = `
 <Link
   url="/topic/football"
 >
@@ -67,7 +67,7 @@ exports[`Article Topics test on android:  2. single topic 1`] = `
 </Link>
 `;
 
-exports[`Article Topics test on android:  4. onpress sends analytics 1`] = `
+exports[`4. onpress sends analytics 1`] = `
 Array [
   Array [
     Object {

--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a group of topics in the correct order 1`] = `
+exports[`Article Topics test on android:  1. group of topics 1`] = `
 <View
   style={
     Object {
@@ -33,7 +33,7 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 </View>
 `;
 
-exports[`2. Render a single topic 1`] = `
+exports[`Article Topics test on android:  2. single topic 1`] = `
 <Link
   url="/topic/football"
 >
@@ -67,7 +67,7 @@ exports[`2. Render a single topic 1`] = `
 </Link>
 `;
 
-exports[`Article Topics test on android:  onPress sends analytics 1`] = `
+exports[`Article Topics test on android:  4. onpress sends analytics 1`] = `
 Array [
   Array [
     Object {

--- a/packages/article-topics/__tests__/android/article-topics.test.js
+++ b/packages/article-topics/__tests__/android/article-topics.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared";
 
-describe("Article Topics test on android: ", () => {
-  shared();
-});
+shared();

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article Topics test on ios:  1. group of topics 1`] = `
+exports[`1. group of topics 1`] = `
 <View
   style={
     Object {
@@ -33,7 +33,7 @@ exports[`Article Topics test on ios:  1. group of topics 1`] = `
 </View>
 `;
 
-exports[`Article Topics test on ios:  2. single topic 1`] = `
+exports[`2. single topic 1`] = `
 <Link
   url="/topic/football"
 >
@@ -67,7 +67,7 @@ exports[`Article Topics test on ios:  2. single topic 1`] = `
 </Link>
 `;
 
-exports[`Article Topics test on ios:  4. onpress sends analytics 1`] = `
+exports[`4. onpress sends analytics 1`] = `
 Array [
   Array [
     Object {

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a group of topics in the correct order 1`] = `
+exports[`Article Topics test on ios:  1. group of topics 1`] = `
 <View
   style={
     Object {
@@ -33,7 +33,7 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 </View>
 `;
 
-exports[`2. Render a single topic 1`] = `
+exports[`Article Topics test on ios:  2. single topic 1`] = `
 <Link
   url="/topic/football"
 >
@@ -67,7 +67,7 @@ exports[`2. Render a single topic 1`] = `
 </Link>
 `;
 
-exports[`Article Topics test on ios:  onPress sends analytics 1`] = `
+exports[`Article Topics test on ios:  4. onpress sends analytics 1`] = `
 Array [
   Array [
     Object {

--- a/packages/article-topics/__tests__/ios/article-topics.test.js
+++ b/packages/article-topics/__tests__/ios/article-topics.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared";
 
-describe("Article Topics test on ios: ", () => {
-  shared();
-});
+shared();

--- a/packages/article-topics/__tests__/shared.js
+++ b/packages/article-topics/__tests__/shared.js
@@ -1,7 +1,7 @@
-import "react-native";
 import React from "react";
 import mockDate from "mockdate";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import ArticleTopics from "../src/article-topics";
 import ArticleTopic from "../src/article-topic";
 import topicData from "../fixtures/topics";
@@ -15,67 +15,77 @@ module.exports = () => {
     mockDate.reset();
   });
 
-  it("renders a group of topics in the correct order", () => {
-    const wrapper = shallow(
-      <ArticleTopics onPress={() => {}} topics={topicData} />
-    );
+  const tests = [
+    {
+      name: "group of topics",
+      test: () => {
+        const wrapper = shallow(
+          <ArticleTopics onPress={() => {}} topics={topicData} />
+        );
 
-    expect(wrapper).toMatchSnapshot(
-      "1. Render a group of topics in the correct order"
-    );
-  });
-
-  it("renders a single topic", () => {
-    const wrapper = shallow(
-      <ArticleTopic
-        name={topicData[0].name}
-        onPress={() => {}}
-        slug={topicData[0].slug}
-      />
-    ).dive();
-
-    expect(wrapper).toMatchSnapshot("2. Render a single topic");
-  });
-
-  it("onPress handler is working", done => {
-    const onPress = (e, { name, slug }) => {
-      expect(e).toBe("event");
-      expect(slug).toBe(slug);
-      expect(name).toBe(name);
-      done();
-    };
-
-    shallow(
-      <ArticleTopic
-        name={topicData[0].name}
-        onPress={(e, data) => onPress(e, data)}
-        slug={topicData[0].slug}
-      />
-    )
-      .dive()
-      .simulate("press", "event");
-  });
-
-  it("onPress sends analytics", () => {
-    const events = jest.fn();
-
-    const context = {
-      tracking: {
-        analytics: events
+        expect(wrapper).toMatchSnapshot();
       }
-    };
+    },
+    {
+      name: "single topic",
+      test: () => {
+        const wrapper = shallow(
+          <ArticleTopic
+            name={topicData[0].name}
+            onPress={() => {}}
+            slug={topicData[0].slug}
+          />
+        ).dive();
 
-    shallow(
-      <ArticleTopic
-        name={topicData[0].name}
-        onPress={() => events}
-        slug={topicData[0].slug}
-      />,
-      {
-        context
+        expect(wrapper).toMatchSnapshot();
       }
-    ).simulate("press");
+    },
+    {
+      name: "onPress handler is working",
+      test: () => {
+        const onPress = (e, { name, slug }) => {
+          expect(e).toBe("event");
+          expect(slug).toBe(slug);
+          expect(name).toBe(name);
+        };
 
-    expect(events.mock.calls).toMatchSnapshot();
-  });
+        shallow(
+          <ArticleTopic
+            name={topicData[0].name}
+            onPress={(e, data) => onPress(e, data)}
+            slug={topicData[0].slug}
+          />
+        )
+          .dive()
+          .simulate("press", "event");
+      }
+    },
+    {
+      name: "onPress sends analytics",
+      test: () => {
+        const events = jest.fn();
+
+        const context = {
+          tracking: {
+            analytics: events
+          }
+        };
+
+        shallow(
+          <ArticleTopic
+            name={topicData[0].name}
+            onPress={() => events}
+            slug={topicData[0].slug}
+          />,
+          {
+            context
+          }
+        ).simulate("press");
+
+        expect(events.mock.calls).toMatchSnapshot();
+      }
+    }
+  ];
+
+  iterator(tests);
 };

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a group of topics in the correct order 1`] = `
+exports[`Article Topics test on web:  1. group of topics 1`] = `
 <View
   style={
     Object {
@@ -33,7 +33,7 @@ exports[`1. Render a group of topics in the correct order 1`] = `
 </View>
 `;
 
-exports[`2. Render a single topic 1`] = `
+exports[`Article Topics test on web:  2. single topic 1`] = `
 <Link
   index="0"
   responsiveLinkStyles={null}
@@ -70,7 +70,7 @@ exports[`2. Render a single topic 1`] = `
 </Link>
 `;
 
-exports[`Article Topics test on web:  onPress sends analytics 1`] = `
+exports[`Article Topics test on web:  4. onpress sends analytics 1`] = `
 Array [
   Array [
     Object {

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article Topics test on web:  1. group of topics 1`] = `
+exports[`1. group of topics 1`] = `
 <View
   style={
     Object {
@@ -33,7 +33,7 @@ exports[`Article Topics test on web:  1. group of topics 1`] = `
 </View>
 `;
 
-exports[`Article Topics test on web:  2. single topic 1`] = `
+exports[`2. single topic 1`] = `
 <Link
   index="0"
   responsiveLinkStyles={null}
@@ -70,7 +70,7 @@ exports[`Article Topics test on web:  2. single topic 1`] = `
 </Link>
 `;
 
-exports[`Article Topics test on web:  4. onpress sends analytics 1`] = `
+exports[`4. onpress sends analytics 1`] = `
 Array [
   Array [
     Object {

--- a/packages/article-topics/__tests__/web/article-topics.test.js
+++ b/packages/article-topics/__tests__/web/article-topics.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared";
 
-describe("Article Topics test on web: ", () => {
-  shared();
-});
+shared();

--- a/packages/article-topics/package.json
+++ b/packages/article-topics/package.json
@@ -40,7 +40,7 @@
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article-topics/package.json
+++ b/packages/article-topics/package.json
@@ -40,6 +40,7 @@
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article tests on android 1. article 1`] = `
+exports[`1. article 1`] = `
 <View>
   <Text>
     An error occurred
@@ -13,7 +13,7 @@ exports[`Article tests on android 1. article 1`] = `
 </View>
 `;
 
-exports[`Article tests on android 2. full article 1`] = `
+exports[`2. full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1028,7 +1028,7 @@ exports[`Article tests on android 2. full article 1`] = `
 />
 `;
 
-exports[`Article tests on android 3. smaller article 1`] = `
+exports[`3. smaller article 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -3032,7 +3032,7 @@ exports[`Article tests on android 3. smaller article 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 4. article with no flags 1`] = `
+exports[`4. article with no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -4726,7 +4726,7 @@ exports[`Article tests on android 4. article with no flags 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 5. article with no byline 1`] = `
+exports[`5. article with no byline 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -6395,7 +6395,7 @@ exports[`Article tests on android 5. article with no byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 6. article with no label 1`] = `
+exports[`6. article with no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -8104,7 +8104,7 @@ exports[`Article tests on android 6. article with no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 7. article with no standfirst 1`] = `
+exports[`7. article with no standfirst 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -9813,7 +9813,7 @@ exports[`Article tests on android 7. article with no standfirst 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 8. article with no standfirst and no flags 1`] = `
+exports[`8. article with no standfirst and no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -11492,7 +11492,7 @@ exports[`Article tests on android 8. article with no standfirst and no flags 1`]
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 9. article with no standfirst and no label 1`] = `
+exports[`9. article with no standfirst and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -13186,7 +13186,7 @@ exports[`Article tests on android 9. article with no standfirst and no label 1`]
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 10. article with no flags and no label 1`] = `
+exports[`10. article with no flags and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -14865,7 +14865,7 @@ exports[`Article tests on android 10. article with no flags and no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 11. article with no standfirst, no label and no no flags 1`] = `
+exports[`11. article with no standfirst, no label and no no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -16529,7 +16529,7 @@ exports[`Article tests on android 11. article with no standfirst, no label and n
 </RCTScrollView>
 `;
 
-exports[`Article tests on android 12. article with a video asset 1`] = `
+exports[`12. article with a video asset 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -17116,36 +17116,7 @@ exports[`Article tests on android 12. article with a video asset 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "flags": undefined,
-      "headline": undefined,
-      "isVideo": false,
-      "label": undefined,
-      "standfirst": undefined,
-    },
-    "type": "header",
-  },
-  Object {
-    "data": Object {
-      "byline": undefined,
-      "publicationName": undefined,
-      "publishedTime": undefined,
-    },
-    "type": "middleContainer",
-  },
-  Object {
-    "data": Object {
-      "topics": undefined,
-    },
-    "type": "topics",
-  },
-]
-`;
-
-exports[`Send analytics when rendering an Article page 1`] = `
+exports[`analytics for page view 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {
@@ -17179,4 +17150,33 @@ Object {
   "component": "Page",
   "object": "Article",
 }
+`;
+
+exports[`should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "flags": undefined,
+      "headline": undefined,
+      "isVideo": false,
+      "label": undefined,
+      "standfirst": undefined,
+    },
+    "type": "header",
+  },
+  Object {
+    "data": Object {
+      "byline": undefined,
+      "publicationName": undefined,
+      "publishedTime": undefined,
+    },
+    "type": "middleContainer",
+  },
+  Object {
+    "data": Object {
+      "topics": undefined,
+    },
+    "type": "topics",
+  },
+]
 `;

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1,19 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. article 1`] = `
-<View>
-  <Text>
-    An error occurred
-  </Text>
-  <Text>
-    {
-  "message": "An example error."
-}
-  </Text>
-</View>
+exports[`Article tests on android should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "flags": undefined,
+      "headline": undefined,
+      "isVideo": false,
+      "label": undefined,
+      "standfirst": undefined,
+    },
+    "type": "header",
+  },
+  Object {
+    "data": Object {
+      "byline": undefined,
+      "publicationName": undefined,
+      "publishedTime": undefined,
+    },
+    "type": "middleContainer",
+  },
+  Object {
+    "data": Object {
+      "topics": undefined,
+    },
+    "type": "topics",
+  },
+]
 `;
 
-exports[`2. full article 1`] = `
+exports[`Article tests on android should render a full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1028,7 +1044,7 @@ exports[`2. full article 1`] = `
 />
 `;
 
-exports[`3. smaller article 1`] = `
+exports[`Article tests on android should render a smaller article 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -3032,31 +3048,39 @@ exports[`3. smaller article 1`] = `
 </RCTScrollView>
 `;
 
-exports[`4. article with no flags 1`] = `
+exports[`Article tests on android should render an article with a video asset 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
         "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          "__typename": "Video",
+          "brightcoveAccountId": "57838016001",
+          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+          "brightcoveVideoId": "4084164751001",
+          "caption": "This is video caption",
+          "isVideo": true,
+          "paidOnly": "false",
+          "posterImage": Object {
+            "caption": "CCTV captures moment of the explosion",
+            "credits": "",
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+            },
+            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
+            "title": "",
           },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
         },
         "type": "leadAsset",
       },
       Object {
         "data": Object {
           "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+          "headline": "Young boy among dead after blast flattens Leicester store",
+          "isVideo": true,
+          "label": "",
+          "standfirst": "",
         },
         "type": "header",
       },
@@ -3068,7 +3092,7 @@ exports[`4. article with no flags 1`] = `
               "children": Array [
                 Object {
                   "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
                   },
                   "children": Array [],
                   "name": "text",
@@ -3078,7 +3102,7 @@ exports[`4. article with no flags 1`] = `
             },
           ],
           "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
+          "publishedTime": "2018-02-26T17:00:00.000Z",
         },
         "type": "middleContainer",
       },
@@ -3088,43 +3112,10 @@ exports[`4. article with no flags 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
               },
               "children": Array [],
               "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -3137,17 +3128,11 @@ exports[`4. article with no flags 1`] = `
           "attributes": Object {},
           "children": Array [
             Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
+              "attributes": Object {
+                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
+              },
+              "children": Array [],
+              "name": "text",
             },
           ],
           "name": "paragraph",
@@ -3161,7 +3146,7 @@ exports[`4. article with no flags 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
               },
               "children": Array [],
               "name": "text",
@@ -3174,17 +3159,15 @@ exports[`4. article with no flags 1`] = `
       },
       Object {
         "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
+          "attributes": Object {
+            "caption": "Some 60 homes near the site of the explosion were evacuated",
+            "credits": "CATERS",
+            "display": "primary",
+            "ratio": "1500:1000",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+          },
+          "children": Array [],
+          "name": "image",
         },
         "index": 3,
         "type": "articleBodyRow",
@@ -3195,7 +3178,7 @@ exports[`4. article with no flags 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
               },
               "children": Array [],
               "name": "text",
@@ -3208,698 +3191,9 @@ exports[`4. article with no flags 1`] = `
       },
       Object {
         "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
           "topics": undefined,
         },
         "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
       },
     ]
   }
@@ -3919,54 +3213,125 @@ exports[`4. article with no flags 1`] = `
       <View
         testID="leadAsset"
       >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
+        <View
+          accessibilityLabel="splash-component"
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackground",
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          style={
+            Object {
+              "height": 421.875,
+              "width": 750,
+            }
+          }
+          testID="splash-component"
+        >
+          <View
+            style={
+              Object {
+                "height": 421.875,
+                "width": 750,
+              }
+            }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
                   "height": "100%",
                   "width": "100%",
                 }
               }
             >
-              <View
-                nativeBackgroundAndroid={
+              <Image
+                source={
                   Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
                   }
                 }
-                pointerEvents="box-only"
+                style={
+                  Object {
+                    "bottom": 0,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
               >
-                <ARTSurfaceView
+                <View
                   style={
                     Object {
-                      "height": 24,
-                      "width": 24,
+                      "flex": 1,
                     }
                   }
                 >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
+                  <ARTSurfaceView
+                    style={
+                      Object {
+                        "bottom": 0,
+                        "height": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                        "width": 0,
+                      }
                     }
                   >
-                    <ARTGroup
+                    <ARTShape
+                      d={
+                        Array [
+                          2,
+                          0,
+                          0,
+                          2,
+                          0,
+                          0,
+                          2,
+                          0,
+                          0,
+                          2,
+                          0,
+                          0,
+                        ]
+                      }
+                      fill={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          -0,
+                          0,
+                          0.9764705882352941,
+                          0.9764705882352941,
+                          0.9764705882352941,
+                          1,
+                          0.9294117647058824,
+                          0.9294117647058824,
+                          0.9294117647058824,
+                          1,
+                          0,
+                          1,
+                        ]
+                      }
                       opacity={1}
+                      stroke={null}
+                      strokeCap={1}
+                      strokeDash={null}
+                      strokeJoin={1}
+                      strokeWidth={1}
                       transform={
                         Array [
                           1,
@@ -3977,394 +3342,45 @@ exports[`4. article with no flags 1`] = `
                           0,
                         ]
                       }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
+                    />
+                  </ARTSurfaceView>
                 </View>
               </View>
             </View>
-          </Modal>
+          </View>
           <View
-            nativeBackgroundAndroid={
+            style={
               Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
+                "alignItems": "center",
+                "flex": 1,
+                "height": 421.875,
+                "justifyContent": "center",
+                "left": 0,
+                "position": "absolute",
+                "top": 0,
+                "width": 750,
               }
             }
-            pointerEvents="box-only"
           >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
+            <View>
+              <svg
+                height={70}
+                viewBox="0 0 100 100"
+                width={70}
               >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
+                <rect
+                  fill="rgba(0,0,0)"
+                  fillOpacity="0.4"
+                  height="100"
+                  stroke="rgb(255,255,255)"
+                  strokeWidth="8"
+                  width="100"
                 />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
+                <polygon
+                  fill="rgb(255,255,255)"
+                  points="30,20 70,50 30,80"
+                />
+              </svg>
             </View>
           </View>
         </View>
@@ -4389,9 +3405,9 @@ exports[`4. article with no flags 1`] = `
           }
           testID="label"
         >
-          <ArticleLabel
+          <VideoLabel
             color="#333333"
-            title="HURRICANE IRMA"
+            title=""
           />
         </View>
         <Text
@@ -4406,22 +3422,7 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 29,
-              "marginTop": -7,
-              "paddingBottom": 12,
-            }
-          }
-          testID="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+          Young boy among dead after blast flattens Leicester store
         </Text>
       </View>
     </View>
@@ -4468,7 +3469,7 @@ exports[`4. article with no flags 1`] = `
                     "children": Array [
                       Object {
                         "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
                         },
                         "children": Array [],
                         "name": "text",
@@ -4501,7 +3502,7 @@ exports[`4. article with no flags 1`] = `
               }
             }
           >
-            Friday March 13 2015, 06:54pm, The Times
+            Monday February 26 2018, 05:00pm, The Times
           </Text>
         </View>
       </View>
@@ -4528,26 +3529,7 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
+          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
         </Text>
       </View>
     </View>
@@ -4573,15 +3555,7 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
+          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
         </Text>
       </View>
     </View>
@@ -4607,34 +3581,27 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
         </Text>
       </View>
     </View>
     <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
+      <View>
+        <ArticleImage
+          captionOptions={
             Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
+              "caption": "Some 60 homes near the site of the explosion were evacuated",
+              "credits": "CATERS",
             }
           }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
+          imageOptions={
+            Object {
+              "display": "primary",
+              "ratio": "1500:1000",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+            }
+          }
+        />
       </View>
     </View>
     <View>
@@ -4659,74 +3626,16 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
         </Text>
       </View>
     </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
 
-exports[`5. article with no byline 1`] = `
+exports[`Article tests on android should render an article with no byline 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -6395,7 +5304,1701 @@ exports[`5. article with no byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`6. article with no label 1`] = `
+exports[`Article tests on android should render an article with no flags 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                nativeBackgroundAndroid={
+                  Object {
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
+                  }
+                }
+                pointerEvents="box-only"
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            pointerEvents="box-only"
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="label"
+          style={
+            Object {
+              "paddingBottom": 5,
+              "paddingTop": 4,
+            }
+          }
+          testID="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </View>
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 37,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Regular",
+              "fontSize": 20,
+              "lineHeight": 29,
+              "marginTop": -7,
+              "paddingBottom": 12,
+            }
+          }
+          testID="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on android should render an article with no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -8104,5089 +8707,7 @@ exports[`6. article with no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`7. article with no standfirst 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [
-            "NEW",
-            "EXCLUSIVE",
-          ],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                pointerEvents="box-only"
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            pointerEvents="box-only"
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="label"
-          style={
-            Object {
-              "paddingBottom": 5,
-              "paddingTop": 4,
-            }
-          }
-          testID="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 37,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 11,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <NewArticleFlag />
-          </View>
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <ExclusiveArticleFlag />
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`8. article with no standfirst and no flags 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                pointerEvents="box-only"
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            pointerEvents="box-only"
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="label"
-          style={
-            Object {
-              "paddingBottom": 5,
-              "paddingTop": 4,
-            }
-          }
-          testID="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 37,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`9. article with no standfirst and no label 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [
-            "NEW",
-            "EXCLUSIVE",
-          ],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": null,
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                pointerEvents="box-only"
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            pointerEvents="box-only"
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 37,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 11,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <NewArticleFlag />
-          </View>
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <ExclusiveArticleFlag />
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`10. article with no flags and no label 1`] = `
+exports[`Article tests on android should render an article with no label and no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -14865,7 +10386,7 @@ exports[`10. article with no flags and no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`11. article with no standfirst, no label and no no flags 1`] = `
+exports[`Article tests on android should render an article with no label, no flags and no standfirst 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -16529,39 +12050,34 @@ exports[`11. article with no standfirst, no label and no no flags 1`] = `
 </RCTScrollView>
 `;
 
-exports[`12. article with a video asset 1`] = `
+exports[`Article tests on android should render an article with no standfirst 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
         "data": Object {
-          "__typename": "Video",
-          "brightcoveAccountId": "57838016001",
-          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-          "brightcoveVideoId": "4084164751001",
-          "caption": "This is video caption",
-          "isVideo": true,
-          "paidOnly": "false",
-          "posterImage": Object {
-            "caption": "CCTV captures moment of the explosion",
-            "credits": "",
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-            },
-            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
-            "title": "",
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
           },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
         },
         "type": "leadAsset",
       },
       Object {
         "data": Object {
-          "flags": Array [],
-          "headline": "Young boy among dead after blast flattens Leicester store",
-          "isVideo": true,
-          "label": "",
-          "standfirst": "",
+          "flags": Array [
+            "NEW",
+            "EXCLUSIVE",
+          ],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": null,
         },
         "type": "header",
       },
@@ -16573,7 +12089,7 @@ exports[`12. article with a video asset 1`] = `
               "children": Array [
                 Object {
                   "attributes": Object {
-                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
                   },
                   "children": Array [],
                   "name": "text",
@@ -16583,7 +12099,7 @@ exports[`12. article with a video asset 1`] = `
             },
           ],
           "publicationName": "TIMES",
-          "publishedTime": "2018-02-26T17:00:00.000Z",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
         },
         "type": "middleContainer",
       },
@@ -16593,10 +12109,43 @@ exports[`12. article with a video asset 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
               },
               "children": Array [],
               "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -16609,11 +12158,17 @@ exports[`12. article with a video asset 1`] = `
           "attributes": Object {},
           "children": Array [
             Object {
-              "attributes": Object {
-                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
-              },
-              "children": Array [],
-              "name": "text",
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -16627,7 +12182,7 @@ exports[`12. article with a video asset 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
               },
               "children": Array [],
               "name": "text",
@@ -16640,15 +12195,17 @@ exports[`12. article with a video asset 1`] = `
       },
       Object {
         "data": Object {
-          "attributes": Object {
-            "caption": "Some 60 homes near the site of the explosion were evacuated",
-            "credits": "CATERS",
-            "display": "primary",
-            "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-          },
-          "children": Array [],
-          "name": "image",
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
         },
         "index": 3,
         "type": "articleBodyRow",
@@ -16659,7 +12216,7 @@ exports[`12. article with a video asset 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
               },
               "children": Array [],
               "name": "text",
@@ -16672,9 +12229,698 @@ exports[`12. article with a video asset 1`] = `
       },
       Object {
         "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
           "topics": undefined,
         },
         "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
       },
     ]
   }
@@ -16694,125 +12940,54 @@ exports[`12. article with a video asset 1`] = `
       <View
         testID="leadAsset"
       >
-        <View
-          accessibilityLabel="splash-component"
-          nativeBackgroundAndroid={
-            Object {
-              "attribute": "selectableItemBackground",
-              "type": "ThemeAttrAndroid",
-            }
-          }
-          style={
-            Object {
-              "height": 421.875,
-              "width": 750,
-            }
-          }
-          testID="splash-component"
-        >
-          <View
-            style={
-              Object {
-                "height": 421.875,
-                "width": 750,
-              }
-            }
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
           >
             <View
               style={
                 Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
                   "height": "100%",
                   "width": "100%",
                 }
               }
             >
-              <Image
-                source={
-                  Object {
-                    "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
-                  }
-                }
-                style={
-                  Object {
-                    "bottom": 0,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": "100%",
-                  }
-                }
-              />
               <View
-                style={
+                nativeBackgroundAndroid={
                   Object {
-                    "flex": 1,
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
                   }
                 }
+                pointerEvents="box-only"
               >
-                <View
+                <ARTSurfaceView
                   style={
                     Object {
-                      "flex": 1,
+                      "height": 24,
+                      "width": 24,
                     }
                   }
                 >
-                  <ARTSurfaceView
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "height": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                        "width": 0,
-                      }
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
                     }
                   >
-                    <ARTShape
-                      d={
-                        Array [
-                          2,
-                          0,
-                          0,
-                          2,
-                          0,
-                          0,
-                          2,
-                          0,
-                          0,
-                          2,
-                          0,
-                          0,
-                        ]
-                      }
-                      fill={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          -0,
-                          0,
-                          0.9764705882352941,
-                          0.9764705882352941,
-                          0.9764705882352941,
-                          1,
-                          0.9294117647058824,
-                          0.9294117647058824,
-                          0.9294117647058824,
-                          1,
-                          0,
-                          1,
-                        ]
-                      }
+                    <ARTGroup
                       opacity={1}
-                      stroke={null}
-                      strokeCap={1}
-                      strokeDash={null}
-                      strokeJoin={1}
-                      strokeWidth={1}
                       transform={
                         Array [
                           1,
@@ -16823,45 +12998,394 @@ exports[`12. article with a video asset 1`] = `
                           0,
                         ]
                       }
-                    />
-                  </ARTSurfaceView>
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
-          </View>
+          </Modal>
           <View
-            style={
+            nativeBackgroundAndroid={
               Object {
-                "alignItems": "center",
-                "flex": 1,
-                "height": 421.875,
-                "justifyContent": "center",
-                "left": 0,
-                "position": "absolute",
-                "top": 0,
-                "width": 750,
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
               }
             }
+            pointerEvents="box-only"
           >
-            <View>
-              <svg
-                height={70}
-                viewBox="0 0 100 100"
-                width={70}
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
               >
-                <rect
-                  fill="rgba(0,0,0)"
-                  fillOpacity="0.4"
-                  height="100"
-                  stroke="rgb(255,255,255)"
-                  strokeWidth="8"
-                  width="100"
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
                 />
-                <polygon
-                  fill="rgb(255,255,255)"
-                  points="30,20 70,50 30,80"
-                />
-              </svg>
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -16886,9 +13410,9 @@ exports[`12. article with a video asset 1`] = `
           }
           testID="label"
         >
-          <VideoLabel
+          <ArticleLabel
             color="#333333"
-            title=""
+            title="HURRICANE IRMA"
           />
         </View>
         <Text
@@ -16903,7 +13427,1713 @@ exports[`12. article with a video asset 1`] = `
             }
           }
         >
-          Young boy among dead after blast flattens Leicester store
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "marginBottom": 11,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <NewArticleFlag />
+          </View>
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <ExclusiveArticleFlag />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on android should render an article with no standfirst and no flags 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                nativeBackgroundAndroid={
+                  Object {
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
+                  }
+                }
+                pointerEvents="box-only"
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            pointerEvents="box-only"
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="label"
+          style={
+            Object {
+              "paddingBottom": 5,
+              "paddingTop": 4,
+            }
+          }
+          testID="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </View>
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 37,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
         </Text>
       </View>
     </View>
@@ -16950,7 +15180,7 @@ exports[`12. article with a video asset 1`] = `
                     "children": Array [
                       Object {
                         "attributes": Object {
-                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
                         },
                         "children": Array [],
                         "name": "text",
@@ -16983,7 +15213,7 @@ exports[`12. article with a video asset 1`] = `
               }
             }
           >
-            Monday February 26 2018, 05:00pm, The Times
+            Friday March 13 2015, 06:54pm, The Times
           </Text>
         </View>
       </View>
@@ -17010,7 +15240,26 @@ exports[`12. article with a video asset 1`] = `
             }
           }
         >
-          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
         </Text>
       </View>
     </View>
@@ -17036,7 +15285,15 @@ exports[`12. article with a video asset 1`] = `
             }
           }
         >
-          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
         </Text>
       </View>
     </View>
@@ -17062,27 +15319,34 @@ exports[`12. article with a video asset 1`] = `
             }
           }
         >
-          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
         </Text>
       </View>
     </View>
     <View>
-      <View>
-        <ArticleImage
-          captionOptions={
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
             Object {
-              "caption": "Some 60 homes near the site of the explosion were evacuated",
-              "credits": "CATERS",
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
             }
           }
-          imageOptions={
-            Object {
-              "display": "primary",
-              "ratio": "1500:1000",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-            }
-          }
-        />
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
       </View>
     </View>
     <View>
@@ -17107,16 +15371,1781 @@ exports[`12. article with a video asset 1`] = `
             }
           }
         >
-          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
         </Text>
       </View>
     </View>
-    <View />
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
 
-exports[`analytics for page view 1`] = `
+exports[`Article tests on android should render an article with no standfirst and no label 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [
+            "NEW",
+            "EXCLUSIVE",
+          ],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": null,
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                nativeBackgroundAndroid={
+                  Object {
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
+                  }
+                }
+                pointerEvents="box-only"
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            pointerEvents="box-only"
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 37,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "marginBottom": 11,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <NewArticleFlag />
+          </View>
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <ExclusiveArticleFlag />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on android should render an error 1`] = `
+<View>
+  <Text>
+    An error occurred
+  </Text>
+  <Text>
+    {
+  "message": "An example error."
+}
+  </Text>
+</View>
+`;
+
+exports[`Send analytics when rendering an Article page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {
@@ -17150,33 +17179,4 @@ Object {
   "component": "Page",
   "object": "Article",
 }
-`;
-
-exports[`should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "flags": undefined,
-      "headline": undefined,
-      "isVideo": false,
-      "label": undefined,
-      "standfirst": undefined,
-    },
-    "type": "header",
-  },
-  Object {
-    "data": Object {
-      "byline": undefined,
-      "publicationName": undefined,
-      "publishedTime": undefined,
-    },
-    "type": "middleContainer",
-  },
-  Object {
-    "data": Object {
-      "topics": undefined,
-    },
-    "type": "topics",
-  },
-]
 `;

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -1,35 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article tests on android should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "flags": undefined,
-      "headline": undefined,
-      "isVideo": false,
-      "label": undefined,
-      "standfirst": undefined,
-    },
-    "type": "header",
-  },
-  Object {
-    "data": Object {
-      "byline": undefined,
-      "publicationName": undefined,
-      "publishedTime": undefined,
-    },
-    "type": "middleContainer",
-  },
-  Object {
-    "data": Object {
-      "topics": undefined,
-    },
-    "type": "topics",
-  },
-]
+exports[`Article tests on android 1. article 1`] = `
+<View>
+  <Text>
+    An error occurred
+  </Text>
+  <Text>
+    {
+  "message": "An example error."
+}
+  </Text>
+</View>
 `;
 
-exports[`Article tests on android should render a full article 1`] = `
+exports[`Article tests on android 2. full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1044,7 +1028,7 @@ exports[`Article tests on android should render a full article 1`] = `
 />
 `;
 
-exports[`Article tests on android should render a smaller article 1`] = `
+exports[`Article tests on android 3. smaller article 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -3048,39 +3032,31 @@ exports[`Article tests on android should render a smaller article 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with a video asset 1`] = `
+exports[`Article tests on android 4. article with no flags 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
         "data": Object {
-          "__typename": "Video",
-          "brightcoveAccountId": "57838016001",
-          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-          "brightcoveVideoId": "4084164751001",
-          "caption": "This is video caption",
-          "isVideo": true,
-          "paidOnly": "false",
-          "posterImage": Object {
-            "caption": "CCTV captures moment of the explosion",
-            "credits": "",
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-            },
-            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
-            "title": "",
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
           },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
         },
         "type": "leadAsset",
       },
       Object {
         "data": Object {
           "flags": Array [],
-          "headline": "Young boy among dead after blast flattens Leicester store",
-          "isVideo": true,
-          "label": "",
-          "standfirst": "",
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
         },
         "type": "header",
       },
@@ -3092,7 +3068,7 @@ exports[`Article tests on android should render an article with a video asset 1`
               "children": Array [
                 Object {
                   "attributes": Object {
-                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
                   },
                   "children": Array [],
                   "name": "text",
@@ -3102,7 +3078,7 @@ exports[`Article tests on android should render an article with a video asset 1`
             },
           ],
           "publicationName": "TIMES",
-          "publishedTime": "2018-02-26T17:00:00.000Z",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
         },
         "type": "middleContainer",
       },
@@ -3112,10 +3088,43 @@ exports[`Article tests on android should render an article with a video asset 1`
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
               },
               "children": Array [],
               "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -3128,11 +3137,17 @@ exports[`Article tests on android should render an article with a video asset 1`
           "attributes": Object {},
           "children": Array [
             Object {
-              "attributes": Object {
-                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
-              },
-              "children": Array [],
-              "name": "text",
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -3146,7 +3161,7 @@ exports[`Article tests on android should render an article with a video asset 1`
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
               },
               "children": Array [],
               "name": "text",
@@ -3159,15 +3174,17 @@ exports[`Article tests on android should render an article with a video asset 1`
       },
       Object {
         "data": Object {
-          "attributes": Object {
-            "caption": "Some 60 homes near the site of the explosion were evacuated",
-            "credits": "CATERS",
-            "display": "primary",
-            "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-          },
-          "children": Array [],
-          "name": "image",
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
         },
         "index": 3,
         "type": "articleBodyRow",
@@ -3178,7 +3195,7 @@ exports[`Article tests on android should render an article with a video asset 1`
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
               },
               "children": Array [],
               "name": "text",
@@ -3191,9 +3208,698 @@ exports[`Article tests on android should render an article with a video asset 1`
       },
       Object {
         "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
           "topics": undefined,
         },
         "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
       },
     ]
   }
@@ -3213,125 +3919,54 @@ exports[`Article tests on android should render an article with a video asset 1`
       <View
         testID="leadAsset"
       >
-        <View
-          accessibilityLabel="splash-component"
-          nativeBackgroundAndroid={
-            Object {
-              "attribute": "selectableItemBackground",
-              "type": "ThemeAttrAndroid",
-            }
-          }
-          style={
-            Object {
-              "height": 421.875,
-              "width": 750,
-            }
-          }
-          testID="splash-component"
-        >
-          <View
-            style={
-              Object {
-                "height": 421.875,
-                "width": 750,
-              }
-            }
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
           >
             <View
               style={
                 Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
                   "height": "100%",
                   "width": "100%",
                 }
               }
             >
-              <Image
-                source={
-                  Object {
-                    "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
-                  }
-                }
-                style={
-                  Object {
-                    "bottom": 0,
-                    "height": "100%",
-                    "left": 0,
-                    "position": "absolute",
-                    "right": 0,
-                    "top": 0,
-                    "width": "100%",
-                  }
-                }
-              />
               <View
-                style={
+                nativeBackgroundAndroid={
                   Object {
-                    "flex": 1,
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
                   }
                 }
+                pointerEvents="box-only"
               >
-                <View
+                <ARTSurfaceView
                   style={
                     Object {
-                      "flex": 1,
+                      "height": 24,
+                      "width": 24,
                     }
                   }
                 >
-                  <ARTSurfaceView
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "height": 0,
-                        "left": 0,
-                        "position": "absolute",
-                        "right": 0,
-                        "top": 0,
-                        "width": 0,
-                      }
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
                     }
                   >
-                    <ARTShape
-                      d={
-                        Array [
-                          2,
-                          0,
-                          0,
-                          2,
-                          0,
-                          0,
-                          2,
-                          0,
-                          0,
-                          2,
-                          0,
-                          0,
-                        ]
-                      }
-                      fill={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          -0,
-                          0,
-                          0.9764705882352941,
-                          0.9764705882352941,
-                          0.9764705882352941,
-                          1,
-                          0.9294117647058824,
-                          0.9294117647058824,
-                          0.9294117647058824,
-                          1,
-                          0,
-                          1,
-                        ]
-                      }
+                    <ARTGroup
                       opacity={1}
-                      stroke={null}
-                      strokeCap={1}
-                      strokeDash={null}
-                      strokeJoin={1}
-                      strokeWidth={1}
                       transform={
                         Array [
                           1,
@@ -3342,45 +3977,394 @@ exports[`Article tests on android should render an article with a video asset 1`
                           0,
                         ]
                       }
-                    />
-                  </ARTSurfaceView>
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
-          </View>
+          </Modal>
           <View
-            style={
+            nativeBackgroundAndroid={
               Object {
-                "alignItems": "center",
-                "flex": 1,
-                "height": 421.875,
-                "justifyContent": "center",
-                "left": 0,
-                "position": "absolute",
-                "top": 0,
-                "width": 750,
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
               }
             }
+            pointerEvents="box-only"
           >
-            <View>
-              <svg
-                height={70}
-                viewBox="0 0 100 100"
-                width={70}
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
               >
-                <rect
-                  fill="rgba(0,0,0)"
-                  fillOpacity="0.4"
-                  height="100"
-                  stroke="rgb(255,255,255)"
-                  strokeWidth="8"
-                  width="100"
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
                 />
-                <polygon
-                  fill="rgb(255,255,255)"
-                  points="30,20 70,50 30,80"
-                />
-              </svg>
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -3405,9 +4389,9 @@ exports[`Article tests on android should render an article with a video asset 1`
           }
           testID="label"
         >
-          <VideoLabel
+          <ArticleLabel
             color="#333333"
-            title=""
+            title="HURRICANE IRMA"
           />
         </View>
         <Text
@@ -3422,7 +4406,22 @@ exports[`Article tests on android should render an article with a video asset 1`
             }
           }
         >
-          Young boy among dead after blast flattens Leicester store
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Regular",
+              "fontSize": 20,
+              "lineHeight": 29,
+              "marginTop": -7,
+              "paddingBottom": 12,
+            }
+          }
+          testID="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
         </Text>
       </View>
     </View>
@@ -3469,7 +4468,7 @@ exports[`Article tests on android should render an article with a video asset 1`
                     "children": Array [
                       Object {
                         "attributes": Object {
-                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
                         },
                         "children": Array [],
                         "name": "text",
@@ -3502,7 +4501,7 @@ exports[`Article tests on android should render an article with a video asset 1`
               }
             }
           >
-            Monday February 26 2018, 05:00pm, The Times
+            Friday March 13 2015, 06:54pm, The Times
           </Text>
         </View>
       </View>
@@ -3529,7 +4528,26 @@ exports[`Article tests on android should render an article with a video asset 1`
             }
           }
         >
-          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
         </Text>
       </View>
     </View>
@@ -3555,7 +4573,15 @@ exports[`Article tests on android should render an article with a video asset 1`
             }
           }
         >
-          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
         </Text>
       </View>
     </View>
@@ -3581,27 +4607,34 @@ exports[`Article tests on android should render an article with a video asset 1`
             }
           }
         >
-          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
         </Text>
       </View>
     </View>
     <View>
-      <View>
-        <ArticleImage
-          captionOptions={
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
             Object {
-              "caption": "Some 60 homes near the site of the explosion were evacuated",
-              "credits": "CATERS",
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
             }
           }
-          imageOptions={
-            Object {
-              "display": "primary",
-              "ratio": "1500:1000",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-            }
-          }
-        />
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
       </View>
     </View>
     <View>
@@ -3626,16 +4659,74 @@ exports[`Article tests on android should render an article with a video asset 1`
             }
           }
         >
-          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
         </Text>
       </View>
     </View>
-    <View />
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with no byline 1`] = `
+exports[`Article tests on android 5. article with no byline 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -5304,1701 +6395,7 @@ exports[`Article tests on android should render an article with no byline 1`] = 
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with no flags 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                pointerEvents="box-only"
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            pointerEvents="box-only"
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="label"
-          style={
-            Object {
-              "paddingBottom": 5,
-              "paddingTop": 4,
-            }
-          }
-          testID="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 37,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 29,
-              "marginTop": -7,
-              "paddingBottom": 12,
-            }
-          }
-          testID="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Article tests on android should render an article with no label 1`] = `
+exports[`Article tests on android 6. article with no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -8707,7 +8104,5089 @@ exports[`Article tests on android should render an article with no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with no label and no flags 1`] = `
+exports[`Article tests on android 7. article with no standfirst 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [
+            "NEW",
+            "EXCLUSIVE",
+          ],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                nativeBackgroundAndroid={
+                  Object {
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
+                  }
+                }
+                pointerEvents="box-only"
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            pointerEvents="box-only"
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="label"
+          style={
+            Object {
+              "paddingBottom": 5,
+              "paddingTop": 4,
+            }
+          }
+          testID="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </View>
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 37,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "marginBottom": 11,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <NewArticleFlag />
+          </View>
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <ExclusiveArticleFlag />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on android 8. article with no standfirst and no flags 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                nativeBackgroundAndroid={
+                  Object {
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
+                  }
+                }
+                pointerEvents="box-only"
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            pointerEvents="box-only"
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="label"
+          style={
+            Object {
+              "paddingBottom": 5,
+              "paddingTop": 4,
+            }
+          }
+          testID="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </View>
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 37,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on android 9. article with no standfirst and no label 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [
+            "NEW",
+            "EXCLUSIVE",
+          ],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": null,
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                nativeBackgroundAndroid={
+                  Object {
+                    "attribute": "selectableItemBackground",
+                    "type": "ThemeAttrAndroid",
+                  }
+                }
+                pointerEvents="box-only"
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            nativeBackgroundAndroid={
+              Object {
+                "attribute": "selectableItemBackground",
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            pointerEvents="box-only"
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 37,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <View
+          style={
+            Object {
+              "flexDirection": "row",
+              "marginBottom": 11,
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <NewArticleFlag />
+          </View>
+          <View
+            style={
+              Object {
+                "marginRight": 14,
+              }
+            }
+          >
+            <ExclusiveArticleFlag />
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on android 10. article with no flags and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -10386,7 +14865,7 @@ exports[`Article tests on android should render an article with no label and no 
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with no label, no flags and no standfirst 1`] = `
+exports[`Article tests on android 11. article with no standfirst, no label and no no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -12050,1740 +16529,39 @@ exports[`Article tests on android should render an article with no label, no fla
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with no standfirst 1`] = `
+exports[`Article tests on android 12. article with a video asset 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
         "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          "__typename": "Video",
+          "brightcoveAccountId": "57838016001",
+          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+          "brightcoveVideoId": "4084164751001",
+          "caption": "This is video caption",
+          "isVideo": true,
+          "paidOnly": "false",
+          "posterImage": Object {
+            "caption": "CCTV captures moment of the explosion",
+            "credits": "",
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+            },
+            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
+            "title": "",
           },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [
-            "NEW",
-            "EXCLUSIVE",
-          ],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                pointerEvents="box-only"
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            pointerEvents="box-only"
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="label"
-          style={
-            Object {
-              "paddingBottom": 5,
-              "paddingTop": 4,
-            }
-          }
-          testID="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 37,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 11,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <NewArticleFlag />
-          </View>
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <ExclusiveArticleFlag />
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Article tests on android should render an article with no standfirst and no flags 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
         },
         "type": "leadAsset",
       },
       Object {
         "data": Object {
           "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": null,
+          "headline": "Young boy among dead after blast flattens Leicester store",
+          "isVideo": true,
+          "label": "",
+          "standfirst": "",
         },
         "type": "header",
       },
@@ -13795,7 +16573,7 @@ exports[`Article tests on android should render an article with no standfirst an
               "children": Array [
                 Object {
                   "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
                   },
                   "children": Array [],
                   "name": "text",
@@ -13805,7 +16583,7 @@ exports[`Article tests on android should render an article with no standfirst an
             },
           ],
           "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
+          "publishedTime": "2018-02-26T17:00:00.000Z",
         },
         "type": "middleContainer",
       },
@@ -13815,43 +16593,10 @@ exports[`Article tests on android should render an article with no standfirst an
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
               },
               "children": Array [],
               "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -13864,17 +16609,11 @@ exports[`Article tests on android should render an article with no standfirst an
           "attributes": Object {},
           "children": Array [
             Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
+              "attributes": Object {
+                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
+              },
+              "children": Array [],
+              "name": "text",
             },
           ],
           "name": "paragraph",
@@ -13888,7 +16627,7 @@ exports[`Article tests on android should render an article with no standfirst an
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
               },
               "children": Array [],
               "name": "text",
@@ -13901,17 +16640,15 @@ exports[`Article tests on android should render an article with no standfirst an
       },
       Object {
         "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
+          "attributes": Object {
+            "caption": "Some 60 homes near the site of the explosion were evacuated",
+            "credits": "CATERS",
+            "display": "primary",
+            "ratio": "1500:1000",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+          },
+          "children": Array [],
+          "name": "image",
         },
         "index": 3,
         "type": "articleBodyRow",
@@ -13922,7 +16659,7 @@ exports[`Article tests on android should render an article with no standfirst an
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
               },
               "children": Array [],
               "name": "text",
@@ -13935,698 +16672,9 @@ exports[`Article tests on android should render an article with no standfirst an
       },
       Object {
         "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
           "topics": undefined,
         },
         "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
       },
     ]
   }
@@ -14646,54 +16694,125 @@ exports[`Article tests on android should render an article with no standfirst an
       <View
         testID="leadAsset"
       >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
+        <View
+          accessibilityLabel="splash-component"
+          nativeBackgroundAndroid={
+            Object {
+              "attribute": "selectableItemBackground",
+              "type": "ThemeAttrAndroid",
+            }
+          }
+          style={
+            Object {
+              "height": 421.875,
+              "width": 750,
+            }
+          }
+          testID="splash-component"
+        >
+          <View
+            style={
+              Object {
+                "height": 421.875,
+                "width": 750,
+              }
+            }
           >
             <View
               style={
                 Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
                   "height": "100%",
                   "width": "100%",
                 }
               }
             >
-              <View
-                nativeBackgroundAndroid={
+              <Image
+                source={
                   Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
+                    "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
                   }
                 }
-                pointerEvents="box-only"
+                style={
+                  Object {
+                    "bottom": 0,
+                    "height": "100%",
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "width": "100%",
+                  }
+                }
+              />
+              <View
+                style={
+                  Object {
+                    "flex": 1,
+                  }
+                }
               >
-                <ARTSurfaceView
+                <View
                   style={
                     Object {
-                      "height": 24,
-                      "width": 24,
+                      "flex": 1,
                     }
                   }
                 >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
+                  <ARTSurfaceView
+                    style={
+                      Object {
+                        "bottom": 0,
+                        "height": 0,
+                        "left": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                        "width": 0,
+                      }
                     }
                   >
-                    <ARTGroup
+                    <ARTShape
+                      d={
+                        Array [
+                          2,
+                          0,
+                          0,
+                          2,
+                          0,
+                          0,
+                          2,
+                          0,
+                          0,
+                          2,
+                          0,
+                          0,
+                        ]
+                      }
+                      fill={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          -0,
+                          0,
+                          0.9764705882352941,
+                          0.9764705882352941,
+                          0.9764705882352941,
+                          1,
+                          0.9294117647058824,
+                          0.9294117647058824,
+                          0.9294117647058824,
+                          1,
+                          0,
+                          1,
+                        ]
+                      }
                       opacity={1}
+                      stroke={null}
+                      strokeCap={1}
+                      strokeDash={null}
+                      strokeJoin={1}
+                      strokeWidth={1}
                       transform={
                         Array [
                           1,
@@ -14704,394 +16823,45 @@ exports[`Article tests on android should render an article with no standfirst an
                           0,
                         ]
                       }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
+                    />
+                  </ARTSurfaceView>
                 </View>
               </View>
             </View>
-          </Modal>
+          </View>
           <View
-            nativeBackgroundAndroid={
+            style={
               Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
+                "alignItems": "center",
+                "flex": 1,
+                "height": 421.875,
+                "justifyContent": "center",
+                "left": 0,
+                "position": "absolute",
+                "top": 0,
+                "width": 750,
               }
             }
-            pointerEvents="box-only"
           >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
+            <View>
+              <svg
+                height={70}
+                viewBox="0 0 100 100"
+                width={70}
               >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
+                <rect
+                  fill="rgba(0,0,0)"
+                  fillOpacity="0.4"
+                  height="100"
+                  stroke="rgb(255,255,255)"
+                  strokeWidth="8"
+                  width="100"
                 />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
+                <polygon
+                  fill="rgb(255,255,255)"
+                  points="30,20 70,50 30,80"
+                />
+              </svg>
             </View>
           </View>
         </View>
@@ -15116,9 +16886,9 @@ exports[`Article tests on android should render an article with no standfirst an
           }
           testID="label"
         >
-          <ArticleLabel
+          <VideoLabel
             color="#333333"
-            title="HURRICANE IRMA"
+            title=""
           />
         </View>
         <Text
@@ -15133,7 +16903,7 @@ exports[`Article tests on android should render an article with no standfirst an
             }
           }
         >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+          Young boy among dead after blast flattens Leicester store
         </Text>
       </View>
     </View>
@@ -15180,7 +16950,7 @@ exports[`Article tests on android should render an article with no standfirst an
                     "children": Array [
                       Object {
                         "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
                         },
                         "children": Array [],
                         "name": "text",
@@ -15213,7 +16983,7 @@ exports[`Article tests on android should render an article with no standfirst an
               }
             }
           >
-            Friday March 13 2015, 06:54pm, The Times
+            Monday February 26 2018, 05:00pm, The Times
           </Text>
         </View>
       </View>
@@ -15240,26 +17010,7 @@ exports[`Article tests on android should render an article with no standfirst an
             }
           }
         >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
+          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
         </Text>
       </View>
     </View>
@@ -15285,15 +17036,7 @@ exports[`Article tests on android should render an article with no standfirst an
             }
           }
         >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
+          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
         </Text>
       </View>
     </View>
@@ -15319,34 +17062,27 @@ exports[`Article tests on android should render an article with no standfirst an
             }
           }
         >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
         </Text>
       </View>
     </View>
     <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
+      <View>
+        <ArticleImage
+          captionOptions={
             Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
+              "caption": "Some 60 homes near the site of the explosion were evacuated",
+              "credits": "CATERS",
             }
           }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
+          imageOptions={
+            Object {
+              "display": "primary",
+              "ratio": "1500:1000",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+            }
+          }
+        />
       </View>
     </View>
     <View>
@@ -15371,1778 +17107,42 @@ exports[`Article tests on android should render an article with no standfirst an
             }
           }
         >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
         </Text>
       </View>
     </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
 
-exports[`Article tests on android should render an article with no standfirst and no label 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [
-            "NEW",
-            "EXCLUSIVE",
-          ],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": null,
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                nativeBackgroundAndroid={
-                  Object {
-                    "attribute": "selectableItemBackground",
-                    "type": "ThemeAttrAndroid",
-                  }
-                }
-                pointerEvents="box-only"
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            pointerEvents="box-only"
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 37,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 11,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <NewArticleFlag />
-          </View>
-          <View
-            style={
-              Object {
-                "marginRight": 14,
-              }
-            }
-          >
-            <ExclusiveArticleFlag />
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "fontStyle": "normal",
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Article tests on android should render an error 1`] = `
-<View>
-  <Text>
-    An error occurred
-  </Text>
-  <Text>
-    {
-  "message": "An example error."
-}
-  </Text>
-</View>
+exports[`Article tests on android should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "flags": undefined,
+      "headline": undefined,
+      "isVideo": false,
+      "label": undefined,
+      "standfirst": undefined,
+    },
+    "type": "header",
+  },
+  Object {
+    "data": Object {
+      "byline": undefined,
+      "publicationName": undefined,
+      "publishedTime": undefined,
+    },
+    "type": "middleContainer",
+  },
+  Object {
+    "data": Object {
+      "topics": undefined,
+    },
+    "type": "topics",
+  },
+]
 `;
 
 exports[`Send analytics when rendering an Article page 1`] = `

--- a/packages/article/__tests__/android/article.android.test.js
+++ b/packages/article/__tests__/android/article.android.test.js
@@ -27,13 +27,9 @@ jest.mock("@times-components/tracking", () => {
   };
 });
 
-describe("Article tests on android", () => {
-  shared();
-  nativeShared();
-});
+shared();
+nativeShared();
 
 jest.unmock("@times-components/tracking");
 
-describe("Article Tracking tests on web", () => {
-  sharedTracking();
-});
+sharedTracking();

--- a/packages/article/__tests__/android/article.android.test.js
+++ b/packages/article/__tests__/android/article.android.test.js
@@ -27,9 +27,13 @@ jest.mock("@times-components/tracking", () => {
   };
 });
 
-shared();
-nativeShared();
+describe("Article tests on android", () => {
+  shared();
+  nativeShared();
+});
 
 jest.unmock("@times-components/tracking");
 
-sharedTracking();
+describe("Article Tracking tests on web", () => {
+  sharedTracking();
+});

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1,35 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article tests on ios should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "flags": undefined,
-      "headline": undefined,
-      "isVideo": false,
-      "label": undefined,
-      "standfirst": undefined,
-    },
-    "type": "header",
-  },
-  Object {
-    "data": Object {
-      "byline": undefined,
-      "publicationName": undefined,
-      "publishedTime": undefined,
-    },
-    "type": "middleContainer",
-  },
-  Object {
-    "data": Object {
-      "topics": undefined,
-    },
-    "type": "topics",
-  },
-]
+exports[`Article tests on ios 1. article 1`] = `
+<View>
+  <Text>
+    An error occurred
+  </Text>
+  <Text>
+    {
+  "message": "An example error."
+}
+  </Text>
+</View>
 `;
 
-exports[`Article tests on ios should render a full article 1`] = `
+exports[`Article tests on ios 2. full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1044,7 +1028,7 @@ exports[`Article tests on ios should render a full article 1`] = `
 />
 `;
 
-exports[`Article tests on ios should render a smaller article 1`] = `
+exports[`Article tests on ios 3. smaller article 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -3044,39 +3028,31 @@ exports[`Article tests on ios should render a smaller article 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an article with a video asset 1`] = `
+exports[`Article tests on ios 4. article with no flags 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
         "data": Object {
-          "__typename": "Video",
-          "brightcoveAccountId": "57838016001",
-          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-          "brightcoveVideoId": "4084164751001",
-          "caption": "This is video caption",
-          "isVideo": true,
-          "paidOnly": "false",
-          "posterImage": Object {
-            "caption": "CCTV captures moment of the explosion",
-            "credits": "",
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-            },
-            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
-            "title": "",
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
           },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
         },
         "type": "leadAsset",
       },
       Object {
         "data": Object {
           "flags": Array [],
-          "headline": "Young boy among dead after blast flattens Leicester store",
-          "isVideo": true,
-          "label": "",
-          "standfirst": "",
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
         },
         "type": "header",
       },
@@ -3088,7 +3064,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
               "children": Array [
                 Object {
                   "attributes": Object {
-                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
                   },
                   "children": Array [],
                   "name": "text",
@@ -3098,7 +3074,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
             },
           ],
           "publicationName": "TIMES",
-          "publishedTime": "2018-02-26T17:00:00.000Z",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
         },
         "type": "middleContainer",
       },
@@ -3108,10 +3084,43 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
               },
               "children": Array [],
               "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -3124,11 +3133,17 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
           "attributes": Object {},
           "children": Array [
             Object {
-              "attributes": Object {
-                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
-              },
-              "children": Array [],
-              "name": "text",
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -3142,7 +3157,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
               },
               "children": Array [],
               "name": "text",
@@ -3155,15 +3170,17 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
       },
       Object {
         "data": Object {
-          "attributes": Object {
-            "caption": "Some 60 homes near the site of the explosion were evacuated",
-            "credits": "CATERS",
-            "display": "primary",
-            "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-          },
-          "children": Array [],
-          "name": "image",
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
         },
         "index": 3,
         "type": "articleBodyRow",
@@ -3174,7 +3191,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
               },
               "children": Array [],
               "name": "text",
@@ -3187,9 +3204,698 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
       },
       Object {
         "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
           "topics": undefined,
         },
         "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
       },
     ]
   }
@@ -3209,31 +3915,339 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
       <View
         testID="leadAsset"
       >
-        <View
-          accessibilityLabel="splash-component"
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
-          testID="splash-component"
-        >
-          <View
-            style={
-              Object {
-                "height": 421.875,
-                "width": 750,
-              }
-            }
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
           >
             <View
               style={
                 Object {
-                  "height": 421.875,
-                  "width": 750,
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
                 }
               }
+            >
+              <View
+                isTVSelectable={true}
+                style={
+                  Object {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            isTVSelectable={true}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              aspectRatio={1.7777777777777777}
             >
               <View
                 style={
@@ -3246,7 +4260,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                 <Image
                   source={
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
                     }
                   }
                   style={
@@ -3346,41 +4360,6 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                 </View>
               </View>
             </View>
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "height": 421.875,
-                  "justifyContent": "center",
-                  "left": 0,
-                  "position": "absolute",
-                  "top": 0,
-                  "width": 750,
-                }
-              }
-            >
-              <View>
-                <svg
-                  height={70}
-                  viewBox="0 0 100 100"
-                  width={70}
-                >
-                  <rect
-                    fill="rgba(0,0,0)"
-                    fillOpacity="0.4"
-                    height="100"
-                    stroke="rgb(255,255,255)"
-                    strokeWidth="8"
-                    width="100"
-                  />
-                  <polygon
-                    fill="rgb(255,255,255)"
-                    points="30,20 70,50 30,80"
-                  />
-                </svg>
-              </View>
-            </View>
           </View>
         </View>
       </View>
@@ -3404,9 +4383,9 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
           }
           testID="label"
         >
-          <VideoLabel
+          <ArticleLabel
             color="#333333"
-            title=""
+            title="HURRICANE IRMA"
           />
         </View>
         <Text
@@ -3421,7 +4400,21 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
             }
           }
         >
-          Young boy among dead after blast flattens Leicester store
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Regular",
+              "fontSize": 20,
+              "lineHeight": 25,
+              "paddingBottom": 9,
+            }
+          }
+          testID="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
         </Text>
       </View>
     </View>
@@ -3468,7 +4461,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
                     "children": Array [
                       Object {
                         "attributes": Object {
-                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
                         },
                         "children": Array [],
                         "name": "text",
@@ -3501,7 +4494,7 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
               }
             }
           >
-            Monday February 26 2018, 05:00pm, The Times
+            Friday March 13 2015, 06:54pm, The Times
           </Text>
         </View>
       </View>
@@ -3527,7 +4520,26 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
             }
           }
         >
-          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
         </Text>
       </View>
     </View>
@@ -3552,7 +4564,15 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
             }
           }
         >
-          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
         </Text>
       </View>
     </View>
@@ -3577,27 +4597,33 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
             }
           }
         >
-          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
         </Text>
       </View>
     </View>
     <View>
-      <View>
-        <ArticleImage
-          captionOptions={
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
             Object {
-              "caption": "Some 60 homes near the site of the explosion were evacuated",
-              "credits": "CATERS",
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
             }
           }
-          imageOptions={
-            Object {
-              "display": "primary",
-              "ratio": "1500:1000",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-            }
-          }
-        />
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
       </View>
     </View>
     <View>
@@ -3621,16 +4647,72 @@ exports[`Article tests on ios should render an article with a video asset 1`] = 
             }
           }
         >
-          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
         </Text>
       </View>
     </View>
-    <View />
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an article with no byline 1`] = `
+exports[`Article tests on ios 5. article with no byline 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -5289,1691 +6371,7 @@ exports[`Article tests on ios should render an article with no byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an article with no flags 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                isTVSelectable={true}
-                style={
-                  Object {
-                    "opacity": 1,
-                  }
-                }
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            isTVSelectable={true}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="label"
-          style={
-            Object {
-              "paddingBottom": 5,
-              "paddingTop": 4,
-            }
-          }
-          testID="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 32,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "paddingBottom": 9,
-            }
-          }
-          testID="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 14,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Article tests on ios should render an article with no label 1`] = `
+exports[`Article tests on ios 6. article with no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -8672,3331 +8070,7 @@ exports[`Article tests on ios should render an article with no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an article with no label and no flags 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": null,
-          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                isTVSelectable={true}
-                style={
-                  Object {
-                    "opacity": 1,
-                  }
-                }
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            isTVSelectable={true}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 32,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "paddingBottom": 9,
-            }
-          }
-          testID="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 14,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Article tests on ios should render an article with no label, no flags and no standfirst 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": null,
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                isTVSelectable={true}
-                style={
-                  Object {
-                    "opacity": 1,
-                  }
-                }
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            isTVSelectable={true}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 32,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 14,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`Article tests on ios should render an article with no standfirst 1`] = `
+exports[`Article tests on ios 7. article with no standfirst 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -13696,7 +9770,7 @@ exports[`Article tests on ios should render an article with no standfirst 1`] = 
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an article with no standfirst and no flags 1`] = `
+exports[`Article tests on ios 8. article with no standfirst and no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -15366,7 +11440,7 @@ exports[`Article tests on ios should render an article with no standfirst and no
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an article with no standfirst and no label 1`] = `
+exports[`Article tests on ios 9. article with no standfirst and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -17051,17 +13125,3943 @@ exports[`Article tests on ios should render an article with no standfirst and no
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should render an error 1`] = `
-<View>
-  <Text>
-    An error occurred
-  </Text>
-  <Text>
-    {
-  "message": "An example error."
-}
-  </Text>
-</View>
+exports[`Article tests on ios 10. article with no flags and no label 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": null,
+          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                isTVSelectable={true}
+                style={
+                  Object {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            isTVSelectable={true}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 32,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Regular",
+              "fontSize": 20,
+              "lineHeight": 25,
+              "paddingBottom": 9,
+            }
+          }
+          testID="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 14,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on ios 11. article with no standfirst, no label and no no flags 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": null,
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                isTVSelectable={true}
+                style={
+                  Object {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            isTVSelectable={true}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 32,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 14,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on ios 12. article with a video asset 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "__typename": "Video",
+          "brightcoveAccountId": "57838016001",
+          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+          "brightcoveVideoId": "4084164751001",
+          "caption": "This is video caption",
+          "isVideo": true,
+          "paidOnly": "false",
+          "posterImage": Object {
+            "caption": "CCTV captures moment of the explosion",
+            "credits": "",
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+            },
+            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
+            "title": "",
+          },
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Young boy among dead after blast flattens Leicester store",
+          "isVideo": true,
+          "label": "",
+          "standfirst": "",
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2018-02-26T17:00:00.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {
+            "caption": "Some 60 homes near the site of the explosion were evacuated",
+            "credits": "CATERS",
+            "display": "primary",
+            "ratio": "1500:1000",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View
+          accessibilityLabel="splash-component"
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="splash-component"
+        >
+          <View
+            style={
+              Object {
+                "height": 421.875,
+                "width": 750,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "height": 421.875,
+                  "width": 750,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "height": 421.875,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "top": 0,
+                  "width": 750,
+                }
+              }
+            >
+              <View>
+                <svg
+                  height={70}
+                  viewBox="0 0 100 100"
+                  width={70}
+                >
+                  <rect
+                    fill="rgba(0,0,0)"
+                    fillOpacity="0.4"
+                    height="100"
+                    stroke="rgb(255,255,255)"
+                    strokeWidth="8"
+                    width="100"
+                  />
+                  <polygon
+                    fill="rgb(255,255,255)"
+                    points="30,20 70,50 30,80"
+                  />
+                </svg>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="label"
+          style={
+            Object {
+              "paddingBottom": 5,
+              "paddingTop": 4,
+            }
+          }
+          testID="label"
+        >
+          <VideoLabel
+            color="#333333"
+            title=""
+          />
+        </View>
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 32,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Young boy among dead after blast flattens Leicester store
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 14,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Monday February 26 2018, 05:00pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleImage
+          captionOptions={
+            Object {
+              "caption": "Some 60 homes near the site of the explosion were evacuated",
+              "credits": "CATERS",
+            }
+          }
+          imageOptions={
+            Object {
+              "display": "primary",
+              "ratio": "1500:1000",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
+        </Text>
+      </View>
+    </View>
+    <View />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on ios should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "flags": undefined,
+      "headline": undefined,
+      "isVideo": false,
+      "label": undefined,
+      "standfirst": undefined,
+    },
+    "type": "header",
+  },
+  Object {
+    "data": Object {
+      "byline": undefined,
+      "publicationName": undefined,
+      "publishedTime": undefined,
+    },
+    "type": "middleContainer",
+  },
+  Object {
+    "data": Object {
+      "topics": undefined,
+    },
+    "type": "topics",
+  },
+]
 `;
 
 exports[`Send analytics when rendering an Article page 1`] = `

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article tests on ios 1. article 1`] = `
+exports[`1. article 1`] = `
 <View>
   <Text>
     An error occurred
@@ -13,7 +13,7 @@ exports[`Article tests on ios 1. article 1`] = `
 </View>
 `;
 
-exports[`Article tests on ios 2. full article 1`] = `
+exports[`2. full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1028,7 +1028,7 @@ exports[`Article tests on ios 2. full article 1`] = `
 />
 `;
 
-exports[`Article tests on ios 3. smaller article 1`] = `
+exports[`3. smaller article 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -3028,7 +3028,7 @@ exports[`Article tests on ios 3. smaller article 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 4. article with no flags 1`] = `
+exports[`4. article with no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -4712,7 +4712,7 @@ exports[`Article tests on ios 4. article with no flags 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 5. article with no byline 1`] = `
+exports[`5. article with no byline 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -6371,7 +6371,7 @@ exports[`Article tests on ios 5. article with no byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 6. article with no label 1`] = `
+exports[`6. article with no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -8070,7 +8070,7 @@ exports[`Article tests on ios 6. article with no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 7. article with no standfirst 1`] = `
+exports[`7. article with no standfirst 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -9770,7 +9770,7 @@ exports[`Article tests on ios 7. article with no standfirst 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 8. article with no standfirst and no flags 1`] = `
+exports[`8. article with no standfirst and no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -11440,7 +11440,7 @@ exports[`Article tests on ios 8. article with no standfirst and no flags 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 9. article with no standfirst and no label 1`] = `
+exports[`9. article with no standfirst and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -13125,7 +13125,7 @@ exports[`Article tests on ios 9. article with no standfirst and no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 10. article with no flags and no label 1`] = `
+exports[`10. article with no flags and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -14794,7 +14794,7 @@ exports[`Article tests on ios 10. article with no flags and no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 11. article with no standfirst, no label and no no flags 1`] = `
+exports[`11. article with no standfirst, no label and no no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -16449,7 +16449,7 @@ exports[`Article tests on ios 11. article with no standfirst, no label and no no
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios 12. article with a video asset 1`] = `
+exports[`12. article with a video asset 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -17035,36 +17035,7 @@ exports[`Article tests on ios 12. article with a video asset 1`] = `
 </RCTScrollView>
 `;
 
-exports[`Article tests on ios should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "flags": undefined,
-      "headline": undefined,
-      "isVideo": false,
-      "label": undefined,
-      "standfirst": undefined,
-    },
-    "type": "header",
-  },
-  Object {
-    "data": Object {
-      "byline": undefined,
-      "publicationName": undefined,
-      "publishedTime": undefined,
-    },
-    "type": "middleContainer",
-  },
-  Object {
-    "data": Object {
-      "topics": undefined,
-    },
-    "type": "topics",
-  },
-]
-`;
-
-exports[`Send analytics when rendering an Article page 1`] = `
+exports[`analytics for page view 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {
@@ -17098,4 +17069,33 @@ Object {
   "component": "Page",
   "object": "Article",
 }
+`;
+
+exports[`should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "flags": undefined,
+      "headline": undefined,
+      "isVideo": false,
+      "label": undefined,
+      "standfirst": undefined,
+    },
+    "type": "header",
+  },
+  Object {
+    "data": Object {
+      "byline": undefined,
+      "publicationName": undefined,
+      "publishedTime": undefined,
+    },
+    "type": "middleContainer",
+  },
+  Object {
+    "data": Object {
+      "topics": undefined,
+    },
+    "type": "topics",
+  },
+]
 `;

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -1,19 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. article 1`] = `
-<View>
-  <Text>
-    An error occurred
-  </Text>
-  <Text>
-    {
-  "message": "An example error."
-}
-  </Text>
-</View>
+exports[`Article tests on ios should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "flags": undefined,
+      "headline": undefined,
+      "isVideo": false,
+      "label": undefined,
+      "standfirst": undefined,
+    },
+    "type": "header",
+  },
+  Object {
+    "data": Object {
+      "byline": undefined,
+      "publicationName": undefined,
+      "publishedTime": undefined,
+    },
+    "type": "middleContainer",
+  },
+  Object {
+    "data": Object {
+      "topics": undefined,
+    },
+    "type": "topics",
+  },
+]
 `;
 
-exports[`2. full article 1`] = `
+exports[`Article tests on ios should render a full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1028,7 +1044,7 @@ exports[`2. full article 1`] = `
 />
 `;
 
-exports[`3. smaller article 1`] = `
+exports[`Article tests on ios should render a smaller article 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -3028,31 +3044,39 @@ exports[`3. smaller article 1`] = `
 </RCTScrollView>
 `;
 
-exports[`4. article with no flags 1`] = `
+exports[`Article tests on ios should render an article with a video asset 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
         "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          "__typename": "Video",
+          "brightcoveAccountId": "57838016001",
+          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+          "brightcoveVideoId": "4084164751001",
+          "caption": "This is video caption",
+          "isVideo": true,
+          "paidOnly": "false",
+          "posterImage": Object {
+            "caption": "CCTV captures moment of the explosion",
+            "credits": "",
+            "crop": Object {
+              "ratio": "16:9",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+            },
+            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
+            "title": "",
           },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
         },
         "type": "leadAsset",
       },
       Object {
         "data": Object {
           "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": "HURRICANE IRMA",
-          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+          "headline": "Young boy among dead after blast flattens Leicester store",
+          "isVideo": true,
+          "label": "",
+          "standfirst": "",
         },
         "type": "header",
       },
@@ -3064,7 +3088,7 @@ exports[`4. article with no flags 1`] = `
               "children": Array [
                 Object {
                   "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
                   },
                   "children": Array [],
                   "name": "text",
@@ -3074,7 +3098,7 @@ exports[`4. article with no flags 1`] = `
             },
           ],
           "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
+          "publishedTime": "2018-02-26T17:00:00.000Z",
         },
         "type": "middleContainer",
       },
@@ -3084,43 +3108,10 @@ exports[`4. article with no flags 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
               },
               "children": Array [],
               "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
             },
           ],
           "name": "paragraph",
@@ -3133,17 +3124,11 @@ exports[`4. article with no flags 1`] = `
           "attributes": Object {},
           "children": Array [
             Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
+              "attributes": Object {
+                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
+              },
+              "children": Array [],
+              "name": "text",
             },
           ],
           "name": "paragraph",
@@ -3157,7 +3142,7 @@ exports[`4. article with no flags 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
               },
               "children": Array [],
               "name": "text",
@@ -3170,17 +3155,15 @@ exports[`4. article with no flags 1`] = `
       },
       Object {
         "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
+          "attributes": Object {
+            "caption": "Some 60 homes near the site of the explosion were evacuated",
+            "credits": "CATERS",
+            "display": "primary",
+            "ratio": "1500:1000",
+            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+          },
+          "children": Array [],
+          "name": "image",
         },
         "index": 3,
         "type": "articleBodyRow",
@@ -3191,7 +3174,7 @@ exports[`4. article with no flags 1`] = `
           "children": Array [
             Object {
               "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
               },
               "children": Array [],
               "name": "text",
@@ -3204,698 +3187,9 @@ exports[`4. article with no flags 1`] = `
       },
       Object {
         "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
           "topics": undefined,
         },
         "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
       },
     ]
   }
@@ -3915,339 +3209,31 @@ exports[`4. article with no flags 1`] = `
       <View
         testID="leadAsset"
       >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                isTVSelectable={true}
-                style={
-                  Object {
-                    "opacity": 1,
-                  }
-                }
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
+        <View
+          accessibilityLabel="splash-component"
+          isTVSelectable={true}
+          style={
+            Object {
+              "opacity": 1,
+            }
+          }
+          testID="splash-component"
+        >
           <View
-            isTVSelectable={true}
             style={
               Object {
-                "opacity": 1,
+                "height": 421.875,
+                "width": 750,
               }
             }
           >
             <View
-              aspectRatio={1.7777777777777777}
+              style={
+                Object {
+                  "height": 421.875,
+                  "width": 750,
+                }
+              }
             >
               <View
                 style={
@@ -4260,7 +3246,7 @@ exports[`4. article with no flags 1`] = `
                 <Image
                   source={
                     Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
                     }
                   }
                   style={
@@ -4360,6 +3346,41 @@ exports[`4. article with no flags 1`] = `
                 </View>
               </View>
             </View>
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "height": 421.875,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "top": 0,
+                  "width": 750,
+                }
+              }
+            >
+              <View>
+                <svg
+                  height={70}
+                  viewBox="0 0 100 100"
+                  width={70}
+                >
+                  <rect
+                    fill="rgba(0,0,0)"
+                    fillOpacity="0.4"
+                    height="100"
+                    stroke="rgb(255,255,255)"
+                    strokeWidth="8"
+                    width="100"
+                  />
+                  <polygon
+                    fill="rgb(255,255,255)"
+                    points="30,20 70,50 30,80"
+                  />
+                </svg>
+              </View>
+            </View>
           </View>
         </View>
       </View>
@@ -4383,9 +3404,9 @@ exports[`4. article with no flags 1`] = `
           }
           testID="label"
         >
-          <ArticleLabel
+          <VideoLabel
             color="#333333"
-            title="HURRICANE IRMA"
+            title=""
           />
         </View>
         <Text
@@ -4400,21 +3421,7 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "paddingBottom": 9,
-            }
-          }
-          testID="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+          Young boy among dead after blast flattens Leicester store
         </Text>
       </View>
     </View>
@@ -4461,7 +3468,7 @@ exports[`4. article with no flags 1`] = `
                     "children": Array [
                       Object {
                         "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
                         },
                         "children": Array [],
                         "name": "text",
@@ -4494,7 +3501,7 @@ exports[`4. article with no flags 1`] = `
               }
             }
           >
-            Friday March 13 2015, 06:54pm, The Times
+            Monday February 26 2018, 05:00pm, The Times
           </Text>
         </View>
       </View>
@@ -4520,26 +3527,7 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
+          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
         </Text>
       </View>
     </View>
@@ -4564,15 +3552,7 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
+          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
         </Text>
       </View>
     </View>
@@ -4597,33 +3577,27 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
         </Text>
       </View>
     </View>
     <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
+      <View>
+        <ArticleImage
+          captionOptions={
             Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
+              "caption": "Some 60 homes near the site of the explosion were evacuated",
+              "credits": "CATERS",
             }
           }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
+          imageOptions={
+            Object {
+              "display": "primary",
+              "ratio": "1500:1000",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+            }
+          }
+        />
       </View>
     </View>
     <View>
@@ -4647,72 +3621,16 @@ exports[`4. article with no flags 1`] = `
             }
           }
         >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
         </Text>
       </View>
     </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
+    <View />
   </View>
 </RCTScrollView>
 `;
 
-exports[`5. article with no byline 1`] = `
+exports[`Article tests on ios should render an article with no byline 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -6371,7 +5289,1691 @@ exports[`5. article with no byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`6. article with no label 1`] = `
+exports[`Article tests on ios should render an article with no flags 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": "HURRICANE IRMA",
+          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                isTVSelectable={true}
+                style={
+                  Object {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            isTVSelectable={true}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <View
+          accessibilityLabel="label"
+          style={
+            Object {
+              "paddingBottom": 5,
+              "paddingTop": 4,
+            }
+          }
+          testID="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </View>
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 32,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Regular",
+              "fontSize": 20,
+              "lineHeight": 25,
+              "paddingBottom": 9,
+            }
+          }
+          testID="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 14,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on ios should render an article with no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -8070,7 +8672,3331 @@ exports[`6. article with no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`7. article with no standfirst 1`] = `
+exports[`Article tests on ios should render an article with no label and no flags 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": null,
+          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                isTVSelectable={true}
+                style={
+                  Object {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            isTVSelectable={true}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 32,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesModern-Regular",
+              "fontSize": 20,
+              "lineHeight": 25,
+              "paddingBottom": 9,
+            }
+          }
+          testID="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 14,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on ios should render an article with no label, no flags and no standfirst 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "data": Object {
+          "caption": "Chris Reynolds Gordon at one of his party venues in London",
+          "credits": null,
+          "crop": Object {
+            "ratio": "16:9",
+            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+          },
+          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+          "isVideo": false,
+          "title": "Chris Reynolds Gordon at one of his party venues in London",
+        },
+        "type": "leadAsset",
+      },
+      Object {
+        "data": Object {
+          "flags": Array [],
+          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+          "isVideo": false,
+          "label": null,
+          "standfirst": null,
+        },
+        "type": "header",
+      },
+      Object {
+        "data": Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-13T18:54:58.000Z",
+        },
+        "type": "middleContainer",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 0,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 1,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 2,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 3,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 4,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 5,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 6,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 7,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 8,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 9,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 10,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 11,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        "index": 12,
+        "type": "articleBodyRow",
+      },
+      Object {
+        "data": Object {
+          "topics": undefined,
+        },
+        "type": "topics",
+      },
+      Object {
+        "data": Object {
+          "relatedArticles": Array [
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Patrick Kidd",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+              "label": "Health",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "TMS: Pratchett’s law of the jungle",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T19:39:39.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Terry Pratchett, who died last week, began his career on the ",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Bucks Free Press",
+                          },
+                          "children": Array [],
+                          "name": "text",
+                        },
+                      ],
+                      "name": "italic",
+                    },
+                    Object {
+                      "attributes": Object {
+                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Graeme Paton Transport Correspondent",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "Rise of centenarian drivers as elderly push on",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:42:27.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+            },
+            Object {
+              "byline": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ],
+              "headline": "Syndicated url: At long last, a burial place fit for a king",
+              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+              "label": "Science",
+              "leadAsset": Object {
+                "crop169": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+                },
+                "crop32": Object {
+                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+                },
+                "title": "At long last, a burial place fit for a king",
+              },
+              "publicationName": "TIMES",
+              "publishedTime": "2015-03-23T20:56:09.000Z",
+              "summary105": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary125": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary145": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary160": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary175": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "summary225": Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "His coffin has been",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "paragraph",
+                },
+              ],
+              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+            },
+          ],
+          "relatedArticlesLayout": Object {
+            "template": "DEFAULT",
+          },
+        },
+        "type": "relatedArticles",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  horizontal={false}
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  testID="flat-list-article"
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View
+        testID="leadAsset"
+      >
+        <View>
+          <Modal
+            hardwareAccelerated={false}
+            presentationStyle="fullScreen"
+            visible={false}
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#1D1D1B",
+                  "flexDirection": "column",
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <View
+                isTVSelectable={true}
+                style={
+                  Object {
+                    "opacity": 1,
+                  }
+                }
+              >
+                <ARTSurfaceView
+                  style={
+                    Object {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                >
+                  <ARTGroup
+                    opacity={1}
+                    transform={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                  >
+                    <ARTGroup
+                      opacity={1}
+                      transform={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            19,
+                            6.41,
+                            2,
+                            17.59,
+                            5,
+                            2,
+                            12,
+                            10.59,
+                            2,
+                            6.41,
+                            5,
+                            2,
+                            5,
+                            6.41,
+                            2,
+                            10.59,
+                            12,
+                            2,
+                            5,
+                            17.59,
+                            2,
+                            6.41,
+                            19,
+                            2,
+                            12,
+                            13.41,
+                            2,
+                            17.59,
+                            19,
+                            2,
+                            19,
+                            17.59,
+                            2,
+                            13.41,
+                            12,
+                            1,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            0,
+                            1,
+                            1,
+                            1,
+                            0.8,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                      <ARTShape
+                        d={
+                          Array [
+                            0,
+                            0,
+                            0,
+                            2,
+                            24,
+                            0,
+                            2,
+                            24,
+                            24,
+                            2,
+                            0,
+                            24,
+                            1,
+                          ]
+                        }
+                        fill={null}
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTGroup>
+                  </ARTGroup>
+                </ARTSurfaceView>
+              </View>
+              <View
+                style={
+                  Object {
+                    "flexGrow": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "flexGrow": 1,
+                      "justifyContent": "center",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "transform": Array [
+                          Object {
+                            "scale": 1,
+                          },
+                          Object {
+                            "rotate": "0 deg",
+                          },
+                          Object {
+                            "perspective": 1000,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <View
+                      aspectRatio={1.7777777777777777}
+                      style={
+                        Object {
+                          "opacity": 1,
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <Image
+                          source={
+                            Object {
+                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                            }
+                          }
+                          style={
+                            Object {
+                              "bottom": 0,
+                              "height": "100%",
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "width": "100%",
+                            }
+                          }
+                        />
+                        <View
+                          style={
+                            Object {
+                              "flex": 1,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              Object {
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <ARTSurfaceView
+                              style={
+                                Object {
+                                  "bottom": 0,
+                                  "height": 0,
+                                  "left": 0,
+                                  "position": "absolute",
+                                  "right": 0,
+                                  "top": 0,
+                                  "width": 0,
+                                }
+                              }
+                            >
+                              <ARTShape
+                                d={
+                                  Array [
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                    2,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                                fill={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    -0,
+                                    0,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    0.9764705882352941,
+                                    1,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    0.9294117647058824,
+                                    1,
+                                    0,
+                                    1,
+                                  ]
+                                }
+                                opacity={1}
+                                stroke={null}
+                                strokeCap={1}
+                                strokeDash={null}
+                                strokeJoin={1}
+                                strokeWidth={1}
+                                transform={
+                                  Array [
+                                    1,
+                                    0,
+                                    0,
+                                    1,
+                                    0,
+                                    0,
+                                  ]
+                                }
+                              />
+                            </ARTSurfaceView>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </Modal>
+          <View
+            isTVSelectable={true}
+            style={
+              Object {
+                "opacity": 1,
+              }
+            }
+          >
+            <View
+              aspectRatio={1.7777777777777777}
+            >
+              <View
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
+                    }
+                  }
+                  style={
+                    Object {
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "flex": 1,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <ARTSurfaceView
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "height": 0,
+                          "left": 0,
+                          "position": "absolute",
+                          "right": 0,
+                          "top": 0,
+                          "width": 0,
+                        }
+                      }
+                    >
+                      <ARTShape
+                        d={
+                          Array [
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                          ]
+                        }
+                        fill={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            -0,
+                            0,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            0.9764705882352941,
+                            1,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            0.9294117647058824,
+                            1,
+                            0,
+                            1,
+                          ]
+                        }
+                        opacity={1}
+                        stroke={null}
+                        strokeCap={1}
+                        strokeDash={null}
+                        strokeJoin={1}
+                        strokeWidth={1}
+                        transform={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                      />
+                    </ARTSurfaceView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 32,
+              "marginBottom": 7,
+            }
+          }
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 0.5,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 14,
+              }
+            }
+          >
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </Text>
+        </View>
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 0.5,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Friday March 13 2015, 06:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-0"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <Text
+            style={
+              Object {
+                "fontStyle": "italic",
+              }
+            }
+          >
+            Telegraph 
+          </Text>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-1"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </Text>
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-2"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-3"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-4"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-5"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+        testID="paragraph-6"
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`Article tests on ios should render an article with no standfirst 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -9770,7 +13696,7 @@ exports[`7. article with no standfirst 1`] = `
 </RCTScrollView>
 `;
 
-exports[`8. article with no standfirst and no flags 1`] = `
+exports[`Article tests on ios should render an article with no standfirst and no flags 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -11440,7 +15366,7 @@ exports[`8. article with no standfirst and no flags 1`] = `
 </RCTScrollView>
 `;
 
-exports[`9. article with no standfirst and no label 1`] = `
+exports[`Article tests on ios should render an article with no standfirst and no label 1`] = `
 <RCTScrollView
   data={
     Array [
@@ -13125,3917 +17051,20 @@ exports[`9. article with no standfirst and no label 1`] = `
 </RCTScrollView>
 `;
 
-exports[`10. article with no flags and no label 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": null,
-          "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                isTVSelectable={true}
-                style={
-                  Object {
-                    "opacity": 1,
-                  }
-                }
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            isTVSelectable={true}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 32,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "paddingBottom": 9,
-            }
-          }
-          testID="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 14,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
+exports[`Article tests on ios should render an error 1`] = `
+<View>
+  <Text>
+    An error occurred
+  </Text>
+  <Text>
+    {
+  "message": "An example error."
+}
+  </Text>
+</View>
 `;
 
-exports[`11. article with no standfirst, no label and no no flags 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "caption": "Chris Reynolds Gordon at one of his party venues in London",
-          "credits": null,
-          "crop": Object {
-            "ratio": "16:9",
-            "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-          },
-          "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-          "isVideo": false,
-          "title": "Chris Reynolds Gordon at one of his party venues in London",
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-          "isVideo": false,
-          "label": null,
-          "standfirst": null,
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-13T18:54:58.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 5,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 6,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 7,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 8,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 9,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 10,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 11,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 12,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-      Object {
-        "data": Object {
-          "relatedArticles": Array [
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Patrick Kidd",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-              "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-              "label": "Health",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "TMS: Pratchett’s law of the jungle",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T19:39:39.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Terry Pratchett, who died last week, began his career on the ",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                    Object {
-                      "attributes": Object {},
-                      "children": Array [
-                        Object {
-                          "attributes": Object {
-                            "value": "Bucks Free Press",
-                          },
-                          "children": Array [],
-                          "name": "text",
-                        },
-                      ],
-                      "name": "italic",
-                    },
-                    Object {
-                      "attributes": Object {
-                        "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Graeme Paton Transport Correspondent",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-              "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "Rise of centenarian drivers as elderly push on",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:42:27.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-            },
-            Object {
-              "byline": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "inline",
-                },
-              ],
-              "headline": "Syndicated url: At long last, a burial place fit for a king",
-              "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-              "label": "Science",
-              "leadAsset": Object {
-                "crop169": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-                },
-                "crop32": Object {
-                  "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-                },
-                "title": "At long last, a burial place fit for a king",
-              },
-              "publicationName": "TIMES",
-              "publishedTime": "2015-03-23T20:56:09.000Z",
-              "summary105": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary125": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary145": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary160": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary175": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "summary225": Array [
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "His coffin has been",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "paragraph",
-                },
-              ],
-              "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-            },
-          ],
-          "relatedArticlesLayout": Object {
-            "template": "DEFAULT",
-          },
-        },
-        "type": "relatedArticles",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View>
-          <Modal
-            hardwareAccelerated={false}
-            presentationStyle="fullScreen"
-            visible={false}
-          >
-            <View
-              style={
-                Object {
-                  "backgroundColor": "#1D1D1B",
-                  "flexDirection": "column",
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <View
-                isTVSelectable={true}
-                style={
-                  Object {
-                    "opacity": 1,
-                  }
-                }
-              >
-                <ARTSurfaceView
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
-                  }
-                >
-                  <ARTGroup
-                    opacity={1}
-                    transform={
-                      Array [
-                        1,
-                        0,
-                        0,
-                        1,
-                        0,
-                        0,
-                      ]
-                    }
-                  >
-                    <ARTGroup
-                      opacity={1}
-                      transform={
-                        Array [
-                          1,
-                          0,
-                          0,
-                          1,
-                          0,
-                          0,
-                        ]
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            19,
-                            6.41,
-                            2,
-                            17.59,
-                            5,
-                            2,
-                            12,
-                            10.59,
-                            2,
-                            6.41,
-                            5,
-                            2,
-                            5,
-                            6.41,
-                            2,
-                            10.59,
-                            12,
-                            2,
-                            5,
-                            17.59,
-                            2,
-                            6.41,
-                            19,
-                            2,
-                            12,
-                            13.41,
-                            2,
-                            17.59,
-                            19,
-                            2,
-                            19,
-                            17.59,
-                            2,
-                            13.41,
-                            12,
-                            1,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            0,
-                            1,
-                            1,
-                            1,
-                            0.8,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                      <ARTShape
-                        d={
-                          Array [
-                            0,
-                            0,
-                            0,
-                            2,
-                            24,
-                            0,
-                            2,
-                            24,
-                            24,
-                            2,
-                            0,
-                            24,
-                            1,
-                          ]
-                        }
-                        fill={null}
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTGroup>
-                  </ARTGroup>
-                </ARTSurfaceView>
-              </View>
-              <View
-                style={
-                  Object {
-                    "flexGrow": 1,
-                  }
-                }
-              >
-                <View
-                  style={
-                    Object {
-                      "flexGrow": 1,
-                      "justifyContent": "center",
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "transform": Array [
-                          Object {
-                            "scale": 1,
-                          },
-                          Object {
-                            "rotate": "0 deg",
-                          },
-                          Object {
-                            "perspective": 1000,
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <View
-                      aspectRatio={1.7777777777777777}
-                      style={
-                        Object {
-                          "opacity": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <View
-                        style={
-                          Object {
-                            "height": "100%",
-                            "width": "100%",
-                          }
-                        }
-                      >
-                        <Image
-                          source={
-                            Object {
-                              "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                            }
-                          }
-                          style={
-                            Object {
-                              "bottom": 0,
-                              "height": "100%",
-                              "left": 0,
-                              "position": "absolute",
-                              "right": 0,
-                              "top": 0,
-                              "width": "100%",
-                            }
-                          }
-                        />
-                        <View
-                          style={
-                            Object {
-                              "flex": 1,
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              Object {
-                                "flex": 1,
-                              }
-                            }
-                          >
-                            <ARTSurfaceView
-                              style={
-                                Object {
-                                  "bottom": 0,
-                                  "height": 0,
-                                  "left": 0,
-                                  "position": "absolute",
-                                  "right": 0,
-                                  "top": 0,
-                                  "width": 0,
-                                }
-                              }
-                            >
-                              <ARTShape
-                                d={
-                                  Array [
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                    2,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                                fill={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    -0,
-                                    0,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    0.9764705882352941,
-                                    1,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    0.9294117647058824,
-                                    1,
-                                    0,
-                                    1,
-                                  ]
-                                }
-                                opacity={1}
-                                stroke={null}
-                                strokeCap={1}
-                                strokeDash={null}
-                                strokeJoin={1}
-                                strokeWidth={1}
-                                transform={
-                                  Array [
-                                    1,
-                                    0,
-                                    0,
-                                    1,
-                                    0,
-                                    0,
-                                  ]
-                                }
-                              />
-                            </ARTSurfaceView>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </Modal>
-          <View
-            isTVSelectable={true}
-            style={
-              Object {
-                "opacity": 1,
-              }
-            }
-          >
-            <View
-              aspectRatio={1.7777777777777777}
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 32,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 14,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Friday March 13 2015, 06:54pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <Text
-            style={
-              Object {
-                "fontStyle": "italic",
-              }
-            }
-          >
-            Telegraph 
-          </Text>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "fontWeight": "bold",
-              }
-            }
-          >
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </Text>
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-3"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-5"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-6"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </Text>
-      </View>
-    </View>
-    <View
-      style={
-        Object {
-          "height": 0,
-        }
-      }
-    />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`12. article with a video asset 1`] = `
-<RCTScrollView
-  data={
-    Array [
-      Object {
-        "data": Object {
-          "__typename": "Video",
-          "brightcoveAccountId": "57838016001",
-          "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-          "brightcoveVideoId": "4084164751001",
-          "caption": "This is video caption",
-          "isVideo": true,
-          "paidOnly": "false",
-          "posterImage": Object {
-            "caption": "CCTV captures moment of the explosion",
-            "credits": "",
-            "crop": Object {
-              "ratio": "16:9",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-            },
-            "id": "2d09f6bb-9106-4f8b-d4bc-f371672bd460",
-            "title": "",
-          },
-        },
-        "type": "leadAsset",
-      },
-      Object {
-        "data": Object {
-          "flags": Array [],
-          "headline": "Young boy among dead after blast flattens Leicester store",
-          "isVideo": true,
-          "label": "",
-          "standfirst": "",
-        },
-        "type": "header",
-      },
-      Object {
-        "data": Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "publicationName": "TIMES",
-          "publishedTime": "2018-02-26T17:00:00.000Z",
-        },
-        "type": "middleContainer",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 0,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 1,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 2,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {
-            "caption": "Some 60 homes near the site of the explosion were evacuated",
-            "credits": "CATERS",
-            "display": "primary",
-            "ratio": "1500:1000",
-            "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        "index": 3,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        "index": 4,
-        "type": "articleBodyRow",
-      },
-      Object {
-        "data": Object {
-          "topics": undefined,
-        },
-        "type": "topics",
-      },
-    ]
-  }
-  disableVirtualization={false}
-  horizontal={false}
-  initialNumToRender={10}
-  maxToRenderPerBatch={10}
-  numColumns={1}
-  onEndReachedThreshold={2}
-  scrollEventThrottle={50}
-  testID="flat-list-article"
-  updateCellsBatchingPeriod={50}
-  windowSize={21}
->
-  <View>
-    <View>
-      <View
-        testID="leadAsset"
-      >
-        <View
-          accessibilityLabel="splash-component"
-          isTVSelectable={true}
-          style={
-            Object {
-              "opacity": 1,
-            }
-          }
-          testID="splash-component"
-        >
-          <View
-            style={
-              Object {
-                "height": 421.875,
-                "width": 750,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "height": 421.875,
-                  "width": 750,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0&resize=1440",
-                    }
-                  }
-                  style={
-                    Object {
-                      "bottom": 0,
-                      "height": "100%",
-                      "left": 0,
-                      "position": "absolute",
-                      "right": 0,
-                      "top": 0,
-                      "width": "100%",
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "flex": 1,
-                      }
-                    }
-                  >
-                    <ARTSurfaceView
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "height": 0,
-                          "left": 0,
-                          "position": "absolute",
-                          "right": 0,
-                          "top": 0,
-                          "width": 0,
-                        }
-                      }
-                    >
-                      <ARTShape
-                        d={
-                          Array [
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                            2,
-                            0,
-                            0,
-                          ]
-                        }
-                        fill={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            -0,
-                            0,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            0.9764705882352941,
-                            1,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            0.9294117647058824,
-                            1,
-                            0,
-                            1,
-                          ]
-                        }
-                        opacity={1}
-                        stroke={null}
-                        strokeCap={1}
-                        strokeDash={null}
-                        strokeJoin={1}
-                        strokeWidth={1}
-                        transform={
-                          Array [
-                            1,
-                            0,
-                            0,
-                            1,
-                            0,
-                            0,
-                          ]
-                        }
-                      />
-                    </ARTSurfaceView>
-                  </View>
-                </View>
-              </View>
-            </View>
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "height": 421.875,
-                  "justifyContent": "center",
-                  "left": 0,
-                  "position": "absolute",
-                  "top": 0,
-                  "width": 750,
-                }
-              }
-            >
-              <View>
-                <svg
-                  height={70}
-                  viewBox="0 0 100 100"
-                  width={70}
-                >
-                  <rect
-                    fill="rgba(0,0,0)"
-                    fillOpacity="0.4"
-                    height="100"
-                    stroke="rgb(255,255,255)"
-                    strokeWidth="8"
-                    width="100"
-                  />
-                  <polygon
-                    fill="rgb(255,255,255)"
-                    points="30,20 70,50 30,80"
-                  />
-                </svg>
-              </View>
-            </View>
-          </View>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
-        <View
-          accessibilityLabel="label"
-          style={
-            Object {
-              "paddingBottom": 5,
-              "paddingTop": 4,
-            }
-          }
-          testID="label"
-        >
-          <VideoLabel
-            color="#333333"
-            title=""
-          />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 32,
-              "marginBottom": 7,
-            }
-          }
-        >
-          Young boy among dead after blast flattens Leicester store
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 0.5,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 14,
-              }
-            }
-          >
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 0.5,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Monday February 26 2018, 05:00pm, The Times
-          </Text>
-        </View>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-0"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-1"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-2"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
-        </Text>
-      </View>
-    </View>
-    <View>
-      <View>
-        <ArticleImage
-          captionOptions={
-            Object {
-              "caption": "Some 60 homes near the site of the explosion were evacuated",
-              "credits": "CATERS",
-            }
-          }
-          imageOptions={
-            Object {
-              "display": "primary",
-              "ratio": "1500:1000",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-            }
-          }
-        />
-      </View>
-    </View>
-    <View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-        testID="paragraph-4"
-      >
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": 20,
-            }
-          }
-        >
-          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
-        </Text>
-      </View>
-    </View>
-    <View />
-  </View>
-</RCTScrollView>
-`;
-
-exports[`analytics for page view 1`] = `
+exports[`Send analytics when rendering an Article page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {
@@ -17069,33 +17098,4 @@ Object {
   "component": "Page",
   "object": "Article",
 }
-`;
-
-exports[`should handles an empty leadAsset object when passed to listViewDataHelper() 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "flags": undefined,
-      "headline": undefined,
-      "isVideo": false,
-      "label": undefined,
-      "standfirst": undefined,
-    },
-    "type": "header",
-  },
-  Object {
-    "data": Object {
-      "byline": undefined,
-      "publicationName": undefined,
-      "publishedTime": undefined,
-    },
-    "type": "middleContainer",
-  },
-  Object {
-    "data": Object {
-      "topics": undefined,
-    },
-    "type": "topics",
-  },
-]
 `;

--- a/packages/article/__tests__/ios/article.ios.test.js
+++ b/packages/article/__tests__/ios/article.ios.test.js
@@ -28,9 +28,13 @@ jest.mock("@times-components/tracking", () => {
   };
 });
 
-shared();
-nativeShared();
+describe("Article tests on ios", () => {
+  shared();
+  nativeShared();
+});
 
 jest.unmock("@times-components/tracking");
 
-sharedTracking();
+describe("Article Tracking tests on web", () => {
+  sharedTracking();
+});

--- a/packages/article/__tests__/ios/article.ios.test.js
+++ b/packages/article/__tests__/ios/article.ios.test.js
@@ -28,13 +28,9 @@ jest.mock("@times-components/tracking", () => {
   };
 });
 
-describe("Article tests on ios", () => {
-  shared();
-  nativeShared();
-});
+shared();
+nativeShared();
 
 jest.unmock("@times-components/tracking");
 
-describe("Article Tracking tests on web", () => {
-  sharedTracking();
-});
+sharedTracking();

--- a/packages/article/__tests__/shared-native.js
+++ b/packages/article/__tests__/shared-native.js
@@ -1,5 +1,3 @@
-import "react-native";
-
 import getLeadAsset, {
   defaultAsset
 } from "../src/article-lead-asset/get-lead-asset";

--- a/packages/article/__tests__/shared-native.js
+++ b/packages/article/__tests__/shared-native.js
@@ -1,3 +1,5 @@
+import "react-native";
+
 import getLeadAsset, {
   defaultAsset
 } from "../src/article-lead-asset/get-lead-asset";

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -15,7 +15,7 @@ export default () => {
     mockDate.reset();
   });
 
-  it("should track page view", () => {
+  it("analytics for page view", () => {
     const stream = jest.fn();
 
     TestRenderer.create(
@@ -32,8 +32,6 @@ export default () => {
     );
     const call = stream.mock.calls[0][0];
 
-    expect(call).toMatchSnapshot(
-      "Send analytics when rendering an Article page"
-    );
+    expect(call).toMatchSnapshot();
   });
 };

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -1,6 +1,5 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import mockDate from "mockdate";
 import Article from "../src/article";
 import { adConfig } from "./shared";
@@ -19,7 +18,7 @@ export default () => {
   it("should track page view", () => {
     const stream = jest.fn();
 
-    renderer.create(
+    TestRenderer.create(
       <Article
         {...fullArticleFixture.data}
         adConfig={adConfig}

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -1,5 +1,6 @@
+import "react-native";
 import React from "react";
-import TestRenderer from "react-test-renderer";
+import renderer from "react-test-renderer";
 import mockDate from "mockdate";
 import Article from "../src/article";
 import { adConfig } from "./shared";
@@ -15,10 +16,10 @@ export default () => {
     mockDate.reset();
   });
 
-  it("analytics for page view", () => {
+  it("should track page view", () => {
     const stream = jest.fn();
 
-    TestRenderer.create(
+    renderer.create(
       <Article
         {...fullArticleFixture.data}
         adConfig={adConfig}
@@ -32,6 +33,8 @@ export default () => {
     );
     const call = stream.mock.calls[0][0];
 
-    expect(call).toMatchSnapshot();
+    expect(call).toMatchSnapshot(
+      "Send analytics when rendering an Article page"
+    );
   });
 };

--- a/packages/article/__tests__/shared.js
+++ b/packages/article/__tests__/shared.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";

--- a/packages/article/__tests__/shared.js
+++ b/packages/article/__tests__/shared.js
@@ -1,7 +1,7 @@
+import "react-native";
 import React from "react";
-import TestRenderer from "react-test-renderer";
+import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
-import { iterator } from "@times-components/test-utils";
 import Article from "../src/article";
 
 import fullArticleFixture from "../fixtures/full-article.json";
@@ -74,242 +74,221 @@ export default () => {
     global.Intl = realIntl;
   });
 
-  const tests = [
-    {
-      name: "article",
-      test: async () => {
-        const props = {
-          error: { message: "An example error." }
-        };
+  it("should render an error", () => {
+    const props = {
+      error: { message: "An example error." }
+    };
 
-        const testInstance = TestRenderer.create(
-          <Article
-            {...props}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        );
+    const tree = renderer.create(
+      <Article
+        {...props}
+        adConfig={adConfig}
+        analyticsStream={() => {}}
+        onAuthorPress={() => {}}
+        onLinkPress={() => {}}
+        onRelatedArticlePress={() => {}}
+        onTopicPress={() => {}}
+        onVideoPress={() => {}}
+      />
+    );
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "full article",
-      test: async () => {
-        const wrapper = shallow(
-          <Article
-            {...fullArticleFixture.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        );
+  it("should render a full article", () => {
+    const tree = shallow(
+      <Article
+        {...fullArticleFixture.data}
+        adConfig={adConfig}
+        analyticsStream={() => {}}
+        onAuthorPress={() => {}}
+        onLinkPress={() => {}}
+        onRelatedArticlePress={() => {}}
+        onTopicPress={() => {}}
+        onVideoPress={() => {}}
+      />
+    );
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(wrapper).toMatchSnapshot();
-      }
-    },
-    {
-      name: "smaller article",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...shortArticleFixture.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render a smaller article", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...shortArticleFixture.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no flags",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoFlags.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no flags", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoFlags.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no byline",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoByline.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no byline", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoByline.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no label",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoLabel.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no label", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoLabel.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no standfirst",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoStandfirst.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no standfirst", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoStandfirst.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no standfirst and no flags",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoStandfirstNoFlags.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no standfirst and no flags", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoStandfirstNoFlags.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no standfirst and no label",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoStandfirstNoLabel.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no standfirst and no label", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoStandfirstNoLabel.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no flags and no label",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoLabelNoFlags.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no label and no flags", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoLabelNoFlags.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with no standfirst, no label and no no flags",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
+  it("should render an article with no label, no flags and no standfirst", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-        expect(testInstance).toMatchSnapshot();
-      }
-    },
-    {
-      name: "article with a video asset",
-      test: async () => {
-        const testInstance = TestRenderer.create(
-          <Article
-            {...articleFixtureWithVideo.data}
-            adConfig={adConfig}
-            analyticsStream={() => {}}
-            onAuthorPress={() => {}}
-            onLinkPress={() => {}}
-            onRelatedArticlePress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-          />
-        ).toJSON();
-
-        expect(testInstance).toMatchSnapshot();
-      }
-    }
-  ];
-
-  iterator(tests);
+  it("should render an article with a video asset", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureWithVideo.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 };
 
 export { adConfig };

--- a/packages/article/__tests__/shared.js
+++ b/packages/article/__tests__/shared.js
@@ -1,6 +1,7 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import Article from "../src/article";
 
 import fullArticleFixture from "../fixtures/full-article.json";
@@ -73,221 +74,262 @@ export default () => {
     global.Intl = realIntl;
   });
 
-  it("should render an error", () => {
-    const props = {
-      error: { message: "An example error." }
-    };
+  const tests = [
+    {
+      name: "article",
+      test: async () => {
+        const props = {
+          error: { message: "An example error." }
+        };
 
-    const tree = renderer.create(
-      <Article
-        {...props}
-        adConfig={adConfig}
-        analyticsStream={() => {}}
-        onAuthorPress={() => {}}
-        onLinkPress={() => {}}
-        onRelatedArticlePress={() => {}}
-        onTopicPress={() => {}}
-        onVideoPress={() => {}}
-      />
-    );
-    expect(tree).toMatchSnapshot();
-  });
+        const tree = renderer.create(
+          <Article
+            {...props}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        );
 
-  it("should render a full article", () => {
-    const tree = shallow(
-      <Article
-        {...fullArticleFixture.data}
-        adConfig={adConfig}
-        analyticsStream={() => {}}
-        onAuthorPress={() => {}}
-        onLinkPress={() => {}}
-        onRelatedArticlePress={() => {}}
-        onTopicPress={() => {}}
-        onVideoPress={() => {}}
-      />
-    );
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "full article",
+      test: async () => {
+        const tree = shallow(
+          <Article
+            {...fullArticleFixture.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        );
 
-  it("should render a smaller article", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...shortArticleFixture.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "smaller article",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...shortArticleFixture.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no flags", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoFlags.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no flags",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoFlags.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no byline", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoByline.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no byline",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoByline.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no label", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoLabel.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no label",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoLabel.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no standfirst", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoStandfirst.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no standfirst",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoStandfirst.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no standfirst and no flags", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoStandfirstNoFlags.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no standfirst and no flags",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoStandfirstNoFlags.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no standfirst and no label", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoStandfirstNoLabel.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no standfirst and no label",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoStandfirstNoLabel.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no label and no flags", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoLabelNoFlags.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no flags and no label",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoLabelNoFlags.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with no label, no flags and no standfirst", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with no standfirst, no label and no no flags",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
 
-  it("should render an article with a video asset", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureWithVideo.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-          onVideoPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "article with a video asset",
+      test: async () => {
+        const tree = renderer
+          .create(
+            <Article
+              {...articleFixtureWithVideo.data}
+              adConfig={adConfig}
+              analyticsStream={() => {}}
+              onAuthorPress={() => {}}
+              onLinkPress={() => {}}
+              onRelatedArticlePress={() => {}}
+              onTopicPress={() => {}}
+              onVideoPress={() => {}}
+            />
+          )
+          .toJSON();
+
+        expect(tree).toMatchSnapshot();
+      }
+    }
+  ];
+
+  iterator(tests);
 };
 
 export { adConfig };

--- a/packages/article/__tests__/shared.js
+++ b/packages/article/__tests__/shared.js
@@ -1,5 +1,5 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import { shallow } from "enzyme";
 import { iterator } from "@times-components/test-utils";
 import Article from "../src/article";
@@ -82,7 +82,7 @@ export default () => {
           error: { message: "An example error." }
         };
 
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <Article
             {...props}
             adConfig={adConfig}
@@ -95,13 +95,13 @@ export default () => {
           />
         );
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "full article",
       test: async () => {
-        const tree = shallow(
+        const wrapper = shallow(
           <Article
             {...fullArticleFixture.data}
             adConfig={adConfig}
@@ -114,217 +114,197 @@ export default () => {
           />
         );
 
-        expect(tree).toMatchSnapshot();
+        expect(wrapper).toMatchSnapshot();
       }
     },
     {
       name: "smaller article",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...shortArticleFixture.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...shortArticleFixture.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no flags",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoFlags.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoFlags.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no byline",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoByline.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoByline.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no label",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoLabel.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoLabel.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no standfirst",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoStandfirst.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoStandfirst.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no standfirst and no flags",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoStandfirstNoFlags.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoStandfirstNoFlags.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no standfirst and no label",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoStandfirstNoLabel.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoStandfirstNoLabel.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no flags and no label",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoLabelNoFlags.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoLabelNoFlags.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with no standfirst, no label and no no flags",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureNoLabelNoFlagsNoStandFirst.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "article with a video asset",
       test: async () => {
-        const tree = renderer
-          .create(
-            <Article
-              {...articleFixtureWithVideo.data}
-              adConfig={adConfig}
-              analyticsStream={() => {}}
-              onAuthorPress={() => {}}
-              onLinkPress={() => {}}
-              onRelatedArticlePress={() => {}}
-              onTopicPress={() => {}}
-              onVideoPress={() => {}}
-            />
-          )
-          .toJSON();
+        const testInstance = TestRenderer.create(
+          <Article
+            {...articleFixtureWithVideo.data}
+            adConfig={adConfig}
+            analyticsStream={() => {}}
+            onAuthorPress={() => {}}
+            onLinkPress={() => {}}
+            onRelatedArticlePress={() => {}}
+            onTopicPress={() => {}}
+            onVideoPress={() => {}}
+          />
+        ).toJSON();
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     }
   ];

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -1,5 +1,13907 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Article tests on web 1. article 1`] = `
+<div>
+  <div>
+    An error occurred
+  </div>
+  <div>
+    {
+  "message": "An example error."
+}
+  </div>
+</div>
+`;
+
+exports[`Article tests on web 2. full article 1`] = `
+<ArticlePage
+  adConfig={
+    Object {
+      "adUnit": "mockAdUnit",
+      "bidderSlots": Array [
+        "ad-header",
+        "ad-article-inline",
+      ],
+      "biddersConfig": Object {
+        "bidders": Object {
+          "amazon": Object {
+            "accountId": "3360",
+          },
+          "appnexus": Object {
+            "placementId": "5823281",
+          },
+          "criteo": Object {
+            "zoneMap": Object {
+              "120x600": "764877",
+            },
+          },
+          "indexExchange": Object {
+            "siteId": "188830",
+          },
+          "pubmatic": Object {
+            "accountId": "156034",
+            "adSlotPrefix": "Thetimes",
+          },
+          "rubicon": Object {
+            "accountId": "14062",
+            "siteId": "70608",
+            "zoneId": "335918",
+          },
+        },
+        "bucketSize": 0.25,
+        "maxBid": 15,
+        "minPrice": 0.01,
+        "timeout": 3000,
+      },
+      "networkId": "mockNetwork",
+      "pageTargeting": Object {
+        "title": "Title",
+      },
+      "slotTargeting": Object {
+        "path": "/news",
+      },
+    }
+  }
+  article={
+    Object {
+      "byline": Array [
+        Object {
+          "attributes": Object {
+            "slug": "camilla-long",
+          },
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Camilla Long",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "author",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": ", Environment Editor",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "inline",
+        },
+      ],
+      "content": Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {
+                "href": "https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "police disclosure of evidence",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "link",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": " Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "brightcoveAccountId": "57838016001",
+            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+            "brightcoveVideoId": "4084164751001",
+            "caption": "This is video caption",
+            "display": "primary",
+            "paidOnly": "false",
+            "posterImageId": "0c0309d4-1aeb-11e8-9010-1eef6ba5d3de",
+            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "video",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "brightcoveAccountId": "57838016001",
+            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+            "brightcoveVideoId": "4084164751001",
+            "caption": "This is video caption secondary",
+            "display": "secondary",
+            "paidOnly": "false",
+            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "video",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "primary",
+            "ratio": "1500:1000",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "secondary",
+            "ratio": "3:2",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "inline",
+            "ratio": "1:1.50",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "inline",
+            "ratio": "3:2",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": Object {
+              "name": "JudgeSapnara",
+              "twitter": "@JudgeSapnara",
+            },
+            "content": "[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child",
+          },
+          "children": Array [],
+          "name": "pullQuote",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {
+                "href": "https://www.cam.ac.uk/",
+                "target": "_blank",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Cambridge University",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "link",
+            },
+            Object {
+              "attributes": Object {
+                "value": ". She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ],
+      "flags": Array [
+        "NEW",
+        "EXCLUSIVE",
+      ],
+      "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+      "id": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+      "label": "HURRICANE IRMA",
+      "leadAsset": Object {
+        "caption": "Chris Reynolds Gordon at one of his party venues in London",
+        "credits": null,
+        "crop": Object {
+          "ratio": "16:9",
+          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+        },
+        "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+        "title": "Chris Reynolds Gordon at one of his party venues in London",
+      },
+      "publicationName": "TIMES",
+      "publishedTime": "2015-03-13T18:54:58.000Z",
+      "relatedArticles": Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ],
+      "relatedArticlesLayout": Object {
+        "template": "DEFAULT",
+      },
+      "section": "news",
+      "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+      "topics": Array [
+        Object {
+          "name": "Football",
+          "slug": "football",
+        },
+        Object {
+          "name": "Manchester United FC",
+          "slug": "manchester-united",
+        },
+        Object {
+          "name": "Chelsea FC",
+          "slug": "chelsea",
+        },
+        Object {
+          "name": "Arsenal",
+          "slug": "arsenal",
+        },
+        Object {
+          "name": "Rugby Union",
+          "slug": "rugby-union",
+        },
+      ],
+      "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
+    }
+  }
+  error={null}
+  isLoading={false}
+/>
+`;
+
+exports[`Article tests on web 3. smaller article 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  display: none;
+}
+
+.c8 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c11 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c12 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c13 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+.c14 {
+  color: #006699;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+}
+
+.c15 {
+  display: block;
+}
+
+.c16 {
+  padding-left: 10px;
+  padding-right: 10px;
+  margin-bottom: 10px;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c9 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c12 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c13 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+@media (min-width:768px) {
+  .c14 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+@media (min-width:768px) {
+  .c15 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c15 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c16 {
+    width: 50%;
+    float: left;
+    margin-right: 20px;
+    margin-bottom: 0px;
+    margin-top: 5px;
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+      <div
+        className="c7"
+      >
+        <ArticleTopics
+          style={
+            Object {
+              "justifyContent": "flex-start",
+            }
+          }
+          topics={
+            Array [
+              Object {
+                "name": "Football",
+                "slug": "football",
+              },
+              Object {
+                "name": "Manchester United FC",
+                "slug": "manchester-united",
+              },
+              Object {
+                "name": "Chelsea FC",
+                "slug": "chelsea",
+              },
+              Object {
+                "name": "Arsenal",
+                "slug": "arsenal",
+              },
+              Object {
+                "name": "Rugby Union",
+                "slug": "rugby-union",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="c8"
+    >
+      <div
+        className="c9"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c10"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c11"
+    >
+      <div
+        className="c12"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c13"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <a
+            className="c14"
+            href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
+            style={
+              Object {
+                "textDecoration": "underline",
+              }
+            }
+          >
+            police disclosure of evidence
+          </a>
+          <em>
+             Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+          <div
+            className="c15"
+          >
+            <div
+              className="c16"
+            >
+              <PullQuote
+                caption="JudgeSapnara"
+                content="[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child"
+                twitter="@JudgeSapnara"
+              />
+            </div>
+          </div>
+        </p>
+      </div>
+    </div>
+  </div>,
+  .c0 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    display: none;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <ArticleTopics
+      style={
+        Object {
+          "borderTopColor": "#DBDBDB",
+          "borderTopWidth": 1,
+        }
+      }
+      topics={
+        Array [
+          Object {
+            "name": "Football",
+            "slug": "football",
+          },
+          Object {
+            "name": "Manchester United FC",
+            "slug": "manchester-united",
+          },
+          Object {
+            "name": "Chelsea FC",
+            "slug": "chelsea",
+          },
+          Object {
+            "name": "Arsenal",
+            "slug": "arsenal",
+          },
+          Object {
+            "name": "Rugby Union",
+            "slug": "rugby-union",
+          },
+        ]
+      }
+    />
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 4. article with no flags 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 5. article with no byline 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 6. article with no label 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 7. article with no standfirst 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 8. article with no standfirst and no flags 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 9. article with no standfirst and no label 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 10. article with no flags and no label 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 11. article with no standfirst, no label and no no flags 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web 12. article with a video asset 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+.c13 {
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 25px;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+@media (min-width:768px) {
+  .c13 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c13 {
+    width: 58.33333%;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <VideoLabel
+            color="#333333"
+            title=""
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Young boy among dead after blast flattens Leicester store
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Monday February 26 2018, 05:00pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              data-testid="video-component"
+              style={
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <video
+                className="video-js"
+                controls={true}
+                data-account="57838016001"
+                data-application-id={true}
+                data-embed="default"
+                data-player="default"
+                data-video-id="4084164751001"
+                id="4084164751001-57838016001-1"
+                poster="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0"
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                This is video caption
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
+        </p>
+      </div>
+      <div
+        className="c13"
+      >
+        <ArticleImage
+          captionOptions={
+            Object {
+              "caption": "Some 60 homes near the site of the explosion were evacuated",
+              "credits": "CATERS",
+            }
+          }
+          imageOptions={
+            Object {
+              "display": "primary",
+              "ratio": "1500:1000",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+            }
+          }
+        />
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
+        </p>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Article tests on web renders article with no lead asset 1`] = `
 Array [
   .c0 {
@@ -1474,13908 +15376,6 @@ Array [
     </div>
   </div>,
 ]
-`;
-
-exports[`Article tests on web should render a full article 1`] = `
-<ArticlePage
-  adConfig={
-    Object {
-      "adUnit": "mockAdUnit",
-      "bidderSlots": Array [
-        "ad-header",
-        "ad-article-inline",
-      ],
-      "biddersConfig": Object {
-        "bidders": Object {
-          "amazon": Object {
-            "accountId": "3360",
-          },
-          "appnexus": Object {
-            "placementId": "5823281",
-          },
-          "criteo": Object {
-            "zoneMap": Object {
-              "120x600": "764877",
-            },
-          },
-          "indexExchange": Object {
-            "siteId": "188830",
-          },
-          "pubmatic": Object {
-            "accountId": "156034",
-            "adSlotPrefix": "Thetimes",
-          },
-          "rubicon": Object {
-            "accountId": "14062",
-            "siteId": "70608",
-            "zoneId": "335918",
-          },
-        },
-        "bucketSize": 0.25,
-        "maxBid": 15,
-        "minPrice": 0.01,
-        "timeout": 3000,
-      },
-      "networkId": "mockNetwork",
-      "pageTargeting": Object {
-        "title": "Title",
-      },
-      "slotTargeting": Object {
-        "path": "/news",
-      },
-    }
-  }
-  article={
-    Object {
-      "byline": Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
-          },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ],
-      "content": Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {
-                "href": "https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89",
-              },
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "police disclosure of evidence",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "link",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": " Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "brightcoveAccountId": "57838016001",
-            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-            "brightcoveVideoId": "4084164751001",
-            "caption": "This is video caption",
-            "display": "primary",
-            "paidOnly": "false",
-            "posterImageId": "0c0309d4-1aeb-11e8-9010-1eef6ba5d3de",
-            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "video",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "brightcoveAccountId": "57838016001",
-            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-            "brightcoveVideoId": "4084164751001",
-            "caption": "This is video caption secondary",
-            "display": "secondary",
-            "paidOnly": "false",
-            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "video",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "primary",
-            "ratio": "1500:1000",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "secondary",
-            "ratio": "3:2",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [],
-          "name": "ad",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "inline",
-            "ratio": "1:1.50",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "inline",
-            "ratio": "3:2",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": Object {
-              "name": "JudgeSapnara",
-              "twitter": "@JudgeSapnara",
-            },
-            "content": "[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child",
-          },
-          "children": Array [],
-          "name": "pullQuote",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {
-                "href": "https://www.cam.ac.uk/",
-                "target": "_blank",
-              },
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Cambridge University",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "link",
-            },
-            Object {
-              "attributes": Object {
-                "value": ". She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ],
-      "flags": Array [
-        "NEW",
-        "EXCLUSIVE",
-      ],
-      "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-      "id": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
-      "label": "HURRICANE IRMA",
-      "leadAsset": Object {
-        "caption": "Chris Reynolds Gordon at one of his party venues in London",
-        "credits": null,
-        "crop": Object {
-          "ratio": "16:9",
-          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-        },
-        "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-        "title": "Chris Reynolds Gordon at one of his party venues in London",
-      },
-      "publicationName": "TIMES",
-      "publishedTime": "2015-03-13T18:54:58.000Z",
-      "relatedArticles": Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ],
-      "relatedArticlesLayout": Object {
-        "template": "DEFAULT",
-      },
-      "section": "news",
-      "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
-      "topics": Array [
-        Object {
-          "name": "Football",
-          "slug": "football",
-        },
-        Object {
-          "name": "Manchester United FC",
-          "slug": "manchester-united",
-        },
-        Object {
-          "name": "Chelsea FC",
-          "slug": "chelsea",
-        },
-        Object {
-          "name": "Arsenal",
-          "slug": "arsenal",
-        },
-        Object {
-          "name": "Rugby Union",
-          "slug": "rugby-union",
-        },
-      ],
-      "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
-    }
-  }
-  error={null}
-  isLoading={false}
-/>
-`;
-
-exports[`Article tests on web should render a smaller article 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  display: none;
-}
-
-.c8 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c9 {
-  margin-bottom: 10px;
-}
-
-.c11 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c12 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c13 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-.c14 {
-  color: #006699;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-}
-
-.c15 {
-  display: block;
-}
-
-.c16 {
-  padding-left: 10px;
-  padding-right: 10px;
-  margin-bottom: 10px;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c9 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c12 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c13 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-@media (min-width:768px) {
-  .c14 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-@media (min-width:768px) {
-  .c15 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c15 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c16 {
-    width: 50%;
-    float: left;
-    margin-right: 20px;
-    margin-bottom: 0px;
-    margin-top: 5px;
-    padding-left: 0px;
-    padding-right: 0px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-      <div
-        className="c7"
-      >
-        <ArticleTopics
-          style={
-            Object {
-              "justifyContent": "flex-start",
-            }
-          }
-          topics={
-            Array [
-              Object {
-                "name": "Football",
-                "slug": "football",
-              },
-              Object {
-                "name": "Manchester United FC",
-                "slug": "manchester-united",
-              },
-              Object {
-                "name": "Chelsea FC",
-                "slug": "chelsea",
-              },
-              Object {
-                "name": "Arsenal",
-                "slug": "arsenal",
-              },
-              Object {
-                "name": "Rugby Union",
-                "slug": "rugby-union",
-              },
-            ]
-          }
-        />
-      </div>
-    </div>
-    <div
-      className="c8"
-    >
-      <div
-        className="c9"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c10"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c11"
-    >
-      <div
-        className="c12"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c13"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <a
-            className="c14"
-            href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            style={
-              Object {
-                "textDecoration": "underline",
-              }
-            }
-          >
-            police disclosure of evidence
-          </a>
-          <em>
-             Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-          <div
-            className="c15"
-          >
-            <div
-              className="c16"
-            >
-              <PullQuote
-                caption="JudgeSapnara"
-                content="[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child"
-                twitter="@JudgeSapnara"
-              />
-            </div>
-          </div>
-        </p>
-      </div>
-    </div>
-  </div>,
-  .c0 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    display: none;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <ArticleTopics
-      style={
-        Object {
-          "borderTopColor": "#DBDBDB",
-          "borderTopWidth": 1,
-        }
-      }
-      topics={
-        Array [
-          Object {
-            "name": "Football",
-            "slug": "football",
-          },
-          Object {
-            "name": "Manchester United FC",
-            "slug": "manchester-united",
-          },
-          Object {
-            "name": "Chelsea FC",
-            "slug": "chelsea",
-          },
-          Object {
-            "name": "Arsenal",
-            "slug": "arsenal",
-          },
-          Object {
-            "name": "Rugby Union",
-            "slug": "rugby-union",
-          },
-        ]
-      }
-    />
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with a video asset 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-.c13 {
-  width: 100%;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 25px;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-@media (min-width:768px) {
-  .c13 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c13 {
-    width: 58.33333%;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <VideoLabel
-            color="#333333"
-            title=""
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Young boy among dead after blast flattens Leicester store
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Monday February 26 2018, 05:00pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div
-              data-testid="video-component"
-              style={
-                Object {
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <video
-                className="video-js"
-                controls={true}
-                data-account="57838016001"
-                data-application-id={true}
-                data-embed="default"
-                data-player="default"
-                data-video-id="4084164751001"
-                id="4084164751001-57838016001-1"
-                poster="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0"
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                This is video caption
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
-        </p>
-      </div>
-      <div
-        className="c13"
-      >
-        <ArticleImage
-          captionOptions={
-            Object {
-              "caption": "Some 60 homes near the site of the explosion were evacuated",
-              "credits": "CATERS",
-            }
-          }
-          imageOptions={
-            Object {
-              "display": "primary",
-              "ratio": "1500:1000",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-            }
-          }
-        />
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
-        </p>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no byline 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no flags 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no label 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no label and no flags 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no label, no flags and no standfirst 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no standfirst 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no standfirst and no flags 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an article with no standfirst and no label 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`Article tests on web should render an error 1`] = `
-<div>
-  <div>
-    An error occurred
-  </div>
-  <div>
-    {
-  "message": "An example error."
-}
-  </div>
-</div>
 `;
 
 exports[`Send analytics when rendering an Article page 1`] = `

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -1,13944 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. article 1`] = `
-<div>
-  <div>
-    An error occurred
-  </div>
-  <div>
-    {
-  "message": "An example error."
-}
-  </div>
-</div>
-`;
-
-exports[`2. full article 1`] = `
-<ArticlePage
-  adConfig={
-    Object {
-      "adUnit": "mockAdUnit",
-      "bidderSlots": Array [
-        "ad-header",
-        "ad-article-inline",
-      ],
-      "biddersConfig": Object {
-        "bidders": Object {
-          "amazon": Object {
-            "accountId": "3360",
-          },
-          "appnexus": Object {
-            "placementId": "5823281",
-          },
-          "criteo": Object {
-            "zoneMap": Object {
-              "120x600": "764877",
-            },
-          },
-          "indexExchange": Object {
-            "siteId": "188830",
-          },
-          "pubmatic": Object {
-            "accountId": "156034",
-            "adSlotPrefix": "Thetimes",
-          },
-          "rubicon": Object {
-            "accountId": "14062",
-            "siteId": "70608",
-            "zoneId": "335918",
-          },
-        },
-        "bucketSize": 0.25,
-        "maxBid": 15,
-        "minPrice": 0.01,
-        "timeout": 3000,
-      },
-      "networkId": "mockNetwork",
-      "pageTargeting": Object {
-        "title": "Title",
-      },
-      "slotTargeting": Object {
-        "path": "/news",
-      },
-    }
-  }
-  article={
-    Object {
-      "byline": Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
-          },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ],
-      "content": Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {
-                "href": "https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89",
-              },
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "police disclosure of evidence",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "link",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": " Telegraph ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "italic",
-            },
-            Object {
-              "attributes": Object {
-                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "brightcoveAccountId": "57838016001",
-            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-            "brightcoveVideoId": "4084164751001",
-            "caption": "This is video caption",
-            "display": "primary",
-            "paidOnly": "false",
-            "posterImageId": "0c0309d4-1aeb-11e8-9010-1eef6ba5d3de",
-            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "video",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "bold",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "brightcoveAccountId": "57838016001",
-            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
-            "brightcoveVideoId": "4084164751001",
-            "caption": "This is video caption secondary",
-            "display": "secondary",
-            "paidOnly": "false",
-            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "video",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "primary",
-            "ratio": "1500:1000",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "secondary",
-            "ratio": "3:2",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [],
-          "name": "ad",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "inline",
-            "ratio": "1:1.50",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": "All the latest stories in culture and books.",
-            "credits": "The credits",
-            "display": "inline",
-            "ratio": "3:2",
-            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0",
-          },
-          "children": Array [],
-          "name": "image",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {
-            "caption": Object {
-              "name": "JudgeSapnara",
-              "twitter": "@JudgeSapnara",
-            },
-            "content": "[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child",
-          },
-          "children": Array [],
-          "name": "pullQuote",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-            Object {
-              "attributes": Object {
-                "href": "https://www.cam.ac.uk/",
-                "target": "_blank",
-              },
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Cambridge University",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "link",
-            },
-            Object {
-              "attributes": Object {
-                "value": ". She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "paragraph",
-        },
-      ],
-      "flags": Array [
-        "NEW",
-        "EXCLUSIVE",
-      ],
-      "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-      "id": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
-      "label": "HURRICANE IRMA",
-      "leadAsset": Object {
-        "caption": "Chris Reynolds Gordon at one of his party venues in London",
-        "credits": null,
-        "crop": Object {
-          "ratio": "16:9",
-          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
-        },
-        "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
-        "title": "Chris Reynolds Gordon at one of his party venues in London",
-      },
-      "publicationName": "TIMES",
-      "publishedTime": "2015-03-13T18:54:58.000Z",
-      "relatedArticles": Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ],
-      "relatedArticlesLayout": Object {
-        "template": "DEFAULT",
-      },
-      "section": "news",
-      "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
-      "topics": Array [
-        Object {
-          "name": "Football",
-          "slug": "football",
-        },
-        Object {
-          "name": "Manchester United FC",
-          "slug": "manchester-united",
-        },
-        Object {
-          "name": "Chelsea FC",
-          "slug": "chelsea",
-        },
-        Object {
-          "name": "Arsenal",
-          "slug": "arsenal",
-        },
-        Object {
-          "name": "Rugby Union",
-          "slug": "rugby-union",
-        },
-      ],
-      "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
-    }
-  }
-  error={null}
-  isLoading={false}
-/>
-`;
-
-exports[`3. smaller article 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  display: none;
-}
-
-.c8 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c9 {
-  margin-bottom: 10px;
-}
-
-.c11 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c12 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c13 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-.c14 {
-  color: #006699;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-}
-
-.c15 {
-  display: block;
-}
-
-.c16 {
-  padding-left: 10px;
-  padding-right: 10px;
-  margin-bottom: 10px;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c9 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c12 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c13 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-@media (min-width:768px) {
-  .c14 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-@media (min-width:768px) {
-  .c15 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c15 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c16 {
-    width: 50%;
-    float: left;
-    margin-right: 20px;
-    margin-bottom: 0px;
-    margin-top: 5px;
-    padding-left: 0px;
-    padding-right: 0px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-      <div
-        className="c7"
-      >
-        <ArticleTopics
-          style={
-            Object {
-              "justifyContent": "flex-start",
-            }
-          }
-          topics={
-            Array [
-              Object {
-                "name": "Football",
-                "slug": "football",
-              },
-              Object {
-                "name": "Manchester United FC",
-                "slug": "manchester-united",
-              },
-              Object {
-                "name": "Chelsea FC",
-                "slug": "chelsea",
-              },
-              Object {
-                "name": "Arsenal",
-                "slug": "arsenal",
-              },
-              Object {
-                "name": "Rugby Union",
-                "slug": "rugby-union",
-              },
-            ]
-          }
-        />
-      </div>
-    </div>
-    <div
-      className="c8"
-    >
-      <div
-        className="c9"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c10"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c11"
-    >
-      <div
-        className="c12"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c13"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <a
-            className="c14"
-            href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
-            style={
-              Object {
-                "textDecoration": "underline",
-              }
-            }
-          >
-            police disclosure of evidence
-          </a>
-          <em>
-             Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-          <div
-            className="c15"
-          >
-            <div
-              className="c16"
-            >
-              <PullQuote
-                caption="JudgeSapnara"
-                content="[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child"
-                twitter="@JudgeSapnara"
-              />
-            </div>
-          </div>
-        </p>
-      </div>
-    </div>
-  </div>,
-  .c0 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    display: none;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <ArticleTopics
-      style={
-        Object {
-          "borderTopColor": "#DBDBDB",
-          "borderTopWidth": 1,
-        }
-      }
-      topics={
-        Array [
-          Object {
-            "name": "Football",
-            "slug": "football",
-          },
-          Object {
-            "name": "Manchester United FC",
-            "slug": "manchester-united",
-          },
-          Object {
-            "name": "Chelsea FC",
-            "slug": "chelsea",
-          },
-          Object {
-            "name": "Arsenal",
-            "slug": "arsenal",
-          },
-          Object {
-            "name": "Rugby Union",
-            "slug": "rugby-union",
-          },
-        ]
-      }
-    />
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`4. article with no flags 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`5. article with no byline 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`6. article with no label 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`7. article with no standfirst 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`8. article with no standfirst and no flags 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <ArticleLabel
-            color="#333333"
-            title="HURRICANE IRMA"
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`9. article with no standfirst and no label 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div>
-          <div>
-            <NewArticleFlag />
-          </div>
-          <div>
-            <ExclusiveArticleFlag />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`10. article with no flags and no label 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-        <div
-          data-testid="standfirst"
-        >
-          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`11. article with no standfirst, no label and no no flags 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c2 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c3 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c4 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c5 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c6 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c7 {
-  margin-bottom: 10px;
-}
-
-.c9 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c10 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c11 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:768px) {
-  .c2 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c3 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c7 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c7 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c10 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c10 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          className="c2"
-        >
-          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
-        </div>
-      </div>
-    </div>
-    <div
-      className="c3"
-    >
-      <div
-        className="c4"
-      >
-        <div
-          className="c5"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c5"
-        >
-          <span>
-            Friday March 13 2015, 06:54pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c6"
-    >
-      <div
-        className="c7"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div>
-              <div
-                style={
-                  Object {
-                    "display": "table",
-                    "height": 0,
-                    "overflow": "hidden",
-                    "paddingBottom": "NaN%",
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
-                  style={
-                    Object {
-                      "display": "block",
-                      "position": "absolute",
-                      "width": "100%",
-                      "zIndex": 1,
-                    }
-                  }
-                />
-                <div
-                  style={
-                    Object {
-                      "bottom": "0px",
-                      "right": "0px",
-                    }
-                  }
-                >
-                  <div
-                    style={
-                      Object {
-                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="c8"
-        >
-          <div>
-            <div>
-              <div>
-                Chris Reynolds Gordon at one of his party venues in London
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c9"
-    >
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
-          <em>
-            Telegraph 
-          </em>
-          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
-          <strong>
-            When Thatcher joined the campaign trail for the 2001 general election...
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          <strong>
-            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
-          </strong>
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
-        </p>
-      </div>
-      <div
-        className="c10"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c11"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
-        </p>
-      </div>
-    </div>
-  </div>,
-  <RelatedArticles
-    articles={
-      Array [
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Patrick Kidd",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
-          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
-          "label": "Health",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "TMS: Pratchett’s law of the jungle",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T19:39:39.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Terry Pratchett, who died last week, began his career on the ",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-                Object {
-                  "attributes": Object {},
-                  "children": Array [
-                    Object {
-                      "attributes": Object {
-                        "value": "Bucks Free Press",
-                      },
-                      "children": Array [],
-                      "name": "text",
-                    },
-                  ],
-                  "name": "italic",
-                },
-                Object {
-                  "attributes": Object {
-                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Graeme Paton Transport Correspondent",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "Rise of centenarian drivers as elderly push on",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:42:27.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
-        },
-        Object {
-          "byline": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "inline",
-            },
-          ],
-          "headline": "Syndicated url: At long last, a burial place fit for a king",
-          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-          "label": "Science",
-          "leadAsset": Object {
-            "crop169": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-            },
-            "crop32": Object {
-              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-            },
-            "title": "At long last, a burial place fit for a king",
-          },
-          "publicationName": "TIMES",
-          "publishedTime": "2015-03-23T20:56:09.000Z",
-          "summary105": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary125": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary145": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary160": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary175": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "summary225": Array [
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-            Object {
-              "attributes": Object {},
-              "children": Array [
-                Object {
-                  "attributes": Object {
-                    "value": "His coffin has been",
-                  },
-                  "children": Array [],
-                  "name": "text",
-                },
-              ],
-              "name": "paragraph",
-            },
-          ],
-          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
-        },
-      ]
-    }
-    template="DEFAULT"
-  />,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`12. article with a video asset 1`] = `
-Array [
-  .c0 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .c0 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    border-top-color: #DBDBDB;
-    border-bottom-color: #DBDBDB;
-    border-bottom-width: 1px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div>
-      <div
-        style={
-          Object {
-            "height": 0,
-            "overflow": "hidden",
-            "width": 0,
-          }
-        }
-      />
-      <div>
-        <div
-          style={
-            Object {
-              "height": "90px",
-              "width": "728px",
-            }
-          }
-        >
-          <div>
-            <Watermark
-              height={90}
-              viewBox="-630 120 1200 50"
-              width={728}
-            />
-          </div>
-          <div>
-            ADVERTISEMENT
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>,
-  .c1 {
-  padding-left: 10px;
-  padding-right: 10px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-}
-
-.c3 {
-  font-size: 30px;
-  color: #1D1D1B;
-  margin-bottom: 8px;
-  font-family: "TimesModern-Bold";
-  font-weight: 400;
-  line-height: 30px;
-}
-
-.c4 {
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c5 {
-  margin-left: 10px;
-  margin-right: 10px;
-}
-
-.c6 {
-  border-top: 1px solid #DBDBDB;
-}
-
-.c7 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
-}
-
-.c8 {
-  margin-bottom: 10px;
-}
-
-.c10 {
-  display: block;
-  -webkit-order: 4;
-  -ms-flex-order: 4;
-  order: 4;
-}
-
-.c11 {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
-.c12 {
-  color: #333333;
-  font-family: "TimesDigitalW04-Regular";
-  line-height: 26px;
-  font-size: 17px;
-  margin-bottom: 25px;
-  margin-top: 0;
-  display: block;
-}
-
-.c13 {
-  width: 100%;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-bottom: 25px;
-}
-
-@media (min-width:1024px) {
-  .c0 {
-    padding-top: 20px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-@media (min-width:768px) {
-  .c1 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c1 {
-    width: 58.33333%;
-    margin-bottom: 15px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c2 {
-    margin-top: 0px;
-  }
-}
-
-@media (min-width:768px) {
-  .c3 {
-    font-size: 45px;
-    line-height: 45px;
-  }
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    margin-bottom: 20px;
-    padding-right: 20px;
-    padding-left: 20px;
-    position: absolute;
-    left: 0;
-    width: 20.8333%;
-    z-index: 1;
-  }
-}
-
-@media (min-width:768px) {
-  .c5 {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c5 {
-    padding-top: 0px;
-    margin-bottom: 0;
-  }
-}
-
-@media (min-width:768px) {
-  .c6 {
-    padding-top: 5px;
-    padding-bottom: 5px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c6 {
-    line-height: 18px;
-    padding-bottom: 25px;
-  }
-}
-
-@media (min-width:768px) {
-  .c8 {
-    margin-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c8 {
-    width: 58.33333%;
-    margin: 0 auto;
-    padding-bottom: 20px;
-  }
-}
-
-@media (min-width:1024px) {
-  .c9 {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-  }
-}
-
-@media (min-width:768px) {
-  .c11 {
-    width: 83.33333333%;
-    margin: 0 auto;
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-@media (min-width:1024px) {
-  .c11 {
-    width: 58.33333%;
-  }
-}
-
-@media (min-width:768px) {
-  .c12 {
-    font-size: 18px;
-    line-height: 30px;
-  }
-}
-
-@media (min-width:768px) {
-  .c13 {
-    width: 83.33333333%;
-    margin: 0 auto;
-  }
-}
-
-@media (min-width:1024px) {
-  .c13 {
-    width: 58.33333%;
-  }
-}
-
-<div
-    className="c0"
-  >
-    <div
-      className="c1"
-    >
-      <div>
-        <div
-          aria-label="label"
-          className="c2"
-          data-testid="label"
-        >
-          <VideoLabel
-            color="#333333"
-            title=""
-          />
-        </div>
-        <div
-          className="c3"
-        >
-          Young boy among dead after blast flattens Leicester store
-        </div>
-      </div>
-    </div>
-    <div
-      className="c4"
-    >
-      <div
-        className="c5"
-      >
-        <div
-          className="c6"
-        >
-          <span>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
-                        },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </span>
-        </div>
-        <div
-          className="c6"
-        >
-          <span>
-            Monday February 26 2018, 05:00pm, The Times
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c7"
-    >
-      <div
-        className="c8"
-      >
-        <div
-          style={
-            Object {
-              "paddingBottom": "56.25%",
-            }
-          }
-        >
-          <div
-            style={
-              Object {
-                "height": "100%",
-                "width": "100%",
-              }
-            }
-          >
-            <div
-              data-testid="video-component"
-              style={
-                Object {
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            >
-              <video
-                className="video-js"
-                controls={true}
-                data-account="57838016001"
-                data-application-id={true}
-                data-embed="default"
-                data-player="default"
-                data-video-id="4084164751001"
-                id="4084164751001-57838016001-1"
-                poster="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0"
-                style={
-                  Object {
-                    "height": "100%",
-                    "width": "100%",
-                  }
-                }
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          className="c9"
-        >
-          <div>
-            <div>
-              <div>
-                This is video caption
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="c10"
-    >
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
-        </p>
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
-        </p>
-      </div>
-      <div
-        className="c13"
-      >
-        <ArticleImage
-          captionOptions={
-            Object {
-              "caption": "Some 60 homes near the site of the explosion were evacuated",
-              "credits": "CATERS",
-            }
-          }
-          imageOptions={
-            Object {
-              "display": "primary",
-              "ratio": "1500:1000",
-              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
-            }
-          }
-        />
-      </div>
-      <div
-        className="c11"
-        style={
-          Object {
-            "paddingLeft": "10px",
-            "paddingRight": "10px",
-          }
-        }
-      >
-        <p
-          className="c12"
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesDigitalW04",
-              "fontSize": 17,
-              "lineHeight": 26,
-              "marginBottom": "25px",
-              "marginTop": 0,
-            }
-          }
-        >
-          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
-        </p>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div>
-    <div
-      style={
-        Object {
-          "height": 0,
-          "overflow": "hidden",
-          "width": 0,
-        }
-      }
-    />
-    <div>
-      <div
-        style={
-          Object {
-            "height": "0px",
-            "width": "0px",
-          }
-        }
-      >
-        <div>
-          <Watermark
-            height={0}
-            viewBox="-50 0 0 0"
-            width={0}
-          />
-        </div>
-        <div>
-          ADVERTISEMENT
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`analytics for page view 1`] = `
-Object {
-  "action": "Viewed",
-  "attrs": Object {
-    "byline": "Camilla Long",
-    "eventTime": "2018-01-01T00:00:00.000Z",
-    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-    "publishedTime": "2015-03-13T18:54:58.000Z",
-    "topics": Array [
-      Object {
-        "name": "Football",
-        "slug": "football",
-      },
-      Object {
-        "name": "Manchester United FC",
-        "slug": "manchester-united",
-      },
-      Object {
-        "name": "Chelsea FC",
-        "slug": "chelsea",
-      },
-      Object {
-        "name": "Arsenal",
-        "slug": "arsenal",
-      },
-      Object {
-        "name": "Rugby Union",
-        "slug": "rugby-union",
-      },
-    ],
-  },
-  "component": "Page",
-  "object": "Article",
-}
-`;
-
-exports[`renders article with no lead asset 1`] = `
+exports[`Article tests on web renders article with no lead asset 1`] = `
 Array [
   .c0 {
   display: none;
@@ -15412,4 +1474,13942 @@ Array [
     </div>
   </div>,
 ]
+`;
+
+exports[`Article tests on web should render a full article 1`] = `
+<ArticlePage
+  adConfig={
+    Object {
+      "adUnit": "mockAdUnit",
+      "bidderSlots": Array [
+        "ad-header",
+        "ad-article-inline",
+      ],
+      "biddersConfig": Object {
+        "bidders": Object {
+          "amazon": Object {
+            "accountId": "3360",
+          },
+          "appnexus": Object {
+            "placementId": "5823281",
+          },
+          "criteo": Object {
+            "zoneMap": Object {
+              "120x600": "764877",
+            },
+          },
+          "indexExchange": Object {
+            "siteId": "188830",
+          },
+          "pubmatic": Object {
+            "accountId": "156034",
+            "adSlotPrefix": "Thetimes",
+          },
+          "rubicon": Object {
+            "accountId": "14062",
+            "siteId": "70608",
+            "zoneId": "335918",
+          },
+        },
+        "bucketSize": 0.25,
+        "maxBid": 15,
+        "minPrice": 0.01,
+        "timeout": 3000,
+      },
+      "networkId": "mockNetwork",
+      "pageTargeting": Object {
+        "title": "Title",
+      },
+      "slotTargeting": Object {
+        "path": "/news",
+      },
+    }
+  }
+  article={
+    Object {
+      "byline": Array [
+        Object {
+          "attributes": Object {
+            "slug": "camilla-long",
+          },
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Camilla Long",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "author",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": ", Environment Editor",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "inline",
+        },
+      ],
+      "content": Array [
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {
+                "href": "https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "police disclosure of evidence",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "link",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": " Telegraph ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "italic",
+            },
+            Object {
+              "attributes": Object {
+                "value": "last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "When Thatcher joined the campaign trail for the 2001 general election...",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "brightcoveAccountId": "57838016001",
+            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+            "brightcoveVideoId": "4084164751001",
+            "caption": "This is video caption",
+            "display": "primary",
+            "paidOnly": "false",
+            "posterImageId": "0c0309d4-1aeb-11e8-9010-1eef6ba5d3de",
+            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "video",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "bold",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "brightcoveAccountId": "57838016001",
+            "brightcovePolicyKey": "BCpkADawqM0NK0Rq8n6sEQyWykemrqeSmIQqqVt3XBrdpl8TYlvqN3hwKphBJRnkPgx6WAbozCW_VgTOBCNf1AQRh8KnmXSXfveQalRc5-pyNlSod5XzP99If2U",
+            "brightcoveVideoId": "4084164751001",
+            "caption": "This is video caption secondary",
+            "display": "secondary",
+            "paidOnly": "false",
+            "posterImageUrl": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "video",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "primary",
+            "ratio": "1500:1000",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fb7ac990a-d872-11e7-9b16-edd3826708d6.jpg?crop=3959%2C2639%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "secondary",
+            "ratio": "3:2",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4476fabc-be54-11e7-b58a-4186f6049f2e.jpg?crop=5760%2C3840%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [],
+          "name": "ad",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "inline",
+            "ratio": "1:1.50",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fdb30ed6a-be62-11e7-b58a-4186f6049f2e.jpg?crop=384%2C576%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": "All the latest stories in culture and books.",
+            "credits": "The credits",
+            "display": "inline",
+            "ratio": "3:2",
+            "url": "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F3ac674bc-beb2-11e7-8bb9-94e1372175c0.jpg?crop=5576%2C3717%2C0%2C0",
+          },
+          "children": Array [],
+          "name": "image",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister.Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {
+            "caption": Object {
+              "name": "JudgeSapnara",
+              "twitter": "@JudgeSapnara",
+            },
+            "content": "[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child",
+          },
+          "children": Array [],
+          "name": "pullQuote",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+            Object {
+              "attributes": Object {
+                "href": "https://www.cam.ac.uk/",
+                "target": "_blank",
+              },
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Cambridge University",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "link",
+            },
+            Object {
+              "attributes": Object {
+                "value": ". She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+        Object {
+          "attributes": Object {},
+          "children": Array [
+            Object {
+              "attributes": Object {
+                "value": "She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. ",
+              },
+              "children": Array [],
+              "name": "text",
+            },
+          ],
+          "name": "paragraph",
+        },
+      ],
+      "flags": Array [
+        "NEW",
+        "EXCLUSIVE",
+      ],
+      "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+      "id": "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
+      "label": "HURRICANE IRMA",
+      "leadAsset": Object {
+        "caption": "Chris Reynolds Gordon at one of his party venues in London",
+        "credits": null,
+        "crop": Object {
+          "ratio": "16:9",
+          "url": "//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156",
+        },
+        "id": "263b03a1-2ce6-4b94-b053-0d35316548c5",
+        "title": "Chris Reynolds Gordon at one of his party venues in London",
+      },
+      "publicationName": "TIMES",
+      "publishedTime": "2015-03-13T18:54:58.000Z",
+      "relatedArticles": Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ],
+      "relatedArticlesLayout": Object {
+        "template": "DEFAULT",
+      },
+      "section": "news",
+      "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+      "topics": Array [
+        Object {
+          "name": "Football",
+          "slug": "football",
+        },
+        Object {
+          "name": "Manchester United FC",
+          "slug": "manchester-united",
+        },
+        Object {
+          "name": "Chelsea FC",
+          "slug": "chelsea",
+        },
+        Object {
+          "name": "Arsenal",
+          "slug": "arsenal",
+        },
+        Object {
+          "name": "Rugby Union",
+          "slug": "rugby-union",
+        },
+      ],
+      "url": "https://www.thetimes.co.uk/edition/news/france-defies-may-over-russia-37b27qd2s",
+    }
+  }
+  error={null}
+  isLoading={false}
+/>
+`;
+
+exports[`Article tests on web should render a smaller article 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  display: none;
+}
+
+.c8 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c9 {
+  margin-bottom: 10px;
+}
+
+.c11 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c12 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c13 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+.c14 {
+  color: #006699;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+}
+
+.c15 {
+  display: block;
+}
+
+.c16 {
+  padding-left: 10px;
+  padding-right: 10px;
+  margin-bottom: 10px;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c9 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c12 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c13 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+@media (min-width:768px) {
+  .c14 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+@media (min-width:768px) {
+  .c15 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c15 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c16 {
+    width: 50%;
+    float: left;
+    margin-right: 20px;
+    margin-bottom: 0px;
+    margin-top: 5px;
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+      <div
+        className="c7"
+      >
+        <ArticleTopics
+          style={
+            Object {
+              "justifyContent": "flex-start",
+            }
+          }
+          topics={
+            Array [
+              Object {
+                "name": "Football",
+                "slug": "football",
+              },
+              Object {
+                "name": "Manchester United FC",
+                "slug": "manchester-united",
+              },
+              Object {
+                "name": "Chelsea FC",
+                "slug": "chelsea",
+              },
+              Object {
+                "name": "Arsenal",
+                "slug": "arsenal",
+              },
+              Object {
+                "name": "Rugby Union",
+                "slug": "rugby-union",
+              },
+            ]
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="c8"
+    >
+      <div
+        className="c9"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c10"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c11"
+    >
+      <div
+        className="c12"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c13"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <a
+            className="c14"
+            href="https://www.thetimes.co.uk/article/peers-call-for-action-after-liam-allan-trial-blunder-vnzn0sz89"
+            style={
+              Object {
+                "textDecoration": "underline",
+              }
+            }
+          >
+            police disclosure of evidence
+          </a>
+          <em>
+             Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+          <div
+            className="c15"
+          >
+            <div
+              className="c16"
+            >
+              <PullQuote
+                caption="JudgeSapnara"
+                content="[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child"
+                twitter="@JudgeSapnara"
+              />
+            </div>
+          </div>
+        </p>
+      </div>
+    </div>
+  </div>,
+  .c0 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    display: none;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <ArticleTopics
+      style={
+        Object {
+          "borderTopColor": "#DBDBDB",
+          "borderTopWidth": 1,
+        }
+      }
+      topics={
+        Array [
+          Object {
+            "name": "Football",
+            "slug": "football",
+          },
+          Object {
+            "name": "Manchester United FC",
+            "slug": "manchester-united",
+          },
+          Object {
+            "name": "Chelsea FC",
+            "slug": "chelsea",
+          },
+          Object {
+            "name": "Arsenal",
+            "slug": "arsenal",
+          },
+          Object {
+            "name": "Rugby Union",
+            "slug": "rugby-union",
+          },
+        ]
+      }
+    />
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with a video asset 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+.c13 {
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 25px;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+@media (min-width:768px) {
+  .c13 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c13 {
+    width: 58.33333%;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <VideoLabel
+            color="#333333"
+            title=""
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Young boy among dead after blast flattens Leicester store
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Neil Johnston | Fariha Karim | Charlie Parker | Sebastian Mann",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Monday February 26 2018, 05:00pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              data-testid="video-component"
+              style={
+                Object {
+                  "height": "100%",
+                  "width": "100%",
+                }
+              }
+            >
+              <video
+                className="video-js"
+                controls={true}
+                data-account="57838016001"
+                data-application-id={true}
+                data-embed="default"
+                data-player="default"
+                data-video-id="4084164751001"
+                id="4084164751001-57838016001-1"
+                poster="//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0c0309d4-1aeb-11e8-9010-1eef6ba5d3de.jpg?crop=1024%2C576%2C0%2C0"
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                This is video caption
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Three members of a family are missing after a massive explosion tore through a shop and a flat in Leicester last night, killing five.
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          A young boy is feared to be among the dead with a further five people taken to hospital, including one in a critical condition, after a blast at a Polish grocery store which sent flames rising 25ft into the air.
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Rescuers used their hands to dig through the rubble to recover those trapped, including a little boy heard crying from beneath the debris.
+        </p>
+      </div>
+      <div
+        className="c13"
+      >
+        <ArticleImage
+          captionOptions={
+            Object {
+              "caption": "Some 60 homes near the site of the explosion were evacuated",
+              "credits": "CATERS",
+            }
+          }
+          imageOptions={
+            Object {
+              "display": "primary",
+              "ratio": "1500:1000",
+              "url": "//www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F34424e00-1af0-11e8-95c3-8b5a448e6e58.jpg?crop=1335%2C890%2C296%2C264",
+            }
+          }
+        />
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Tony Hartley, who lives 50 yards away from the site, said he had found a man buried beneath the rubble. “Me and a friend lifted up a steel girder with about five other blokes and removed a man
+        </p>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no byline 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no flags 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no label 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no label and no flags 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div
+          data-testid="standfirst"
+        >
+          How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no label, no flags and no standfirst 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no standfirst 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no standfirst and no flags 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c3 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c4 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c5 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c6 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c7 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c8 {
+  margin-bottom: 10px;
+}
+
+.c10 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c11 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c12 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    margin-top: 0px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c6 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c8 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c12 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          aria-label="label"
+          className="c2"
+          data-testid="label"
+        >
+          <ArticleLabel
+            color="#333333"
+            title="HURRICANE IRMA"
+          />
+        </div>
+        <div
+          className="c3"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+      </div>
+    </div>
+    <div
+      className="c4"
+    >
+      <div
+        className="c5"
+      >
+        <div
+          className="c6"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c6"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c7"
+    >
+      <div
+        className="c8"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c9"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c10"
+    >
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c11"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c12"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an article with no standfirst and no label 1`] = `
+Array [
+  .c0 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    border-top-color: #DBDBDB;
+    border-bottom-color: #DBDBDB;
+    border-bottom-width: 1px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div>
+      <div
+        style={
+          Object {
+            "height": 0,
+            "overflow": "hidden",
+            "width": 0,
+          }
+        }
+      />
+      <div>
+        <div
+          style={
+            Object {
+              "height": "90px",
+              "width": "728px",
+            }
+          }
+        >
+          <div>
+            <Watermark
+              height={90}
+              viewBox="-630 120 1200 50"
+              width={728}
+            />
+          </div>
+          <div>
+            ADVERTISEMENT
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  .c1 {
+  padding-left: 10px;
+  padding-right: 10px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c2 {
+  font-size: 30px;
+  color: #1D1D1B;
+  margin-bottom: 8px;
+  font-family: "TimesModern-Bold";
+  font-weight: 400;
+  line-height: 30px;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.c5 {
+  border-top: 1px solid #DBDBDB;
+}
+
+.c6 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c7 {
+  margin-bottom: 10px;
+}
+
+.c9 {
+  display: block;
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c10 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.c11 {
+  color: #333333;
+  font-family: "TimesDigitalW04-Regular";
+  line-height: 26px;
+  font-size: 17px;
+  margin-bottom: 25px;
+  margin-top: 0;
+  display: block;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    padding-top: 20px;
+    margin: 0 auto;
+    display: block;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 58.33333%;
+    margin-bottom: 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    font-size: 45px;
+    line-height: 45px;
+  }
+}
+
+@media (min-width:768px) {
+  .c3 {
+    width: 83.33333333%;
+    margin: 0 auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3 {
+    margin-bottom: 20px;
+    padding-right: 20px;
+    padding-left: 20px;
+    position: absolute;
+    left: 0;
+    width: 20.8333%;
+    z-index: 1;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    padding-top: 0px;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c5 {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    line-height: 18px;
+    padding-bottom: 25px;
+  }
+}
+
+@media (min-width:768px) {
+  .c7 {
+    margin-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    width: 58.33333%;
+    margin: 0 auto;
+    padding-bottom: 20px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+  }
+}
+
+@media (min-width:768px) {
+  .c10 {
+    width: 83.33333333%;
+    margin: 0 auto;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    width: 58.33333%;
+  }
+}
+
+@media (min-width:768px) {
+  .c11 {
+    font-size: 18px;
+    line-height: 30px;
+  }
+}
+
+<div
+    className="c0"
+  >
+    <div
+      className="c1"
+    >
+      <div>
+        <div
+          className="c2"
+        >
+          Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record
+        </div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+          <div>
+            <ExclusiveArticleFlag />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c3"
+    >
+      <div
+        className="c4"
+      >
+        <div
+          className="c5"
+        >
+          <span>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Rosemary Bennett, Education Editor | Nicola Woolcock, Education Correspondent",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </span>
+        </div>
+        <div
+          className="c5"
+        >
+          <span>
+            Friday March 13 2015, 06:54pm, The Times
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c6"
+    >
+      <div
+        className="c7"
+      >
+        <div
+          style={
+            Object {
+              "paddingBottom": "56.25%",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "height": "100%",
+                "width": "100%",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "display": "table",
+                    "height": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": "NaN%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  src="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5f243dd6-93aa-11e7-a2ce-ce94682a575d.jpg?crop=3000%2C1687%2C0%2C156"
+                  style={
+                    Object {
+                      "display": "block",
+                      "position": "absolute",
+                      "width": "100%",
+                      "zIndex": 1,
+                    }
+                  }
+                />
+                <div
+                  style={
+                    Object {
+                      "bottom": "0px",
+                      "right": "0px",
+                    }
+                  }
+                >
+                  <div
+                    style={
+                      Object {
+                        "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
+                      }
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="c8"
+        >
+          <div>
+            <div>
+              <div>
+                Chris Reynolds Gordon at one of his party venues in London
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="c9"
+    >
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Mr Gove has previously said that memorising a poem is to “own a great work of art forever”. Andrew Motion, the former Poet Laureate, wrote in the 
+          <em>
+            Telegraph 
+          </em>
+          last year that rote learning has “a lot to be said against it”, but added: “As the phrase ‘learning by heart’ implies, this sort of remembering places the poem at a central place in ourselves and makes it precious.”
+          <strong>
+            When Thatcher joined the campaign trail for the 2001 general election...
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          <strong>
+            Baroness Thatcher, LG, OM, PC, FRS, Prime Minister, 1979-90, was born on October 13, 1925. She died on April 8, 2013, aged 87.
+          </strong>
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          When Thatcher joined the campaign trail for the 2001 general election, she was followed closely by the media. After several minor strokes, however, it was announced in 2002 that she would cut back her heavy schedule. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher plainly admired the style and determination of Tony Blair, who crushed John Major’s Conservatives in the 1997 election, and he for his part seemed content from time to time to be compared with her as a strong leader. She regularly revisited some of the issues that had dominated her years in office; for example she gave strong support to the development of democracy and the protection of the rule of law in Hong Kong as promised in the treaty she had signed with China. In 1999, in her first conference speech since her resignation as leader, she defended General Augusto Pinochet, the former dictator of Chile, who was held in Britain after his arrest in 1998. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          By this time she was set to have a permanent place in the House of Commons, after the a rule change meant that an 8ft marble statue, for which she posed with her familiar handbag, could be placed there during her lifetime. When on display at Guildhall, however, it was decapitated by a man with a cricket bat, and so was withdrawn from public view. It was to be placed outside the House of Commons chamber, opposite Winston Churchill. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She was driven by those beliefs to tackle the task of halting and reversing her country’s decline and to ensure that it played its full part in defending the freedoms of the democratic West. Her record and her personality will be the subject of continuing controversy. But no one will ever doubt her sincerity and her courage, and most will concede that the far-reaching changes she made would have been impossible without her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Margaret Thatcher was one of the greatest British politicians of the 20th century. The first woman prime minister in Europe, she held the job for 11 years. In the 20th century no other prime minister had been in office for such a long unbroken period, and no one since Lord Liverpool (1812-27) had had such a long continuous run as Prime Minister. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She led the Conservative Party for 15 years, won three general elections in succession, and never lost a significant vote in the House of Commons. Since Walpole in effect invented the role, only six men have served for longer than her as prime minister: Walpole himself, Pitt, Lord Liverpool, Lord Salisbury, Gladstone and Lord North. She fully earned her place in this company. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher set out, first as party leader and then as prime minister, to overturn the consensus that had shaped postwar British politics and to replace it with a more competitive ethos of free enterprise. She wanted to rescue Britain from the debilitated state to which she believed it had been reduced by socialism and, in the words of her last bravura speech as Prime Minister to the House of Commons, to give back “control to people over their own lives and over their livelihood”. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          It was time to depart, and she announced this to a meeting of the Cabinet on November 22. With typical courage she then went to the House of Commons to speak in a confidence debate. It was a rousing performance, a reminder of her gallantry, flair and conviction. She had not tired of her mission, but those whom she had led had tired of her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Thatcher resigned as Prime Minister on November 28, leaving Downing Street, a little tearfully, though with the partial satisfaction of knowing that she was not to be succeeded by Heseltine but by her own favourite, Major, who had defeated Heseltine and Hurd in the parliamentary ballot to follow her. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          Life out of office was initially miserable. Like her predecessor, Heath, she seemed disorientated by the loss of power. But with typical gumption she threw herself into establishing a foundation (named after her) to support business training projects in Eastern Europe and the former Soviet Union and the establishment of a chair of Enterprise Studies at Cambridge University. She toured the world, speaking for large fees in the foundation’s name and to its great financial benefit. She remained immensely popular in several countries, particularly the US, Japan and Eastern Europe. She was the symbol of the defeat of communism and the triumph in the 1980s of market economics. 
+        </p>
+      </div>
+      <div
+        className="c10"
+        style={
+          Object {
+            "paddingLeft": "10px",
+            "paddingRight": "10px",
+          }
+        }
+      >
+        <p
+          className="c11"
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": "25px",
+              "marginTop": 0,
+            }
+          }
+        >
+          She returned sporadically, and not always helpfully, to the political fray. Her support for Major waned as he set out on a more pragmatic European policy than her own. She allowed her own more nationalist opinions to seep out into the public domain, and became ever more forceful, outspoken and extreme in her denunciations of the moves towards political and monetary union in Europe. 
+        </p>
+      </div>
+    </div>
+  </div>,
+  <RelatedArticles
+    articles={
+      Array [
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Patrick Kidd",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "TMS: Pratchett’s law of the jungle - Disable Saving",
+          "id": "ea16d744-cb4a-11e4-a202-50ac5def393a",
+          "label": "Health",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "TMS: Pratchett’s law of the jungle",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T19:39:39.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Terry Pratchett, who died last week, began his career on the ",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Bucks Free Press",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "italic",
+                },
+                Object {
+                  "attributes": Object {
+                    "value": " in 1965, aged 17, and the paper recalls in a tribute that he wore his school uniform to his job interview. The editor, impressed, told him: “I like",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/tms-pratchetts-law-of-the-jungle-xgqrcw779",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Graeme Paton Transport Correspondent",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+          "id": "b09fc422-cb53-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "Rise of centenarian drivers as elderly push on",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:42:27.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "More than 200 motorists are still on the road after celebrating their 100th birthday as older people become increasingly reliant on the car.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Figures from the Driver and Vehicle Licensing Agency revealed that record numbers of",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/rise-of-centenarian-drivers-as-elderly-push-on-6gb0bjnpz",
+        },
+        Object {
+          "byline": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "Jack Malvern Arts Correspondent Dominic Kennedy",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "inline",
+            },
+          ],
+          "headline": "Syndicated url: At long last, a burial place fit for a king",
+          "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
+          "label": "Science",
+          "leadAsset": Object {
+            "crop169": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
+            },
+            "crop32": Object {
+              "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
+            },
+            "title": "At long last, a burial place fit for a king",
+          },
+          "publicationName": "TIMES",
+          "publishedTime": "2015-03-23T20:56:09.000Z",
+          "summary105": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary125": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary145": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary160": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary175": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "summary225": Array [
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time.",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+            Object {
+              "attributes": Object {},
+              "children": Array [
+                Object {
+                  "attributes": Object {
+                    "value": "His coffin has been",
+                  },
+                  "children": Array [],
+                  "name": "text",
+                },
+              ],
+              "name": "paragraph",
+            },
+          ],
+          "url": "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+        },
+      ]
+    }
+    template="DEFAULT"
+  />,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <div
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+          "width": 0,
+        }
+      }
+    />
+    <div>
+      <div
+        style={
+          Object {
+            "height": "0px",
+            "width": "0px",
+          }
+        }
+      >
+        <div>
+          <Watermark
+            height={0}
+            viewBox="-50 0 0 0"
+            width={0}
+          />
+        </div>
+        <div>
+          ADVERTISEMENT
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Article tests on web should render an error 1`] = `
+<div>
+  <div>
+    An error occurred
+  </div>
+  <div>
+    {
+  "message": "An example error."
+}
+  </div>
+</div>
+`;
+
+exports[`Send analytics when rendering an Article page 1`] = `
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "byline": "Camilla Long",
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+    "publishedTime": "2015-03-13T18:54:58.000Z",
+    "topics": Array [
+      Object {
+        "name": "Football",
+        "slug": "football",
+      },
+      Object {
+        "name": "Manchester United FC",
+        "slug": "manchester-united",
+      },
+      Object {
+        "name": "Chelsea FC",
+        "slug": "chelsea",
+      },
+      Object {
+        "name": "Arsenal",
+        "slug": "arsenal",
+      },
+      Object {
+        "name": "Rugby Union",
+        "slug": "rugby-union",
+      },
+    ],
+  },
+  "component": "Page",
+  "object": "Article",
+}
 `;

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Article tests on web 1. article 1`] = `
+exports[`1. article 1`] = `
 <div>
   <div>
     An error occurred
@@ -13,7 +13,7 @@ exports[`Article tests on web 1. article 1`] = `
 </div>
 `;
 
-exports[`Article tests on web 2. full article 1`] = `
+exports[`2. full article 1`] = `
 <ArticlePage
   adConfig={
     Object {
@@ -1028,7 +1028,7 @@ exports[`Article tests on web 2. full article 1`] = `
 />
 `;
 
-exports[`Article tests on web 3. smaller article 1`] = `
+exports[`3. smaller article 1`] = `
 Array [
   .c0 {
   display: none;
@@ -2295,7 +2295,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 4. article with no flags 1`] = `
+exports[`4. article with no flags 1`] = `
 Array [
   .c0 {
   display: none;
@@ -3678,7 +3678,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 5. article with no byline 1`] = `
+exports[`5. article with no byline 1`] = `
 Array [
   .c0 {
   display: none;
@@ -5044,7 +5044,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 6. article with no label 1`] = `
+exports[`6. article with no label 1`] = `
 Array [
   .c0 {
   display: none;
@@ -6419,7 +6419,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 7. article with no standfirst 1`] = `
+exports[`7. article with no standfirst 1`] = `
 Array [
   .c0 {
   display: none;
@@ -7805,7 +7805,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 8. article with no standfirst and no flags 1`] = `
+exports[`8. article with no standfirst and no flags 1`] = `
 Array [
   .c0 {
   display: none;
@@ -9183,7 +9183,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 9. article with no standfirst and no label 1`] = `
+exports[`9. article with no standfirst and no label 1`] = `
 Array [
   .c0 {
   display: none;
@@ -10553,7 +10553,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 10. article with no flags and no label 1`] = `
+exports[`10. article with no flags and no label 1`] = `
 Array [
   .c0 {
   display: none;
@@ -11920,7 +11920,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 11. article with no standfirst, no label and no no flags 1`] = `
+exports[`11. article with no standfirst, no label and no no flags 1`] = `
 Array [
   .c0 {
   display: none;
@@ -13282,7 +13282,7 @@ Array [
 ]
 `;
 
-exports[`Article tests on web 12. article with a video asset 1`] = `
+exports[`12. article with a video asset 1`] = `
 Array [
   .c0 {
   display: none;
@@ -13902,7 +13902,43 @@ Array [
 ]
 `;
 
-exports[`Article tests on web renders article with no lead asset 1`] = `
+exports[`analytics for page view 1`] = `
+Object {
+  "action": "Viewed",
+  "attrs": Object {
+    "byline": "Camilla Long",
+    "eventTime": "2018-01-01T00:00:00.000Z",
+    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
+    "publishedTime": "2015-03-13T18:54:58.000Z",
+    "topics": Array [
+      Object {
+        "name": "Football",
+        "slug": "football",
+      },
+      Object {
+        "name": "Manchester United FC",
+        "slug": "manchester-united",
+      },
+      Object {
+        "name": "Chelsea FC",
+        "slug": "chelsea",
+      },
+      Object {
+        "name": "Arsenal",
+        "slug": "arsenal",
+      },
+      Object {
+        "name": "Rugby Union",
+        "slug": "rugby-union",
+      },
+    ],
+  },
+  "component": "Page",
+  "object": "Article",
+}
+`;
+
+exports[`renders article with no lead asset 1`] = `
 Array [
   .c0 {
   display: none;
@@ -15376,40 +15412,4 @@ Array [
     </div>
   </div>,
 ]
-`;
-
-exports[`Send analytics when rendering an Article page 1`] = `
-Object {
-  "action": "Viewed",
-  "attrs": Object {
-    "byline": "Camilla Long",
-    "eventTime": "2018-01-01T00:00:00.000Z",
-    "headline": "Caribbean islands devastated by Hurricane Irma, the worst Atlantic storm on record",
-    "publishedTime": "2015-03-13T18:54:58.000Z",
-    "topics": Array [
-      Object {
-        "name": "Football",
-        "slug": "football",
-      },
-      Object {
-        "name": "Manchester United FC",
-        "slug": "manchester-united",
-      },
-      Object {
-        "name": "Chelsea FC",
-        "slug": "chelsea",
-      },
-      Object {
-        "name": "Arsenal",
-        "slug": "arsenal",
-      },
-      Object {
-        "name": "Rugby Union",
-        "slug": "rugby-union",
-      },
-    ],
-  },
-  "component": "Page",
-  "object": "Article",
-}
 `;

--- a/packages/article/__tests__/web/article.web.test.js
+++ b/packages/article/__tests__/web/article.web.test.js
@@ -1,7 +1,6 @@
 import "jest-styled-components";
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import { mount } from "enzyme";
 import ArticleRow from "../../src/article-body/article-body-row";
 import ArticleLink from "../../src/article-body/article-link";
@@ -40,20 +39,18 @@ describe("Article tests on web", () => {
   shared();
 
   it("renders article with no lead asset", () => {
-    const tree = renderer
-      .create(
-        <Article
-          {...articleFixtureNoLeadAsset.data}
-          adConfig={adConfig}
-          analyticsStream={() => {}}
-          onAuthorPress={() => {}}
-          onLinkPress={() => {}}
-          onRelatedArticlePress={() => {}}
-          onTopicPress={() => {}}
-        />
-      )
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const testInstance = TestRenderer.create(
+      <Article
+        {...articleFixtureNoLeadAsset.data}
+        adConfig={adConfig}
+        analyticsStream={() => {}}
+        onAuthorPress={() => {}}
+        onLinkPress={() => {}}
+        onRelatedArticlePress={() => {}}
+        onTopicPress={() => {}}
+      />
+    ).toJSON();
+    expect(testInstance).toMatchSnapshot();
   });
 
   it("ArticleRow should handle a link onPress", () => {
@@ -79,11 +76,9 @@ describe("Article tests on web", () => {
       }
     };
     const onPressMock = jest.fn();
-    const component = mount(
-      <ArticleRow {...props} onLinkPress={onPressMock} />
-    );
+    const wrapper = mount(<ArticleRow {...props} onLinkPress={onPressMock} />);
     const eventObject = { event: true };
-    component
+    wrapper
       .find(ArticleLink)
       .props()
       .onPress(eventObject);

--- a/packages/article/__tests__/web/article.web.test.js
+++ b/packages/article/__tests__/web/article.web.test.js
@@ -1,6 +1,7 @@
 import "jest-styled-components";
+import "react-native";
 import React from "react";
-import TestRenderer from "react-test-renderer";
+import renderer from "react-test-renderer";
 import { mount } from "enzyme";
 import ArticleRow from "../../src/article-body/article-body-row";
 import ArticleLink from "../../src/article-body/article-link";
@@ -35,55 +36,63 @@ jest.mock("@times-components/tracking", () => {
   };
 });
 
-shared();
+describe("Article tests on web", () => {
+  shared();
 
-it("renders article with no lead asset", () => {
-  const testInstance = TestRenderer.create(
-    <Article
-      {...articleFixtureNoLeadAsset.data}
-      adConfig={adConfig}
-      analyticsStream={() => {}}
-      onAuthorPress={() => {}}
-      onLinkPress={() => {}}
-      onRelatedArticlePress={() => {}}
-      onTopicPress={() => {}}
-    />
-  ).toJSON();
-  expect(testInstance).toMatchSnapshot();
-});
+  it("renders article with no lead asset", () => {
+    const tree = renderer
+      .create(
+        <Article
+          {...articleFixtureNoLeadAsset.data}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          onAuthorPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-it("ArticleRow should handle a link onPress", () => {
-  const testUrl = "http://www.test.com";
-  const props = {
-    content: {
-      data: {
-        attributes: {
-          href: testUrl
+  it("ArticleRow should handle a link onPress", () => {
+    const testUrl = "http://www.test.com";
+    const props = {
+      content: {
+        data: {
+          attributes: {
+            href: testUrl
+          },
+          children: [
+            {
+              name: "text",
+              attributes: {
+                value: "police disclosure of evidence"
+              },
+              children: []
+            }
+          ],
+          name: "link"
         },
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "police disclosure of evidence"
-            },
-            children: []
-          }
-        ],
-        name: "link"
-      },
-      index: 1
-    }
-  };
-  const onPressMock = jest.fn();
-  const wrapper = mount(<ArticleRow {...props} onLinkPress={onPressMock} />);
-  const eventObject = { event: true };
-  wrapper
-    .find(ArticleLink)
-    .props()
-    .onPress(eventObject);
-  expect(onPressMock).toHaveBeenCalledWith(eventObject, { href: testUrl });
+        index: 1
+      }
+    };
+    const onPressMock = jest.fn();
+    const component = mount(
+      <ArticleRow {...props} onLinkPress={onPressMock} />
+    );
+    const eventObject = { event: true };
+    component
+      .find(ArticleLink)
+      .props()
+      .onPress(eventObject);
+    expect(onPressMock).toHaveBeenCalledWith(eventObject, { href: testUrl });
+  });
 });
 
 jest.unmock("@times-components/tracking");
 
-sharedTracking();
+describe("Article Tracking tests on web", () => {
+  sharedTracking();
+});

--- a/packages/article/__tests__/web/article.web.test.js
+++ b/packages/article/__tests__/web/article.web.test.js
@@ -35,59 +35,55 @@ jest.mock("@times-components/tracking", () => {
   };
 });
 
-describe("Article tests on web", () => {
-  shared();
+shared();
 
-  it("renders article with no lead asset", () => {
-    const testInstance = TestRenderer.create(
-      <Article
-        {...articleFixtureNoLeadAsset.data}
-        adConfig={adConfig}
-        analyticsStream={() => {}}
-        onAuthorPress={() => {}}
-        onLinkPress={() => {}}
-        onRelatedArticlePress={() => {}}
-        onTopicPress={() => {}}
-      />
-    ).toJSON();
-    expect(testInstance).toMatchSnapshot();
-  });
+it("renders article with no lead asset", () => {
+  const testInstance = TestRenderer.create(
+    <Article
+      {...articleFixtureNoLeadAsset.data}
+      adConfig={adConfig}
+      analyticsStream={() => {}}
+      onAuthorPress={() => {}}
+      onLinkPress={() => {}}
+      onRelatedArticlePress={() => {}}
+      onTopicPress={() => {}}
+    />
+  ).toJSON();
+  expect(testInstance).toMatchSnapshot();
+});
 
-  it("ArticleRow should handle a link onPress", () => {
-    const testUrl = "http://www.test.com";
-    const props = {
-      content: {
-        data: {
-          attributes: {
-            href: testUrl
-          },
-          children: [
-            {
-              name: "text",
-              attributes: {
-                value: "police disclosure of evidence"
-              },
-              children: []
-            }
-          ],
-          name: "link"
+it("ArticleRow should handle a link onPress", () => {
+  const testUrl = "http://www.test.com";
+  const props = {
+    content: {
+      data: {
+        attributes: {
+          href: testUrl
         },
-        index: 1
-      }
-    };
-    const onPressMock = jest.fn();
-    const wrapper = mount(<ArticleRow {...props} onLinkPress={onPressMock} />);
-    const eventObject = { event: true };
-    wrapper
-      .find(ArticleLink)
-      .props()
-      .onPress(eventObject);
-    expect(onPressMock).toHaveBeenCalledWith(eventObject, { href: testUrl });
-  });
+        children: [
+          {
+            name: "text",
+            attributes: {
+              value: "police disclosure of evidence"
+            },
+            children: []
+          }
+        ],
+        name: "link"
+      },
+      index: 1
+    }
+  };
+  const onPressMock = jest.fn();
+  const wrapper = mount(<ArticleRow {...props} onLinkPress={onPressMock} />);
+  const eventObject = { event: true };
+  wrapper
+    .find(ArticleLink)
+    .props()
+    .onPress(eventObject);
+  expect(onPressMock).toHaveBeenCalledWith(eventObject, { href: testUrl });
 });
 
 jest.unmock("@times-components/tracking");
 
-describe("Article Tracking tests on web", () => {
-  sharedTracking();
-});
+sharedTracking();

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -40,7 +40,7 @@
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "apollo-utilities": "1.0.12",
     "babel-cli": "6.26.0",

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -40,7 +40,6 @@
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
-    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "apollo-utilities": "1.0.12",
     "babel-cli": "6.26.0",

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -40,6 +40,7 @@
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "apollo-utilities": "1.0.12",
     "babel-cli": "6.26.0",

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile-head.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile-head.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Should not re-render when twitter prop is changed 1`] = `
+exports[`1. should not re-render when twitter is changed 1`] = `
 <AuthorProfileHeadTwitter
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
 `;
 
-exports[`2. Should not re-render when twitter prop is changed 1`] = `
+exports[`1. should not re-render when twitter is changed 2`] = `
 <AuthorProfileHeadTwitter
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
 `;
 
-exports[`3. Should re-render when isLoading prop is changed 1`] = `
+exports[`2. should only re-render when isloading is changed 1`] = `
 <FadeIn
   style={
     Object {
@@ -45,4 +45,4 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
 </FadeIn>
 `;
 
-exports[`4. Should re-render when isLoading prop is changed 1`] = `<AuthorProfileHeadLoading />`;
+exports[`2. should only re-render when isloading is changed 2`] = `<AuthorProfileHeadLoading />`;

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AuthorProfile tests on android 1. with images 1`] = `
+exports[`1. with images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -1382,7 +1382,7 @@ exports[`AuthorProfile tests on android 1. with images 1`] = `
 </RCTScrollView>
 `;
 
-exports[`AuthorProfile tests on android 2. without images 1`] = `
+exports[`2. without images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -2754,7 +2754,7 @@ exports[`AuthorProfile tests on android 2. without images 1`] = `
 </RCTScrollView>
 `;
 
-exports[`AuthorProfile tests on android 3. loading state 1`] = `
+exports[`3. loading state 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -4366,7 +4366,7 @@ exports[`AuthorProfile tests on android 3. loading state 1`] = `
 </RCTScrollView>
 `;
 
-exports[`AuthorProfile tests on android 4. author profile page error state 1`] = `
+exports[`4. author profile page error state 1`] = `
 <View
   style={
     Object {
@@ -4467,7 +4467,7 @@ exports[`AuthorProfile tests on android 4. author profile page error state 1`] =
 </View>
 `;
 
-exports[`AuthorProfile tests on android 5. send analytics when rendering an author profile page 1`] = `
+exports[`5. send analytics when rendering an author profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an author profile page 1`] = `
+exports[`AuthorProfile tests on android 1. with images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -1382,7 +1382,7 @@ exports[`1. Render an author profile page 1`] = `
 </RCTScrollView>
 `;
 
-exports[`2. Render an author profile page without images 1`] = `
+exports[`AuthorProfile tests on android 2. without images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -2754,7 +2754,7 @@ exports[`2. Render an author profile page without images 1`] = `
 </RCTScrollView>
 `;
 
-exports[`3. Render an author profile page loading state 1`] = `
+exports[`AuthorProfile tests on android 3. loading state 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -4366,7 +4366,7 @@ exports[`3. Render an author profile page loading state 1`] = `
 </RCTScrollView>
 `;
 
-exports[`4. Render an author profile page error state 1`] = `
+exports[`AuthorProfile tests on android 4. author profile page error state 1`] = `
 <View
   style={
     Object {
@@ -4467,7 +4467,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </View>
 `;
 
-exports[`5. Send analytics when rendering an Author Profile page 1`] = `
+exports[`AuthorProfile tests on android 5. send analytics when rendering an author profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/android/author-profile-head.test.js
+++ b/packages/author-profile/__tests__/android/author-profile-head.test.js
@@ -1,5 +1,3 @@
 import shared from "../author-profile-head";
 
-describe("AuthorProfileHead tests on android", () => {
-  shared();
-});
+shared();

--- a/packages/author-profile/__tests__/android/author-profile.test.js
+++ b/packages/author-profile/__tests__/android/author-profile.test.js
@@ -1,7 +1,5 @@
 import sharedNative from "../shared-native";
 import shared from "../author-profile";
 
-describe("AuthorProfile tests on android", () => {
-  shared();
-  sharedNative();
-});
+shared();
+sharedNative();

--- a/packages/author-profile/__tests__/author-profile-head.js
+++ b/packages/author-profile/__tests__/author-profile-head.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Image } from "react-native";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import { AuthorProfileHeadBase as AuthorProfileHeadBaseWithoutTracking } from "../src/author-profile-head-base";
 import AuthorProfileHeadTwitter from "../src/author-profile-head-twitter";
 
@@ -15,55 +16,58 @@ export default () => {
     twitter: "testTwitterHandle"
   };
 
-  it("should not re-render when twitter is changed", () => {
-    const wrapper = shallow(
-      <AuthorProfileHeadBaseWithoutTracking {...headProps} />
-    );
+  const tests = [
+    {
+      name: "should not re-render when twitter is changed",
+      test: () => {
+        const wrapper = shallow(
+          <AuthorProfileHeadBaseWithoutTracking {...headProps} />
+        );
 
-    expect(wrapper.find("AuthorProfileHeadTwitter")).toMatchSnapshot(
-      "1. Should not re-render when twitter prop is changed"
-    );
+        expect(wrapper.find("AuthorProfileHeadTwitter")).toMatchSnapshot();
 
-    wrapper.setProps({
-      twitter: "newTestTwitter"
-    });
+        wrapper.setProps({
+          twitter: "newTestTwitter"
+        });
 
-    expect(wrapper.find("AuthorProfileHeadTwitter")).toMatchSnapshot(
-      "2. Should not re-render when twitter prop is changed"
-    );
-  });
+        expect(wrapper.find("AuthorProfileHeadTwitter")).toMatchSnapshot();
+      }
+    },
+    {
+      name: "should only re-render when isLoading is changed",
+      test: () => {
+        const wrapper = shallow(
+          <AuthorProfileHeadBaseWithoutTracking {...headProps} />
+        );
 
-  it("should only re-render when isLoading is changed", () => {
-    const wrapper = shallow(
-      <AuthorProfileHeadBaseWithoutTracking {...headProps} />
-    );
+        expect(wrapper).toMatchSnapshot();
 
-    expect(wrapper).toMatchSnapshot(
-      "3. Should re-render when isLoading prop is changed"
-    );
+        wrapper.setProps({
+          isLoading: true
+        });
 
-    wrapper.setProps({
-      isLoading: true
-    });
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "should handle the twitter link when pressed",
+      test: () => {
+        const mockOnPress = jest.fn();
+        const twitterProps = {
+          isLoading: false,
+          onTwitterLinkPress: mockOnPress,
+          twitter: "testTwitterHandle",
+          url: "https://twitter.com/testTwitterHandle"
+        };
 
-    expect(wrapper).toMatchSnapshot(
-      "4. Should re-render when isLoading prop is changed"
-    );
-  });
+        const wrapper = shallow(<AuthorProfileHeadTwitter {...twitterProps} />);
 
-  const mockOnPress = jest.fn();
-  const twitterProps = {
-    isLoading: false,
-    onTwitterLinkPress: mockOnPress,
-    twitter: "testTwitterHandle",
-    url: "https://twitter.com/testTwitterHandle"
-  };
+        wrapper.find("TextLink").simulate("press");
 
-  it("should handle the twitter link when pressed", () => {
-    const wrapper = shallow(<AuthorProfileHeadTwitter {...twitterProps} />);
+        expect(mockOnPress).toHaveBeenCalled();
+      }
+    }
+  ];
 
-    wrapper.find("TextLink").simulate("press");
-
-    expect(mockOnPress).toHaveBeenCalled();
-  });
+  iterator(tests);
 };

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -2,6 +2,7 @@ import React from "react";
 import renderer from "react-test-renderer";
 import mockDate from "mockdate";
 import { MockedProvider } from "@times-components/provider-test-tools";
+import { iterator } from "@times-components/test-utils";
 import { delay } from "@times-components/utils";
 import AuthorProfile from "../src/author-profile";
 import {
@@ -28,65 +29,72 @@ export default () => {
     mockDate.reset();
   });
 
-  it("should render with images", async () => {
-    const tree = renderer.create(
-      <MockedProvider mocks={mockArticles}>
-        <AuthorProfile {...props} />
-      </MockedProvider>
-    );
+  const tests = [
+    {
+      name: "with images",
+      test: async () => {
+        const tree = renderer.create(
+          <MockedProvider mocks={mockArticles}>
+            <AuthorProfile {...props} />
+          </MockedProvider>
+        );
 
-    await delay(1500);
+        await delay(1500);
 
-    expect(tree).toMatchSnapshot("1. Render an author profile page");
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "without images",
+      test: async () => {
+        const tree = renderer.create(
+          <MockedProvider mocks={mockArticlesWithoutImages}>
+            <AuthorProfile {...props} author={mockAuthorWithoutImages} />
+          </MockedProvider>
+        );
 
-  it("should render without images", async () => {
-    const tree = renderer.create(
-      <MockedProvider mocks={mockArticlesWithoutImages}>
-        <AuthorProfile {...props} author={mockAuthorWithoutImages} />
-      </MockedProvider>
-    );
+        await delay(1500);
 
-    await delay(1500);
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "loading state",
+      test: () => {
+        const tree = renderer.create(
+          <MockedProvider isLoading mocks={mockArticles}>
+            <AuthorProfile {...props} isLoading />
+          </MockedProvider>
+        );
 
-    expect(tree).toMatchSnapshot(
-      "2. Render an author profile page without images"
-    );
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "author profile page error state",
+      test: () => {
+        const tree = renderer.create(<AuthorProfile {...props} error={{}} />);
 
-  it("should render the loading state", () => {
-    const tree = renderer.create(
-      <MockedProvider isLoading mocks={mockArticles}>
-        <AuthorProfile {...props} isLoading />
-      </MockedProvider>
-    );
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "send analytics when rendering an author profile page",
+      test: () => {
+        const reporter = jest.fn();
 
-    expect(tree).toMatchSnapshot(
-      "3. Render an author profile page loading state"
-    );
-  });
+        renderer.create(
+          <MockedProvider mocks={mockArticles}>
+            <AuthorProfile {...props} analyticsStream={reporter} />
+          </MockedProvider>
+        );
 
-  it("should render the author page with an article list page error state", () => {
-    const tree = renderer.create(<AuthorProfile {...props} error={{}} />);
+        const call = reporter.mock.calls[0][0];
 
-    expect(tree).toMatchSnapshot(
-      "4. Render an author profile page error state"
-    );
-  });
+        expect(call).toMatchSnapshot();
+      }
+    }
+  ];
 
-  it("should send analytics when rendering an Author Profile page", () => {
-    const reporter = jest.fn();
-
-    renderer.create(
-      <MockedProvider mocks={mockArticles}>
-        <AuthorProfile {...props} analyticsStream={reporter} />
-      </MockedProvider>
-    );
-
-    const call = reporter.mock.calls[0][0];
-
-    expect(call).toMatchSnapshot(
-      "5. Send analytics when rendering an Author Profile page"
-    );
-  });
+  iterator(tests);
 };

--- a/packages/author-profile/__tests__/author-profile.js
+++ b/packages/author-profile/__tests__/author-profile.js
@@ -1,5 +1,5 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import mockDate from "mockdate";
 import { MockedProvider } from "@times-components/provider-test-tools";
 import { iterator } from "@times-components/test-utils";
@@ -33,7 +33,7 @@ export default () => {
     {
       name: "with images",
       test: async () => {
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <MockedProvider mocks={mockArticles}>
             <AuthorProfile {...props} />
           </MockedProvider>
@@ -41,13 +41,13 @@ export default () => {
 
         await delay(1500);
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "without images",
       test: async () => {
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <MockedProvider mocks={mockArticlesWithoutImages}>
             <AuthorProfile {...props} author={mockAuthorWithoutImages} />
           </MockedProvider>
@@ -55,27 +55,29 @@ export default () => {
 
         await delay(1500);
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "loading state",
       test: () => {
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <MockedProvider isLoading mocks={mockArticles}>
             <AuthorProfile {...props} isLoading />
           </MockedProvider>
         );
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "author profile page error state",
       test: () => {
-        const tree = renderer.create(<AuthorProfile {...props} error={{}} />);
+        const testInstance = TestRenderer.create(
+          <AuthorProfile {...props} error={{}} />
+        );
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
@@ -83,7 +85,7 @@ export default () => {
       test: () => {
         const reporter = jest.fn();
 
-        renderer.create(
+        TestRenderer.create(
           <MockedProvider mocks={mockArticles}>
             <AuthorProfile {...props} analyticsStream={reporter} />
           </MockedProvider>

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile-head.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile-head.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Should not re-render when twitter prop is changed 1`] = `
+exports[`1. should not re-render when twitter is changed 1`] = `
 <AuthorProfileHeadTwitter
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
 `;
 
-exports[`2. Should not re-render when twitter prop is changed 1`] = `
+exports[`1. should not re-render when twitter is changed 2`] = `
 <AuthorProfileHeadTwitter
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
 `;
 
-exports[`3. Should re-render when isLoading prop is changed 1`] = `
+exports[`2. should only re-render when isloading is changed 1`] = `
 <FadeIn
   style={
     Object {
@@ -45,4 +45,4 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
 </FadeIn>
 `;
 
-exports[`4. Should re-render when isLoading prop is changed 1`] = `<AuthorProfileHeadLoading />`;
+exports[`2. should only re-render when isloading is changed 2`] = `<AuthorProfileHeadLoading />`;

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an author profile page 1`] = `
+exports[`AuthorProfile tests on ios 1. with images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -1378,7 +1378,7 @@ exports[`1. Render an author profile page 1`] = `
 </RCTScrollView>
 `;
 
-exports[`2. Render an author profile page without images 1`] = `
+exports[`AuthorProfile tests on ios 2. without images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -2746,7 +2746,7 @@ exports[`2. Render an author profile page without images 1`] = `
 </RCTScrollView>
 `;
 
-exports[`3. Render an author profile page loading state 1`] = `
+exports[`AuthorProfile tests on ios 3. loading state 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -4358,7 +4358,7 @@ exports[`3. Render an author profile page loading state 1`] = `
 </RCTScrollView>
 `;
 
-exports[`4. Render an author profile page error state 1`] = `
+exports[`AuthorProfile tests on ios 4. author profile page error state 1`] = `
 <View
   style={
     Object {
@@ -4451,7 +4451,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </View>
 `;
 
-exports[`5. Send analytics when rendering an Author Profile page 1`] = `
+exports[`AuthorProfile tests on ios 5. send analytics when rendering an author profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AuthorProfile tests on ios 1. with images 1`] = `
+exports[`1. with images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -1378,7 +1378,7 @@ exports[`AuthorProfile tests on ios 1. with images 1`] = `
 </RCTScrollView>
 `;
 
-exports[`AuthorProfile tests on ios 2. without images 1`] = `
+exports[`2. without images 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -2746,7 +2746,7 @@ exports[`AuthorProfile tests on ios 2. without images 1`] = `
 </RCTScrollView>
 `;
 
-exports[`AuthorProfile tests on ios 3. loading state 1`] = `
+exports[`3. loading state 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <AuthorProfileHead
@@ -4358,7 +4358,7 @@ exports[`AuthorProfile tests on ios 3. loading state 1`] = `
 </RCTScrollView>
 `;
 
-exports[`AuthorProfile tests on ios 4. author profile page error state 1`] = `
+exports[`4. author profile page error state 1`] = `
 <View
   style={
     Object {
@@ -4451,7 +4451,7 @@ exports[`AuthorProfile tests on ios 4. author profile page error state 1`] = `
 </View>
 `;
 
-exports[`AuthorProfile tests on ios 5. send analytics when rendering an author profile page 1`] = `
+exports[`5. send analytics when rendering an author profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/ios/author-profile-head.test.js
+++ b/packages/author-profile/__tests__/ios/author-profile-head.test.js
@@ -1,5 +1,3 @@
 import shared from "../author-profile-head";
 
-describe("AuthorProfileHead tests on ios", () => {
-  shared();
-});
+shared();

--- a/packages/author-profile/__tests__/ios/author-profile.test.js
+++ b/packages/author-profile/__tests__/ios/author-profile.test.js
@@ -1,7 +1,5 @@
 import sharedNative from "../shared-native";
 import shared from "../author-profile";
 
-describe("AuthorProfile tests on ios", () => {
-  shared();
-  sharedNative();
-});
+shared();
+sharedNative();

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-head.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-head.web.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Should not re-render when twitter prop is changed 1`] = `
+exports[`1. should not re-render when twitter is changed 1`] = `
 <AuthorProfileHeadTwitter
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
 `;
 
-exports[`2. Should not re-render when twitter prop is changed 1`] = `
+exports[`1. should not re-render when twitter is changed 2`] = `
 <AuthorProfileHeadTwitter
   twitter="testTwitterHandle"
   url="https://twitter.com/testTwitterHandle"
 />
 `;
 
-exports[`3. Should re-render when isLoading prop is changed 1`] = `
+exports[`2. should only re-render when isloading is changed 1`] = `
 <FadeIn
   style={
     Object {
@@ -45,4 +45,4 @@ exports[`3. Should re-render when isLoading prop is changed 1`] = `
 </FadeIn>
 `;
 
-exports[`4. Should re-render when isLoading prop is changed 1`] = `<AuthorProfileHeadLoading />`;
+exports[`2. should only re-render when isloading is changed 2`] = `<AuthorProfileHeadLoading />`;

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an author profile page 1`] = `
+exports[`AuthorProfile tests on web 1. with images 1`] = `
 <div>
   <header
     className="responsive-styles__component-fbPFZZ dornVt"
@@ -618,7 +618,7 @@ exports[`1. Render an author profile page 1`] = `
 </div>
 `;
 
-exports[`2. Render an author profile page without images 1`] = `
+exports[`AuthorProfile tests on web 2. without images 1`] = `
 <div>
   <header
     className="responsive-styles__component-fbPFZZ dornVt"
@@ -1322,7 +1322,7 @@ exports[`2. Render an author profile page without images 1`] = `
 </div>
 `;
 
-exports[`3. Render an author profile page loading state 1`] = `
+exports[`AuthorProfile tests on web 3. loading state 1`] = `
 <div>
   <header
     className="responsive-styles__component-fbPFZZ dornVt"
@@ -1689,7 +1689,7 @@ exports[`3. Render an author profile page loading state 1`] = `
 </div>
 `;
 
-exports[`4. Render an author profile page error state 1`] = `
+exports[`AuthorProfile tests on web 4. author profile page error state 1`] = `
 <div
   className="responsive-styles__component-fbPFZZ NudQU"
 >
@@ -1764,7 +1764,7 @@ exports[`4. Render an author profile page error state 1`] = `
 </div>
 `;
 
-exports[`5. Send analytics when rendering an Author Profile page 1`] = `
+exports[`AuthorProfile tests on web 5. send analytics when rendering an author profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AuthorProfile tests on web 1. with images 1`] = `
+exports[`1. with images 1`] = `
 <div>
   <header
     className="responsive-styles__component-fbPFZZ dornVt"
@@ -618,7 +618,7 @@ exports[`AuthorProfile tests on web 1. with images 1`] = `
 </div>
 `;
 
-exports[`AuthorProfile tests on web 2. without images 1`] = `
+exports[`2. without images 1`] = `
 <div>
   <header
     className="responsive-styles__component-fbPFZZ dornVt"
@@ -1322,7 +1322,7 @@ exports[`AuthorProfile tests on web 2. without images 1`] = `
 </div>
 `;
 
-exports[`AuthorProfile tests on web 3. loading state 1`] = `
+exports[`3. loading state 1`] = `
 <div>
   <header
     className="responsive-styles__component-fbPFZZ dornVt"
@@ -1689,7 +1689,7 @@ exports[`AuthorProfile tests on web 3. loading state 1`] = `
 </div>
 `;
 
-exports[`AuthorProfile tests on web 4. author profile page error state 1`] = `
+exports[`4. author profile page error state 1`] = `
 <div
   className="responsive-styles__component-fbPFZZ NudQU"
 >
@@ -1764,7 +1764,7 @@ exports[`AuthorProfile tests on web 4. author profile page error state 1`] = `
 </div>
 `;
 
-exports[`AuthorProfile tests on web 5. send analytics when rendering an author profile page 1`] = `
+exports[`5. send analytics when rendering an author profile page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/author-profile/__tests__/web/author-profile-head.web.test.js
+++ b/packages/author-profile/__tests__/web/author-profile-head.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../author-profile-head";
 
-describe("AuthorProfileHead tests on web", () => {
-  shared();
-});
+shared();

--- a/packages/author-profile/__tests__/web/author-profile.web.test.js
+++ b/packages/author-profile/__tests__/web/author-profile.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../author-profile";
 
-describe("AuthorProfile tests on web", () => {
-  shared();
-});
+shared();

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import { AdComposer } from "@times-components/ad";
 import { AuthorProfileProvider } from "@times-components/provider";

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -42,6 +42,7 @@
     "@times-components/provider-test-tools": "0.14.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -42,7 +42,7 @@
     "@times-components/provider-test-tools": "0.14.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/brightcove-video/__tests__/brightcove-player-helper.test.js
+++ b/packages/brightcove-video/__tests__/brightcove-player-helper.test.js
@@ -1,73 +1,64 @@
-import "react-native";
 import React, { Component } from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import BrightcovePlayer from "../src/brightcove-player-helper";
 
 describe("brightcove-player native component", () => {
   it("renders correctly", () => {
-    const tree = renderer
-      .create(
-        <BrightcovePlayer
-          accountId="[ACCOUNT_ID]"
-          policyKey="[POLICY_KEY]"
-          videoId="[VIDEO_ID]"
-        />
-      )
-      .toJSON();
+    const testInstance = TestRenderer.create(
+      <BrightcovePlayer
+        accountId="[ACCOUNT_ID]"
+        policyKey="[POLICY_KEY]"
+        videoId="[VIDEO_ID]"
+      />
+    );
 
-    expect(tree).toMatchSnapshot();
+    expect(testInstance.toJSON()).toMatchSnapshot();
   });
 
   it("width x height default to 320 x 180", () => {
-    const tree = renderer
-      .create(
-        <BrightcovePlayer
-          accountId="[ACCOUNT_ID]"
-          policyKey="[POLICY_KEY]"
-          videoId="[VIDEO_ID]"
-        />
-      )
-      .toJSON();
+    const testInstance = TestRenderer.create(
+      <BrightcovePlayer
+        accountId="[ACCOUNT_ID]"
+        policyKey="[POLICY_KEY]"
+        videoId="[VIDEO_ID]"
+      />
+    );
 
-    expect(tree.props.style.width).toBe(320);
-    expect(tree.props.style.height).toBe(180);
+    expect(testInstance.toJSON().props.style.width).toBe(320);
+    expect(testInstance.toJSON().props.style.height).toBe(180);
   });
 
   it("width x height can be overridden", () => {
-    const tree = renderer
-      .create(
-        <BrightcovePlayer
-          accountId="[ACCOUNT_ID]"
-          height={400}
-          policyKey="[POLICY_KEY]"
-          videoId="[VIDEO_ID]"
-          width={600}
-        />
-      )
-      .toJSON();
+    const testInstance = TestRenderer.create(
+      <BrightcovePlayer
+        accountId="[ACCOUNT_ID]"
+        height={400}
+        policyKey="[POLICY_KEY]"
+        videoId="[VIDEO_ID]"
+        width={600}
+      />
+    );
 
-    expect(tree.props.style.width).toBe(600);
-    expect(tree.props.style.height).toBe(400);
+    expect(testInstance.toJSON().props.style.width).toBe(600);
+    expect(testInstance.toJSON().props.style.height).toBe(400);
   });
 
   it("passes accountId, videoId & policyKey to video correctly", () => {
-    const tree = renderer
-      .create(
-        <BrightcovePlayer
-          accountId="[ACCOUNT_ID]"
-          policyKey="[POLICY_KEY]"
-          videoId="[VIDEO_ID]"
-        />
-      )
-      .toJSON();
+    const testInstance = TestRenderer.create(
+      <BrightcovePlayer
+        accountId="[ACCOUNT_ID]"
+        policyKey="[POLICY_KEY]"
+        videoId="[VIDEO_ID]"
+      />
+    );
 
-    expect(tree.props.policyKey).toBe("[POLICY_KEY]");
-    expect(tree.props.videoId).toBe("[VIDEO_ID]");
-    expect(tree.props.accountId).toBe("[ACCOUNT_ID]");
+    expect(testInstance.toJSON().props.policyKey).toBe("[POLICY_KEY]");
+    expect(testInstance.toJSON().props.videoId).toBe("[VIDEO_ID]");
+    expect(testInstance.toJSON().props.accountId).toBe("[ACCOUNT_ID]");
   });
 
   it("will call passed 'runNativeCommand' method property with 'play' when play is called", done => {
-    const root = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         policyKey="[POLICY_KEY]"
@@ -80,13 +71,13 @@ describe("brightcove-player native component", () => {
       />
     );
 
-    const rootInstance = root.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.play();
   });
 
   it("will call passed 'runNativeCommand' method property with 'pause' when pause is called", done => {
-    const root = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         policyKey="[POLICY_KEY]"
@@ -99,7 +90,7 @@ describe("brightcove-player native component", () => {
       />
     );
 
-    const rootInstance = root.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.pause();
   });
@@ -114,7 +105,7 @@ describe("brightcove-player native component", () => {
     let playSpy;
 
     beforeEach(() => {
-      const root = renderer.create(
+      const testInstance = TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           policyKey="[POLICY_KEY]"
@@ -122,7 +113,7 @@ describe("brightcove-player native component", () => {
         />
       );
 
-      rootInstance = root.getInstance();
+      rootInstance = testInstance.getInstance();
 
       pauseSpy = jest.spyOn(rootInstance, "pause");
       playSpy = jest.spyOn(rootInstance, "play");
@@ -215,7 +206,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("will ignore unrecognised props in native change event", () => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           policyKey="[POLICY_KEY]"
@@ -227,7 +218,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("trigger a general change event", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onChange={evt => {
@@ -243,7 +234,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("trigger a play event", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onPlay={done}
@@ -256,7 +247,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("trigger a pause event", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onPause={done}
@@ -270,7 +261,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("trigger a pause event", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onDuration={duration => {
@@ -286,7 +277,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("trigger a finish event", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onFinish={done}
@@ -299,7 +290,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("will correctly handle native (android) errors", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onError={evt => {
@@ -315,7 +306,7 @@ describe("brightcove-player native component", () => {
     });
 
     it("will correctly handle native (iOS) errors", done => {
-      renderer.create(
+      TestRenderer.create(
         <BrightcovePlayer
           accountId="[ACCOUNT_ID]"
           onError={evt => {

--- a/packages/brightcove-video/__tests__/brightcove-player.android.test.js
+++ b/packages/brightcove-video/__tests__/brightcove-player.android.test.js
@@ -1,7 +1,5 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
-
+import TestRenderer from "react-test-renderer";
 import BrightcovePlayer from "../src/brightcove-player.android";
 
 describe("brightcove-player Android component", () => {
@@ -10,7 +8,7 @@ describe("brightcove-player Android component", () => {
   });
 
   it("will attempt to call the correct native method", () => {
-    const brightcoveVideo = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         policyKey="[POLICY_KEY]"
@@ -31,7 +29,7 @@ describe("brightcove-player Android component", () => {
       }
     }));
 
-    const rootInstance = brightcoveVideo.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.runNativeCommand("play", []);
 
@@ -40,7 +38,7 @@ describe("brightcove-player Android component", () => {
   });
 
   it("will go fullscreen if it receives an 'onChange' event with 'isFullscreen' equal to true", () => {
-    const brightcoveVideo = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         policyKey="[POLICY_KEY]"
@@ -48,15 +46,15 @@ describe("brightcove-player Android component", () => {
       />
     );
 
-    const rootInstance = brightcoveVideo.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.onChange({ isFullscreen: true });
 
-    expect(brightcoveVideo.toJSON()).toMatchSnapshot();
+    expect(testInstance.toJSON()).toMatchSnapshot();
   });
 
   it("will fire 'onEnterFullscreen' event if it receives an 'onChange' event with 'isFullscreen' equal to true", done => {
-    const brightcoveVideo = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         onEnterFullscreen={done}
@@ -65,13 +63,13 @@ describe("brightcove-player Android component", () => {
       />
     );
 
-    const rootInstance = brightcoveVideo.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.onChange({ isFullscreen: true });
   });
 
   it("will fire 'onExitFullscreen' event if it receives an 'onChange' event with 'isFullscreen' equal to false", done => {
-    const brightcoveVideo = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         onExitFullscreen={done}
@@ -80,14 +78,14 @@ describe("brightcove-player Android component", () => {
       />
     );
 
-    const rootInstance = brightcoveVideo.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.onChange({ isFullscreen: true });
     rootInstance.onChange({ isFullscreen: false });
   });
 
   it("will filter android only props from being passed native component", () => {
-    const brightcoveVideo = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         policyKey="[POLICY_KEY]"
@@ -95,7 +93,7 @@ describe("brightcove-player Android component", () => {
       />
     );
 
-    const rootInstance = brightcoveVideo.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     expect(rootInstance.bcv.props.videoId).toEqual("[VIDEO_ID]");
     expect(rootInstance.bcv.props.accountId).toEqual("[ACCOUNT_ID]");

--- a/packages/brightcove-video/__tests__/brightcove-player.ios.test.js
+++ b/packages/brightcove-video/__tests__/brightcove-player.ios.test.js
@@ -1,6 +1,5 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 
 import BrightcovePlayer from "../src/brightcove-player";
 
@@ -10,7 +9,7 @@ describe("brightcove-player iOS component", () => {
   });
 
   it("will attempt to call the correct native method", () => {
-    const brightcoveVideo = renderer.create(
+    const testInstance = TestRenderer.create(
       <BrightcovePlayer
         accountId="[ACCOUNT_ID]"
         policyKey="[POLICY_KEY]"
@@ -26,7 +25,7 @@ describe("brightcove-player iOS component", () => {
       }
     }));
 
-    const rootInstance = brightcoveVideo.getInstance();
+    const rootInstance = testInstance.getInstance();
 
     rootInstance.runNativeCommand("play", []);
 

--- a/packages/brightcove-video/__tests__/brightcove-video.test.js
+++ b/packages/brightcove-video/__tests__/brightcove-video.test.js
@@ -1,7 +1,5 @@
-import "react-native";
 import React from "react";
-import renderer from "react-test-renderer";
-
+import TestRenderer from "react-test-renderer";
 import BrightcoveVideo from "../src/brightcove-video";
 
 const policyKey = "[POLICY_KEY]";
@@ -29,36 +27,36 @@ beforeEach(() => {
 });
 
 it("renders poster correctly before launch", () => {
-  const tree = renderer
-    .create(<BrightcoveVideo {...defaultVideoProps} />)
-    .toJSON();
+  const testInstance = TestRenderer.create(
+    <BrightcoveVideo {...defaultVideoProps} />
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("renders poster with custom play icon if specified", () => {
-  const tree = renderer
-    .create(
-      <BrightcoveVideo {...defaultVideoProps} playIcon={playIconEmoji()} />
-    )
-    .toJSON();
+  const testInstance = TestRenderer.create(
+    <BrightcoveVideo {...defaultVideoProps} playIcon={playIconEmoji()} />
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("will launch if play is called", () => {
-  const root = renderer.create(<BrightcoveVideo {...defaultVideoProps} />);
+  const testInstance = TestRenderer.create(
+    <BrightcoveVideo {...defaultVideoProps} />
+  );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   rootInstance.play();
 
-  expect(root.toJSON()).toMatchSnapshot();
+  expect(testInstance.toJSON()).toMatchSnapshot();
 });
 
 it("pauses other playing videos if play is called", () => {
-  renderer.create(<BrightcoveVideo {...defaultVideoProps} />);
-  renderer.create(<BrightcoveVideo {...defaultVideoProps} />);
+  TestRenderer.create(<BrightcoveVideo {...defaultVideoProps} />);
+  TestRenderer.create(<BrightcoveVideo {...defaultVideoProps} />);
 
   const [component1, component2] = BrightcoveVideo.activePlayers;
   jest.spyOn(component1, "pause");
@@ -71,8 +69,8 @@ it("pauses other playing videos if play is called", () => {
 });
 
 it("doesn't hold references to players after they have been unmounted", () => {
-  renderer.create(<BrightcoveVideo {...defaultVideoProps} />);
-  const p2 = renderer.create(<BrightcoveVideo {...defaultVideoProps} />);
+  TestRenderer.create(<BrightcoveVideo {...defaultVideoProps} />);
+  const p2 = TestRenderer.create(<BrightcoveVideo {...defaultVideoProps} />);
 
   expect(BrightcoveVideo.activePlayers.length).toBe(2);
   const [component1] = BrightcoveVideo.activePlayers;
@@ -82,23 +80,23 @@ it("doesn't hold references to players after they have been unmounted", () => {
 });
 
 it("will reset properly", () => {
-  const root = renderer.create(
+  const testInstance = TestRenderer.create(
     <BrightcoveVideo {...defaultVideoProps} autoplay />
   );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   rootInstance.reset();
 
-  expect(root.toJSON()).toMatchSnapshot();
+  expect(testInstance.toJSON()).toMatchSnapshot();
 });
 
 it("will reset if 'resetOnFinish' is true & video finishes", done => {
-  const root = renderer.create(
+  const testInstance = TestRenderer.create(
     <BrightcoveVideo {...defaultVideoProps} resetOnFinish />
   );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   rootInstance.play();
 
@@ -106,17 +104,17 @@ it("will reset if 'resetOnFinish' is true & video finishes", done => {
 
   // handleFinish calls reset asyc - wait for it
   setTimeout(() => {
-    expect(root.toJSON()).toMatchSnapshot();
+    expect(testInstance.toJSON()).toMatchSnapshot();
     done();
   }, 0);
 });
 
 it("will call child components play and pause methods if child component is ready", () => {
-  const root = renderer.create(
+  const testInstance = TestRenderer.create(
     <BrightcoveVideo {...defaultVideoProps} autoplay />
   );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   rootInstance.playerRef = {
     play: jest.fn(),
@@ -135,11 +133,11 @@ it("will call child components play and pause methods if child component is read
 });
 
 it("will call native fullscreen player if 'directToFullscreen option passed'", () => {
-  const root = renderer.create(
+  const testInstance = TestRenderer.create(
     <BrightcoveVideo {...defaultVideoProps} directToFullscreen />
   );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   const mockNativeModule = {
     playVideo: jest.fn()
@@ -153,23 +151,23 @@ it("will call native fullscreen player if 'directToFullscreen option passed'", (
 });
 
 it("will handle an error properly", () => {
-  const root = renderer.create(
+  const testInstance = TestRenderer.create(
     <BrightcoveVideo {...defaultVideoProps} autoplay />
   );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   rootInstance.handleError({ code: "XxX", message: "a bad booboo occured" });
 
-  expect(root.toJSON()).toMatchSnapshot();
+  expect(testInstance.toJSON()).toMatchSnapshot();
 });
 
 it("the player can trigger errors", () => {
-  const root = renderer.create(
+  const testInstance = TestRenderer.create(
     <BrightcoveVideo {...defaultVideoProps} autoplay />
   );
 
-  const rootInstance = root.getInstance();
+  const rootInstance = testInstance.getInstance();
 
   rootInstance.setState({ isLaunched: true });
 
@@ -180,5 +178,5 @@ it("the player can trigger errors", () => {
     }
   });
 
-  expect(root.toJSON()).toMatchSnapshot();
+  expect(testInstance.toJSON()).toMatchSnapshot();
 });

--- a/packages/button/__tests__/android/__snapshots__/button-accessible.android.test.js.snap
+++ b/packages/button/__tests__/android/__snapshots__/button-accessible.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android accessible button 1`] = `
+exports[`accessible button 1`] = `
 <TouchableHighlight
   accessibilityComponentType="button"
   accessibilityLabel="T E S T   B U T T O N"

--- a/packages/button/__tests__/android/__snapshots__/button-accessible.android.test.js.snap
+++ b/packages/button/__tests__/android/__snapshots__/button-accessible.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an accessible button 1`] = `
+exports[`android accessible button 1`] = `
 <TouchableHighlight
   accessibilityComponentType="button"
   accessibilityLabel="T E S T   B U T T O N"

--- a/packages/button/__tests__/android/__snapshots__/button.android.test.js.snap
+++ b/packages/button/__tests__/android/__snapshots__/button.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. button 1`] = `
+exports[`1. button 1`] = `
 <TouchableHighlight
   activeOpacity={1}
   delayPressOut={100}

--- a/packages/button/__tests__/android/__snapshots__/button.android.test.js.snap
+++ b/packages/button/__tests__/android/__snapshots__/button.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render the button 1`] = `
+exports[`android 1. button 1`] = `
 <TouchableHighlight
   activeOpacity={1}
   delayPressOut={100}

--- a/packages/button/__tests__/android/button-accessible.android.test.js
+++ b/packages/button/__tests__/android/button-accessible.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-accessible.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/button/__tests__/android/button.android.test.js
+++ b/packages/button/__tests__/android/button.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/button/__tests__/ios/__snapshots__/button-accessible.ios.test.js.snap
+++ b/packages/button/__tests__/ios/__snapshots__/button-accessible.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an accessible button 1`] = `
+exports[`ios accessible button 1`] = `
 <TouchableHighlight
   accessibilityComponentType="button"
   accessibilityLabel="Test button"

--- a/packages/button/__tests__/ios/__snapshots__/button-accessible.ios.test.js.snap
+++ b/packages/button/__tests__/ios/__snapshots__/button-accessible.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios accessible button 1`] = `
+exports[`accessible button 1`] = `
 <TouchableHighlight
   accessibilityComponentType="button"
   accessibilityLabel="Test button"

--- a/packages/button/__tests__/ios/__snapshots__/button.ios.test.js.snap
+++ b/packages/button/__tests__/ios/__snapshots__/button.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. button 1`] = `
+exports[`1. button 1`] = `
 <TouchableHighlight
   activeOpacity={1}
   delayPressOut={100}

--- a/packages/button/__tests__/ios/__snapshots__/button.ios.test.js.snap
+++ b/packages/button/__tests__/ios/__snapshots__/button.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render the button 1`] = `
+exports[`ios 1. button 1`] = `
 <TouchableHighlight
   activeOpacity={1}
   delayPressOut={100}

--- a/packages/button/__tests__/ios/button-accessible.ios.test.js
+++ b/packages/button/__tests__/ios/button-accessible.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-accessible.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/button/__tests__/ios/button.ios.test.js
+++ b/packages/button/__tests__/ios/button.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/button/__tests__/shared-accessible.base.js
+++ b/packages/button/__tests__/shared-accessible.base.js
@@ -1,13 +1,12 @@
-import "react-native";
 import React from "react";
 import Button from "../src/button";
 
 export default renderMethod => {
-  it("should render an accessible button", () => {
+  it("accessible button", () => {
     const wrapper = renderMethod(
       <Button onPress={() => null} title="test button" />
     );
 
-    expect(wrapper).toMatchSnapshot("1. Render an accessible button");
+    expect(wrapper).toMatchSnapshot();
   });
 };

--- a/packages/button/__tests__/shared-accessible.base.js
+++ b/packages/button/__tests__/shared-accessible.base.js
@@ -3,10 +3,10 @@ import Button from "../src/button";
 
 export default renderMethod => {
   it("accessible button", () => {
-    const wrapper = renderMethod(
+    const output = renderMethod(
       <Button onPress={() => null} title="test button" />
     );
 
-    expect(wrapper).toMatchSnapshot();
+    expect(output).toMatchSnapshot();
   });
 };

--- a/packages/button/__tests__/shared.base.js
+++ b/packages/button/__tests__/shared.base.js
@@ -8,11 +8,11 @@ export default renderMethod => {
     {
       name: "button",
       test: () => {
-        const wrapper = renderMethod(
+        const output = renderMethod(
           <Button onPress={() => null} title="test button" />
         );
 
-        expect(wrapper).toMatchSnapshot();
+        expect(output).toMatchSnapshot();
       }
     },
     {

--- a/packages/button/__tests__/shared.base.js
+++ b/packages/button/__tests__/shared.base.js
@@ -1,25 +1,34 @@
-import "react-native";
 import React from "react";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import Button from "../src/button";
 
 export default renderMethod => {
-  it("should render the button", () => {
-    const wrapper = renderMethod(
-      <Button onPress={() => null} title="test button" />
-    );
+  const tests = [
+    {
+      name: "button",
+      test: () => {
+        const wrapper = renderMethod(
+          <Button onPress={() => null} title="test button" />
+        );
 
-    expect(wrapper).toMatchSnapshot("1. Render the button");
-  });
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "should handle the onPress event",
+      test: () => {
+        const onPressMock = jest.fn();
+        const wrapper = shallow(
+          <Button onPress={onPressMock} title="test button" />
+        );
 
-  it("should handle the onPress event", () => {
-    const onPressMock = jest.fn();
-    const wrapper = shallow(
-      <Button onPress={onPressMock} title="test button" />
-    );
+        wrapper.simulate("press");
 
-    wrapper.simulate("press");
+        expect(onPressMock).toHaveBeenCalled();
+      }
+    }
+  ];
 
-    expect(onPressMock).toHaveBeenCalled();
-  });
+  iterator(tests);
 };

--- a/packages/button/__tests__/web/__snapshots__/button-accessible.web.test.js.snap
+++ b/packages/button/__tests__/web/__snapshots__/button-accessible.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render an accessible button 1`] = `
+exports[`web accessible button 1`] = `
 <div
   aria-label="Test button"
   role="button"

--- a/packages/button/__tests__/web/__snapshots__/button-accessible.web.test.js.snap
+++ b/packages/button/__tests__/web/__snapshots__/button-accessible.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web accessible button 1`] = `
+exports[`accessible button 1`] = `
 <div
   aria-label="Test button"
   role="button"

--- a/packages/button/__tests__/web/__snapshots__/button.web.test.js.snap
+++ b/packages/button/__tests__/web/__snapshots__/button.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render the button 1`] = `
+exports[`web 1. button 1`] = `
 <style>
 {
   "S1": {

--- a/packages/button/__tests__/web/__snapshots__/button.web.test.js.snap
+++ b/packages/button/__tests__/web/__snapshots__/button.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. button 1`] = `
+exports[`1. button 1`] = `
 <style>
 {
   "S1": {

--- a/packages/button/__tests__/web/button-accessible.web.test.js
+++ b/packages/button/__tests__/web/button-accessible.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-accessible.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/button/__tests__/web/button.web.test.js
+++ b/packages/button/__tests__/web/button.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -39,6 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders with specific styles 1`] = `
+exports[`caption with specific styles 1`] = `
 <View>
   <View
     style={

--- a/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. caption without credits 1`] = `
+exports[`1. caption without credits 1`] = `
 <View>
   <View>
     <Text>
@@ -10,7 +10,7 @@ exports[`android 1. caption without credits 1`] = `
 </View>
 `;
 
-exports[`android 2. caption with credits 1`] = `
+exports[`2. caption with credits 1`] = `
 <View>
   <View>
     <Text>
@@ -23,7 +23,7 @@ exports[`android 2. caption with credits 1`] = `
 </View>
 `;
 
-exports[`android 3. caption with credits only 1`] = `
+exports[`3. caption with credits only 1`] = `
 <View>
   <View>
     <Text>
@@ -33,7 +33,7 @@ exports[`android 3. caption with credits only 1`] = `
 </View>
 `;
 
-exports[`android 4. caption with child 1`] = `
+exports[`4. caption with child 1`] = `
 <View>
   <Text>
     Hello world!

--- a/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders without credits 1`] = `
+exports[`android 1. caption without credits 1`] = `
 <View>
   <View>
     <Text>
@@ -10,7 +10,7 @@ exports[`1. renders without credits 1`] = `
 </View>
 `;
 
-exports[`2. renders with credits 1`] = `
+exports[`android 2. caption with credits 1`] = `
 <View>
   <View>
     <Text>
@@ -23,7 +23,7 @@ exports[`2. renders with credits 1`] = `
 </View>
 `;
 
-exports[`3. renders with credits only 1`] = `
+exports[`android 3. caption with credits only 1`] = `
 <View>
   <View>
     <Text>
@@ -33,7 +33,7 @@ exports[`3. renders with credits only 1`] = `
 </View>
 `;
 
-exports[`4. renders a child 1`] = `
+exports[`android 4. caption with child 1`] = `
 <View>
   <Text>
     Hello world!

--- a/packages/caption/__tests__/android/caption-with-style.android.test.js
+++ b/packages/caption/__tests__/android/caption-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/caption/__tests__/android/caption.android.test.js
+++ b/packages/caption/__tests__/android/caption.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/caption/__tests__/ios/__snapshots__/caption-with-style.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders with specific styles 1`] = `
+exports[`caption with specific styles 1`] = `
 <View>
   <View
     style={

--- a/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. caption without credits 1`] = `
+exports[`1. caption without credits 1`] = `
 <View>
   <View>
     <Text>
@@ -10,7 +10,7 @@ exports[`ios 1. caption without credits 1`] = `
 </View>
 `;
 
-exports[`ios 2. caption with credits 1`] = `
+exports[`2. caption with credits 1`] = `
 <View>
   <View>
     <Text>
@@ -23,7 +23,7 @@ exports[`ios 2. caption with credits 1`] = `
 </View>
 `;
 
-exports[`ios 3. caption with credits only 1`] = `
+exports[`3. caption with credits only 1`] = `
 <View>
   <View>
     <Text>
@@ -33,7 +33,7 @@ exports[`ios 3. caption with credits only 1`] = `
 </View>
 `;
 
-exports[`ios 4. caption with child 1`] = `
+exports[`4. caption with child 1`] = `
 <View>
   <Text>
     Hello world!

--- a/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders without credits 1`] = `
+exports[`ios 1. caption without credits 1`] = `
 <View>
   <View>
     <Text>
@@ -10,7 +10,7 @@ exports[`1. renders without credits 1`] = `
 </View>
 `;
 
-exports[`2. renders with credits 1`] = `
+exports[`ios 2. caption with credits 1`] = `
 <View>
   <View>
     <Text>
@@ -23,7 +23,7 @@ exports[`2. renders with credits 1`] = `
 </View>
 `;
 
-exports[`3. renders with credits only 1`] = `
+exports[`ios 3. caption with credits only 1`] = `
 <View>
   <View>
     <Text>
@@ -33,7 +33,7 @@ exports[`3. renders with credits only 1`] = `
 </View>
 `;
 
-exports[`4. renders a child 1`] = `
+exports[`ios 4. caption with child 1`] = `
 <View>
   <Text>
     Hello world!

--- a/packages/caption/__tests__/ios/caption-with-style.ios.test.js
+++ b/packages/caption/__tests__/ios/caption-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/caption/__tests__/ios/caption.ios.test.js
+++ b/packages/caption/__tests__/ios/caption.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/caption/__tests__/shared-with-style.base.js
+++ b/packages/caption/__tests__/shared-with-style.base.js
@@ -14,13 +14,11 @@ const style = {
 };
 
 export default () => {
-  it("renders with specific styles", () => {
+  it("caption with specific styles", () => {
     const testInstance = TestRenderer.create(
       <Caption credits={credits} style={style} text={captionText} />
     );
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "1. renders with specific styles"
-    );
+    expect(testInstance.toJSON()).toMatchSnapshot();
   });
 };

--- a/packages/caption/__tests__/shared.base.js
+++ b/packages/caption/__tests__/shared.base.js
@@ -1,41 +1,55 @@
 import React from "react";
 import { Text } from "react-native";
 import TestRenderer from "react-test-renderer";
+import { iterator } from "@times-components/test-utils";
 import Caption from "../src/caption";
 
 const captionText = "Some caption text goes in here";
 const credits = "Just credits";
 
 export default () => {
-  it("renders without credits", () => {
-    const testInstance = TestRenderer.create(<Caption text={captionText} />);
+  const tests = [
+    {
+      name: "caption without credits",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Caption text={captionText} />
+        );
 
-    expect(testInstance.toJSON()).toMatchSnapshot("1. renders without credits");
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "caption with credits",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Caption credits={credits} text={captionText} />
+        );
 
-  it("renders with credits", () => {
-    const testInstance = TestRenderer.create(
-      <Caption credits={credits} text={captionText} />
-    );
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "caption with credits only",
+      test: () => {
+        const testInstance = TestRenderer.create(<Caption credits={credits} />);
 
-    expect(testInstance.toJSON()).toMatchSnapshot("2. renders with credits");
-  });
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "caption with child",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Caption credits={credits} text={captionText}>
+            <Text>Hello world!</Text>
+          </Caption>
+        );
 
-  it("renders with credits only", () => {
-    const testInstance = TestRenderer.create(<Caption credits={credits} />);
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    }
+  ];
 
-    expect(testInstance.toJSON()).toMatchSnapshot(
-      "3. renders with credits only"
-    );
-  });
-
-  it("renders a child", () => {
-    const testInstance = TestRenderer.create(
-      <Caption credits={credits} text={captionText}>
-        <Text>Hello world!</Text>
-      </Caption>
-    );
-
-    expect(testInstance.toJSON()).toMatchSnapshot("4. renders a child");
-  });
+  iterator(tests);
 };

--- a/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders with specific styles 1`] = `
+exports[`caption with specific styles 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders without credits 1`] = `
+exports[`web 1. caption without credits 1`] = `
 <div>
   <div>
     <div>
@@ -10,7 +10,7 @@ exports[`1. renders without credits 1`] = `
 </div>
 `;
 
-exports[`2. renders with credits 1`] = `
+exports[`web 2. caption with credits 1`] = `
 <div>
   <div>
     <div>
@@ -23,7 +23,7 @@ exports[`2. renders with credits 1`] = `
 </div>
 `;
 
-exports[`3. renders with credits only 1`] = `
+exports[`web 3. caption with credits only 1`] = `
 <div>
   <div>
     <div>
@@ -33,7 +33,7 @@ exports[`3. renders with credits only 1`] = `
 </div>
 `;
 
-exports[`4. renders a child 1`] = `
+exports[`web 4. caption with child 1`] = `
 <div>
   <div>
     Hello world!

--- a/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. caption without credits 1`] = `
+exports[`1. caption without credits 1`] = `
 <div>
   <div>
     <div>
@@ -10,7 +10,7 @@ exports[`web 1. caption without credits 1`] = `
 </div>
 `;
 
-exports[`web 2. caption with credits 1`] = `
+exports[`2. caption with credits 1`] = `
 <div>
   <div>
     <div>
@@ -23,7 +23,7 @@ exports[`web 2. caption with credits 1`] = `
 </div>
 `;
 
-exports[`web 3. caption with credits only 1`] = `
+exports[`3. caption with credits only 1`] = `
 <div>
   <div>
     <div>
@@ -33,7 +33,7 @@ exports[`web 3. caption with credits only 1`] = `
 </div>
 `;
 
-exports[`web 4. caption with child 1`] = `
+exports[`4. caption with child 1`] = `
 <div>
   <div>
     Hello world!

--- a/packages/caption/__tests__/web/caption-with-style.web.test.js
+++ b/packages/caption/__tests__/web/caption-with-style.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/caption/__tests__/web/caption.web.test.js
+++ b/packages/caption/__tests__/web/caption.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -44,6 +44,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -44,7 +44,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/card/__tests__/android/__snapshots__/card-with-style.android.test.js.snap
+++ b/packages/card/__tests__/android/__snapshots__/card-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render the default layout 1`] = `
+exports[`android 1. card default state 1`] = `
 <View
   style={
     Object {
@@ -50,7 +50,7 @@ exports[`1. should render the default layout 1`] = `
 </View>
 `;
 
-exports[`2. should render with reversed layout 1`] = `
+exports[`android 2. card with reversed state 1`] = `
 <View
   style={
     Object {
@@ -101,7 +101,7 @@ exports[`2. should render with reversed layout 1`] = `
 </View>
 `;
 
-exports[`3. should render a loading state 1`] = `
+exports[`android 3. card loading state 1`] = `
 <View
   style={
     Object {
@@ -177,7 +177,7 @@ exports[`3. should render a loading state 1`] = `
 </View>
 `;
 
-exports[`4. should render a reversed loading component 1`] = `
+exports[`android 4. card reversed loading state 1`] = `
 <View
   style={
     Object {

--- a/packages/card/__tests__/android/__snapshots__/card-with-style.android.test.js.snap
+++ b/packages/card/__tests__/android/__snapshots__/card-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. card default state 1`] = `
+exports[`1. card default state 1`] = `
 <View
   style={
     Object {
@@ -50,7 +50,7 @@ exports[`android 1. card default state 1`] = `
 </View>
 `;
 
-exports[`android 2. card with reversed state 1`] = `
+exports[`2. card with reversed state 1`] = `
 <View
   style={
     Object {
@@ -101,7 +101,7 @@ exports[`android 2. card with reversed state 1`] = `
 </View>
 `;
 
-exports[`android 3. card loading state 1`] = `
+exports[`3. card loading state 1`] = `
 <View
   style={
     Object {
@@ -177,7 +177,7 @@ exports[`android 3. card loading state 1`] = `
 </View>
 `;
 
-exports[`android 4. card reversed loading state 1`] = `
+exports[`4. card reversed loading state 1`] = `
 <View
   style={
     Object {

--- a/packages/card/__tests__/android/__snapshots__/card.android.test.js.snap
+++ b/packages/card/__tests__/android/__snapshots__/card.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render the default layout 1`] = `
+exports[`android 1. card default state 1`] = `
 <View>
   <View>
     <View>
@@ -18,7 +18,7 @@ exports[`1. should render the default layout 1`] = `
 </View>
 `;
 
-exports[`2. should pass an empty state to the image component 1`] = `
+exports[`android 2. pass an empty state to the image component 1`] = `
 <View>
   <View>
     <View>
@@ -36,7 +36,7 @@ exports[`2. should pass an empty state to the image component 1`] = `
 </View>
 `;
 
-exports[`4. should render without an image when showImage is false 1`] = `
+exports[`android 3. card without an image when showimage is false 1`] = `
 <View>
   <View>
     <View>
@@ -48,7 +48,7 @@ exports[`4. should render without an image when showImage is false 1`] = `
 </View>
 `;
 
-exports[`5. should pass an empty state to the image component when uri is null 1`] = `
+exports[`android 4. pass an empty state to the image component when uri is null 1`] = `
 <View>
   <View>
     <View>
@@ -66,7 +66,7 @@ exports[`5. should pass an empty state to the image component when uri is null 1
 </View>
 `;
 
-exports[`6. should render with reversed layout 1`] = `
+exports[`android 5. card with reversed layout 1`] = `
 <View>
   <View>
     <View>
@@ -84,7 +84,7 @@ exports[`6. should render with reversed layout 1`] = `
 </View>
 `;
 
-exports[`7. should render with reversed layout and no image 1`] = `
+exports[`android 6. card with reversed layout and no image 1`] = `
 <View>
   <View>
     <View>
@@ -96,7 +96,7 @@ exports[`7. should render with reversed layout and no image 1`] = `
 </View>
 `;
 
-exports[`8. should render a loading state 1`] = `
+exports[`android 7. card with a loading state 1`] = `
 <View>
   <View>
     <Image
@@ -120,7 +120,7 @@ exports[`8. should render a loading state 1`] = `
 </View>
 `;
 
-exports[`10. should render a loading card with no image 1`] = `
+exports[`android 8. card with a loading state and no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -139,7 +139,7 @@ exports[`10. should render a loading card with no image 1`] = `
 </View>
 `;
 
-exports[`11. should render a reversed loading component 1`] = `
+exports[`android 9. card with reversed loading state 1`] = `
 <View>
   <View>
     <Gradient
@@ -163,7 +163,7 @@ exports[`11. should render a reversed loading component 1`] = `
 </View>
 `;
 
-exports[`12. should render a reversed loading component with no image 1`] = `
+exports[`android 10. card with reversed loading state with no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -182,7 +182,7 @@ exports[`12. should render a reversed loading component with no image 1`] = `
 </View>
 `;
 
-exports[`13. should not re-render when imageRatio prop is changed 1`] = `
+exports[`android 11. card should not re-render when imageratio prop is changed 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -200,7 +200,7 @@ exports[`13. should not re-render when imageRatio prop is changed 1`] = `
 </FadeIn>
 `;
 
-exports[`13. should not re-render when imageRatio prop is changed 2`] = `
+exports[`android 11. card should not re-render when imageratio prop is changed 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -218,7 +218,7 @@ exports[`13. should not re-render when imageRatio prop is changed 2`] = `
 </FadeIn>
 `;
 
-exports[`14. should re-render when image uri changes 1`] = `
+exports[`android 12. card should re-render when image uri changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -236,7 +236,7 @@ exports[`14. should re-render when image uri changes 1`] = `
 </FadeIn>
 `;
 
-exports[`14. should re-render when image uri changes 2`] = `
+exports[`android 12. card should re-render when image uri changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -254,7 +254,7 @@ exports[`14. should re-render when image uri changes 2`] = `
 </FadeIn>
 `;
 
-exports[`15. should re-render when image size changes 1`] = `
+exports[`android 13. card should re-render when image size changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -272,7 +272,7 @@ exports[`15. should re-render when image size changes 1`] = `
 </FadeIn>
 `;
 
-exports[`15. should re-render when image size changes 2`] = `
+exports[`android 13. card should re-render when image size changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -290,7 +290,7 @@ exports[`15. should re-render when image size changes 2`] = `
 </FadeIn>
 `;
 
-exports[`16. should re-render when loading state changes 1`] = `
+exports[`android 14. card should re-render when loading state changes 1`] = `
 <Loading
   imageRatio={0.6666666666666666}
   isReversed={false}
@@ -298,7 +298,7 @@ exports[`16. should re-render when loading state changes 1`] = `
 />
 `;
 
-exports[`16. should re-render when loading state changes 2`] = `
+exports[`android 14. card should re-render when loading state changes 2`] = `
 <FadeIn>
   <View>
     <View>

--- a/packages/card/__tests__/android/__snapshots__/card.android.test.js.snap
+++ b/packages/card/__tests__/android/__snapshots__/card.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. card default state 1`] = `
+exports[`1. card default state 1`] = `
 <View>
   <View>
     <View>
@@ -18,7 +18,7 @@ exports[`android 1. card default state 1`] = `
 </View>
 `;
 
-exports[`android 2. pass an empty state to the image component 1`] = `
+exports[`2. pass an empty state to the image component 1`] = `
 <View>
   <View>
     <View>
@@ -36,7 +36,7 @@ exports[`android 2. pass an empty state to the image component 1`] = `
 </View>
 `;
 
-exports[`android 3. card without an image when showimage is false 1`] = `
+exports[`3. card without an image when showimage is false 1`] = `
 <View>
   <View>
     <View>
@@ -48,7 +48,7 @@ exports[`android 3. card without an image when showimage is false 1`] = `
 </View>
 `;
 
-exports[`android 4. pass an empty state to the image component when uri is null 1`] = `
+exports[`4. pass an empty state to the image component when uri is null 1`] = `
 <View>
   <View>
     <View>
@@ -66,7 +66,7 @@ exports[`android 4. pass an empty state to the image component when uri is null 
 </View>
 `;
 
-exports[`android 5. card with reversed layout 1`] = `
+exports[`5. card with reversed layout 1`] = `
 <View>
   <View>
     <View>
@@ -84,7 +84,7 @@ exports[`android 5. card with reversed layout 1`] = `
 </View>
 `;
 
-exports[`android 6. card with reversed layout and no image 1`] = `
+exports[`6. card with reversed layout and no image 1`] = `
 <View>
   <View>
     <View>
@@ -96,7 +96,7 @@ exports[`android 6. card with reversed layout and no image 1`] = `
 </View>
 `;
 
-exports[`android 7. card with a loading state 1`] = `
+exports[`7. card with a loading state 1`] = `
 <View>
   <View>
     <Image
@@ -120,7 +120,7 @@ exports[`android 7. card with a loading state 1`] = `
 </View>
 `;
 
-exports[`android 8. card with a loading state and no image 1`] = `
+exports[`8. card with a loading state and no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -139,7 +139,7 @@ exports[`android 8. card with a loading state and no image 1`] = `
 </View>
 `;
 
-exports[`android 9. card with reversed loading state 1`] = `
+exports[`9. card with reversed loading state 1`] = `
 <View>
   <View>
     <Gradient
@@ -163,7 +163,7 @@ exports[`android 9. card with reversed loading state 1`] = `
 </View>
 `;
 
-exports[`android 10. card with reversed loading state with no image 1`] = `
+exports[`10. card with reversed loading state with no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -182,7 +182,7 @@ exports[`android 10. card with reversed loading state with no image 1`] = `
 </View>
 `;
 
-exports[`android 11. card should not re-render when imageratio prop is changed 1`] = `
+exports[`11. card should not re-render when imageratio prop is changed 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -200,7 +200,7 @@ exports[`android 11. card should not re-render when imageratio prop is changed 1
 </FadeIn>
 `;
 
-exports[`android 11. card should not re-render when imageratio prop is changed 2`] = `
+exports[`11. card should not re-render when imageratio prop is changed 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -218,7 +218,7 @@ exports[`android 11. card should not re-render when imageratio prop is changed 2
 </FadeIn>
 `;
 
-exports[`android 12. card should re-render when image uri changes 1`] = `
+exports[`12. card should re-render when image uri changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -236,7 +236,7 @@ exports[`android 12. card should re-render when image uri changes 1`] = `
 </FadeIn>
 `;
 
-exports[`android 12. card should re-render when image uri changes 2`] = `
+exports[`12. card should re-render when image uri changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -254,7 +254,7 @@ exports[`android 12. card should re-render when image uri changes 2`] = `
 </FadeIn>
 `;
 
-exports[`android 13. card should re-render when image size changes 1`] = `
+exports[`13. card should re-render when image size changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -272,7 +272,7 @@ exports[`android 13. card should re-render when image size changes 1`] = `
 </FadeIn>
 `;
 
-exports[`android 13. card should re-render when image size changes 2`] = `
+exports[`13. card should re-render when image size changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -290,7 +290,7 @@ exports[`android 13. card should re-render when image size changes 2`] = `
 </FadeIn>
 `;
 
-exports[`android 14. card should re-render when loading state changes 1`] = `
+exports[`14. card should re-render when loading state changes 1`] = `
 <Loading
   imageRatio={0.6666666666666666}
   isReversed={false}
@@ -298,7 +298,7 @@ exports[`android 14. card should re-render when loading state changes 1`] = `
 />
 `;
 
-exports[`android 14. card should re-render when loading state changes 2`] = `
+exports[`14. card should re-render when loading state changes 2`] = `
 <FadeIn>
   <View>
     <View>

--- a/packages/card/__tests__/android/card-with-style.android.test.js
+++ b/packages/card/__tests__/android/card-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/card/__tests__/android/card.android.test.js
+++ b/packages/card/__tests__/android/card.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/card/__tests__/ios/__snapshots__/card-with-style.ios.test.js.snap
+++ b/packages/card/__tests__/ios/__snapshots__/card-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render the default layout 1`] = `
+exports[`ios 1. card default state 1`] = `
 <View
   style={
     Object {
@@ -50,7 +50,7 @@ exports[`1. should render the default layout 1`] = `
 </View>
 `;
 
-exports[`2. should render with reversed layout 1`] = `
+exports[`ios 2. card with reversed state 1`] = `
 <View
   style={
     Object {
@@ -101,7 +101,7 @@ exports[`2. should render with reversed layout 1`] = `
 </View>
 `;
 
-exports[`3. should render a loading state 1`] = `
+exports[`ios 3. card loading state 1`] = `
 <View
   style={
     Object {
@@ -177,7 +177,7 @@ exports[`3. should render a loading state 1`] = `
 </View>
 `;
 
-exports[`4. should render a reversed loading component 1`] = `
+exports[`ios 4. card reversed loading state 1`] = `
 <View
   style={
     Object {

--- a/packages/card/__tests__/ios/__snapshots__/card-with-style.ios.test.js.snap
+++ b/packages/card/__tests__/ios/__snapshots__/card-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. card default state 1`] = `
+exports[`1. card default state 1`] = `
 <View
   style={
     Object {
@@ -50,7 +50,7 @@ exports[`ios 1. card default state 1`] = `
 </View>
 `;
 
-exports[`ios 2. card with reversed state 1`] = `
+exports[`2. card with reversed state 1`] = `
 <View
   style={
     Object {
@@ -101,7 +101,7 @@ exports[`ios 2. card with reversed state 1`] = `
 </View>
 `;
 
-exports[`ios 3. card loading state 1`] = `
+exports[`3. card loading state 1`] = `
 <View
   style={
     Object {
@@ -177,7 +177,7 @@ exports[`ios 3. card loading state 1`] = `
 </View>
 `;
 
-exports[`ios 4. card reversed loading state 1`] = `
+exports[`4. card reversed loading state 1`] = `
 <View
   style={
     Object {

--- a/packages/card/__tests__/ios/__snapshots__/card.ios.test.js.snap
+++ b/packages/card/__tests__/ios/__snapshots__/card.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render the default layout 1`] = `
+exports[`ios 1. card default state 1`] = `
 <View>
   <View>
     <View>
@@ -18,7 +18,7 @@ exports[`1. should render the default layout 1`] = `
 </View>
 `;
 
-exports[`2. should pass an empty state to the image component 1`] = `
+exports[`ios 2. pass an empty state to the image component 1`] = `
 <View>
   <View>
     <View>
@@ -36,7 +36,7 @@ exports[`2. should pass an empty state to the image component 1`] = `
 </View>
 `;
 
-exports[`4. should render without an image when showImage is false 1`] = `
+exports[`ios 3. card without an image when showimage is false 1`] = `
 <View>
   <View>
     <View>
@@ -48,7 +48,7 @@ exports[`4. should render without an image when showImage is false 1`] = `
 </View>
 `;
 
-exports[`5. should pass an empty state to the image component when uri is null 1`] = `
+exports[`ios 4. pass an empty state to the image component when uri is null 1`] = `
 <View>
   <View>
     <View>
@@ -66,7 +66,7 @@ exports[`5. should pass an empty state to the image component when uri is null 1
 </View>
 `;
 
-exports[`6. should render with reversed layout 1`] = `
+exports[`ios 5. card with reversed layout 1`] = `
 <View>
   <View>
     <View>
@@ -84,7 +84,7 @@ exports[`6. should render with reversed layout 1`] = `
 </View>
 `;
 
-exports[`7. should render with reversed layout and no image 1`] = `
+exports[`ios 6. card with reversed layout and no image 1`] = `
 <View>
   <View>
     <View>
@@ -96,7 +96,7 @@ exports[`7. should render with reversed layout and no image 1`] = `
 </View>
 `;
 
-exports[`8. should render a loading state 1`] = `
+exports[`ios 7. card with a loading state 1`] = `
 <View>
   <View>
     <Image
@@ -120,7 +120,7 @@ exports[`8. should render a loading state 1`] = `
 </View>
 `;
 
-exports[`10. should render a loading card with no image 1`] = `
+exports[`ios 8. card with a loading state and no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -139,7 +139,7 @@ exports[`10. should render a loading card with no image 1`] = `
 </View>
 `;
 
-exports[`11. should render a reversed loading component 1`] = `
+exports[`ios 9. card with reversed loading state 1`] = `
 <View>
   <View>
     <Gradient
@@ -163,7 +163,7 @@ exports[`11. should render a reversed loading component 1`] = `
 </View>
 `;
 
-exports[`12. should render a reversed loading component with no image 1`] = `
+exports[`ios 10. card with reversed loading state with no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -182,7 +182,7 @@ exports[`12. should render a reversed loading component with no image 1`] = `
 </View>
 `;
 
-exports[`13. should not re-render when imageRatio prop is changed 1`] = `
+exports[`ios 11. card should not re-render when imageratio prop is changed 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -200,7 +200,7 @@ exports[`13. should not re-render when imageRatio prop is changed 1`] = `
 </FadeIn>
 `;
 
-exports[`13. should not re-render when imageRatio prop is changed 2`] = `
+exports[`ios 11. card should not re-render when imageratio prop is changed 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -218,7 +218,7 @@ exports[`13. should not re-render when imageRatio prop is changed 2`] = `
 </FadeIn>
 `;
 
-exports[`14. should re-render when image uri changes 1`] = `
+exports[`ios 12. card should re-render when image uri changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -236,7 +236,7 @@ exports[`14. should re-render when image uri changes 1`] = `
 </FadeIn>
 `;
 
-exports[`14. should re-render when image uri changes 2`] = `
+exports[`ios 12. card should re-render when image uri changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -254,7 +254,7 @@ exports[`14. should re-render when image uri changes 2`] = `
 </FadeIn>
 `;
 
-exports[`15. should re-render when image size changes 1`] = `
+exports[`ios 13. card should re-render when image size changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -272,7 +272,7 @@ exports[`15. should re-render when image size changes 1`] = `
 </FadeIn>
 `;
 
-exports[`15. should re-render when image size changes 2`] = `
+exports[`ios 13. card should re-render when image size changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -290,7 +290,7 @@ exports[`15. should re-render when image size changes 2`] = `
 </FadeIn>
 `;
 
-exports[`16. should re-render when loading state changes 1`] = `
+exports[`ios 14. card should re-render when loading state changes 1`] = `
 <Loading
   imageRatio={0.6666666666666666}
   isReversed={false}
@@ -298,7 +298,7 @@ exports[`16. should re-render when loading state changes 1`] = `
 />
 `;
 
-exports[`16. should re-render when loading state changes 2`] = `
+exports[`ios 14. card should re-render when loading state changes 2`] = `
 <FadeIn>
   <View>
     <View>

--- a/packages/card/__tests__/ios/__snapshots__/card.ios.test.js.snap
+++ b/packages/card/__tests__/ios/__snapshots__/card.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. card default state 1`] = `
+exports[`1. card default state 1`] = `
 <View>
   <View>
     <View>
@@ -18,7 +18,7 @@ exports[`ios 1. card default state 1`] = `
 </View>
 `;
 
-exports[`ios 2. pass an empty state to the image component 1`] = `
+exports[`2. pass an empty state to the image component 1`] = `
 <View>
   <View>
     <View>
@@ -36,7 +36,7 @@ exports[`ios 2. pass an empty state to the image component 1`] = `
 </View>
 `;
 
-exports[`ios 3. card without an image when showimage is false 1`] = `
+exports[`3. card without an image when showimage is false 1`] = `
 <View>
   <View>
     <View>
@@ -48,7 +48,7 @@ exports[`ios 3. card without an image when showimage is false 1`] = `
 </View>
 `;
 
-exports[`ios 4. pass an empty state to the image component when uri is null 1`] = `
+exports[`4. pass an empty state to the image component when uri is null 1`] = `
 <View>
   <View>
     <View>
@@ -66,7 +66,7 @@ exports[`ios 4. pass an empty state to the image component when uri is null 1`] 
 </View>
 `;
 
-exports[`ios 5. card with reversed layout 1`] = `
+exports[`5. card with reversed layout 1`] = `
 <View>
   <View>
     <View>
@@ -84,7 +84,7 @@ exports[`ios 5. card with reversed layout 1`] = `
 </View>
 `;
 
-exports[`ios 6. card with reversed layout and no image 1`] = `
+exports[`6. card with reversed layout and no image 1`] = `
 <View>
   <View>
     <View>
@@ -96,7 +96,7 @@ exports[`ios 6. card with reversed layout and no image 1`] = `
 </View>
 `;
 
-exports[`ios 7. card with a loading state 1`] = `
+exports[`7. card with a loading state 1`] = `
 <View>
   <View>
     <Image
@@ -120,7 +120,7 @@ exports[`ios 7. card with a loading state 1`] = `
 </View>
 `;
 
-exports[`ios 8. card with a loading state and no image 1`] = `
+exports[`8. card with a loading state and no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -139,7 +139,7 @@ exports[`ios 8. card with a loading state and no image 1`] = `
 </View>
 `;
 
-exports[`ios 9. card with reversed loading state 1`] = `
+exports[`9. card with reversed loading state 1`] = `
 <View>
   <View>
     <Gradient
@@ -163,7 +163,7 @@ exports[`ios 9. card with reversed loading state 1`] = `
 </View>
 `;
 
-exports[`ios 10. card with reversed loading state with no image 1`] = `
+exports[`10. card with reversed loading state with no image 1`] = `
 <View>
   <View>
     <Gradient
@@ -182,7 +182,7 @@ exports[`ios 10. card with reversed loading state with no image 1`] = `
 </View>
 `;
 
-exports[`ios 11. card should not re-render when imageratio prop is changed 1`] = `
+exports[`11. card should not re-render when imageratio prop is changed 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -200,7 +200,7 @@ exports[`ios 11. card should not re-render when imageratio prop is changed 1`] =
 </FadeIn>
 `;
 
-exports[`ios 11. card should not re-render when imageratio prop is changed 2`] = `
+exports[`11. card should not re-render when imageratio prop is changed 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -218,7 +218,7 @@ exports[`ios 11. card should not re-render when imageratio prop is changed 2`] =
 </FadeIn>
 `;
 
-exports[`ios 12. card should re-render when image uri changes 1`] = `
+exports[`12. card should re-render when image uri changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -236,7 +236,7 @@ exports[`ios 12. card should re-render when image uri changes 1`] = `
 </FadeIn>
 `;
 
-exports[`ios 12. card should re-render when image uri changes 2`] = `
+exports[`12. card should re-render when image uri changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -254,7 +254,7 @@ exports[`ios 12. card should re-render when image uri changes 2`] = `
 </FadeIn>
 `;
 
-exports[`ios 13. card should re-render when image size changes 1`] = `
+exports[`13. card should re-render when image size changes 1`] = `
 <FadeIn>
   <View>
     <View>
@@ -272,7 +272,7 @@ exports[`ios 13. card should re-render when image size changes 1`] = `
 </FadeIn>
 `;
 
-exports[`ios 13. card should re-render when image size changes 2`] = `
+exports[`13. card should re-render when image size changes 2`] = `
 <FadeIn>
   <View>
     <View>
@@ -290,7 +290,7 @@ exports[`ios 13. card should re-render when image size changes 2`] = `
 </FadeIn>
 `;
 
-exports[`ios 14. card should re-render when loading state changes 1`] = `
+exports[`14. card should re-render when loading state changes 1`] = `
 <Loading
   imageRatio={0.6666666666666666}
   isReversed={false}
@@ -298,7 +298,7 @@ exports[`ios 14. card should re-render when loading state changes 1`] = `
 />
 `;
 
-exports[`ios 14. card should re-render when loading state changes 2`] = `
+exports[`14. card should re-render when loading state changes 2`] = `
 <FadeIn>
   <View>
     <View>

--- a/packages/card/__tests__/ios/card-with-style.ios.test.js
+++ b/packages/card/__tests__/ios/card-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/card/__tests__/ios/card.ios.test.js
+++ b/packages/card/__tests__/ios/card.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/card/__tests__/shared-with-style.base.js
+++ b/packages/card/__tests__/shared-with-style.base.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
+import { iterator } from "@times-components/test-utils";
 import Card from "../src/card";
 
 const props = {
@@ -14,51 +15,62 @@ const props = {
 export default renderMethod => {
   jest.useFakeTimers();
 
-  it("should render the default layout", () => {
-    const output = renderMethod(
-      <Card {...props}>
-        <Text>A card</Text>
-      </Card>
-    );
+  const tests = [
+    {
+      name: "card default state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props}>
+            <Text>A card</Text>
+          </Card>
+        );
 
-    jest.runTimersToTime();
+        jest.runTimersToTime();
 
-    expect(output).toMatchSnapshot("1. should render the default layout");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with reversed state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isReversed>
+            <Text>A card in reverse</Text>
+          </Card>
+        );
 
-  it("should render with reversed layout", () => {
-    const output = renderMethod(
-      <Card {...props} isReversed>
-        <Text>A card in reverse</Text>
-      </Card>
-    );
+        jest.runTimersToTime();
 
-    jest.runTimersToTime();
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card loading state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isLoading>
+            <Text>Loading state</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot("2. should render with reversed layout");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card reversed loading state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isLoading isReversed>
+            <Text>Loading in reverse</Text>
+          </Card>
+        );
 
-  it("should render a loading state", () => {
-    const output = renderMethod(
-      <Card {...props} isLoading>
-        <Text>Loading state</Text>
-      </Card>
-    );
+        jest.runTimersToTime();
 
-    expect(output).toMatchSnapshot("3. should render a loading state");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    }
+  ];
 
-  it("should render a reversed loading component", () => {
-    const output = renderMethod(
-      <Card {...props} isLoading isReversed>
-        <Text>Loading in reverse</Text>
-      </Card>
-    );
-
-    jest.runTimersToTime();
-
-    expect(output).toMatchSnapshot(
-      "4. should render a reversed loading component"
-    );
-  });
+  iterator(tests);
 };

--- a/packages/card/__tests__/shared.base.js
+++ b/packages/card/__tests__/shared.base.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import Card from "../src/card";
 
 const props = {
@@ -16,197 +17,200 @@ export default renderMethod => {
   // magic to stop the React Native Animated library from dying, as each test kicks off another animation that uses timing
   jest.useFakeTimers();
 
-  it("should render the default layout", () => {
-    const output = renderMethod(
-      <Card {...props}>
-        <Text>A card</Text>
-      </Card>
-    );
+  const tests = [
+    {
+      name: "card default state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props}>
+            <Text>A card</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot("1. should render the default layout");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "pass an empty state to the image component",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} image={null}>
+            <Text>A card with an empty image</Text>
+          </Card>
+        );
 
-  it("should pass an empty state to the image component", () => {
-    const output = renderMethod(
-      <Card {...props} image={null}>
-        <Text>A card with an empty image</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card without an image when showImage is false",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} showImage={false}>
+            <Text>No image</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot(
-      "2. should pass an empty state to the image component"
-    );
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "pass an empty state to the image component when uri is null",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} image={{ uri: null }}>
+            <Text>No URI</Text>
+          </Card>
+        );
 
-  it("should render without an image when showImage is false", () => {
-    const output = renderMethod(
-      <Card {...props} showImage={false}>
-        <Text>No image</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with reversed layout",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isReversed>
+            <Text>A card in reverse</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot(
-      "4. should render without an image when showImage is false"
-    );
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with reversed layout and no image",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isReversed showImage={false}>
+            <Text>A card in reverse with no image</Text>
+          </Card>
+        );
 
-  it("should pass an empty state to the image component when uri is null", () => {
-    const output = renderMethod(
-      <Card {...props} image={{ uri: null }}>
-        <Text>No URI</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with a loading state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isLoading>
+            <Text>Loading state</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot(
-      "5. should pass an empty state to the image component when uri is null"
-    );
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with a loading state and no image",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isLoading showImage={false}>
+            <Text>Loading with no image</Text>
+          </Card>
+        );
 
-  it("should render with reversed layout", () => {
-    const output = renderMethod(
-      <Card {...props} isReversed>
-        <Text>A card in reverse</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with reversed loading state",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isLoading isReversed>
+            <Text>Loading in reverse</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot("6. should render with reversed layout");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card with reversed loading state with no image",
+      test: () => {
+        const output = renderMethod(
+          <Card {...props} isLoading isReversed showImage={false}>
+            <Text>Loading in reverse with no image</Text>
+          </Card>
+        );
 
-  it("should render with reversed layout and no image", () => {
-    const output = renderMethod(
-      <Card {...props} isReversed showImage={false}>
-        <Text>A card in reverse with no image</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card should not re-render when imageRatio prop is changed",
+      test: () => {
+        const output = shallow(
+          <Card {...props}>
+            <Text>Do not re-render me</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot(
-      "7. should render with reversed layout and no image"
-    );
-  });
+        expect(output).toMatchSnapshot();
 
-  it("should render a loading state", () => {
-    const output = renderMethod(
-      <Card {...props} isLoading>
-        <Text>Loading state</Text>
-      </Card>
-    );
+        output.setProps({
+          imageRatio: 16 / 9
+        });
 
-    expect(output).toMatchSnapshot("8. should render a loading state");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card should re-render when image uri changes",
+      test: () => {
+        const output = shallow(
+          <Card {...props}>
+            <Text>Some text</Text>
+          </Card>
+        );
 
-  it("should render a loading card with no image", () => {
-    const output = renderMethod(
-      <Card {...props} isLoading showImage={false}>
-        <Text>Loading with no image</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
 
-    expect(output).toMatchSnapshot(
-      "10. should render a loading card with no image"
-    );
-  });
+        output.setProps({
+          image: { uri: "http://foo" }
+        });
 
-  it("should render a reversed loading component", () => {
-    const output = renderMethod(
-      <Card {...props} isLoading isReversed>
-        <Text>Loading in reverse</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card should re-render when image size changes",
+      test: () => {
+        const output = shallow(
+          <Card {...props}>
+            <Text>Some content</Text>
+          </Card>
+        );
 
-    expect(output).toMatchSnapshot(
-      "11. should render a reversed loading component"
-    );
-  });
+        expect(output).toMatchSnapshot();
 
-  it("should render a reversed loading component with no image", () => {
-    const output = renderMethod(
-      <Card {...props} isLoading isReversed showImage={false}>
-        <Text>Loading in reverse with no image</Text>
-      </Card>
-    );
+        output.setProps({
+          imageSize: null
+        });
 
-    expect(output).toMatchSnapshot(
-      "12. should render a reversed loading component with no image"
-    );
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "card should re-render when loading state changes",
+      test: () => {
+        const output = shallow(
+          <Card {...props} isLoading>
+            <Text>Re-render me</Text>
+          </Card>
+        );
 
-  it("should not re-render when imageRatio prop is changed", () => {
-    const output = shallow(
-      <Card {...props}>
-        <Text>Do not re-render me</Text>
-      </Card>
-    );
+        expect(output).toMatchSnapshot();
 
-    expect(output).toMatchSnapshot(
-      "13. should not re-render when imageRatio prop is changed"
-    );
+        output.setProps({
+          isLoading: false
+        });
 
-    output.setProps({
-      imageRatio: 16 / 9
-    });
+        expect(output).toMatchSnapshot();
+      }
+    }
+  ];
 
-    expect(output).toMatchSnapshot(
-      "13. should not re-render when imageRatio prop is changed"
-    );
-  });
-
-  it("should re-render when image uri changes", () => {
-    const output = shallow(
-      <Card {...props}>
-        <Text>Some text</Text>
-      </Card>
-    );
-
-    expect(output).toMatchSnapshot(
-      "14. should re-render when image uri changes"
-    );
-
-    output.setProps({
-      image: { uri: "http://foo" }
-    });
-
-    expect(output).toMatchSnapshot(
-      "14. should re-render when image uri changes"
-    );
-  });
-
-  it("should re-render when image size changes", () => {
-    const output = shallow(
-      <Card {...props}>
-        <Text>Some content</Text>
-      </Card>
-    );
-
-    expect(output).toMatchSnapshot(
-      "15. should re-render when image size changes"
-    );
-
-    output.setProps({
-      imageSize: null
-    });
-
-    expect(output).toMatchSnapshot(
-      "15. should re-render when image size changes"
-    );
-  });
-
-  it("should re-render when loading state changes", () => {
-    const output = shallow(
-      <Card {...props} isLoading>
-        <Text>Re-render me</Text>
-      </Card>
-    );
-
-    expect(output).toMatchSnapshot(
-      "16. should re-render when loading state changes"
-    );
-
-    output.setProps({
-      isLoading: false
-    });
-
-    expect(output).toMatchSnapshot(
-      "16. should re-render when loading state changes"
-    );
-  });
+  iterator(tests);
 };

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render a loading state 1`] = `
+exports[`1. card loading state 1`] = `
 <style>
 {
   "IS1": {
@@ -269,7 +269,7 @@ exports[`1. should render a loading state 1`] = `
 </div>
 `;
 
-exports[`2. should render a reversed loading component 1`] = `
+exports[`2. card with reversed loading state 1`] = `
 <style>
 {
   "IS1": {

--- a/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render the default layout 1`] = `
+exports[`card with default layout 1`] = `
 .c0 {
   -webkit-animation: eMLfYp 0.3s ease-in-out;
   animation: eMLfYp 0.3s ease-in-out;

--- a/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render with reversed layout 1`] = `
+exports[`card with reversed layout 1`] = `
 .c0 {
   -webkit-animation: eMLfYp 0.3s ease-in-out;
   animation: eMLfYp 0.3s ease-in-out;

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. card default state 1`] = `
+exports[`1. card default state 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -20,7 +20,7 @@ exports[`web 1. card default state 1`] = `
 </FadeIn>
 `;
 
-exports[`web 2. pass an empty state to the image component 1`] = `
+exports[`2. pass an empty state to the image component 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -40,7 +40,7 @@ exports[`web 2. pass an empty state to the image component 1`] = `
 </FadeIn>
 `;
 
-exports[`web 3. card without an image when showimage is false 1`] = `
+exports[`3. card without an image when showimage is false 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -54,7 +54,7 @@ exports[`web 3. card without an image when showimage is false 1`] = `
 </FadeIn>
 `;
 
-exports[`web 4. pass an empty state to the image component when uri is null 1`] = `
+exports[`4. pass an empty state to the image component when uri is null 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -74,7 +74,7 @@ exports[`web 4. pass an empty state to the image component when uri is null 1`] 
 </FadeIn>
 `;
 
-exports[`web 5. card with reversed layout 1`] = `
+exports[`5. card with reversed layout 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -94,7 +94,7 @@ exports[`web 5. card with reversed layout 1`] = `
 </FadeIn>
 `;
 
-exports[`web 6. card with reversed layout and no image 1`] = `
+exports[`6. card with reversed layout and no image 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -108,7 +108,7 @@ exports[`web 6. card with reversed layout and no image 1`] = `
 </FadeIn>
 `;
 
-exports[`web 7. card with a loading state 1`] = `
+exports[`7. card with a loading state 1`] = `
 <div>
   <div>
     <TimesImage
@@ -133,7 +133,7 @@ exports[`web 7. card with a loading state 1`] = `
 </div>
 `;
 
-exports[`web 8. card with a loading state and no image 1`] = `
+exports[`8. card with a loading state and no image 1`] = `
 <div>
   <div>
     <Gradient
@@ -152,7 +152,7 @@ exports[`web 8. card with a loading state and no image 1`] = `
 </div>
 `;
 
-exports[`web 9. card with reversed loading state 1`] = `
+exports[`9. card with reversed loading state 1`] = `
 <div>
   <div>
     <Gradient
@@ -177,7 +177,7 @@ exports[`web 9. card with reversed loading state 1`] = `
 </div>
 `;
 
-exports[`web 10. card with reversed loading state with no image 1`] = `
+exports[`10. card with reversed loading state with no image 1`] = `
 <div>
   <div>
     <Gradient
@@ -196,7 +196,7 @@ exports[`web 10. card with reversed loading state with no image 1`] = `
 </div>
 `;
 
-exports[`web 11. card should not re-render when imageratio prop is changed 1`] = `
+exports[`11. card should not re-render when imageratio prop is changed 1`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -206,7 +206,7 @@ exports[`web 11. card should not re-render when imageratio prop is changed 1`] =
 </FadeIn>
 `;
 
-exports[`web 11. card should not re-render when imageratio prop is changed 2`] = `
+exports[`11. card should not re-render when imageratio prop is changed 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -216,7 +216,7 @@ exports[`web 11. card should not re-render when imageratio prop is changed 2`] =
 </FadeIn>
 `;
 
-exports[`web 12. card should re-render when image uri changes 1`] = `
+exports[`12. card should re-render when image uri changes 1`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -226,7 +226,7 @@ exports[`web 12. card should re-render when image uri changes 1`] = `
 </FadeIn>
 `;
 
-exports[`web 12. card should re-render when image uri changes 2`] = `
+exports[`12. card should re-render when image uri changes 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -236,7 +236,7 @@ exports[`web 12. card should re-render when image uri changes 2`] = `
 </FadeIn>
 `;
 
-exports[`web 13. card should re-render when image size changes 1`] = `
+exports[`13. card should re-render when image size changes 1`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -246,7 +246,7 @@ exports[`web 13. card should re-render when image size changes 1`] = `
 </FadeIn>
 `;
 
-exports[`web 13. card should re-render when image size changes 2`] = `
+exports[`13. card should re-render when image size changes 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -256,9 +256,9 @@ exports[`web 13. card should re-render when image size changes 2`] = `
 </FadeIn>
 `;
 
-exports[`web 14. card should re-render when loading state changes 1`] = `Array []`;
+exports[`14. card should re-render when loading state changes 1`] = `Array []`;
 
-exports[`web 14. card should re-render when loading state changes 2`] = `
+exports[`14. card should re-render when loading state changes 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render the default layout 1`] = `
+exports[`web 1. card default state 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -20,7 +20,7 @@ exports[`1. should render the default layout 1`] = `
 </FadeIn>
 `;
 
-exports[`2. should pass an empty state to the image component 1`] = `
+exports[`web 2. pass an empty state to the image component 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -40,7 +40,7 @@ exports[`2. should pass an empty state to the image component 1`] = `
 </FadeIn>
 `;
 
-exports[`4. should render without an image when showImage is false 1`] = `
+exports[`web 3. card without an image when showimage is false 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -54,7 +54,7 @@ exports[`4. should render without an image when showImage is false 1`] = `
 </FadeIn>
 `;
 
-exports[`5. should pass an empty state to the image component when uri is null 1`] = `
+exports[`web 4. pass an empty state to the image component when uri is null 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -74,7 +74,7 @@ exports[`5. should pass an empty state to the image component when uri is null 1
 </FadeIn>
 `;
 
-exports[`6. should render with reversed layout 1`] = `
+exports[`web 5. card with reversed layout 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -94,7 +94,7 @@ exports[`6. should render with reversed layout 1`] = `
 </FadeIn>
 `;
 
-exports[`7. should render with reversed layout and no image 1`] = `
+exports[`web 6. card with reversed layout and no image 1`] = `
 <FadeIn>
   <div>
     <div>
@@ -108,7 +108,7 @@ exports[`7. should render with reversed layout and no image 1`] = `
 </FadeIn>
 `;
 
-exports[`8. should render a loading state 1`] = `
+exports[`web 7. card with a loading state 1`] = `
 <div>
   <div>
     <TimesImage
@@ -133,7 +133,7 @@ exports[`8. should render a loading state 1`] = `
 </div>
 `;
 
-exports[`10. should render a loading card with no image 1`] = `
+exports[`web 8. card with a loading state and no image 1`] = `
 <div>
   <div>
     <Gradient
@@ -152,7 +152,7 @@ exports[`10. should render a loading card with no image 1`] = `
 </div>
 `;
 
-exports[`11. should render a reversed loading component 1`] = `
+exports[`web 9. card with reversed loading state 1`] = `
 <div>
   <div>
     <Gradient
@@ -177,7 +177,7 @@ exports[`11. should render a reversed loading component 1`] = `
 </div>
 `;
 
-exports[`12. should render a reversed loading component with no image 1`] = `
+exports[`web 10. card with reversed loading state with no image 1`] = `
 <div>
   <div>
     <Gradient
@@ -196,7 +196,7 @@ exports[`12. should render a reversed loading component with no image 1`] = `
 </div>
 `;
 
-exports[`13. should not re-render when imageRatio prop is changed 1`] = `
+exports[`web 11. card should not re-render when imageratio prop is changed 1`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -206,7 +206,7 @@ exports[`13. should not re-render when imageRatio prop is changed 1`] = `
 </FadeIn>
 `;
 
-exports[`13. should not re-render when imageRatio prop is changed 2`] = `
+exports[`web 11. card should not re-render when imageratio prop is changed 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -216,7 +216,7 @@ exports[`13. should not re-render when imageRatio prop is changed 2`] = `
 </FadeIn>
 `;
 
-exports[`14. should re-render when image uri changes 1`] = `
+exports[`web 12. card should re-render when image uri changes 1`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -226,7 +226,7 @@ exports[`14. should re-render when image uri changes 1`] = `
 </FadeIn>
 `;
 
-exports[`14. should re-render when image uri changes 2`] = `
+exports[`web 12. card should re-render when image uri changes 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -236,7 +236,7 @@ exports[`14. should re-render when image uri changes 2`] = `
 </FadeIn>
 `;
 
-exports[`15. should re-render when image size changes 1`] = `
+exports[`web 13. card should re-render when image size changes 1`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -246,7 +246,7 @@ exports[`15. should re-render when image size changes 1`] = `
 </FadeIn>
 `;
 
-exports[`15. should re-render when image size changes 2`] = `
+exports[`web 13. card should re-render when image size changes 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}
@@ -256,9 +256,9 @@ exports[`15. should re-render when image size changes 2`] = `
 </FadeIn>
 `;
 
-exports[`16. should re-render when loading state changes 1`] = `Array []`;
+exports[`web 14. card should re-render when loading state changes 1`] = `Array []`;
 
-exports[`16. should re-render when loading state changes 2`] = `
+exports[`web 14. card should re-render when loading state changes 2`] = `
 <FadeIn>
   <TimesImage
     aspectRatio={0.6666666666666666}

--- a/packages/card/__tests__/web/card-loading-style.test.js
+++ b/packages/card/__tests__/web/card-loading-style.test.js
@@ -22,19 +22,19 @@ const tests = [
   {
     name: "card loading state",
     test: () => {
-      const output = mount(
+      const wrapper = mount(
         <Card {...props} isLoading>
           <Text>Loading state</Text>
         </Card>
       );
 
-      expect(output).toMatchSnapshot();
+      expect(wrapper).toMatchSnapshot();
     }
   },
   {
     name: "card with reversed loading state",
     test: () => {
-      const output = mount(
+      const wrapper = mount(
         <Card {...props} isLoading isReversed>
           <Text>Loading in reverse</Text>
         </Card>
@@ -42,7 +42,7 @@ const tests = [
 
       jest.runTimersToTime();
 
-      expect(output).toMatchSnapshot();
+      expect(wrapper).toMatchSnapshot();
     }
   }
 ];

--- a/packages/card/__tests__/web/card-loading-style.test.js
+++ b/packages/card/__tests__/web/card-loading-style.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { mount } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import serializers from "./serializers";
 import Card from "../../src/card";
 
@@ -13,32 +14,37 @@ const props = {
   showImage: true
 };
 
-describe("web", () => {
-  jest.useFakeTimers();
+jest.useFakeTimers();
 
-  serializers();
+serializers();
 
-  it("should render a loading state", () => {
-    const output = mount(
-      <Card {...props} isLoading>
-        <Text>Loading state</Text>
-      </Card>
-    );
+const tests = [
+  {
+    name: "card loading state",
+    test: () => {
+      const output = mount(
+        <Card {...props} isLoading>
+          <Text>Loading state</Text>
+        </Card>
+      );
 
-    expect(output).toMatchSnapshot("1. should render a loading state");
-  });
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
+    name: "card with reversed loading state",
+    test: () => {
+      const output = mount(
+        <Card {...props} isLoading isReversed>
+          <Text>Loading in reverse</Text>
+        </Card>
+      );
 
-  it("should render a reversed loading component", () => {
-    const output = mount(
-      <Card {...props} isLoading isReversed>
-        <Text>Loading in reverse</Text>
-      </Card>
-    );
+      jest.runTimersToTime();
 
-    jest.runTimersToTime();
+      expect(output).toMatchSnapshot();
+    }
+  }
+];
 
-    expect(output).toMatchSnapshot(
-      "2. should render a reversed loading component"
-    );
-  });
-});
+iterator(tests);

--- a/packages/card/__tests__/web/card-render-style.test.js
+++ b/packages/card/__tests__/web/card-render-style.test.js
@@ -13,20 +13,18 @@ const props = {
   showImage: true
 };
 
-describe("web", () => {
-  jest.useFakeTimers();
+jest.useFakeTimers();
 
-  serializers();
+serializers();
 
-  it("should render the default layout", () => {
-    const output = mount(
-      <Card {...props}>
-        <Text>A card</Text>
-      </Card>
-    );
+it("card with default layout", () => {
+  const output = mount(
+    <Card {...props}>
+      <Text>A card</Text>
+    </Card>
+  );
 
-    jest.runTimersToTime();
+  jest.runTimersToTime();
 
-    expect(output).toMatchSnapshot("1. should render the default layout");
-  });
+  expect(output).toMatchSnapshot();
 });

--- a/packages/card/__tests__/web/card-render-style.test.js
+++ b/packages/card/__tests__/web/card-render-style.test.js
@@ -18,7 +18,7 @@ jest.useFakeTimers();
 serializers();
 
 it("card with default layout", () => {
-  const output = mount(
+  const wrapper = mount(
     <Card {...props}>
       <Text>A card</Text>
     </Card>
@@ -26,5 +26,5 @@ it("card with default layout", () => {
 
   jest.runTimersToTime();
 
-  expect(output).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/card/__tests__/web/card-reverse-style.test.js
+++ b/packages/card/__tests__/web/card-reverse-style.test.js
@@ -18,7 +18,7 @@ jest.useFakeTimers();
 serializers();
 
 it("card with reversed layout", () => {
-  const output = mount(
+  const wrapper = mount(
     <Card {...props} isReversed>
       <Text>A card in reverse</Text>
     </Card>
@@ -26,5 +26,5 @@ it("card with reversed layout", () => {
 
   jest.runTimersToTime();
 
-  expect(output).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/card/__tests__/web/card-reverse-style.test.js
+++ b/packages/card/__tests__/web/card-reverse-style.test.js
@@ -13,20 +13,18 @@ const props = {
   showImage: true
 };
 
-describe("web", () => {
-  jest.useFakeTimers();
+jest.useFakeTimers();
 
-  serializers();
+serializers();
 
-  it("should render with reversed layout", () => {
-    const output = mount(
-      <Card {...props} isReversed>
-        <Text>A card in reverse</Text>
-      </Card>
-    );
+it("card with reversed layout", () => {
+  const output = mount(
+    <Card {...props} isReversed>
+      <Text>A card in reverse</Text>
+    </Card>
+  );
 
-    jest.runTimersToTime();
+  jest.runTimersToTime();
 
-    expect(output).toMatchSnapshot("1. should render with reversed layout");
-  });
+  expect(output).toMatchSnapshot();
 });

--- a/packages/card/__tests__/web/card.web.test.js
+++ b/packages/card/__tests__/web/card.web.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared.web";
 
-describe("web", () => {
-  shared();
-});
+shared();

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -38,7 +38,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -38,6 +38,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-fill.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-fill.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders with no angle 1`] = `
+exports[`android 1. gradient with no angle 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -28,7 +28,7 @@ exports[`1. renders with no angle 1`] = `
 </View>
 `;
 
-exports[`2. renders with an angle (-45) 1`] = `
+exports[`android 2. gradient with an angle (-45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -56,7 +56,7 @@ exports[`2. renders with an angle (-45) 1`] = `
 </View>
 `;
 
-exports[`3. renders with an angle (45) 1`] = `
+exports[`android 3. gradient with an angle (45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -84,7 +84,7 @@ exports[`3. renders with an angle (45) 1`] = `
 </View>
 `;
 
-exports[`4. renders with an angle (90) 1`] = `
+exports[`android 4. gradient with an angle (90) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -112,7 +112,7 @@ exports[`4. renders with an angle (90) 1`] = `
 </View>
 `;
 
-exports[`5. renders with an angle (180) 1`] = `
+exports[`android 5. gradient with an angle (180) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -140,7 +140,7 @@ exports[`5. renders with an angle (180) 1`] = `
 </View>
 `;
 
-exports[`6. renders with an angle (270) 1`] = `
+exports[`android 6. gradient with an angle (270) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-fill.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-fill.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. gradient with no angle 1`] = `
+exports[`1. gradient with no angle 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -28,7 +28,7 @@ exports[`android 1. gradient with no angle 1`] = `
 </View>
 `;
 
-exports[`android 2. gradient with an angle (-45) 1`] = `
+exports[`2. gradient with an angle (-45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -56,7 +56,7 @@ exports[`android 2. gradient with an angle (-45) 1`] = `
 </View>
 `;
 
-exports[`android 3. gradient with an angle (45) 1`] = `
+exports[`3. gradient with an angle (45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -84,7 +84,7 @@ exports[`android 3. gradient with an angle (45) 1`] = `
 </View>
 `;
 
-exports[`android 4. gradient with an angle (90) 1`] = `
+exports[`4. gradient with an angle (90) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -112,7 +112,7 @@ exports[`android 4. gradient with an angle (90) 1`] = `
 </View>
 `;
 
-exports[`android 5. gradient with an angle (180) 1`] = `
+exports[`5. gradient with an angle (180) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -140,7 +140,7 @@ exports[`android 5. gradient with an angle (180) 1`] = `
 </View>
 `;
 
-exports[`android 6. gradient with an angle (270) 1`] = `
+exports[`6. gradient with an angle (270) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-path.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-path.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. gradient 1`] = `
+exports[`1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -35,7 +35,7 @@ exports[`android 1. gradient 1`] = `
 </View>
 `;
 
-exports[`android 2. gradient with a child 1`] = `
+exports[`2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-path.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-path.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders 1`] = `
+exports[`android 1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -35,7 +35,7 @@ exports[`1. renders 1`] = `
 </View>
 `;
 
-exports[`2. renders with a child 1`] = `
+exports[`android 2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-stroke.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-stroke.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. gradient 1`] = `
+exports[`1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -14,7 +14,7 @@ exports[`android 1. gradient 1`] = `
 </View>
 `;
 
-exports[`android 2. gradient with a child 1`] = `
+exports[`2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-stroke.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-stroke.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders 1`] = `
+exports[`android 1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -14,7 +14,7 @@ exports[`1. renders 1`] = `
 </View>
 `;
 
-exports[`2. renders with a child 1`] = `
+exports[`android 2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-with-style.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. gradient using prop styles 1`] = `
+exports[`1. gradient using prop styles 1`] = `
 <View
   style={
     Object {
@@ -28,7 +28,7 @@ exports[`android 1. gradient using prop styles 1`] = `
 </View>
 `;
 
-exports[`android 2. gradient using array prop styles 1`] = `
+exports[`2. gradient using array prop styles 1`] = `
 <View
   style={
     Object {
@@ -56,7 +56,7 @@ exports[`android 2. gradient using array prop styles 1`] = `
 </View>
 `;
 
-exports[`android 3. gradient using stylesheets 1`] = `
+exports[`3. gradient using stylesheets 1`] = `
 <View
   style={
     Object {

--- a/packages/gradient/__tests__/android/__snapshots__/gradient-with-style.android.test.js.snap
+++ b/packages/gradient/__tests__/android/__snapshots__/gradient-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders using prop styles 1`] = `
+exports[`android 1. gradient using prop styles 1`] = `
 <View
   style={
     Object {
@@ -28,7 +28,7 @@ exports[`1. renders using prop styles 1`] = `
 </View>
 `;
 
-exports[`2. renders using array prop styles 1`] = `
+exports[`android 2. gradient using array prop styles 1`] = `
 <View
   style={
     Object {
@@ -56,7 +56,7 @@ exports[`2. renders using array prop styles 1`] = `
 </View>
 `;
 
-exports[`3. renders using stylesheets 1`] = `
+exports[`android 3. gradient using stylesheets 1`] = `
 <View
   style={
     Object {

--- a/packages/gradient/__tests__/android/gradient-fill.android.test.js
+++ b/packages/gradient/__tests__/android/gradient-fill.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-fill.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/android/gradient-path.android.test.js
+++ b/packages/gradient/__tests__/android/gradient-path.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-path.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/android/gradient-stroke.android.test.js
+++ b/packages/gradient/__tests__/android/gradient-stroke.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-stroke.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/android/gradient-with-style.android.test.js
+++ b/packages/gradient/__tests__/android/gradient-with-style.android.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("android", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-fill.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-fill.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. gradient with no angle 1`] = `
+exports[`1. gradient with no angle 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -28,7 +28,7 @@ exports[`ios 1. gradient with no angle 1`] = `
 </View>
 `;
 
-exports[`ios 2. gradient with an angle (-45) 1`] = `
+exports[`2. gradient with an angle (-45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -56,7 +56,7 @@ exports[`ios 2. gradient with an angle (-45) 1`] = `
 </View>
 `;
 
-exports[`ios 3. gradient with an angle (45) 1`] = `
+exports[`3. gradient with an angle (45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -84,7 +84,7 @@ exports[`ios 3. gradient with an angle (45) 1`] = `
 </View>
 `;
 
-exports[`ios 4. gradient with an angle (90) 1`] = `
+exports[`4. gradient with an angle (90) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -112,7 +112,7 @@ exports[`ios 4. gradient with an angle (90) 1`] = `
 </View>
 `;
 
-exports[`ios 5. gradient with an angle (180) 1`] = `
+exports[`5. gradient with an angle (180) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -140,7 +140,7 @@ exports[`ios 5. gradient with an angle (180) 1`] = `
 </View>
 `;
 
-exports[`ios 6. gradient with an angle (270) 1`] = `
+exports[`6. gradient with an angle (270) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-fill.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-fill.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders with no angle 1`] = `
+exports[`ios 1. gradient with no angle 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -28,7 +28,7 @@ exports[`1. renders with no angle 1`] = `
 </View>
 `;
 
-exports[`2. renders with an angle (-45) 1`] = `
+exports[`ios 2. gradient with an angle (-45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -56,7 +56,7 @@ exports[`2. renders with an angle (-45) 1`] = `
 </View>
 `;
 
-exports[`3. renders with an angle (45) 1`] = `
+exports[`ios 3. gradient with an angle (45) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -84,7 +84,7 @@ exports[`3. renders with an angle (45) 1`] = `
 </View>
 `;
 
-exports[`4. renders with an angle (90) 1`] = `
+exports[`ios 4. gradient with an angle (90) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -112,7 +112,7 @@ exports[`4. renders with an angle (90) 1`] = `
 </View>
 `;
 
-exports[`5. renders with an angle (180) 1`] = `
+exports[`ios 5. gradient with an angle (180) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -140,7 +140,7 @@ exports[`5. renders with an angle (180) 1`] = `
 </View>
 `;
 
-exports[`6. renders with an angle (270) 1`] = `
+exports[`ios 6. gradient with an angle (270) 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-path.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-path.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders 1`] = `
+exports[`ios 1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -35,7 +35,7 @@ exports[`1. renders 1`] = `
 </View>
 `;
 
-exports[`2. renders with a child 1`] = `
+exports[`ios 2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-path.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-path.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. gradient 1`] = `
+exports[`1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -35,7 +35,7 @@ exports[`ios 1. gradient 1`] = `
 </View>
 `;
 
-exports[`ios 2. gradient with a child 1`] = `
+exports[`2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-stroke.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-stroke.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders 1`] = `
+exports[`ios 1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -14,7 +14,7 @@ exports[`1. renders 1`] = `
 </View>
 `;
 
-exports[`2. renders with a child 1`] = `
+exports[`ios 2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-stroke.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-stroke.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. gradient 1`] = `
+exports[`1. gradient 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape
@@ -14,7 +14,7 @@ exports[`ios 1. gradient 1`] = `
 </View>
 `;
 
-exports[`ios 2. gradient with a child 1`] = `
+exports[`2. gradient with a child 1`] = `
 <View>
   <ARTSurfaceView>
     <ARTShape

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-with-style.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. gradient using prop styles 1`] = `
+exports[`1. gradient using prop styles 1`] = `
 <View
   style={
     Object {
@@ -28,7 +28,7 @@ exports[`ios 1. gradient using prop styles 1`] = `
 </View>
 `;
 
-exports[`ios 2. gradient using array prop styles 1`] = `
+exports[`2. gradient using array prop styles 1`] = `
 <View
   style={
     Object {
@@ -56,7 +56,7 @@ exports[`ios 2. gradient using array prop styles 1`] = `
 </View>
 `;
 
-exports[`ios 3. gradient using stylesheets 1`] = `
+exports[`3. gradient using stylesheets 1`] = `
 <View
   style={
     Object {

--- a/packages/gradient/__tests__/ios/__snapshots__/gradient-with-style.ios.test.js.snap
+++ b/packages/gradient/__tests__/ios/__snapshots__/gradient-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders using prop styles 1`] = `
+exports[`ios 1. gradient using prop styles 1`] = `
 <View
   style={
     Object {
@@ -28,7 +28,7 @@ exports[`1. renders using prop styles 1`] = `
 </View>
 `;
 
-exports[`2. renders using array prop styles 1`] = `
+exports[`ios 2. gradient using array prop styles 1`] = `
 <View
   style={
     Object {
@@ -56,7 +56,7 @@ exports[`2. renders using array prop styles 1`] = `
 </View>
 `;
 
-exports[`3. renders using stylesheets 1`] = `
+exports[`ios 3. gradient using stylesheets 1`] = `
 <View
   style={
     Object {

--- a/packages/gradient/__tests__/ios/gradient-fill.ios.test.js
+++ b/packages/gradient/__tests__/ios/gradient-fill.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-fill.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/ios/gradient-path.ios.test.js
+++ b/packages/gradient/__tests__/ios/gradient-path.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-path.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/ios/gradient-stroke.ios.test.js
+++ b/packages/gradient/__tests__/ios/gradient-stroke.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-stroke.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/ios/gradient-with-style.ios.test.js
+++ b/packages/gradient/__tests__/ios/gradient-with-style.ios.test.js
@@ -1,5 +1,3 @@
 import shared from "../shared-with-style.native";
 
-describe("ios", () => {
-  shared();
-});
+shared();

--- a/packages/gradient/__tests__/shared-fill.native.js
+++ b/packages/gradient/__tests__/shared-fill.native.js
@@ -7,6 +7,7 @@ import {
   minimalNativeTransform,
   print
 } from "@times-components/jest-serializer";
+import { iterator } from "@times-components/test-utils";
 import Gradient from "../src/gradient";
 
 export default () => {
@@ -19,39 +20,56 @@ export default () => {
     )
   );
 
-  it("renders with no angle", () => {
-    const testInstance = TestRenderer.create(<Gradient />);
+  const tests = [
+    {
+      name: "gradient with no angle",
+      test: () => {
+        const testInstance = TestRenderer.create(<Gradient />);
 
-    expect(testInstance).toMatchSnapshot("1. renders with no angle");
-  });
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient with an angle (-45)",
+      test: () => {
+        const testInstance = TestRenderer.create(<Gradient degrees={-45} />);
 
-  it("renders with an angle (-45)", () => {
-    const testInstance = TestRenderer.create(<Gradient degrees={-45} />);
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient with an angle (45)",
+      test: () => {
+        const testInstance = TestRenderer.create(<Gradient degrees={45} />);
 
-    expect(testInstance).toMatchSnapshot("2. renders with an angle (-45)");
-  });
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient with an angle (90)",
+      test: () => {
+        const testInstance = TestRenderer.create(<Gradient degrees={90} />);
 
-  it("renders with an angle (45)", () => {
-    const testInstance = TestRenderer.create(<Gradient degrees={45} />);
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient with an angle (180)",
+      test: () => {
+        const testInstance = TestRenderer.create(<Gradient degrees={180} />);
 
-    expect(testInstance).toMatchSnapshot("3. renders with an angle (45)");
-  });
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient with an angle (270)",
+      test: () => {
+        const testInstance = TestRenderer.create(<Gradient degrees={270} />);
 
-  it("renders with an angle (90)", () => {
-    const testInstance = TestRenderer.create(<Gradient degrees={90} />);
+        expect(testInstance).toMatchSnapshot();
+      }
+    }
+  ];
 
-    expect(testInstance).toMatchSnapshot("4. renders with an angle (90)");
-  });
-
-  it("renders with an angle (180)", () => {
-    const testInstance = TestRenderer.create(<Gradient degrees={180} />);
-
-    expect(testInstance).toMatchSnapshot("5. renders with an angle (180)");
-  });
-
-  it("renders with an angle (270)", () => {
-    const testInstance = TestRenderer.create(<Gradient degrees={270} />);
-
-    expect(testInstance).toMatchSnapshot("6. renders with an angle (270)");
-  });
+  iterator(tests);
 };

--- a/packages/gradient/__tests__/shared-with-style.native.js
+++ b/packages/gradient/__tests__/shared-with-style.native.js
@@ -9,6 +9,7 @@ import {
   minimalNativeTransform,
   print
 } from "@times-components/jest-serializer";
+import { iterator } from "@times-components/test-utils";
 import Gradient from "../src/gradient";
 
 export default () => {
@@ -22,57 +23,68 @@ export default () => {
     )
   );
 
-  it("renders using prop styles", () => {
-    const testInstance = TestRenderer.create(
-      <Gradient
-        style={{
-          height: 200,
-          width: 200
-        }}
-      />
-    );
+  const tests = [
+    {
+      name: "gradient using prop styles",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Gradient
+            style={{
+              height: 200,
+              width: 200
+            }}
+          />
+        );
 
-    expect(testInstance).toMatchSnapshot("1. renders using prop styles");
-  });
-
-  it("renders using array prop styles", () => {
-    const testInstance = TestRenderer.create(
-      <Gradient
-        style={[
-          {
-            height: 300
-          },
-          {
-            width: 400
-          }
-        ]}
-      />
-    );
-
-    expect(testInstance).toMatchSnapshot("2. renders using array prop styles");
-  });
-
-  it("renders using stylesheets", () => {
-    const styles = StyleSheet.create({
-      container: {
-        margin: 10
+        expect(testInstance).toMatchSnapshot();
       }
-    });
+    },
+    {
+      name: "gradient using array prop styles",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Gradient
+            style={[
+              {
+                height: 300
+              },
+              {
+                width: 400
+              }
+            ]}
+          />
+        );
 
-    const testInstance = TestRenderer.create(
-      <Gradient
-        style={[
-          styles.container,
-          {
-            height: 200
-          },
-          {
-            width: 200
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient using stylesheets",
+      test: () => {
+        const styles = StyleSheet.create({
+          container: {
+            margin: 10
           }
-        ]}
-      />
-    );
+        });
 
-    expect(testInstance).toMatchSnapshot("3. renders using stylesheets");
-  });
+        const testInstance = TestRenderer.create(
+          <Gradient
+            style={[
+              styles.container,
+              {
+                height: 200
+              },
+              {
+                width: 200
+              }
+            ]}
+          />
+        );
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    }
+  ];
+
+  iterator(tests);
 };

--- a/packages/gradient/__tests__/shared.base.js
+++ b/packages/gradient/__tests__/shared.base.js
@@ -1,21 +1,31 @@
 import React from "react";
 import { Text } from "react-native";
+import { iterator } from "@times-components/test-utils";
 import Gradient from "../src/gradient";
 
 export default renderMethod => {
-  it("renders", () => {
-    const output = renderMethod(<Gradient />);
+  const tests = [
+    {
+      name: "gradient",
+      test: () => {
+        const output = renderMethod(<Gradient />);
 
-    expect(output).toMatchSnapshot("1. renders");
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "gradient with a child",
+      test: () => {
+        const output = renderMethod(
+          <Gradient>
+            <Text>Hello world!</Text>
+          </Gradient>
+        );
 
-  it("renders with a child", () => {
-    const output = renderMethod(
-      <Gradient>
-        <Text>Hello world!</Text>
-      </Gradient>
-    );
+        expect(output).toMatchSnapshot();
+      }
+    }
+  ];
 
-    expect(output).toMatchSnapshot("2. renders with a child");
-  });
+  iterator(tests);
 };

--- a/packages/gradient/__tests__/web/__snapshots__/gradient.web.test.js.snap
+++ b/packages/gradient/__tests__/web/__snapshots__/gradient.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. should render with the expected style 1`] = `
+exports[`1. gradient with style 1`] = `
 <style>
 {
   "IS1": {
@@ -17,7 +17,7 @@ exports[`1. should render with the expected style 1`] = `
 />
 `;
 
-exports[`2. should render with a child 1`] = `
+exports[`2. gradient with a child 1`] = `
 <div>
   <div>
     Hello world!

--- a/packages/gradient/__tests__/web/gradient.web.test.js
+++ b/packages/gradient/__tests__/web/gradient.web.test.js
@@ -12,49 +12,57 @@ import {
   rnwTransform,
   stylePrinter
 } from "@times-components/jest-serializer";
+import { iterator } from "@times-components/test-utils";
 import Gradient from "../../src/gradient";
 
-describe("web", () => {
-  addSerializers(
-    expect,
-    enzymeRenderedSerializer(),
-    compose(
-      stylePrinter,
-      hoistStyleTransform,
-      minimalWebTransform,
-      rnwTransform(["backgroundColor"])
-    )
-  );
+addSerializers(
+  expect,
+  enzymeRenderedSerializer(),
+  compose(
+    stylePrinter,
+    hoistStyleTransform,
+    minimalWebTransform,
+    rnwTransform(["backgroundColor"])
+  )
+);
 
-  it("should render with the expected style", () => {
-    const styles = StyleSheet.create({
-      gradient: {
-        backgroundColor: "red"
-      }
-    });
+const tests = [
+  {
+    name: "gradient with style",
+    test: () => {
+      const styles = StyleSheet.create({
+        gradient: {
+          backgroundColor: "red"
+        }
+      });
 
-    expect(
-      mount(<Gradient degrees={30} style={styles.gradient} />)
-    ).toMatchSnapshot("1. should render with the expected style");
-  });
+      expect(
+        mount(<Gradient degrees={30} style={styles.gradient} />)
+      ).toMatchSnapshot();
+    }
+  },
+  {
+    name: "gradient with a child",
+    test: () => {
+      addSerializers(
+        expect,
+        compose(
+          print,
+          minimaliseTransform((value, key) => key === "style"),
+          minimalWebTransform,
+          rnwTransform()
+        )
+      );
 
-  it("should render with a child", () => {
-    addSerializers(
-      expect,
-      compose(
-        print,
-        minimaliseTransform((value, key) => key === "style"),
-        minimalWebTransform,
-        rnwTransform()
-      )
-    );
+      expect(
+        mount(
+          <Gradient>
+            <Text>Hello world!</Text>
+          </Gradient>
+        )
+      ).toMatchSnapshot();
+    }
+  }
+];
 
-    expect(
-      mount(
-        <Gradient>
-          <Text>Hello world!</Text>
-        </Gradient>
-      )
-    ).toMatchSnapshot("2. should render with a child");
-  });
-});
+iterator(tests);

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -50,7 +50,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/video": "3.0.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",

--- a/packages/gradient/package.json
+++ b/packages/gradient/package.json
@@ -50,6 +50,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/video": "3.0.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Renders default layout 1`] = `
+exports[`Image tests on android 1. default layout 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -22,7 +22,29 @@ exports[`1. Renders default layout 1`] = `
 </View>
 `;
 
-exports[`2. Renders default layout without uri 1`] = `
+exports[`Image tests on android 1. prepend https schema 1`] = `
+<View
+  aspectRatio={1.5}
+>
+  <ImageBackground
+    source={
+      Object {
+        "uri": "https://example.com/image.jpg?resize=1440",
+      }
+    }
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <Placeholder />
+  </ImageBackground>
+</View>
+`;
+
+exports[`Image tests on android 2. default layout without uri 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -39,7 +61,7 @@ exports[`2. Renders default layout without uri 1`] = `
 </View>
 `;
 
-exports[`3. Renders with a passed style prop 1`] = `
+exports[`Image tests on android 3. should accept styling prop 1`] = `
 <View
   aspectRatio={1.5}
   style={
@@ -66,7 +88,7 @@ exports[`3. Renders with a passed style prop 1`] = `
 </View>
 `;
 
-exports[`4. Renders a placeholder 1`] = `
+exports[`Image tests on android 4. loading image when width set 1`] = `
 <View
   style={
     Object {
@@ -96,27 +118,5 @@ exports[`4. Renders a placeholder 1`] = `
       />
     </View>
   </Gradient>
-</View>
-`;
-
-exports[`5. Renders with prepended https schema 1`] = `
-<View
-  aspectRatio={1.5}
->
-  <ImageBackground
-    source={
-      Object {
-        "uri": "https://example.com/image.jpg?resize=1440",
-      }
-    }
-    style={
-      Object {
-        "height": "100%",
-        "width": "100%",
-      }
-    }
-  >
-    <Placeholder />
-  </ImageBackground>
 </View>
 `;

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image tests on android 1. default layout 1`] = `
+exports[`1. default layout 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -22,7 +22,7 @@ exports[`Image tests on android 1. default layout 1`] = `
 </View>
 `;
 
-exports[`Image tests on android 1. prepend https schema 1`] = `
+exports[`1. prepend https schema 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -44,7 +44,7 @@ exports[`Image tests on android 1. prepend https schema 1`] = `
 </View>
 `;
 
-exports[`Image tests on android 2. default layout without uri 1`] = `
+exports[`2. default layout without uri 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -61,7 +61,7 @@ exports[`Image tests on android 2. default layout without uri 1`] = `
 </View>
 `;
 
-exports[`Image tests on android 3. should accept styling prop 1`] = `
+exports[`3. should accept styling prop 1`] = `
 <View
   aspectRatio={1.5}
   style={
@@ -88,7 +88,7 @@ exports[`Image tests on android 3. should accept styling prop 1`] = `
 </View>
 `;
 
-exports[`Image tests on android 4. loading image when width set 1`] = `
+exports[`4. loading image when width set 1`] = `
 <View
   style={
     Object {

--- a/packages/image/__tests__/android/image.android.test.js
+++ b/packages/image/__tests__/android/image.android.test.js
@@ -1,7 +1,5 @@
 import shared from "../shared";
 import sharedNative from "../shared-native";
 
-describe("Image tests on android", () => {
-  shared();
-  sharedNative();
-});
+shared();
+sharedNative();

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Renders default layout 1`] = `
+exports[`Image tests on ios 1. default layout 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -22,7 +22,29 @@ exports[`1. Renders default layout 1`] = `
 </View>
 `;
 
-exports[`2. Renders default layout without uri 1`] = `
+exports[`Image tests on ios 1. prepend https schema 1`] = `
+<View
+  aspectRatio={1.5}
+>
+  <ImageBackground
+    source={
+      Object {
+        "uri": "https://example.com/image.jpg?resize=1440",
+      }
+    }
+    style={
+      Object {
+        "height": "100%",
+        "width": "100%",
+      }
+    }
+  >
+    <Placeholder />
+  </ImageBackground>
+</View>
+`;
+
+exports[`Image tests on ios 2. default layout without uri 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -39,7 +61,7 @@ exports[`2. Renders default layout without uri 1`] = `
 </View>
 `;
 
-exports[`3. Renders with a passed style prop 1`] = `
+exports[`Image tests on ios 3. should accept styling prop 1`] = `
 <View
   aspectRatio={1.5}
   style={
@@ -66,7 +88,7 @@ exports[`3. Renders with a passed style prop 1`] = `
 </View>
 `;
 
-exports[`4. Renders a placeholder 1`] = `
+exports[`Image tests on ios 4. loading image when width set 1`] = `
 <View
   style={
     Object {
@@ -96,27 +118,5 @@ exports[`4. Renders a placeholder 1`] = `
       />
     </View>
   </Gradient>
-</View>
-`;
-
-exports[`5. Renders with prepended https schema 1`] = `
-<View
-  aspectRatio={1.5}
->
-  <ImageBackground
-    source={
-      Object {
-        "uri": "https://example.com/image.jpg?resize=1440",
-      }
-    }
-    style={
-      Object {
-        "height": "100%",
-        "width": "100%",
-      }
-    }
-  >
-    <Placeholder />
-  </ImageBackground>
 </View>
 `;

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image tests on ios 1. default layout 1`] = `
+exports[`1. default layout 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -22,7 +22,7 @@ exports[`Image tests on ios 1. default layout 1`] = `
 </View>
 `;
 
-exports[`Image tests on ios 1. prepend https schema 1`] = `
+exports[`1. prepend https schema 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -44,7 +44,7 @@ exports[`Image tests on ios 1. prepend https schema 1`] = `
 </View>
 `;
 
-exports[`Image tests on ios 2. default layout without uri 1`] = `
+exports[`2. default layout without uri 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -61,7 +61,7 @@ exports[`Image tests on ios 2. default layout without uri 1`] = `
 </View>
 `;
 
-exports[`Image tests on ios 3. should accept styling prop 1`] = `
+exports[`3. should accept styling prop 1`] = `
 <View
   aspectRatio={1.5}
   style={
@@ -88,7 +88,7 @@ exports[`Image tests on ios 3. should accept styling prop 1`] = `
 </View>
 `;
 
-exports[`Image tests on ios 4. loading image when width set 1`] = `
+exports[`4. loading image when width set 1`] = `
 <View
   style={
     Object {

--- a/packages/image/__tests__/ios/image.ios.test.js
+++ b/packages/image/__tests__/ios/image.ios.test.js
@@ -1,7 +1,5 @@
 import shared from "../shared";
 import sharedNative from "../shared-native";
 
-describe("Image tests on ios", () => {
-  shared();
-  sharedNative();
-});
+shared();
+sharedNative();

--- a/packages/image/__tests__/shared-native.js
+++ b/packages/image/__tests__/shared-native.js
@@ -1,85 +1,112 @@
-/* global context */
 import React from "react";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import Image, { ModalImage } from "../src";
 
 export default () => {
-  context("Native only", () => {
-    const props = {
-      aspectRatio: 3 / 2,
-      uri: "http://example.com/image.jpg"
-    };
+  const props = {
+    aspectRatio: 3 / 2,
+    uri: "http://example.com/image.jpg"
+  };
 
-    it("should return image url with a correctly formatted query string", () => {
-      const wrapper = shallow(<Image {...props} />);
-      expect(wrapper.find("ImageBackground").props().source.uri).toEqual(
-        "http://example.com/image.jpg?resize=1440"
-      );
-    });
+  const tests = [
+    {
+      name: "prepend https schema",
+      test: () => {
+        const wrapper = shallow(
+          <Image {...props} uri="//example.com/image.jpg" />
+        );
 
-    it("should return a data image url without a query string", () => {
-      const dataUri =
-        "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-      const wrapper = shallow(<Image {...props} uri={dataUri} />);
-      expect(wrapper.find("ImageBackground").props().source.uri).toEqual(
-        dataUri
-      );
-    });
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "image url with a correctly formatted query string",
+      test: () => {
+        const wrapper = shallow(<Image {...props} />);
 
-    it("should handle onPress event on the link", () => {
-      const wrapper = shallow(<ModalImage {...props} />);
-      const imageLink = wrapper
-        .dive()
-        .find("Link")
-        .at(1);
+        expect(wrapper.find("ImageBackground").props().source.uri).toEqual(
+          "http://example.com/image.jpg?resize=1440"
+        );
+      }
+    },
+    {
+      name: "data image url without a query string",
+      test: () => {
+        const dataUri =
+          "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+        const wrapper = shallow(<Image {...props} uri={dataUri} />);
 
-      imageLink.simulate("press");
-      wrapper.update();
+        expect(wrapper.find("ImageBackground").props().source.uri).toEqual(
+          dataUri
+        );
+      }
+    },
+    {
+      name: "handle onPress event on the link",
+      test: () => {
+        const wrapper = shallow(<ModalImage {...props} />);
+        const imageLink = wrapper
+          .dive()
+          .find("Link")
+          .at(1);
 
-      const modal = wrapper.childAt(0);
-      expect(modal.props().visible).toBe(true);
-    });
+        imageLink.simulate("press");
+        wrapper.update();
 
-    it("should handle onPress event on the close button", () => {
-      const wrapper = shallow(<ModalImage {...props} />);
-      wrapper.setState({ showModal: true });
+        const modal = wrapper.childAt(0);
 
-      const closeButton = wrapper
-        .dive()
-        .find("Link")
-        .at(0);
-      closeButton.simulate("press");
-      wrapper.update();
+        expect(modal.props().visible).toBe(true);
+      }
+    },
+    {
+      name: "handle onPress event on the close button",
+      test: () => {
+        const wrapper = shallow(<ModalImage {...props} />);
+        wrapper.setState({ showModal: true });
 
-      const modal = wrapper.childAt(0);
-      expect(modal.props().visible).toBe(false);
-    });
+        const closeButton = wrapper
+          .dive()
+          .find("Link")
+          .at(0);
+        closeButton.simulate("press");
+        wrapper.update();
 
-    it("should show as not loaded when first created", () => {
-      const wrapper = shallow(<Image {...props} />);
-      expect(wrapper.state("isLoaded")).toEqual(false);
-    });
+        const modal = wrapper.childAt(0);
 
-    it("should handle onload event", () => {
-      const wrapper = shallow(<Image {...props} />);
-      wrapper.instance().handleLoad();
-      expect(wrapper.state("isLoaded")).toEqual(true);
-    });
+        expect(modal.props().visible).toBe(false);
+      }
+    },
+    {
+      name: "show as not loaded when first created",
+      test: () => {
+        const wrapper = shallow(<Image {...props} />);
 
-    it("should handle handlePreviewLoad event if it exists", () => {
-      const wrapper = shallow(<Image {...props} />);
-      const { handlePreviewLoad } = wrapper.instance();
-      if (handlePreviewLoad) {
-        handlePreviewLoad();
+        expect(wrapper.state("isLoaded")).toEqual(false);
+      }
+    },
+    {
+      name: "handle onload event",
+      test: () => {
+        const wrapper = shallow(<Image {...props} />);
+        wrapper.instance().handleLoad();
+
         expect(wrapper.state("isLoaded")).toEqual(true);
       }
-    });
+    },
+    {
+      name: "handle handlePreviewLoad event if it exists",
+      test: () => {
+        const wrapper = shallow(<Image {...props} />);
+        const { handlePreviewLoad } = wrapper.instance();
+        if (handlePreviewLoad) {
+          handlePreviewLoad();
 
-    it("should prepend https schema", () => {
-      const wrapper = shallow(
-        <Image {...props} uri="//example.com/image.jpg" />
-      );
-      expect(wrapper).toMatchSnapshot("5. Renders with prepended https schema");
-    });
-  });
+          expect(wrapper.state("isLoaded")).toEqual(true);
+        }
+      }
+    }
+  ];
+
+  iterator(tests);
 };

--- a/packages/image/__tests__/shared.js
+++ b/packages/image/__tests__/shared.js
@@ -1,60 +1,77 @@
-/* global context */
-import "react-native";
 import React from "react";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 import Image from "../src";
 import Placeholder from "../src/placeholder";
 
 jest.mock("@times-components/gradient", () => "Gradient");
 
 export default () => {
-  context("Image", () => {
-    it("should render default layout", () => {
-      const wrapper = shallow(
-        <Image aspectRatio={3 / 2} uri="http://example.com/image.jpg" />
-      );
-      expect(wrapper).toMatchSnapshot("1. Renders default layout");
-    });
+  const tests = [
+    {
+      name: "default layout",
+      test: () => {
+        const wrapper = shallow(
+          <Image aspectRatio={3 / 2} uri="http://example.com/image.jpg" />
+        );
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "default layout without uri",
+      test: () => {
+        const wrapper = shallow(<Image aspectRatio={3 / 2} />);
 
-    it("should render default layout without uri", () => {
-      const wrapper = shallow(<Image aspectRatio={3 / 2} />);
-      expect(wrapper).toMatchSnapshot("2. Renders default layout without uri");
-    });
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "should accept styling prop",
+      test: () => {
+        const wrapper = shallow(
+          <Image
+            aspectRatio={3 / 2}
+            style={{ width: 100 }}
+            uri="http://example.com/image.jpg"
+          />
+        );
 
-    it("should accept styling prop", () => {
-      const wrapper = shallow(
-        <Image
-          aspectRatio={3 / 2}
-          style={{ width: 100 }}
-          uri="http://example.com/image.jpg"
-        />
-      );
-      expect(wrapper).toMatchSnapshot("3. Renders with a passed style prop");
-    });
-  });
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "loading image when width set",
+      test: () => {
+        const wrapper = shallow(<Placeholder />);
+        wrapper.setState({
+          width: 300
+        });
 
-  context("Placeholder", () => {
-    it("should render a loading image when width set", () => {
-      const wrapper = shallow(<Placeholder />);
-      wrapper.setState({
-        width: 300
-      });
+        wrapper.update();
 
-      wrapper.update();
-      expect(wrapper).toMatchSnapshot("4. Renders a placeholder");
-    });
+        expect(wrapper).toMatchSnapshot();
+      }
+    },
+    {
+      name: "empty state when first loaded",
+      test: () => {
+        const wrapper = shallow(<Placeholder />);
 
-    it("should have an empty state when first loaded", () => {
-      const wrapper = shallow(<Placeholder />);
-      expect(wrapper.state()).toEqual({});
-    });
+        expect(wrapper.state()).toEqual({});
+      }
+    },
+    {
+      name: "handle layout width",
+      test: () => {
+        const wrapper = shallow(<Placeholder />);
+        wrapper
+          .instance()
+          .handleLayout({ nativeEvent: { layout: { width: 320 } } });
 
-    it("should handle layout width", () => {
-      const wrapper = shallow(<Placeholder />);
-      wrapper
-        .instance()
-        .handleLayout({ nativeEvent: { layout: { width: 320 } } });
-      expect(wrapper.state()).toEqual({ width: 320 });
-    });
-  });
+        expect(wrapper.state()).toEqual({ width: 320 });
+      }
+    }
+  ];
+
+  iterator(tests);
 };

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Image tests on web 1. default layout 1`] = `
+exports[`1. default layout 1`] = `
 <View>
   <div
     style={
@@ -40,7 +40,7 @@ exports[`Image tests on web 1. default layout 1`] = `
 </View>
 `;
 
-exports[`Image tests on web 2. default layout without uri 1`] = `
+exports[`2. default layout without uri 1`] = `
 <View>
   <div
     style={
@@ -80,7 +80,7 @@ exports[`Image tests on web 2. default layout without uri 1`] = `
 </View>
 `;
 
-exports[`Image tests on web 3. should accept styling prop 1`] = `
+exports[`3. should accept styling prop 1`] = `
 <View
   style={
     Object {
@@ -126,7 +126,7 @@ exports[`Image tests on web 3. should accept styling prop 1`] = `
 </View>
 `;
 
-exports[`Image tests on web 4. loading image when width set 1`] = `
+exports[`4. loading image when width set 1`] = `
 <View
   style={
     Object {
@@ -159,7 +159,7 @@ exports[`Image tests on web 4. loading image when width set 1`] = `
 </View>
 `;
 
-exports[`Image tests on web ModalImage passes through to Image 1`] = `
+exports[`modal props pass through to image 1`] = `
 <View>
   <div
     style={

--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Renders default layout 1`] = `
+exports[`Image tests on web 1. default layout 1`] = `
 <View>
   <div
     style={
@@ -40,7 +40,7 @@ exports[`1. Renders default layout 1`] = `
 </View>
 `;
 
-exports[`2. Renders default layout without uri 1`] = `
+exports[`Image tests on web 2. default layout without uri 1`] = `
 <View>
   <div
     style={
@@ -80,7 +80,7 @@ exports[`2. Renders default layout without uri 1`] = `
 </View>
 `;
 
-exports[`3. Renders with a passed style prop 1`] = `
+exports[`Image tests on web 3. should accept styling prop 1`] = `
 <View
   style={
     Object {
@@ -126,7 +126,7 @@ exports[`3. Renders with a passed style prop 1`] = `
 </View>
 `;
 
-exports[`4. Renders a placeholder 1`] = `
+exports[`Image tests on web 4. loading image when width set 1`] = `
 <View
   style={
     Object {

--- a/packages/image/__tests__/web/image.web.test.js
+++ b/packages/image/__tests__/web/image.web.test.js
@@ -1,18 +1,13 @@
-/* global context */
 import React from "react";
 import { shallow } from "enzyme";
 import ModalImage from "../../src/modal-image";
 import shared from "../shared";
 
-describe("Image tests on web", () => {
-  context("ModalImage", () => {
-    it("passes through to Image", () => {
-      const wrapper = shallow(
-        <ModalImage aspectRatio={3 / 2} uri="http://example.com/image.jpg" />
-      );
-      expect(wrapper).toMatchSnapshot();
-    });
-  });
-
-  shared();
+it("modal props pass through to image", () => {
+  const wrapper = shallow(
+    <ModalImage aspectRatio={3 / 2} uri="http://example.com/image.jpg" />
+  );
+  expect(wrapper).toMatchSnapshot();
 });
+
+shared();

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -39,6 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-configurator": "2.0.1",
     "@times-components/jest-serializer": "2.0.1",
     "@times-components/storybook": "2.0.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/webpack-configurator": "2.0.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/pages/pages.showcase.js
+++ b/packages/pages/pages.showcase.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import "react-native";
 import React from "react";
 import { Article, AuthorProfile, Topic } from "./src/pages";
 

--- a/packages/pages/pages.showcase.web.js
+++ b/packages/pages/pages.showcase.web.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import "react-native";
 import React from "react";
 import { Article } from "./src/pages";
 

--- a/packages/pagination/__tests__/android/__snapshots__/pagination-wrapper.android.test.js.snap
+++ b/packages/pagination/__tests__/android/__snapshots__/pagination-wrapper.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders inner component with page 1 1`] = `
+exports[`android renders inner component with page 1`] = `
 <Text>
   {
   "page": 1

--- a/packages/pagination/__tests__/android/__snapshots__/pagination-wrapper.android.test.js.snap
+++ b/packages/pagination/__tests__/android/__snapshots__/pagination-wrapper.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android 1. inner component with page 1`] = `
+exports[`1. inner component with page 1`] = `
 <Text>
   {
   "page": 1

--- a/packages/pagination/__tests__/android/__snapshots__/pagination-wrapper.android.test.js.snap
+++ b/packages/pagination/__tests__/android/__snapshots__/pagination-wrapper.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`android renders inner component with page 1`] = `
+exports[`android 1. inner component with page 1`] = `
 <Text>
   {
   "page": 1

--- a/packages/pagination/__tests__/android/pagination-wrapper.android.test.js
+++ b/packages/pagination/__tests__/android/pagination-wrapper.android.test.js
@@ -1,6 +1,4 @@
 import shared from "../shared.native";
 import withPageState from "../../src/pagination-wrapper";
 
-describe("android", () => {
-  shared(withPageState);
-});
+shared(withPageState);

--- a/packages/pagination/__tests__/ios/__snapshots__/pagination-wrapper.ios.test.js.snap
+++ b/packages/pagination/__tests__/ios/__snapshots__/pagination-wrapper.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios 1. inner component with page 1`] = `
+exports[`1. inner component with page 1`] = `
 <Text>
   {
   "page": 1

--- a/packages/pagination/__tests__/ios/__snapshots__/pagination-wrapper.ios.test.js.snap
+++ b/packages/pagination/__tests__/ios/__snapshots__/pagination-wrapper.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders inner component with page 1 1`] = `
+exports[`ios renders inner component with page 1`] = `
 <Text>
   {
   "page": 1

--- a/packages/pagination/__tests__/ios/__snapshots__/pagination-wrapper.ios.test.js.snap
+++ b/packages/pagination/__tests__/ios/__snapshots__/pagination-wrapper.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ios renders inner component with page 1`] = `
+exports[`ios 1. inner component with page 1`] = `
 <Text>
   {
   "page": 1

--- a/packages/pagination/__tests__/ios/pagination-wrapper.ios.test.js
+++ b/packages/pagination/__tests__/ios/pagination-wrapper.ios.test.js
@@ -1,6 +1,4 @@
 import shared from "../shared.native";
 import withPageState from "../../src/pagination-wrapper";
 
-describe("ios", () => {
-  shared(withPageState);
-});
+shared(withPageState);

--- a/packages/pagination/__tests__/shared.base.js
+++ b/packages/pagination/__tests__/shared.base.js
@@ -3,7 +3,7 @@ import { Text } from "react-native";
 import { shallow } from "enzyme";
 
 export default (withPageState, renderComponent) => {
-  it("renders inner component with page 1", () => {
+  it("renders inner component with page", () => {
     const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
     const PageChanger = withPageState(Component);
 
@@ -13,7 +13,7 @@ export default (withPageState, renderComponent) => {
 
     const output = renderComponent(<PageChanger {...props} />);
 
-    expect(output).toMatchSnapshot("1. renders inner component with page 1");
+    expect(output).toMatchSnapshot();
   });
 
   it("renders inner component with new props", () => {

--- a/packages/pagination/__tests__/shared.base.js
+++ b/packages/pagination/__tests__/shared.base.js
@@ -1,66 +1,88 @@
 import React from "react";
 import { Text } from "react-native";
 import { shallow } from "enzyme";
+import { iterator } from "@times-components/test-utils";
 
 export default (withPageState, renderComponent) => {
-  it("renders inner component with page", () => {
-    const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
-    const PageChanger = withPageState(Component);
+  const tests = [
+    {
+      name: "inner component with page",
+      test: () => {
+        const Component = props => (
+          <Text>{JSON.stringify(props, null, 2)}</Text>
+        );
+        const PageChanger = withPageState(Component);
 
-    const props = {
-      page: 1
-    };
+        const props = {
+          page: 1
+        };
 
-    const output = renderComponent(<PageChanger {...props} />);
+        const output = renderComponent(<PageChanger {...props} />);
 
-    expect(output).toMatchSnapshot();
-  });
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "inner component with new props",
+      test: () => {
+        const Component = props => (
+          <Text>{JSON.stringify(props, null, 2)}</Text>
+        );
+        const PageChanger = withPageState(Component);
 
-  it("renders inner component with new props", () => {
-    const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
-    const PageChanger = withPageState(Component);
+        const props = {
+          foo: "not bar",
+          page: 1
+        };
 
-    const props = {
-      foo: "not bar",
-      page: 1
-    };
+        const wrapper = shallow(<PageChanger {...props} />);
 
-    const wrapper = shallow(<PageChanger {...props} />);
+        wrapper.setProps({ foo: "bar" });
+        wrapper.update();
 
-    wrapper.setProps({ foo: "bar" });
-    wrapper.update();
+        expect(wrapper.state().foo).toEqual("bar");
+        expect(wrapper.state().page).toEqual(1);
+      }
+    },
+    {
+      name: "inner component with prev page",
+      test: () => {
+        const Component = props => (
+          <Text>{JSON.stringify(props, null, 2)}</Text>
+        );
+        const PageChanger = withPageState(Component);
 
-    expect(wrapper.state().foo).toEqual("bar");
-    expect(wrapper.state().page).toEqual(1);
-  });
+        const props = {
+          page: 2
+        };
 
-  it("renders inner component with prev page", () => {
-    const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
-    const PageChanger = withPageState(Component);
+        const wrapper = shallow(<PageChanger {...props} />);
+        wrapper.instance().handleChangePage({ preventDefault: () => {} }, 1);
+        wrapper.update();
 
-    const props = {
-      page: 2
-    };
+        expect(wrapper.state().page).toEqual(1);
+      }
+    },
+    {
+      name: "inner component with next page",
+      test: () => {
+        const Component = props => (
+          <Text>{JSON.stringify(props, null, 2)}</Text>
+        );
+        const PageChanger = withPageState(Component);
 
-    const wrapper = shallow(<PageChanger {...props} />);
-    wrapper.instance().handleChangePage({ preventDefault: () => {} }, 1);
-    wrapper.update();
+        const props = {
+          page: 2
+        };
 
-    expect(wrapper.state().page).toEqual(1);
-  });
+        const wrapper = shallow(<PageChanger {...props} />);
+        wrapper.instance().handleChangePage({ preventDefault: () => {} }, 3);
+        wrapper.update();
 
-  it("renders inner component with next page", () => {
-    const Component = props => <Text>{JSON.stringify(props, null, 2)}</Text>;
-    const PageChanger = withPageState(Component);
+        expect(wrapper.state().page).toEqual(3);
+      }
+    }
+  ];
 
-    const props = {
-      page: 2
-    };
-
-    const wrapper = shallow(<PageChanger {...props} />);
-    wrapper.instance().handleChangePage({ preventDefault: () => {} }, 3);
-    wrapper.update();
-
-    expect(wrapper.state().page).toEqual(3);
-  });
+  iterator(tests);
 };

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
@@ -319,7 +319,7 @@ exports[`1. renders 1`] = `
 </div>
 `;
 
-exports[`2. renders without results 1`] = `
+exports[`2. renders with no results 1`] = `
 .c2 {
   padding-left: 10px;
   padding-right: 10px;

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web renders inner component with page 1`] = `
+exports[`web 1. inner component with page 1`] = `
 <div>
   {
   "page": 1

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web 1. inner component with page 1`] = `
+exports[`1. inner component with page 1`] = `
 <div>
   {
   "page": 1

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. renders inner component with page 1 1`] = `
+exports[`web renders inner component with page 1`] = `
 <div>
   {
   "page": 1

--- a/packages/pagination/__tests__/web/pagination-with-styles.web.test.js
+++ b/packages/pagination/__tests__/web/pagination-with-styles.web.test.js
@@ -10,61 +10,69 @@ import {
   rnwTransform,
   stylePrinter
 } from "@times-components/jest-serializer";
+import { iterator } from "@times-components/test-utils";
 import Pagination from "../../src/pagination";
 
-describe("web", () => {
-  const styles = [
-    "alignItems",
-    "color",
-    "height",
-    "flexDirection",
-    "fontFamily",
-    "fontSize",
-    "marginRight",
-    "paddingTop",
-    "paddingVertical",
-    "textAlign"
-  ];
+const styles = [
+  "alignItems",
+  "color",
+  "height",
+  "flexDirection",
+  "fontFamily",
+  "fontSize",
+  "marginRight",
+  "paddingTop",
+  "paddingVertical",
+  "textAlign"
+];
 
-  addSerializers(
-    expect,
-    enzymeRenderedSerializer(),
-    compose(
-      stylePrinter,
-      replaceTransform({
-        svg: null
-      }),
-      rnwTransform(styles),
-      minimalWebTransform,
-      hoistStyleTransform
-    )
-  );
+addSerializers(
+  expect,
+  enzymeRenderedSerializer(),
+  compose(
+    stylePrinter,
+    replaceTransform({
+      svg: null
+    }),
+    rnwTransform(styles),
+    minimalWebTransform,
+    hoistStyleTransform
+  )
+);
 
-  // eslint-disable-next-line global-require
-  require("jest-styled-components");
+// eslint-disable-next-line global-require
+require("jest-styled-components");
 
-  it("renders", () => {
-    const props = {
-      count: 21,
-      page: 2,
-      pageSize: 3
-    };
+const tests = [
+  {
+    name: "renders",
+    test: () => {
+      const props = {
+        count: 21,
+        page: 2,
+        pageSize: 3
+      };
 
-    const wrapper = mount(<Pagination {...props} />);
+      const wrapper = mount(<Pagination {...props} />);
 
-    expect(wrapper).toMatchSnapshot("1. renders");
-  });
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
+    name: "renders with no results",
+    test: () => {
+      const props = {
+        count: 0,
+        hideResults: true,
+        page: 0,
+        pageSize: 0
+      };
 
-  it("renders without results", () => {
-    const props = {
-      count: 0,
-      hideResults: true,
-      page: 0,
-      pageSize: 0
-    };
+      const wrapper = mount(<Pagination {...props} />);
 
-    const wrapper = mount(<Pagination {...props} />);
+      expect(wrapper).toMatchSnapshot();
+    }
+  }
+];
 
-    expect(wrapper).toMatchSnapshot("2. renders without results");
-  });
-});
+iterator(tests);

--- a/packages/pagination/__tests__/web/pagination-wrapper.web.test.js
+++ b/packages/pagination/__tests__/web/pagination-wrapper.web.test.js
@@ -1,6 +1,4 @@
 import shared from "../shared.web";
 import withPageState from "../../src/pagination-wrapper";
 
-describe("web", () => {
-  shared(withPageState);
-});
+shared(withPageState);

--- a/packages/pagination/__tests__/web/pagination.web.test.js
+++ b/packages/pagination/__tests__/web/pagination.web.test.js
@@ -10,143 +10,154 @@ import {
   stylePrinter,
   replacePropTransform
 } from "@times-components/jest-serializer";
-import { hash } from "@times-components/test-utils";
+import { hash, iterator } from "@times-components/test-utils";
 import Pagination from "../../src/pagination";
 
-describe("web", () => {
-  addSerializers(
-    expect,
-    enzymeRenderedSerializer(),
-    compose(
-      stylePrinter,
-      rnwTransform(),
-      minimalWebTransform,
-      minimaliseTransform(
-        (value, key) =>
-          key === "style" || key === "className" || key === "data-testid"
-      ),
-      replacePropTransform((value, key) => (key === "d" ? hash(value) : value))
-    )
-  );
+addSerializers(
+  expect,
+  enzymeRenderedSerializer(),
+  compose(
+    stylePrinter,
+    rnwTransform(),
+    minimalWebTransform,
+    minimaliseTransform(
+      (value, key) =>
+        key === "style" || key === "className" || key === "data-testid"
+    ),
+    replacePropTransform((value, key) => (key === "d" ? hash(value) : value))
+  )
+);
 
-  it("renders results, previous and next", () => {
-    const props = {
-      count: 20,
-      page: 5,
-      pageSize: 3
-    };
+const tests = [
+  {
+    name: "renders results, previous and next",
+    test: () => {
+      const props = {
+        count: 20,
+        page: 5,
+        pageSize: 3
+      };
 
-    const wrapper = mount(<Pagination {...props} />);
+      const wrapper = mount(<Pagination {...props} />);
 
-    expect(wrapper).toMatchSnapshot("1. renders results, previous and next");
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
+    name: "renders with no results",
+    test: () => {
+      const props = {
+        count: 20,
+        page: 5,
+        pageSize: 3,
+        hideResults: true
+      };
+
+      const wrapper = mount(<Pagination {...props} />);
+
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
+    name: "does not give a count smaller than a single page",
+    test: () => {
+      const props = {
+        count: 20,
+        page: 1,
+        pageSize: 25
+      };
+
+      const wrapper = mount(<Pagination {...props} />);
+
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
+    name: "limits the starting result to the total count",
+    test: () => {
+      const props = {
+        count: 20,
+        page: 4,
+        pageSize: 10
+      };
+
+      const wrapper = mount(<Pagination {...props} />);
+
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
+    name: "renders previous and not next",
+    test: () => {
+      const props = {
+        count: 20,
+        page: 5,
+        pageSize: 4,
+        hideResults: true
+      };
+
+      const wrapper = mount(<Pagination {...props} />);
+
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
+    name: "renders next and not previous",
+    test: () => {
+      const props = {
+        count: 20,
+        page: 1,
+        pageSize: 4,
+        hideResults: true
+      };
+
+      const wrapper = mount(<Pagination {...props} />);
+
+      expect(wrapper).toMatchSnapshot();
+    }
+  }
+];
+
+iterator(tests);
+
+it("tracks next page interaction", () => {
+  const stream = jest.fn();
+  const wrapper = shallow(<Pagination count={21} page={1} />, {
+    context: { tracking: { analytics: stream } }
   });
 
-  it("renders with no results", () => {
-    const props = {
-      count: 20,
-      page: 5,
-      pageSize: 3,
-      hideResults: true
-    };
+  wrapper
+    .dive()
+    .find("Link")
+    .simulate("press");
 
-    const wrapper = mount(<Pagination {...props} />);
+  expect(stream).toHaveBeenCalledWith({
+    component: "Pagination",
+    action: "Pressed",
+    attrs: {
+      direction: "next",
+      destinationPage: 2
+    }
+  });
+});
 
-    expect(wrapper).toMatchSnapshot("2. renders with no results");
+it("tracks previous page interaction", () => {
+  const stream = jest.fn();
+  const wrapper = shallow(<Pagination count={21} page={2} />, {
+    context: { tracking: { analytics: stream } }
   });
 
-  it("does not give a count smaller than a single page", () => {
-    const props = {
-      count: 20,
-      page: 1,
-      pageSize: 25
-    };
+  wrapper
+    .dive()
+    .find("Link")
+    .simulate("press");
 
-    const wrapper = mount(<Pagination {...props} />);
-
-    expect(wrapper).toMatchSnapshot(
-      "3. does not give a count smaller than a single page"
-    );
-  });
-
-  it("limits the starting result to the total count", () => {
-    const props = {
-      count: 20,
-      page: 4,
-      pageSize: 10
-    };
-
-    const wrapper = mount(<Pagination {...props} />);
-
-    expect(wrapper).toMatchSnapshot(
-      "4. limits the starting result to the total count"
-    );
-  });
-
-  it("renders previous and not next", () => {
-    const props = {
-      count: 20,
-      page: 5,
-      pageSize: 4,
-      hideResults: true
-    };
-
-    const wrapper = mount(<Pagination {...props} />);
-
-    expect(wrapper).toMatchSnapshot("5. renders previous and not next");
-  });
-
-  it("renders next and not previous", () => {
-    const props = {
-      count: 20,
-      page: 1,
-      pageSize: 4,
-      hideResults: true
-    };
-
-    const wrapper = mount(<Pagination {...props} />);
-
-    expect(wrapper).toMatchSnapshot("6. renders next and not previous");
-  });
-
-  it("tracks next page interaction", () => {
-    const stream = jest.fn();
-    const wrapper = shallow(<Pagination count={21} page={1} />, {
-      context: { tracking: { analytics: stream } }
-    });
-
-    wrapper
-      .dive()
-      .find("Link")
-      .simulate("press");
-
-    expect(stream).toHaveBeenCalledWith({
-      component: "Pagination",
-      action: "Pressed",
-      attrs: {
-        direction: "next",
-        destinationPage: 2
-      }
-    });
-  });
-
-  it("tracks previous page interaction", () => {
-    const stream = jest.fn();
-    const wrapper = shallow(<Pagination count={21} page={2} />, {
-      context: { tracking: { analytics: stream } }
-    });
-
-    wrapper
-      .dive()
-      .find("Link")
-      .simulate("press");
-
-    expect(stream).toHaveBeenCalledWith({
-      component: "Pagination",
-      action: "Pressed",
-      attrs: {
-        direction: "previous",
-        destinationPage: 1
-      }
-    });
+  expect(stream).toHaveBeenCalledWith({
+    component: "Pagination",
+    action: "Pressed",
+    attrs: {
+      direction: "previous",
+      destinationPage: 1
+    }
   });
 });

--- a/packages/pagination/__tests__/web/pagination.web.test.js
+++ b/packages/pagination/__tests__/web/pagination.web.test.js
@@ -115,49 +115,53 @@ const tests = [
 
       expect(wrapper).toMatchSnapshot();
     }
+  },
+  {
+    name: "tracks next page interaction",
+    test: () => {
+      const stream = jest.fn();
+      const wrapper = shallow(<Pagination count={21} page={1} />, {
+        context: { tracking: { analytics: stream } }
+      });
+
+      wrapper
+        .dive()
+        .find("Link")
+        .simulate("press");
+
+      expect(stream).toHaveBeenCalledWith({
+        component: "Pagination",
+        action: "Pressed",
+        attrs: {
+          direction: "next",
+          destinationPage: 2
+        }
+      });
+    }
+  },
+  {
+    name: "tracks previous page interaction",
+    test: () => {
+      const stream = jest.fn();
+      const wrapper = shallow(<Pagination count={21} page={2} />, {
+        context: { tracking: { analytics: stream } }
+      });
+
+      wrapper
+        .dive()
+        .find("Link")
+        .simulate("press");
+
+      expect(stream).toHaveBeenCalledWith({
+        component: "Pagination",
+        action: "Pressed",
+        attrs: {
+          direction: "previous",
+          destinationPage: 1
+        }
+      });
+    }
   }
 ];
 
 iterator(tests);
-
-it("tracks next page interaction", () => {
-  const stream = jest.fn();
-  const wrapper = shallow(<Pagination count={21} page={1} />, {
-    context: { tracking: { analytics: stream } }
-  });
-
-  wrapper
-    .dive()
-    .find("Link")
-    .simulate("press");
-
-  expect(stream).toHaveBeenCalledWith({
-    component: "Pagination",
-    action: "Pressed",
-    attrs: {
-      direction: "next",
-      destinationPage: 2
-    }
-  });
-});
-
-it("tracks previous page interaction", () => {
-  const stream = jest.fn();
-  const wrapper = shallow(<Pagination count={21} page={2} />, {
-    context: { tracking: { analytics: stream } }
-  });
-
-  wrapper
-    .dive()
-    .find("Link")
-    .simulate("press");
-
-  expect(stream).toHaveBeenCalledWith({
-    component: "Pagination",
-    action: "Pressed",
-    attrs: {
-      direction: "previous",
-      destinationPage: 1
-    }
-  });
-});

--- a/packages/pull-quote/pull-quote.showcase.js
+++ b/packages/pull-quote/pull-quote.showcase.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import PullQuotes from "./src/pull-quote";
 

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 <View
   style={
     Object {

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 <View
   style={
     Object {

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 <View
   style={
     Object {

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 <View
   style={
     Object {

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 <View
   style={
     Object {

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 <View
   style={
     Object {

--- a/packages/related-articles/__tests__/shared-la2-with-style.base.js
+++ b/packages/related-articles/__tests__/shared-la2-with-style.base.js
@@ -39,6 +39,6 @@ export default renderComponent => {
       />
     );
 
-    expect(output).toMatchSnapshot("1. default styles");
+    expect(output).toMatchSnapshot();
   });
 };

--- a/packages/related-articles/__tests__/shared-oa2-with-style.base.js
+++ b/packages/related-articles/__tests__/shared-oa2-with-style.base.js
@@ -42,6 +42,6 @@ export default renderComponent => {
       />
     );
 
-    expect(output).toMatchSnapshot("1. default styles");
+    expect(output).toMatchSnapshot();
   });
 };

--- a/packages/related-articles/__tests__/shared-std-with-style.base.js
+++ b/packages/related-articles/__tests__/shared-std-with-style.base.js
@@ -38,6 +38,6 @@ export default renderComponent => {
       />
     );
 
-    expect(output).toMatchSnapshot("1. default styles");
+    expect(output).toMatchSnapshot();
   });
 };

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 .c0 .supportImageContainerClass {
   display: none;
 }

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 .c0 .opinionContentContainerClass {
   min-height: 250px;
 }

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. default styles 1`] = `
+exports[`default styles 1`] = `
 .c0 .imageContainerClass {
   display: block;
 }

--- a/packages/responsive-styles/__tests__/web/responsive-styles.test.js
+++ b/packages/responsive-styles/__tests__/web/responsive-styles.test.js
@@ -1,7 +1,6 @@
-import "react-native";
 import React from "react";
 import PropTypes from "prop-types";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import "jest-styled-components";
 
 import withResponsiveStyles from "../../src/responsive-styles";
@@ -12,16 +11,20 @@ Hello.defaultProps = { className: "" };
 
 it("handles missing styles object", () => {
   const WithStyles = withResponsiveStyles("div");
-  const tree = renderer.create(<WithStyles>Foo</WithStyles>).toJSON();
+  const testInstance = TestRenderer.create(
+    <WithStyles>Foo</WithStyles>
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("handles empty styles object", () => {
   const WithStyles = withResponsiveStyles("div", {});
-  const tree = renderer.create(<WithStyles>Foo</WithStyles>).toJSON();
+  const testInstance = TestRenderer.create(
+    <WithStyles>Foo</WithStyles>
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("applies styles for all breakpoints", () => {
@@ -32,27 +35,31 @@ it("applies styles for all breakpoints", () => {
     wideUp: () => "color: green;",
     hugeUp: () => "color: yellow;"
   });
-  const tree = renderer.create(<WithColours>Foo</WithColours>).toJSON();
+  const testInstance = TestRenderer.create(
+    <WithColours>Foo</WithColours>
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("optimises un-used breakpoints away", () => {
   const WithStyles = withResponsiveStyles("div", {
     mediumUp: () => "color: blue;"
   });
-  const tree = renderer.create(<WithStyles>Foo</WithStyles>).toJSON();
+  const testInstance = TestRenderer.create(
+    <WithStyles>Foo</WithStyles>
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("applies styles to custom components via className", () => {
   const BlueHello = withResponsiveStyles(Hello, {
     mediumUp: () => "color: blue;"
   });
-  const tree = renderer.create(<BlueHello>Foo</BlueHello>).toJSON();
+  const testInstance = TestRenderer.create(<BlueHello>Foo</BlueHello>).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });
 
 it("supports responsive styles based on props", () => {
@@ -61,9 +68,9 @@ it("supports responsive styles based on props", () => {
       color: ${props.special ? "red" : "blue"};
     `
   });
-  const tree = renderer
-    .create(<ResponsiveHello special>Foo</ResponsiveHello>)
-    .toJSON();
+  const testInstance = TestRenderer.create(
+    <ResponsiveHello special>Foo</ResponsiveHello>
+  ).toJSON();
 
-  expect(tree).toMatchSnapshot();
+  expect(testInstance).toMatchSnapshot();
 });

--- a/packages/responsive-styles/responsive-styles.showcase.js
+++ b/packages/responsive-styles/responsive-styles.showcase.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import withResponsiveStyles from "./src/responsive-styles";
 

--- a/packages/svgs/__tests__/shared.js
+++ b/packages/svgs/__tests__/shared.js
@@ -1,4 +1,3 @@
-import "react-native";
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a Topic page 1`] = `
+exports[`Topic functional tests on android 1. topic page 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -192,7 +192,7 @@ exports[`1. Render a Topic page 1`] = `
 />
 `;
 
-exports[`2. Render a topics page loading state 1`] = `
+exports[`Topic functional tests on android 2. loading state 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -212,9 +212,9 @@ exports[`2. Render a topics page loading state 1`] = `
 />
 `;
 
-exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `<ArticleListPageError />`;
+exports[`Topic functional tests on android 3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
 
-exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
+exports[`Topic functional tests on android 4. send analytics when rendering a topic page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic functional tests on android 1. topic page 1`] = `
+exports[`1. topic page 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -192,7 +192,7 @@ exports[`Topic functional tests on android 1. topic page 1`] = `
 />
 `;
 
-exports[`Topic functional tests on android 2. loading state 1`] = `
+exports[`2. loading state 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -212,9 +212,9 @@ exports[`Topic functional tests on android 2. loading state 1`] = `
 />
 `;
 
-exports[`Topic functional tests on android 3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
+exports[`3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
 
-exports[`Topic functional tests on android 4. send analytics when rendering a topic page 1`] = `
+exports[`4. send analytics when rendering a topic page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/android/__snapshots__/topic-head-functional.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-head-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicHead functional tests on android should render correctly 1`] = `
+exports[`should render correctly 1`] = `
 <View>
   <View>
     <Text
@@ -13,9 +13,9 @@ exports[`TopicHead functional tests on android should render correctly 1`] = `
 </View>
 `;
 
-exports[`TopicHead functional tests on android should render correctly when loading 1`] = `<View />`;
+exports[`should render correctly when loading 1`] = `<View />`;
 
-exports[`TopicHead functional tests on android should render correctly with a description 1`] = `
+exports[`should render correctly with a description 1`] = `
 <View>
   <View>
     <Text

--- a/packages/topic/__tests__/android/__snapshots__/topic-head-styling.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-head-styling.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicHead styling tests on android should render styling correctly 1`] = `
+exports[`should render styling correctly 1`] = `
 <View
   style={
     Object {

--- a/packages/topic/__tests__/android/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-styling.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic styling tests on android should render styling correctly 1`] = `
+exports[`should render styling correctly 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <TopicHead

--- a/packages/topic/__tests__/android/topic-functional.test.js
+++ b/packages/topic/__tests__/android/topic-functional.test.js
@@ -1,5 +1,3 @@
-import sharedFunctional from "../topic-functional";
+import shared from "../topic-functional";
 
-describe("Topic functional tests on android", () => {
-  sharedFunctional();
-});
+shared();

--- a/packages/topic/__tests__/android/topic-head-functional.test.js
+++ b/packages/topic/__tests__/android/topic-head-functional.test.js
@@ -1,9 +1,7 @@
 import { mockReactNativeComponent } from "@times-components/jest-configurator";
-import sharedFunctional from "../topic-head-functional";
+import shared from "../topic-head-functional";
 
-describe("TopicHead functional tests on android", () => {
-  jest.mock("Text", () => mockReactNativeComponent("Text"));
-  jest.mock("View", () => mockReactNativeComponent("View"));
+jest.mock("Text", () => mockReactNativeComponent("Text"));
+jest.mock("View", () => mockReactNativeComponent("View"));
 
-  sharedFunctional();
-});
+shared();

--- a/packages/topic/__tests__/android/topic-head-styling.test.js
+++ b/packages/topic/__tests__/android/topic-head-styling.test.js
@@ -1,5 +1,3 @@
-import sharedStyling from "../topic-head-styling";
+import shared from "../topic-head-styling";
 
-describe("TopicHead styling tests on android", () => {
-  sharedStyling();
-});
+shared();

--- a/packages/topic/__tests__/android/topic-styling.test.js
+++ b/packages/topic/__tests__/android/topic-styling.test.js
@@ -1,5 +1,3 @@
-import sharedStyling from "../topic-styling";
+import shared from "../topic-styling";
 
-describe("Topic styling tests on android", () => {
-  sharedStyling();
-});
+shared();

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic functional tests on ios 1. topic page 1`] = `
+exports[`1. topic page 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -192,7 +192,7 @@ exports[`Topic functional tests on ios 1. topic page 1`] = `
 />
 `;
 
-exports[`Topic functional tests on ios 2. loading state 1`] = `
+exports[`2. loading state 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -212,9 +212,9 @@ exports[`Topic functional tests on ios 2. loading state 1`] = `
 />
 `;
 
-exports[`Topic functional tests on ios 3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
+exports[`3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
 
-exports[`Topic functional tests on ios 4. send analytics when rendering a topic page 1`] = `
+exports[`4. send analytics when rendering a topic page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a Topic page 1`] = `
+exports[`Topic functional tests on ios 1. topic page 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -192,7 +192,7 @@ exports[`1. Render a Topic page 1`] = `
 />
 `;
 
-exports[`2. Render a topics page loading state 1`] = `
+exports[`Topic functional tests on ios 2. loading state 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -212,9 +212,9 @@ exports[`2. Render a topics page loading state 1`] = `
 />
 `;
 
-exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `<ArticleListPageError />`;
+exports[`Topic functional tests on ios 3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
 
-exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
+exports[`Topic functional tests on ios 4. send analytics when rendering a topic page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/ios/__snapshots__/topic-head-functional.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-head-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicHead functional tests on ios should render correctly 1`] = `
+exports[`should render correctly 1`] = `
 <View>
   <View>
     <Text
@@ -13,9 +13,9 @@ exports[`TopicHead functional tests on ios should render correctly 1`] = `
 </View>
 `;
 
-exports[`TopicHead functional tests on ios should render correctly when loading 1`] = `<View />`;
+exports[`should render correctly when loading 1`] = `<View />`;
 
-exports[`TopicHead functional tests on ios should render correctly with a description 1`] = `
+exports[`should render correctly with a description 1`] = `
 <View>
   <View>
     <Text

--- a/packages/topic/__tests__/ios/__snapshots__/topic-head-styling.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-head-styling.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicHead styling tests on ios should render styling correctly 1`] = `
+exports[`should render styling correctly 1`] = `
 <View
   style={
     Object {

--- a/packages/topic/__tests__/ios/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-styling.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic styling tests on ios should render styling correctly 1`] = `
+exports[`should render styling correctly 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <TopicHead

--- a/packages/topic/__tests__/ios/topic-functional.test.js
+++ b/packages/topic/__tests__/ios/topic-functional.test.js
@@ -1,5 +1,3 @@
-import sharedFunctional from "../topic-functional";
+import shared from "../topic-functional";
 
-describe("Topic functional tests on ios", () => {
-  sharedFunctional();
-});
+shared();

--- a/packages/topic/__tests__/ios/topic-head-functional.test.js
+++ b/packages/topic/__tests__/ios/topic-head-functional.test.js
@@ -1,9 +1,7 @@
 import { mockReactNativeComponent } from "@times-components/jest-configurator";
-import sharedFunctional from "../topic-head-functional";
+import shared from "../topic-head-functional";
 
-describe("TopicHead functional tests on ios", () => {
-  jest.mock("Text", () => mockReactNativeComponent("Text"));
-  jest.mock("View", () => mockReactNativeComponent("View"));
+jest.mock("Text", () => mockReactNativeComponent("Text"));
+jest.mock("View", () => mockReactNativeComponent("View"));
 
-  sharedFunctional();
-});
+shared();

--- a/packages/topic/__tests__/ios/topic-head-styling.test.js
+++ b/packages/topic/__tests__/ios/topic-head-styling.test.js
@@ -1,5 +1,3 @@
-import sharedStyling from "../topic-head-styling";
+import shared from "../topic-head-styling";
 
-describe("TopicHead styling tests on ios", () => {
-  sharedStyling();
-});
+shared();

--- a/packages/topic/__tests__/ios/topic-styling.test.js
+++ b/packages/topic/__tests__/ios/topic-styling.test.js
@@ -1,5 +1,3 @@
-import sharedStyling from "../topic-styling";
+import shared from "../topic-styling";
 
-describe("Topic styling tests on ios", () => {
-  sharedStyling();
-});
+shared();

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -5,6 +5,7 @@ import {
   fixtureGenerator,
   MockedProvider
 } from "@times-components/provider-test-tools";
+import { iterator } from "@times-components/test-utils";
 import { delay } from "@times-components/utils";
 import Topic from "../src/topic";
 
@@ -53,56 +54,65 @@ export default () => {
     mockDate.reset();
   });
 
-  it("should render correctly", async () => {
-    const tree = renderer.create(
-      <MockedProvider mocks={mockArticles}>
-        <Topic {...props} page={1} pageSize={pageSize} />
-      </MockedProvider>
-    );
+  const tests = [
+    {
+      name: "topic page",
+      test: async () => {
+        const tree = renderer.create(
+          <MockedProvider mocks={mockArticles}>
+            <Topic {...props} page={1} pageSize={pageSize} />
+          </MockedProvider>
+        );
 
-    await delay(1500);
+        await delay(1500);
 
-    expect(tree).toMatchSnapshot("1. Render a Topic page");
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "loading state",
+      test: () => {
+        const tree = renderer.create(
+          <MockedProvider isLoading mocks={mockArticles}>
+            <Topic {...props} isLoading topic={{}} />
+          </MockedProvider>
+        );
 
-  it("should render the loading state", () => {
-    const tree = renderer.create(
-      <MockedProvider isLoading mocks={mockArticles}>
-        <Topic {...props} isLoading topic={{}} />
-      </MockedProvider>
-    );
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "error state with an invalid Topic Query",
+      test: () => {
+        const tree = renderer.create(
+          <Topic {...props} error={{}} refetch={() => null} />
+        );
 
-    expect(tree).toMatchSnapshot("2. Render a topics page loading state");
-  });
+        expect(tree).toMatchSnapshot();
+      }
+    },
+    {
+      name: "send analytics when rendering a topic page",
+      test: () => {
+        const reporter = jest.fn();
 
-  it("should render an error state with an invalid Topic Query", () => {
-    const tree = renderer.create(
-      <Topic {...props} error={{}} refetch={() => null} />
-    );
+        renderer.create(
+          <MockedProvider mocks={mockArticles}>
+            <Topic
+              {...props}
+              analyticsStream={reporter}
+              page={1}
+              pageSize={pageSize}
+            />
+          </MockedProvider>
+        );
 
-    expect(tree).toMatchSnapshot(
-      "3. Render a topics page error state with an invalid Topic Query"
-    );
-  });
+        const call = reporter.mock.calls[0][0];
 
-  it("should send analytics when rendering a topic page", () => {
-    const reporter = jest.fn();
+        expect(call).toMatchSnapshot();
+      }
+    }
+  ];
 
-    renderer.create(
-      <MockedProvider mocks={mockArticles}>
-        <Topic
-          {...props}
-          analyticsStream={reporter}
-          page={1}
-          pageSize={pageSize}
-        />
-      </MockedProvider>
-    );
-
-    const call = reporter.mock.calls[0][0];
-
-    expect(call).toMatchSnapshot(
-      "4. Send analytics when rendering a topics page (with null event time)"
-    );
-  });
+  iterator(tests);
 };

--- a/packages/topic/__tests__/topic-functional.js
+++ b/packages/topic/__tests__/topic-functional.js
@@ -1,5 +1,5 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import TestRenderer from "react-test-renderer";
 import mockDate from "mockdate";
 import {
   fixtureGenerator,
@@ -58,7 +58,7 @@ export default () => {
     {
       name: "topic page",
       test: async () => {
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <MockedProvider mocks={mockArticles}>
             <Topic {...props} page={1} pageSize={pageSize} />
           </MockedProvider>
@@ -66,29 +66,29 @@ export default () => {
 
         await delay(1500);
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "loading state",
       test: () => {
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <MockedProvider isLoading mocks={mockArticles}>
             <Topic {...props} isLoading topic={{}} />
           </MockedProvider>
         );
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
       name: "error state with an invalid Topic Query",
       test: () => {
-        const tree = renderer.create(
+        const testInstance = TestRenderer.create(
           <Topic {...props} error={{}} refetch={() => null} />
         );
 
-        expect(tree).toMatchSnapshot();
+        expect(testInstance).toMatchSnapshot();
       }
     },
     {
@@ -96,7 +96,7 @@ export default () => {
       test: () => {
         const reporter = jest.fn();
 
-        renderer.create(
+        TestRenderer.create(
           <MockedProvider mocks={mockArticles}>
             <Topic
               {...props}

--- a/packages/topic/__tests__/web/__snapshots__/responsive.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/responsive.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic responsive tests on web should render HeadContainer correctly 1`] = `
+exports[`should render HeadContainer correctly 1`] = `
 .c0 {
   width: 100%;
   padding-left: 10px;
@@ -31,7 +31,7 @@ exports[`Topic responsive tests on web should render HeadContainer correctly 1`]
 />
 `;
 
-exports[`Topic responsive tests on web should render HeadContainer correctly 2`] = `
+exports[`should render HeadContainer correctly 2`] = `
 .c0 {
   width: 100%;
   padding-left: 10px;
@@ -62,7 +62,7 @@ exports[`Topic responsive tests on web should render HeadContainer correctly 2`]
 />
 `;
 
-exports[`Topic responsive tests on web should render ResponsiveDivider correctly 1`] = `
+exports[`should render ResponsiveDivider correctly 1`] = `
 .c0 {
   border-top-color: #DBDBDB;
   border-top-style: solid;
@@ -82,7 +82,7 @@ exports[`Topic responsive tests on web should render ResponsiveDivider correctly
 />
 `;
 
-exports[`Topic responsive tests on web should render ResponsiveName correctly 1`] = `
+exports[`should render ResponsiveName correctly 1`] = `
 .c0 {
   font-family: TimesModern-Bold;
   font-size: 40px;

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. Render a Topic page 1`] = `
+exports[`Topic functional tests on web 1. topic page 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -192,7 +192,7 @@ exports[`1. Render a Topic page 1`] = `
 />
 `;
 
-exports[`2. Render a topics page loading state 1`] = `
+exports[`Topic functional tests on web 2. loading state 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -212,9 +212,9 @@ exports[`2. Render a topics page loading state 1`] = `
 />
 `;
 
-exports[`3. Render a topics page error state with an invalid Topic Query 1`] = `<ArticleListPageError />`;
+exports[`Topic functional tests on web 3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
 
-exports[`4. Send analytics when rendering a topics page (with null event time) 1`] = `
+exports[`Topic functional tests on web 4. send analytics when rendering a topic page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic functional tests on web 1. topic page 1`] = `
+exports[`1. topic page 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -192,7 +192,7 @@ exports[`Topic functional tests on web 1. topic page 1`] = `
 />
 `;
 
-exports[`Topic functional tests on web 2. loading state 1`] = `
+exports[`2. loading state 1`] = `
 <ArticleList
   articleListHeader={
     <TopicHead
@@ -212,9 +212,9 @@ exports[`Topic functional tests on web 2. loading state 1`] = `
 />
 `;
 
-exports[`Topic functional tests on web 3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
+exports[`3. error state with an invalid topic query 1`] = `<ArticleListPageError />`;
 
-exports[`Topic functional tests on web 4. send analytics when rendering a topic page 1`] = `
+exports[`4. send analytics when rendering a topic page 1`] = `
 Object {
   "action": "Viewed",
   "attrs": Object {

--- a/packages/topic/__tests__/web/__snapshots__/topic-head-functional.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-head-functional.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicHead functional tests on web should render correctly 1`] = `
+exports[`should render correctly 1`] = `
 <div>
   <div
     className="responsive-styles__component-fbPFZZ kPljll"
@@ -16,9 +16,9 @@ exports[`TopicHead functional tests on web should render correctly 1`] = `
 </div>
 `;
 
-exports[`TopicHead functional tests on web should render correctly when loading 1`] = `<div />`;
+exports[`should render correctly when loading 1`] = `<div />`;
 
-exports[`TopicHead functional tests on web should render correctly with a description 1`] = `
+exports[`should render correctly with a description 1`] = `
 <div>
   <div
     className="responsive-styles__component-fbPFZZ fqtkRE"

--- a/packages/topic/__tests__/web/__snapshots__/topic-head-styling.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-head-styling.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TopicHead styling tests on web should render styling correctly 1`] = `
+exports[`should render styling correctly 1`] = `
 .c0 {
   width: 100%;
   padding-left: 10px;

--- a/packages/topic/__tests__/web/__snapshots__/topic-styling.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-styling.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Topic styling tests on web should render styling correctly 1`] = `
+exports[`should render styling correctly 1`] = `
 .c0 {
   width: 100%;
   padding-left: 10px;

--- a/packages/topic/__tests__/web/responsive.web.test.js
+++ b/packages/topic/__tests__/web/responsive.web.test.js
@@ -8,19 +8,17 @@ import {
   ResponsiveDivider
 } from "../../src/styles/responsive.web";
 
-describe("Topic responsive tests on web", () => {
-  it("should render HeadContainer correctly", () => {
-    let HeadContainer = getHeadContainer({ hasDescription: true });
-    expect(renderer.create(<HeadContainer />).toJSON()).toMatchSnapshot();
-    HeadContainer = getHeadContainer({ hasDescription: false });
-    expect(renderer.create(<HeadContainer />).toJSON()).toMatchSnapshot();
-  });
+it("should render HeadContainer correctly", () => {
+  let HeadContainer = getHeadContainer({ hasDescription: true });
+  expect(renderer.create(<HeadContainer />).toJSON()).toMatchSnapshot();
+  HeadContainer = getHeadContainer({ hasDescription: false });
+  expect(renderer.create(<HeadContainer />).toJSON()).toMatchSnapshot();
+});
 
-  it("should render ResponsiveName correctly", () => {
-    expect(renderer.create(<ResponsiveName />).toJSON()).toMatchSnapshot();
-  });
+it("should render ResponsiveName correctly", () => {
+  expect(renderer.create(<ResponsiveName />).toJSON()).toMatchSnapshot();
+});
 
-  it("should render ResponsiveDivider correctly", () => {
-    expect(renderer.create(<ResponsiveDivider />).toJSON()).toMatchSnapshot();
-  });
+it("should render ResponsiveDivider correctly", () => {
+  expect(renderer.create(<ResponsiveDivider />).toJSON()).toMatchSnapshot();
 });

--- a/packages/topic/__tests__/web/topic-functional.test.js
+++ b/packages/topic/__tests__/web/topic-functional.test.js
@@ -1,5 +1,3 @@
-import sharedFunctional from "../topic-functional";
+import shared from "../topic-functional";
 
-describe("Topic functional tests on web", () => {
-  sharedFunctional();
-});
+shared();

--- a/packages/topic/__tests__/web/topic-head-functional.test.js
+++ b/packages/topic/__tests__/web/topic-head-functional.test.js
@@ -1,5 +1,3 @@
-import sharedFunctional from "../topic-head-functional";
+import shared from "../topic-head-functional";
 
-describe("TopicHead functional tests on web", () => {
-  sharedFunctional();
-});
+shared();

--- a/packages/topic/__tests__/web/topic-head-styling.test.js
+++ b/packages/topic/__tests__/web/topic-head-styling.test.js
@@ -1,5 +1,3 @@
-import sharedStyling from "../topic-head-styling";
+import shared from "../topic-head-styling";
 
-describe("TopicHead styling tests on web", () => {
-  sharedStyling();
-});
+shared();

--- a/packages/topic/__tests__/web/topic-styling.test.js
+++ b/packages/topic/__tests__/web/topic-styling.test.js
@@ -1,5 +1,3 @@
-import sharedStyling from "../topic-styling";
+import shared from "../topic-styling";
 
-describe("Topic styling tests on web", () => {
-  sharedStyling();
-});
+shared();

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -42,7 +42,7 @@
     "@times-components/provider-test-tools": "0.14.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
-    "@times-components/test-utils": "0.2.0",
+    "@times-components/test-utils": "0.2.1",
     "@times-components/utils": "2.0.1",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -42,6 +42,7 @@
     "@times-components/provider-test-tools": "0.14.1",
     "@times-components/storybook": "2.0.1",
     "@times-components/tealium-utils": "0.5.1",
+    "@times-components/test-utils": "0.2.0",
     "@times-components/utils": "2.0.1",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",


### PR DESCRIPTION
This PR is to prepare the ground for an upcoming Jest version bump. Jest now concats test names in the `it` and `toMatchSnapshot` methods. This PR removes the given names from `toMatchSnapshot` methods.

- amend various test names
- amend test variable names to follow new conventions
- add iterators to various tests
- remove unrequired imports

This PR is _not_ intended to fix all conventions across all tests.
