### PR TITLE
fix: Allow poster image to show with lead asset videos

### DIFF
--- a/packages/article/fixtures/full-article.js
+++ b/packages/article/fixtures/full-article.js
@@ -1435,7 +1435,7 @@ const defaultRelatedArticles = [
       title: "TMS: Pratchett’s law of the jungle",
       crop169: {
         url:
-          "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
+          "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104",
         __typename: "Crop"
       },
       crop32: {
@@ -1618,7 +1618,7 @@ const defaultRelatedArticles = [
       title: "Rise of centenarian drivers as elderly push on",
       crop169: {
         url:
-          "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9bc3086dbe80a6be3b1974aac6df2d6e7a16af57.jpg?crop=780%2C439%2C0%2C40",
+          "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F82723c10-fb7f-11e7-a987-7fcf5e9983dc.jpg?crop=4886%2C2748%2C92%2C108",
         __typename: "Crop"
       },
       crop32: {
@@ -1633,37 +1633,34 @@ const defaultRelatedArticles = [
     __typename: "Article"
   },
   {
-    id: "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-    headline: "Syndicated url: At long last, a burial place fit for a king",
+    id: "cab431f6-39df-11e8-b5b4-b935584040f4",
+    headline: "YouTube ignored police pleas to remove threatening videos",
+    section: "news",
     byline: [
       {
         name: "inline",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value: "Jack Malvern Arts Correspondent Dominic Kennedy"
+              value: "John Simpson, Crime Correspondent | Will Humphries"
             },
             children: []
           }
         ]
       }
     ],
-    label: "Science",
+    label: "Youtube",
     publicationName: "TIMES",
-    publishedTime: "2015-03-23T20:56:09.000Z",
-    section: "",
+    publishedTime: "2018-04-06T23:01:00.000Z",
     summary105: [
       {
         name: "paragraph",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value:
-                "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and"
+              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of"
             },
             children: []
           }
@@ -1673,13 +1670,11 @@ const defaultRelatedArticles = [
     summary125: [
       {
         name: "paragraph",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value:
-                "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can"
+              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and"
             },
             children: []
           }
@@ -1689,13 +1684,11 @@ const defaultRelatedArticles = [
     summary145: [
       {
         name: "paragraph",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value:
-                "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the"
+              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey"
             },
             children: []
           }
@@ -1705,13 +1698,11 @@ const defaultRelatedArticles = [
     summary160: [
       {
         name: "paragraph",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value:
-                "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will"
+              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London"
             },
             children: []
           }
@@ -1721,13 +1712,11 @@ const defaultRelatedArticles = [
     summary175: [
       {
         name: "paragraph",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value:
-                "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family"
+              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a"
             },
             children: []
           }
@@ -1737,26 +1726,11 @@ const defaultRelatedArticles = [
     summary225: [
       {
         name: "paragraph",
-        attributes: {},
         children: [
           {
             name: "text",
             attributes: {
-              value:
-                "It has been 530 years in the coming, but Richard III will finally be reburied with honour next week — and the late king can rest assured that the ceremony will be a family affair, even after all this time."
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "paragraph",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "His coffin has been"
+              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a boy linked to a group known as G Lanes had been"
             },
             children: []
           }
@@ -1764,22 +1738,22 @@ const defaultRelatedArticles = [
       }
     ],
     leadAsset: {
-      id: "8557a3d2-cb55-11e4-81dd-064fe933cd41",
-      title: "At long last, a burial place fit for a king",
-      crop169: {
-        url:
-          "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-        __typename: "Crop"
+      posterImage: {
+        id: "f5eacb2d-2f87-46cb-a36a-225bf9a6482f",
+        title: "",
+        crop169: {
+          url: "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
+          __typename: "Crop"
+        },
+        crop32: {
+          url: "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
+          __typename: "Crop"
+        },
+        __typename: "Image"
       },
-      crop32: {
-        url:
-          "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-        __typename: "Crop"
-      },
-      __typename: "Image"
+      __typename: "Video"
     },
-    url:
-      "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",
+    url: "https://www.thetimes.co.uk/article/youtube-ignored-police-pleas-to-remove-threatening-videos-62v2mqp23",
     __typename: "Article"
   }
 ];

--- a/packages/article/fixtures/full-article.js
+++ b/packages/article/fixtures/full-article.js
@@ -1660,7 +1660,8 @@ const defaultRelatedArticles = [
           {
             name: "text",
             attributes: {
-              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of"
+              value:
+                "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of"
             },
             children: []
           }
@@ -1674,7 +1675,8 @@ const defaultRelatedArticles = [
           {
             name: "text",
             attributes: {
-              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and"
+              value:
+                "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and"
             },
             children: []
           }
@@ -1688,7 +1690,8 @@ const defaultRelatedArticles = [
           {
             name: "text",
             attributes: {
-              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey"
+              value:
+                "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey"
             },
             children: []
           }
@@ -1702,7 +1705,8 @@ const defaultRelatedArticles = [
           {
             name: "text",
             attributes: {
-              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London"
+              value:
+                "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London"
             },
             children: []
           }
@@ -1716,7 +1720,8 @@ const defaultRelatedArticles = [
           {
             name: "text",
             attributes: {
-              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a"
+              value:
+                "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a"
             },
             children: []
           }
@@ -1730,7 +1735,8 @@ const defaultRelatedArticles = [
           {
             name: "text",
             attributes: {
-              value: "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a boy linked to a group known as G Lanes had been"
+              value:
+                "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a boy linked to a group known as G Lanes had been"
             },
             children: []
           }
@@ -1742,18 +1748,21 @@ const defaultRelatedArticles = [
         id: "f5eacb2d-2f87-46cb-a36a-225bf9a6482f",
         title: "",
         crop169: {
-          url: "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
+          url:
+            "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
           __typename: "Crop"
         },
         crop32: {
-          url: "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
+          url:
+            "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
           __typename: "Crop"
         },
         __typename: "Image"
       },
       __typename: "Video"
     },
-    url: "https://www.thetimes.co.uk/article/youtube-ignored-police-pleas-to-remove-threatening-videos-62v2mqp23",
+    url:
+      "https://www.thetimes.co.uk/article/youtube-ignored-police-pleas-to-remove-threatening-videos-62v2mqp23",
     __typename: "Article"
   }
 ];

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -1133,19 +1133,20 @@
             }
           ],
           "leadAsset": {
-            "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
-            "title": "At long last, a burial place fit for a king",
-            "crop169": {
-              "url":
-                "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C439%2C0%2C40",
-              "__typename": "Crop"
+            "posterImage": {
+              "id": "f5eacb2d-2f87-46cb-a36a-225bf9a6482f",
+              "title": "",
+              "crop169": {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
+                "__typename": "Crop"
+              },
+              "crop32": {
+                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
+                "__typename": "Crop"
+              },
+              "__typename": "Image"
             },
-            "crop32": {
-              "url":
-                "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/966beb186f2a7951c2b7f6d3ac4339862a7c381b.jpg?crop=780%2C520%2C0%2C0",
-              "__typename": "Crop"
-            },
-            "__typename": "Image"
+            "__typename": "Video"
           },
           "url":
             "http://cps-render-ci.elb.tnl-dev.ntch.co.uk/article/at-long-last-a-burial-place-fit-for-a-king-25l88wl2k",

--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -1137,11 +1137,13 @@
               "id": "f5eacb2d-2f87-46cb-a36a-225bf9a6482f",
               "title": "",
               "crop169": {
-                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
+                "url":
+                  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
                 "__typename": "Crop"
               },
               "crop32": {
-                "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
+                "url":
+                  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
                 "__typename": "Crop"
               },
               "__typename": "Image"

--- a/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
@@ -667,20 +667,24 @@ Object {
       "id": "8557a3d2-cb55-11e4-81dd-064fe933cd41",
       "label": "Science",
       "leadAsset": Object {
-        "__typename": "Image",
-        "crop169": Object {
-          "__typename": "Crop",
-          "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C439%2C0%2C40",
-          Symbol(id): "$Image:6c1c108e-ed63-47af-df1d-46c63be16627.crop({\\"ratio\\":\\"16:9\\"})",
+        "__typename": "Video",
+        "posterImage": Object {
+          "__typename": "Image",
+          "crop169": Object {
+            "__typename": "Crop",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0",
+            Symbol(id): "$Image:f5eacb2d-2f87-46cb-a36a-225bf9a6482f.crop({\\"ratio\\":\\"16:9\\"})",
+          },
+          "crop32": Object {
+            "__typename": "Crop",
+            "url": "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=792%2C528%2C73%2C0",
+            Symbol(id): "$Image:f5eacb2d-2f87-46cb-a36a-225bf9a6482f.crop({\\"ratio\\":\\"3:2\\"})",
+          },
+          "id": "f5eacb2d-2f87-46cb-a36a-225bf9a6482f",
+          "title": "",
+          Symbol(id): "Image:f5eacb2d-2f87-46cb-a36a-225bf9a6482f",
         },
-        "crop32": Object {
-          "__typename": "Crop",
-          "url": "//nu-cps-imgsrv-tnl-dev-webapp.elb.tnl-dev.ntch.co.uk/imageserver/image/9a9cf7c4b313584c4b1a231ffea56ad3154cc520.jpg?crop=780%2C520%2C0%2C0",
-          Symbol(id): "$Image:6c1c108e-ed63-47af-df1d-46c63be16627.crop({\\"ratio\\":\\"3:2\\"})",
-        },
-        "id": "6c1c108e-ed63-47af-df1d-46c63be16627",
-        "title": "TMS: Pratchett’s law of the jungle",
-        Symbol(id): "Image:6c1c108e-ed63-47af-df1d-46c63be16627",
+        Symbol(id): "$Article:8557a3d2-cb55-11e4-81dd-064fe933cd41.leadAsset",
       },
       "publicationName": "TIMES",
       "publishedTime": "2015-03-23T20:56:09.000Z",

--- a/packages/provider/src/article.js
+++ b/packages/provider/src/article.js
@@ -56,7 +56,7 @@ export const query = gql`
           }
           ... on Video {
             posterImage {
-            	id
+              id
               title
               crop169: crop(ratio: "16:9") {
                 url
@@ -66,7 +66,6 @@ export const query = gql`
               }
             }
           }
-
         }
         url
       }

--- a/packages/provider/src/article.js
+++ b/packages/provider/src/article.js
@@ -54,6 +54,19 @@ export const query = gql`
               url
             }
           }
+          ... on Video {
+            posterImage {
+            	id
+              title
+              crop169: crop(ratio: "16:9") {
+                url
+              }
+              crop32: crop(ratio: "3:2") {
+                url
+              }
+            }
+          }
+
         }
         url
       }

--- a/packages/provider/src/article.web.js
+++ b/packages/provider/src/article.web.js
@@ -62,6 +62,18 @@ export const query = gql`
               url
             }
           }
+          ... on Video {
+            posterImage {
+            	id
+              title
+              crop169: crop(ratio: "16:9") {
+                url
+              }
+              crop32: crop(ratio: "3:2") {
+                url
+              }
+            }
+          }
         }
         url
       }

--- a/packages/provider/src/article.web.js
+++ b/packages/provider/src/article.web.js
@@ -64,7 +64,7 @@ export const query = gql`
           }
           ... on Video {
             posterImage {
-            	id
+              id
               title
               crop169: crop(ratio: "16:9") {
                 url

--- a/packages/related-articles/fixtures/standard/3-articles.js
+++ b/packages/related-articles/fixtures/standard/3-articles.js
@@ -373,38 +373,18 @@ const defaultSecondUrl =
   "https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx";
 
 const defaultThirdCrop169 =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F82723c10-fb7f-11e7-a987-7fcf5e9983dc.jpg?crop=4886%2C2748%2C92%2C108";
-const defaultThirdHeadline = "Bayeux Tapestry to be displayed in Britain";
+  "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ffa613a54-39c4-11e8-b5b4-b935584040f4.jpg?crop=939%2C528%2C0%2C0";
+const defaultThirdHeadline =
+  "YouTube ignored police pleas to remove threatening videos";
 const defaultThirdSummary105 = [
   {
     name: "paragraph",
-    attributes: {},
     children: [
       {
         name: "text",
         attributes: {
           value:
-            "The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by "
-        },
-        children: []
-      },
-      {
-        name: "italic",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "The Times"
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "text",
-        attributes: {
-          value: ", is"
+            "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of"
         },
         children: []
       }
@@ -414,33 +394,12 @@ const defaultThirdSummary105 = [
 const defaultThirdSummary125 = [
   {
     name: "paragraph",
-    attributes: {},
     children: [
       {
         name: "text",
         attributes: {
           value:
-            "The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by "
-        },
-        children: []
-      },
-      {
-        name: "italic",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "The Times"
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "text",
-        attributes: {
-          value: ", is expected to be to the"
+            "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and"
         },
         children: []
       }
@@ -450,87 +409,27 @@ const defaultThirdSummary125 = [
 const defaultThirdSummary145 = [
   {
     name: "paragraph",
-    attributes: {},
     children: [
       {
         name: "text",
         attributes: {
           value:
-            "The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by "
-        },
-        children: []
-      },
-      {
-        name: "italic",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "The Times"
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "text",
-        attributes: {
-          value: ", is expected to be to the British Museum in 2022"
+            "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey"
         },
         children: []
       }
     ]
-  },
-  {
-    name: "paragraph",
-    attributes: {},
-    children: []
   }
 ];
 const defaultThirdSummary160 = [
   {
     name: "paragraph",
-    attributes: {},
     children: [
       {
         name: "text",
         attributes: {
           value:
-            "The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by "
-        },
-        children: []
-      },
-      {
-        name: "italic",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "The Times"
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "text",
-        attributes: {
-          value: ", is expected to be to the British Museum in 2022."
-        },
-        children: []
-      }
-    ]
-  },
-  {
-    name: "paragraph",
-    attributes: {},
-    children: [
-      {
-        name: "text",
-        attributes: {
-          value: "Although the"
+            "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London"
         },
         children: []
       }
@@ -540,46 +439,12 @@ const defaultThirdSummary160 = [
 const defaultThirdSummary175 = [
   {
     name: "paragraph",
-    attributes: {},
     children: [
       {
         name: "text",
         attributes: {
           value:
-            "The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by "
-        },
-        children: []
-      },
-      {
-        name: "italic",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "The Times"
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "text",
-        attributes: {
-          value: ", is expected to be to the British Museum in 2022."
-        },
-        children: []
-      }
-    ]
-  },
-  {
-    name: "paragraph",
-    attributes: {},
-    children: [
-      {
-        name: "text",
-        attributes: {
-          value: "Although the museum stopped"
+            "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a"
         },
         children: []
       }
@@ -589,57 +454,21 @@ const defaultThirdSummary175 = [
 const defaultThirdSummary225 = [
   {
     name: "paragraph",
-    attributes: {},
     children: [
       {
         name: "text",
         attributes: {
           value:
-            "The first loan of the Bayeux Tapestry outside France for 950 years, revealed today by "
-        },
-        children: []
-      },
-      {
-        name: "italic",
-        attributes: {},
-        children: [
-          {
-            name: "text",
-            attributes: {
-              value: "The Times"
-            },
-            children: []
-          }
-        ]
-      },
-      {
-        name: "text",
-        attributes: {
-          value: ", is expected to be to the British Museum in 2022."
-        },
-        children: []
-      }
-    ]
-  },
-  {
-    name: "paragraph",
-    attributes: {},
-    children: [
-      {
-        name: "text",
-        attributes: {
-          value:
-            "Although the museum stopped short of confirming that it had secured the loan"
+            "Light gleamed from the blade of what appeared to be a combat knife in a video of a huddled group of teenage boys in hoods and masks in Haringey, north London. Within a week a boy linked to a group known as G Lanes had been"
         },
         children: []
       }
     ]
   }
 ];
-const defaultThirdTitle =
-  "Bayeux Tapestry 1067: Battle of Hastings, 14 October 1066. The death of Harold II, last Anglo-Saxon king of England. Left, figure pulling arrow from eye and then being cut down by Norman knight. Armour Chain Mail Sword Axe Textile";
+const defaultThirdTitle = "Some scary people";
 const defaultThirdUrl =
-  "https://www.thetimes.co.uk/article/britain-to-get-bayeux-tapestry-as-macron-agrees-loan-n5brflnjx";
+  "https://www.thetimes.co.uk/article/youtube-ignored-police-pleas-to-remove-threatening-videos-62v2mqp23";
 
 export default (
   {
@@ -755,9 +584,11 @@ export default (
         id: "8b47c1b8-fb05-11e7-a987-7fcf5e99898c",
         publishedTime: "2018-01-17T12:00:00.000Z",
         leadAsset: {
-          title: thirdTitle,
-          crop169: {
-            url: thirdCrop169
+          posterImage: {
+            title: thirdTitle,
+            crop169: {
+              url: thirdCrop169
+            }
           }
         },
         label: "BAYEUX TAPESTRY",

--- a/packages/related-articles/src/related-article-item.js
+++ b/packages/related-articles/src/related-article-item.js
@@ -48,11 +48,15 @@ const RelatedArticleItem = ({
     style: imageStyle = {}
   } = imageConfig;
 
+  const imageUri = leadAsset.posterImage
+    ? get(article, `leadAsset.posterImage.crop${cropSize}.url`)
+    : get(article, `leadAsset.crop${cropSize}.url`);
+
   return (
     <Link onPress={e => onPress(e, { url: article.url })} url={url}>
       <Card
         contentContainerClass={contentContainerClass}
-        image={{ uri: get(article, `leadAsset.crop${cropSize}.url`) }}
+        image={{ uri: imageUri }}
         imageContainerClass={imageContainerClass}
         imageRatio={imageRatio}
         imageStyle={imageStyle}

--- a/packages/utils/src/schema.json
+++ b/packages/utils/src/schema.json
@@ -438,31 +438,6 @@
               "deprecationReason": null
             },
             {
-              "name": "keywords",
-              "description":
-                "A field that is populated from the article headline, a string delineated with commas such as [\"this,is,a,headline\"]",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "id",
               "description": "",
               "args": [],


### PR DESCRIPTION
This PR fixes the issue mentioned in: https://nidigitalsolutions.jira.com/browse/REPLAT-2809
