### PR TITLE
docs: add article readme

### DIFF
--- a/packages/article/README.md
+++ b/packages/article/README.md
@@ -2,19 +2,42 @@
 
 The article component is a composed collection of components and features which
 go to make up an article. This is distinct from the concept of an article page
-in the pages package, as that page deals with the data provider, whereas this
-package is intended to be a dumb component.
+in the pages package, as that page deals with the data provider, whereas the
+article component is intended to be a dumb component.
 
-The Article component consumes components such as `ArticleHeader`,
-`ArticleTopics` and `RelatedArticles`, all of which are related to a specific
-article. Some of these components are self-contained with the article package
-itself, and some have been split out into separate packages (see the Future
-section below). The article data which forms the article content comes from an
-Abstract Syntax Tree ("AST"). It is this AST, handled in the markup package (see
-the
-[markup README](https://github.com/newsuk/times-components/tree/master/packages/markup)
-for a full description), that forms the majority of the content within the
-article itself.
+Article consumes components such as `ArticleHeader`, `ArticleTopics` and
+`RelatedArticles`, all of which are related to a specific article. Some of these
+components are self-contained within the article package itself, and some have
+been split out into separate packages. Components that are quite large or
+complex (e.g. related articles), or are used elsewhere (e.g. article label) are
+separated and put into separate packages.
+
+These are some of the packages that live within the article package:
+
+## Article Header & Article Header Label
+
+The intro content at the top of an article.
+
+## Article Meta
+
+The article publication date and byline data.
+
+## Article Lead Asset
+
+Manages the main lead image or video of an article.
+
+## Article Body
+
+The article data which forms the article content comes from an Abstract Syntax
+Tree ("AST"). The AST data is managed from within the
+[markup package](https://github.com/newsuk/times-components/tree/master/packages/markup),
+and article overrides some of this handling with components of its own (e.g.
+paragraphs or images).
+
+## Article Topics
+
+A list of topic tags, attached to a particular article, that link to topic
+pages.
 
 ## Contributing
 
@@ -49,11 +72,3 @@ yarn test:web
 Visit the official
 [storybook](http://components.thetimes.co.uk/?knob-Size%20of%20ad%20placeholder%3A=default&selectedKind=Pages%2FArticle&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
 to see our available article templates.
-
-## Future
-
-We plan on adopting a better and more well-defined approach as to which
-components belong in the article package and which ones should be split out. At
-the moment, this feels fairly arbitrary.
-
-Also, a better error component design will be adopted going forward.

--- a/packages/article/README.md
+++ b/packages/article/README.md
@@ -1,14 +1,20 @@
 # Article
 
-Article essentially represents an article page and all of the components and
-features found therein. This package is comprised of numerous other components
-and packages, such as `ArticleHeader`, `ArticleTopics` and `RelatedArticles`,
-all of which are related to a specific article. Some of the components utilised
-in the package are self-contained with the article package itself, and some have
-been split out into separate packages. The article data which forms the article
-content comes from an Abstract Syntax Tree ("AST"). It is this AST, handled in
-the markup package, that forms the majority of the content within the article
-itself.
+The article component is a composed collection of components and features which
+go to make up an article. This is distinct from the concept of an article page
+in the pages package, as that page deals with the data provider, whereas this
+package is intended to be a dumb component.
+
+The Article component consumes components such as `ArticleHeader`,
+`ArticleTopics` and `RelatedArticles`, all of which are related to a specific
+article. Some of these components are self-contained with the article package
+itself, and some have been split out into separate packages (see the Future
+section below). The article data which forms the article content comes from an
+Abstract Syntax Tree ("AST"). It is this AST, handled in the markup package (see
+the
+[markup README](https://github.com/newsuk/times-components/tree/master/packages/markup)
+for a full description), that forms the majority of the content within the
+article itself.
 
 ## Contributing
 

--- a/packages/article/README.md
+++ b/packages/article/README.md
@@ -5,7 +5,7 @@ features found therein. This package is comprised of numerous other components
 and packages, such as `ArticleHeader`, `ArticleTopics` and `RelatedArticles`,
 all of which are related to a specific article. Some of the components utilised
 in the package are self-contained with the article package itself, and some have
-been split out into separate pacakges. The article data which forms the article
+been split out into separate packages. The article data which forms the article
 content comes from an Abstract Syntax Tree ("AST"). It is this AST, handled in
 the markup package, that forms the majority of the content within the article
 itself.

--- a/packages/article/README.md
+++ b/packages/article/README.md
@@ -1,0 +1,53 @@
+# Article
+
+Article essentially represents an article page and all of the components and
+features found therein. This package is comprised of numerous other components
+and packages, such as `ArticleHeader`, `ArticleTopics` and `RelatedArticles`,
+all of which are related to a specific article. Some of the components utilised
+in the package are self-contained with the article package itself, and some have
+been split out into separate pacakges. The article data which forms the article
+content comes from an Abstract Syntax Tree ("AST"). It is this AST, handled in
+the markup package, that forms the majority of the content within the article
+itself.
+
+## Contributing
+
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before contributing to this
+package
+
+## Running the code
+
+Please see our main [README.md](../README.md) to get the project running locally
+
+## Development
+
+The code can be formatted and linted in accordance with the agreed standards.
+
+```
+yarn fmt
+yarn lint
+```
+
+## Testing
+
+This package uses [yarn](https://yarnpkg.com) (latest) to run unit tests on each
+platform with [jest](https://facebook.github.io/jest/).
+
+```
+yarn test:all
+yarn test:android
+yarn test:ios
+yarn test:web
+```
+
+Visit the official
+[storybook](http://components.thetimes.co.uk/?knob-Size%20of%20ad%20placeholder%3A=default&selectedKind=Pages%2FArticle&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
+to see our available article templates.
+
+## Future
+
+We plan on adopting a better and more well-defined approach as to which
+components belong in the article package and which ones should be split out. At
+the moment, this feels fairly arbitrary.
+
+Also, a better error component design will be adopted going forward.

--- a/packages/key-facts/README.md
+++ b/packages/key-facts/README.md
@@ -2,7 +2,7 @@
 
 An unordered list of textual content, Key Facts are used at the top or bottom of
 an article, appearing with indented bullet points and an optional title. The
-data is derived from an (Abstract Syntax Tree) AST, comprised of nodes that
+data is derived from an Abstract Syntax Tree ("AST"), comprised of nodes that
 dictate text, links and styled elements.
 
 ## Contributing


### PR DESCRIPTION
- add a simple article package README
- adopt a standard when refering to ASTs in the docs
