### PR TITLE
fix(depend): add missing param for --only

### DIFF
--- a/packages/depend/src/cli-parser.js
+++ b/packages/depend/src/cli-parser.js
@@ -59,7 +59,7 @@ export default commander
     validateStrategies
   )
   .option(
-    "-on --only",
+    "-on --only <glob>",
     "glob expression that restricts dependencies to process"
   )
   .option("-f --fix", "fixed dependencies with wrong versions")


### PR DESCRIPTION
Without `<glob>` part commander interpret this option as boolean flag. Tests didn't catch this because commander is stubbed.

Without this change I get this:
```
$ npx @times-components/depend --only foo --list --lerna ./
TypeError: glob pattern string required
```

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
