### PR TITLE
Fix: Bylines coloured by section

### DIFF
--- a/packages/article/src/article-meta/article-meta-base.js
+++ b/packages/article/src/article-meta/article-meta-base.js
@@ -63,14 +63,16 @@ ArticleMetaBase.propTypes = {
   byline: PropTypes.arrayOf(PropTypes.shape(nodeShape)),
   publishedTime: PropTypes.string,
   publicationName: PropTypes.string,
-  onAuthorPress: PropTypes.func.isRequired
+  onAuthorPress: PropTypes.func.isRequired,
+  section: PropTypes.string
 };
 
 ArticleMetaBase.defaultProps = {
   byline: [],
   publishedTime: null,
   publicationName: null,
-  RowWrapper: View
+  RowWrapper: View,
+  section: ""
 };
 
 export default ArticleMetaBase;

--- a/packages/article/src/article-meta/article-meta-base.js
+++ b/packages/article/src/article-meta/article-meta-base.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { View, Text } from "react-native";
 import { ArticleBylineWithLinks } from "@times-components/article-byline";
 import DatePublication from "@times-components/date-publication";
+import { colours } from "@times-components/styleguide";
 import styles from "../styles/article-meta";
 
 const ArticleMetaRow = (textStyle, component, key, RowWrapper) => (
@@ -13,6 +14,7 @@ const ArticleMetaRow = (textStyle, component, key, RowWrapper) => (
 
 const ArticleMetaBase = ({
   byline,
+  section,
   publishedTime,
   publicationName,
   RowWrapper,
@@ -31,7 +33,11 @@ const ArticleMetaBase = ({
     return [
       ArticleMetaRow(
         styles.byline,
-        <ArticleBylineWithLinks ast={byline} onAuthorPress={onAuthorPress} />,
+        <ArticleBylineWithLinks
+          ast={byline}
+          color={colours.section[section]}
+          onAuthorPress={onAuthorPress}
+        />,
         "articleByline",
         RowWrapper
       ),

--- a/packages/article/src/article-meta/article-meta-base.js
+++ b/packages/article/src/article-meta/article-meta-base.js
@@ -72,7 +72,7 @@ ArticleMetaBase.defaultProps = {
   publishedTime: null,
   publicationName: null,
   RowWrapper: View,
-  section: ""
+  section: null
 };
 
 export default ArticleMetaBase;

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -62,7 +62,7 @@ const renderRow = analyticsStream => (
     }
 
     case "middleContainer": {
-      const { byline, publishedTime, publicationName } = rowData.data;
+      const { byline, publishedTime, publicationName, section } = rowData.data;
       return (
         <ArticleMeta
           byline={byline}
@@ -70,6 +70,7 @@ const renderRow = analyticsStream => (
           onAuthorPress={onAuthorPress}
           publicationName={publicationName}
           publishedTime={publishedTime}
+          section={section}
         />
       );
     }

--- a/packages/article/src/article.web.js
+++ b/packages/article/src/article.web.js
@@ -85,6 +85,7 @@ const renderArticle = (
             onAuthorPress={onAuthorPress}
             publicationName={publicationName}
             publishedTime={publishedTime}
+            section={section}
           />
           <ArticleTopics
             device="DESKTOP"

--- a/packages/article/src/data-helper.js
+++ b/packages/article/src/data-helper.js
@@ -28,7 +28,8 @@ const prepareDataForListView = articleData => {
   const articleMidContainerData = {
     publicationName: articleData.publicationName,
     publishedTime: articleData.publishedTime,
-    byline: articleData.byline
+    byline: articleData.byline,
+    section: articleData.section
   };
   const relatedArticlesData = articleData.relatedArticles
     ? {


### PR DESCRIPTION
First part of https://nidigitalsolutions.jira.com/browse/REPLAT-2522.

- Fixes bylines that should be coloured by section.

## Before
![before](https://user-images.githubusercontent.com/1736782/43840515-cbc7e476-9b18-11e8-89a8-fa48eed3c5dc.png)

## After
![after](https://user-images.githubusercontent.com/1736782/43840535-d4d6463e-9b18-11e8-8225-35556af29dcc.png)
