### PR TITLE
Fix: Article label coloured by section

### DIFF
--- a/packages/article/src/article-header-label/article-header-label.base.js
+++ b/packages/article/src/article-header-label/article-header-label.base.js
@@ -1,10 +1,9 @@
 import React from "react";
 import ArticleLabel from "@times-components/article-label";
 import VideoLabel from "@times-components/video-label";
-import { colours } from "@times-components/styleguide";
 import styles from "../styles/article-header";
 
-export default render => ({ isVideo, label }) => {
+export default render => ({ isVideo, label, color }) => {
   if (!isVideo && !label) return null;
 
   const Label = isVideo ? VideoLabel : ArticleLabel;
@@ -15,6 +14,6 @@ export default render => ({ isVideo, label }) => {
       testID: "label",
       style: styles.articleLabel
     },
-    <Label color={colours.section.default} title={label} />
+    <Label color={color} title={label} />
   );
 };

--- a/packages/article/src/article-header/article-header.js
+++ b/packages/article/src/article-header/article-header.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Text, View, ViewPropTypes } from "react-native";
 
+import { colours } from "@times-components/styleguide";
 import HeaderLabel from "../article-header-label/article-header-label";
 import HeaderFlags from "./article-header-flags";
 import HeaderStandfirst from "./article-header-standfirst";
@@ -15,10 +16,15 @@ const ArticleHeader = ({
   standfirst,
   flags,
   isVideo,
+  section,
   style
 }) => (
   <View style={[...style]}>
-    <HeaderLabel isVideo={isVideo} label={label} />
+    <HeaderLabel
+      color={colours.section[section]}
+      isVideo={isVideo}
+      label={label}
+    />
     <Text style={styles.articleHeadLineText}>{headline}</Text>
     <HeaderStandfirst standfirst={standfirst} />
     <HeaderFlags flags={flags} />
@@ -31,6 +37,7 @@ ArticleHeader.propTypes = {
   standfirst: PropTypes.string,
   flags: PropTypes.arrayOf(PropTypes.string),
   isVideo: PropTypes.bool,
+  section: PropTypes.string,
   style: ViewStylePropTypes
 };
 
@@ -39,6 +46,7 @@ ArticleHeader.defaultProps = {
   standfirst: null,
   flags: [],
   isVideo: false,
+  section: null,
   style: {}
 };
 

--- a/packages/article/src/article-header/article-header.web.js
+++ b/packages/article/src/article-header/article-header.web.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { View, ViewPropTypes } from "react-native";
 
+import { colours } from "@times-components/styleguide";
 import HeaderLabel from "../article-header-label/article-header-label";
 import HeaderFlags from "./article-header-flags";
 import HeaderStandfirst from "./article-header-standfirst";
@@ -17,10 +18,15 @@ const ArticleHeader = ({
   standfirst,
   flags,
   isVideo,
+  section,
   style
 }) => (
   <View style={[...style]}>
-    <HeaderLabel isVideo={isVideo} label={label} />
+    <HeaderLabel
+      color={colours.section[section]}
+      isVideo={isVideo}
+      label={label}
+    />
     <HeadlineContainer style={styles.articleHeadLineText}>
       {headline}
     </HeadlineContainer>
@@ -35,6 +41,7 @@ ArticleHeader.propTypes = {
   standfirst: PropTypes.string,
   flags: PropTypes.arrayOf(PropTypes.string),
   isVideo: PropTypes.bool,
+  section: PropTypes.string,
   style: ViewStylePropTypes
 };
 
@@ -43,6 +50,7 @@ ArticleHeader.defaultProps = {
   standfirst: null,
   flags: [],
   isVideo: false,
+  section: null,
   style: {}
 };
 

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -47,7 +47,7 @@ const renderRow = analyticsStream => (
     }
 
     case "header": {
-      const { headline, flags, standfirst, label, isVideo } = rowData.data;
+      const { flags, headline, isVideo, label, section, standfirst } = rowData.data;
       return (
         <ArticleHeader
           flags={flags}
@@ -55,6 +55,7 @@ const renderRow = analyticsStream => (
           isVideo={isVideo}
           key={rowData.type}
           label={label}
+          section={section}
           standfirst={standfirst}
           style={[styles.articleMainContentRow]}
         />

--- a/packages/article/src/article.web.js
+++ b/packages/article/src/article.web.js
@@ -76,6 +76,7 @@ const renderArticle = (
             headline={headline}
             isVideo={leadAssetProps.isVideo}
             label={label}
+            section={section}
             standfirst={standfirst}
           />
         </HeaderContainer>

--- a/packages/article/src/data-helper.js
+++ b/packages/article/src/data-helper.js
@@ -21,6 +21,7 @@ const prepareDataForListView = articleData => {
   const articleHeaderData = {
     label: articleData.label,
     headline: articleData.headline,
+    section: articleData.section,
     standfirst: articleData.standfirst,
     flags: articleData.flags,
     isVideo


### PR DESCRIPTION
Second part of https://nidigitalsolutions.jira.com/browse/REPLAT-2522

- Labels now coloured by section

## Before
![screen shot 2018-08-08 at 17 30 48](https://user-images.githubusercontent.com/1736782/43850892-128548f0-9b31-11e8-9a23-fc07ba1b82fc.png)

## After
![screen shot 2018-08-08 at 17 23 14](https://user-images.githubusercontent.com/1736782/43850896-143efd1c-9b31-11e8-8cd9-84478fcef843.png)

