### PR TITLE
fix: markup forest linting on master

### DIFF
--- a/lib/cli/files/.eslintignore
+++ b/lib/cli/files/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 **/coverage/*
 dist
+rnw.js

--- a/lib/cli/files/.prettierignore
+++ b/lib/cli/files/.prettierignore
@@ -11,3 +11,4 @@ CHANGELOG.md
 LICENSE
 yarn.lock
 *.log
+rnw.js

--- a/packages/markup-forest/.eslintignore
+++ b/packages/markup-forest/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 **/coverage/*
 dist
+rnw.js


### PR DESCRIPTION
- fix linting `rnw.js` ignores
- adds ignores to CLI for future packages
