### PR TITLE
chore: remove dep

### DIFF
--- a/packages/caption/caption.showcase.js
+++ b/packages/caption/caption.showcase.js
@@ -62,7 +62,7 @@ export default {
               paddingBottom: `${100 / 16 / 9}%`
             }}
           >
-            <img src={exampleImage} />
+            <img alt="Man with beard" src={exampleImage} />
           </div>
         </Caption>
       )

--- a/packages/caption/caption.showcase.js
+++ b/packages/caption/caption.showcase.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Image from "@times-components/image";
+import { Image } from "react-native";
 import Caption from "./src/caption";
 
 const captionText =
@@ -43,10 +43,27 @@ export default {
     },
     {
       type: "story",
+      platform: "native",
       name: "Image with caption",
       component: () => (
         <Caption credits={credits} text={captionText}>
           <Image aspectRatio={16 / 9} uri={exampleImage} />
+        </Caption>
+      )
+    },
+    {
+      type: "story",
+      platform: "web",
+      name: "Image with caption",
+      component: () => (
+        <Caption credits={credits} text={captionText}>
+          <div
+            style={{
+              paddingBottom: `${100 / 16 / 9}%`
+            }}
+          >
+            <img src={exampleImage} />
+          </div>
         </Caption>
       )
     }

--- a/packages/caption/package.json
+++ b/packages/caption/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.7.1",
-    "@times-components/image": "3.2.3",
     "@times-components/jest-configurator": "2.1.4",
     "@times-components/jest-serializer": "3.0.1",
     "@times-components/storybook": "3.0.3",


### PR DESCRIPTION
Circular deps in the repo can lead to confusing bugs and slows down setup time, this PR provides a simple image for the showcase instead