### PR TITLE
fix: bundling in key-facts and context

### DIFF
--- a/packages/context/.prettierignore
+++ b/packages/context/.prettierignore
@@ -11,3 +11,4 @@ CHANGELOG.md
 LICENSE
 yarn.lock
 *.log
+rnw.js

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -51,7 +51,8 @@
     "react-dom": "16.4.2",
     "react-native": "0.55.4",
     "react-test-renderer": "16.4.2",
-    "webpack": "4.6.0"
+    "webpack": "4.6.0",
+    "webpack-cli": "2.1.4"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/key-facts/.prettierignore
+++ b/packages/key-facts/.prettierignore
@@ -11,3 +11,4 @@ CHANGELOG.md
 LICENSE
 yarn.lock
 *.log
+rnw.js

--- a/packages/key-facts/package.json
+++ b/packages/key-facts/package.json
@@ -54,7 +54,8 @@
     "react-dom": "16.4.2",
     "react-native": "0.55.4",
     "react-test-renderer": "16.4.2",
-    "webpack": "4.6.0"
+    "webpack": "4.6.0",
+    "webpack-cli": "2.1.4"
   },
   "dependencies": {
     "@times-components/context": "0.4.1",


### PR DESCRIPTION
- no `rnw.js` file is being published for `key-facts` and `context` packages.
- This change fixes the bundling