### PR TITLE
fix: broken prop types

### DIFF
--- a/packages/article-byline/src/article-byline-prop-types.js
+++ b/packages/article-byline/src/article-byline-prop-types.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { Text } from "react-native";
-import { treePropType } from "@times-components/markup";
+import { propTypes as treePropType } from "@times-components/markup-forest";
 
 export const propTypes = {
   ast: PropTypes.arrayOf(treePropType).isRequired,

--- a/packages/article-summary/src/article-summary-content.js
+++ b/packages/article-summary/src/article-summary-content.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import PropTypes from "prop-types";
-import { treePropType } from "@times-components/markup";
+import { propTypes as treePropType } from "@times-components/markup-forest";
 import { renderAst } from "./article-summary";
 import styles from "./styles";
 

--- a/packages/author-profile/src/author-profile-head-prop-types.base.js
+++ b/packages/author-profile/src/author-profile-head-prop-types.base.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { treePropType } from "@times-components/markup";
+import { propTypes as treePropType } from "@times-components/markup-forest";
 
 export const propTypes = {
   biography: PropTypes.arrayOf(treePropType),

--- a/packages/related-articles/package.json
+++ b/packages/related-articles/package.json
@@ -69,6 +69,7 @@
     "@times-components/card": "3.0.12",
     "@times-components/link": "3.0.9",
     "@times-components/markup": "3.0.8",
+    "@times-components/markup-forest": "1.0.2",
     "@times-components/slice": "3.0.8",
     "@times-components/styleguide": "3.2.1",
     "@times-components/tracking": "2.1.8",

--- a/packages/related-articles/src/related-article-item-prop-types.js
+++ b/packages/related-articles/src/related-article-item-prop-types.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { ViewPropTypes } from "react-native";
-import { treePropType } from "@times-components/markup";
+import { propTypes as treePropType } from "@times-components/markup-forest";
 
 const { style: ViewPropTypesStyle } = ViewPropTypes;
 

--- a/packages/topic/src/topic-head-prop-types.js
+++ b/packages/topic/src/topic-head-prop-types.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { treePropType } from "@times-components/markup";
+import { propTypes as treePropType } from "@times-components/markup-forest";
 
 export const propTypes = {
   name: PropTypes.string,


### PR DESCRIPTION
This fixes the rest of the `treePropType` imports that broke in the move over to `markup-forest`