### PR TITLE
fix: Omit arguments in onCommentGuidelinesPress

### DIFF
--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -40,7 +40,7 @@ const ArticleDetailsPage = ({
             error={error}
             isLoading={isLoading}
             onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
-            onCommentGuidelinesPress={onCommentGuidelinesPress}
+            onCommentGuidelinesPress={() => onCommentGuidelinesPress()}
             onCommentsPress={(event, { articleId: id, url }) =>
               onCommentsPress(id, url)
             }


### PR DESCRIPTION
Remove arguments from onCommentGuidelinesPress, as they are crashing the native app with unexpected arguments