### PR TITLE
feat: Add network error callback for native apps

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -12,6 +12,7 @@ const {
   onCommentsPress,
   onCommentGuidelinesPress,
   onLinkPress,
+  onNetworkError,
   onTopicPress,
   onVideoPress
 } = NativeModules.ArticleEvents;
@@ -45,6 +46,7 @@ const ArticleView = ({ articleId, scale, sectionName }) => {
       onCommentsPress={onCommentsPress}
       onCommentGuidelinesPress={onCommentGuidelinesPress}
       onLinkPress={onLinkPress}
+      onNetworkError={onNetworkError}
       onVideoPress={onVideoPress}
       onTopicPress={onTopicPress}
       platformAdConfig={adConfig}

--- a/packages/article/__tests__/comments.base.js
+++ b/packages/article/__tests__/comments.base.js
@@ -35,6 +35,7 @@ export default () =>
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
@@ -63,6 +64,7 @@ export default () =>
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}

--- a/packages/article/__tests__/comments.native.js
+++ b/packages/article/__tests__/comments.native.js
@@ -71,6 +71,7 @@ export default () => {
         onCommentGuidelinesPress={() => {}}
         onCommentsPress={() => {}}
         onLinkPress={() => {}}
+        onNetworkError={() => {}}
         onRelatedArticlePress={() => {}}
         onTopicPress={() => {}}
         onTwitterLinkPress={() => {}}

--- a/packages/article/__tests__/scaling.base.js
+++ b/packages/article/__tests__/scaling.base.js
@@ -21,6 +21,7 @@ export default renderComponent => [
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
@@ -47,6 +48,7 @@ export default renderComponent => [
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
@@ -73,6 +75,7 @@ export default renderComponent => [
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -26,6 +26,7 @@ export default () => {
         onCommentGuidelinesPress={() => {}}
         onCommentsPress={() => {}}
         onLinkPress={() => {}}
+        onNetworkError={() => {}}
         onRelatedArticlePress={() => {}}
         onTopicPress={() => {}}
         onTwitterLinkPress={() => {}}

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -50,6 +50,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -143,6 +144,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -172,6 +174,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -197,6 +200,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -229,6 +233,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -305,6 +310,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -328,6 +334,7 @@ export const snapshotTests = renderComponent => [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -379,6 +386,7 @@ export const snapshotTests = renderComponent => [
                 onCommentGuidelinesPress={() => {}}
                 onCommentsPress={() => {}}
                 onLinkPress={() => {}}
+                onNetworkError={() => {}}
                 onRelatedArticlePress={() => {}}
                 onTopicPress={() => {}}
                 onTwitterLinkPress={() => {}}
@@ -414,6 +422,7 @@ const negativeTests = [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -438,6 +447,7 @@ const negativeTests = [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -462,6 +472,7 @@ const negativeTests = [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
@@ -489,6 +500,7 @@ const negativeTests = [
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onRelatedArticlePress={() => {}}
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}

--- a/packages/article/__tests__/shared.native.js
+++ b/packages/article/__tests__/shared.native.js
@@ -78,6 +78,7 @@ export default () => {
                 onCommentGuidelinesPress={() => {}}
                 onCommentsPress={() => {}}
                 onLinkPress={() => {}}
+                onNetworkError={() => {}}
                 onRelatedArticlePress={() => {}}
                 onTopicPress={() => {}}
                 onTwitterLinkPress={() => {}}
@@ -130,6 +131,7 @@ export default () => {
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={onLinkPress}
+            onNetworkError={() => {}}
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. an error 1`] = `
     An error occurred
   </div>
   <div>
-    {
-  "message": "An example error."
-}
+    An example error.
   </div>
 </div>
 `;

--- a/packages/article/src/article-error.js
+++ b/packages/article/src/article-error.js
@@ -1,11 +1,16 @@
 import React from "react";
 import { Text, View } from "react-native";
+import PropTypes from "prop-types";
 
-const ArticleError = props => (
+const ArticleError = ({ message }) => (
   <View>
     <Text>An error occurred</Text>
-    <Text>{JSON.stringify(props, null, 2)}</Text>
+    <Text>{message}</Text>
   </View>
 );
+
+ArticleError.propTypes = {
+  message: PropTypes.string.isRequired
+};
 
 export default ArticleError;

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -147,10 +147,11 @@ class ArticlePage extends Component {
   }
 
   render() {
-    const { error, isLoading } = this.props;
+    const { error, isLoading, onNetworkError } = this.props;
 
     if (error) {
-      return <ArticleError {...error} />;
+      onNetworkError(error);
+      return <ArticleError message={JSON.stringify(error, null, 2)} />;
     }
 
     if (isLoading) {
@@ -186,6 +187,7 @@ ArticlePage.propTypes = {
   onCommentsPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onLinkPress: PropTypes.func.isRequired,
+  onNetworkError: PropTypes.func.isRequired,
   onTwitterLinkPress: PropTypes.func.isRequired,
   onVideoPress: PropTypes.func.isRequired
 };

--- a/packages/pages/__tests__/shared.base.js
+++ b/packages/pages/__tests__/shared.base.js
@@ -19,6 +19,7 @@ export default makeTest => {
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
           onLinkPress={() => {}}
+          onNetworkError={() => {}}
           onTopicPress={() => {}}
           onVideoPress={() => {}}
           platformAdConfig={{}}

--- a/packages/pages/pages.showcase.js
+++ b/packages/pages/pages.showcase.js
@@ -32,6 +32,7 @@ export default {
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onTopicPress={() => {}}
             onVideoPress={() => {}}
             platformAdConfig={{ sectionName: "news" }}

--- a/packages/pages/pages.showcase.web.js
+++ b/packages/pages/pages.showcase.web.js
@@ -32,6 +32,7 @@ export default {
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
             onLinkPress={() => {}}
+            onNetworkError={() => {}}
             onTopicPress={() => {}}
             onVideoPress={() => {}}
             platformAdConfig={{ sectionName: "news" }}

--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -15,6 +15,7 @@ const ArticleDetailsPage = ({
   onAuthorPress,
   onCommentsPress,
   onCommentGuidelinesPress,
+  onNetworkError,
   onVideoPress,
   onLinkPress,
   onTopicPress,
@@ -53,6 +54,7 @@ const ArticleDetailsPage = ({
                 onLinkPress(url);
               }
             }}
+            onNetworkError={() => onNetworkError(articleId)}
             onRelatedArticlePress={(event, { url }) => onArticlePress(url)}
             onTopicPress={(event, { slug }) => onTopicPress(slug)}
             onTwitterLinkPress={(_, { url }) => onLinkPress(url)}
@@ -67,14 +69,15 @@ const ArticleDetailsPage = ({
 ArticleDetailsPage.propTypes = {
   articleId: PropTypes.string.isRequired,
   analyticsStream: PropTypes.func.isRequired,
-  platformAdConfig: PropTypes.shape({}).isRequired,
   onArticlePress: PropTypes.func.isRequired,
   onAuthorPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
-  onVideoPress: PropTypes.func.isRequired,
+  onNetworkError: PropTypes.func.isRequired,
   onLinkPress: PropTypes.func.isRequired,
   onTopicPress: PropTypes.func.isRequired,
+  onVideoPress: PropTypes.func.isRequired,
+  platformAdConfig: PropTypes.shape({}).isRequired,
   scale: PropTypes.string.isRequired,
   sectionName: PropTypes.string.isRequired
 };


### PR DESCRIPTION
Native apps need a callback for network errors, so they can fallback to native views in certain cases