### PR TITLE
feat: native error callback

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -11,6 +11,7 @@ const {
   onAuthorPress,
   onCommentsPress,
   onCommentGuidelinesPress,
+  onError,
   onLinkPress,
   onTopicPress,
   onVideoPress
@@ -44,6 +45,7 @@ const ArticleView = ({ articleId, scale, sectionName }) => {
       onAuthorPress={onAuthorPress}
       onCommentsPress={onCommentsPress}
       onCommentGuidelinesPress={onCommentGuidelinesPress}
+      onError={onError}
       onLinkPress={onLinkPress}
       onVideoPress={onVideoPress}
       onTopicPress={onTopicPress}

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -6,9 +6,7 @@ exports[`1. an error 1`] = `
     An error occurred
   </div>
   <div>
-    {
-  "message": "An example error."
-}
+    An example error.
   </div>
 </div>
 `;

--- a/packages/article/src/article-error.js
+++ b/packages/article/src/article-error.js
@@ -1,11 +1,16 @@
 import React from "react";
 import { Text, View } from "react-native";
+import PropTypes from "prop-types";
 
-const ArticleError = props => (
+const ArticleError = ({ message }) => (
   <View>
     <Text>An error occurred</Text>
-    <Text>{JSON.stringify(props, null, 2)}</Text>
+    <Text>{message}</Text>
   </View>
 );
+
+ArticleError.propTypes = {
+  message: PropTypes.string.isRequired
+};
 
 export default ArticleError;

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -150,7 +150,7 @@ class ArticlePage extends Component {
     const { error, isLoading } = this.props;
 
     if (error) {
-      return <ArticleError {...error} />;
+      return <ArticleError message={JSON.stringify(error, null, 2)} />;
     }
 
     if (isLoading) {

--- a/packages/pages/__tests__/shared.base.js
+++ b/packages/pages/__tests__/shared.base.js
@@ -18,6 +18,7 @@ export default makeTest => {
           onAuthorPress={() => {}}
           onCommentGuidelinesPress={() => {}}
           onCommentsPress={() => {}}
+          onError={() => {}}
           onLinkPress={() => {}}
           onTopicPress={() => {}}
           onVideoPress={() => {}}

--- a/packages/pages/pages.showcase.js
+++ b/packages/pages/pages.showcase.js
@@ -31,6 +31,7 @@ export default {
             onAuthorPress={() => {}}
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
+            onError={() => {}}
             onLinkPress={() => {}}
             onTopicPress={() => {}}
             onVideoPress={() => {}}

--- a/packages/pages/pages.showcase.web.js
+++ b/packages/pages/pages.showcase.web.js
@@ -31,6 +31,7 @@ export default {
             onAuthorPress={() => {}}
             onCommentGuidelinesPress={() => {}}
             onCommentsPress={() => {}}
+            onError={() => {}}
             onLinkPress={() => {}}
             onTopicPress={() => {}}
             onVideoPress={() => {}}

--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -15,6 +15,7 @@ const ArticleDetailsPage = ({
   onAuthorPress,
   onCommentsPress,
   onCommentGuidelinesPress,
+  onError,
   onVideoPress,
   onLinkPress,
   onTopicPress,
@@ -30,6 +31,10 @@ const ArticleDetailsPage = ({
         scale: scale || defaults.theme.scale,
         sectionColour: colours.section[pageSection || articleSection]
       };
+
+      if (error) {
+        onError(articleId);
+      }
 
       return (
         <Context.Provider value={{ theme }}>
@@ -72,6 +77,7 @@ ArticleDetailsPage.propTypes = {
   onAuthorPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
   onVideoPress: PropTypes.func.isRequired,
   onLinkPress: PropTypes.func.isRequired,
   onTopicPress: PropTypes.func.isRequired,


### PR DESCRIPTION
Native apps need a callback for network errors, so they can fallback to native views in certain cases

Also fixed an issue with error with props, that was causing a crash on tracking

