### PR TITLE
feat: add new fields to article query

### DIFF
--- a/packages/provider-queries/src/article.js
+++ b/packages/provider-queries/src/article.js
@@ -8,6 +8,8 @@ export default gql`
       content
       flags
       keywords
+      slug
+      shortIdentifier
       leadAsset {
         ... on Video {
           brightcoveAccountId

--- a/packages/provider-queries/src/article.web.js
+++ b/packages/provider-queries/src/article.web.js
@@ -8,6 +8,8 @@ export default gql`
       content
       flags
       keywords
+      slug
+      shortIdentifier
       leadAsset {
         ... on Video {
           brightcoveAccountId

--- a/packages/provider-test-tools/fixtures/article.js
+++ b/packages/provider-test-tools/fixtures/article.js
@@ -513,6 +513,8 @@ const defaultContent = [
   }
 ];
 const defaultFlags = ["NEW", "EXCLUSIVE"];
+const defaultSlug = "british-trio-stopped-on-the-way-to-join-isis";
+const defaultShortIdentifier = "57nwljmbn";
 const defaultHeadline = "Supplement In Depth Template (Style)";
 const defaultKeywords = ["Supplement", "In", "Depth", "Template", "Style"];
 const defaultLabel = "Random label";
@@ -1157,6 +1159,8 @@ export default (
     commentsEnabled = defaultCommentsEnabled,
     content = defaultContent,
     flags = defaultFlags,
+    slug = defaultSlug,
+    shortIdentifier = defaultShortIdentifier,
     headline = defaultHeadline,
     keywords = defaultKeywords,
     label = defaultLabel,
@@ -1179,6 +1183,8 @@ export default (
       headline,
       id: "198c4b2f-ecec-4f34-be53-c89f83bc1b44",
       keywords,
+      slug,
+      shortIdentifier,
       label,
       leadAsset,
       publicationName: "TIMES",

--- a/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
@@ -111,6 +111,8 @@ Object {
     Symbol(id): "$Article:198c4b2f-ecec-4f34-be53-c89f83bc1b44.relatedArticleSlice",
   },
   "section": "business",
+  "shortIdentifier": "57nwljmbn",
+  "slug": "british-trio-stopped-on-the-way-to-join-isis",
   "standfirst": "Standfirst",
   "topics": Array [
     Object {

--- a/packages/provider/__tests__/article-provider.test.js
+++ b/packages/provider/__tests__/article-provider.test.js
@@ -41,6 +41,8 @@ const mocks = [
       ],
       flags: ["NEW"],
       keywords: ["WORD"],
+      slug: "british-trio-stopped-on-the-way-to-join-isis",
+      shortIdentifier: "57nwljmbn",
       leadAsset: {
         type: "Image",
         id: "263b03a1-2ce6-4b94-b053-0d35316548c5",


### PR DESCRIPTION
This PR adds the new fields which will allow the render to construct the canonical url in render