### PR TITLE
Omit errors prop for android app

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -33,13 +33,14 @@ const platformAdConfig = {
   platform: "mobile"
 };
 
-const ArticleView = ({ articleId, scale, sectionName }) => {
+const ArticleView = ({ articleId, omitErrors, scale, sectionName }) => {
   const adConfig = { ...platformAdConfig, sectionName };
 
   return (
     <ArticlePageView
       articleId={articleId}
       analyticsStream={track}
+      omitErrors={omitErrors}
       onArticlePress={onArticlePress}
       onAuthorPress={onAuthorPress}
       onCommentsPress={onCommentsPress}
@@ -56,6 +57,7 @@ const ArticleView = ({ articleId, scale, sectionName }) => {
 
 ArticleView.propTypes = {
   articleId: PropTypes.string.isRequired,
+  omitErrors: PropTypes.bool.isRequired,
   scale: PropTypes.string.isRequired,
   sectionName: PropTypes.string.isRequired
 };

--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -11,6 +11,7 @@ const ArticleDetailsPage = ({
   articleId,
   analyticsStream,
   platformAdConfig,
+  omitErrors,
   onArticlePress,
   onAuthorPress,
   onCommentsPress,
@@ -37,8 +38,8 @@ const ArticleDetailsPage = ({
             adConfig={adConfig}
             analyticsStream={analyticsStream}
             article={article}
-            error={error}
-            isLoading={isLoading}
+            error={omitErrors ? null : error}
+            isLoading={isLoading || (omitErrors && error != null)}
             onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
             onCommentGuidelinesPress={() => onCommentGuidelinesPress()}
             onCommentsPress={(event, { articleId: id, url }) =>
@@ -70,6 +71,7 @@ ArticleDetailsPage.propTypes = {
   articleId: PropTypes.string.isRequired,
   analyticsStream: PropTypes.func.isRequired,
   platformAdConfig: PropTypes.shape({}).isRequired,
+  omitErrors: PropTypes.bool,
   onArticlePress: PropTypes.func.isRequired,
   onAuthorPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -79,6 +81,10 @@ ArticleDetailsPage.propTypes = {
   onTopicPress: PropTypes.func.isRequired,
   scale: PropTypes.string.isRequired,
   sectionName: PropTypes.string.isRequired
+};
+
+ArticleDetailsPage.defaultProps = {
+  omitErrors: false
 };
 
 export default withClient(ArticleDetailsPage);

--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -39,7 +39,7 @@ const ArticleDetailsPage = ({
             analyticsStream={analyticsStream}
             article={article}
             error={omitErrors ? null : error}
-            isLoading={isLoading || (omitErrors && error != null)}
+            isLoading={isLoading || (omitErrors && error !== null)}
             onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
             onCommentGuidelinesPress={() => onCommentGuidelinesPress()}
             onCommentsPress={(event, { articleId: id, url }) =>


### PR DESCRIPTION
Adds the ability to omit errors by introducing a new prop to pages package. 

With this prop, native apps can choose to do their own error handling, so react-native just ignores the errors and stays in a loading state