### PR TITLE
feat: add markup support for `emphasis` and `strong`.

### DIFF
--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -172,9 +172,9 @@ exports[`4. article summary component with content including line breaks 1`] = `
   <div>
     <span>
       
-      <strong>
+      <b>
         Review 1
-      </strong>
+      </b>
       <br />
        ITV
       <br />
@@ -182,9 +182,9 @@ exports[`4. article summary component with content including line breaks 1`] = `
     </span>
     <span>
        
-      <strong>
+      <b>
         Review 2
-      </strong>
+      </b>
       <br />
        BBC Two
       <br />

--- a/packages/key-facts/__tests__/web/__snapshots__/key-facts-with-style.web.test.js.snap
+++ b/packages/key-facts/__tests__/web/__snapshots__/key-facts-with-style.web.test.js.snap
@@ -64,12 +64,12 @@ exports[`key facts with title 1`] = `
       <div />
       <div>
         Example text 
-        <strong>
+        <b>
           this is bold 
-        </strong>
-        <em>
+        </b>
+        <i>
           this is in italics.
-        </em>
+        </i>
       </div>
     </div>
   </div>
@@ -140,12 +140,12 @@ exports[`key facts with title and context theme 1`] = `
       <div />
       <div>
         Example text 
-        <strong>
+        <b>
           this is bold 
-        </strong>
-        <em>
+        </b>
+        <i>
           this is in italics.
-        </em>
+        </i>
       </div>
     </div>
   </div>

--- a/packages/key-facts/__tests__/web/__snapshots__/key-facts.web.test.js.snap
+++ b/packages/key-facts/__tests__/web/__snapshots__/key-facts.web.test.js.snap
@@ -34,12 +34,12 @@ exports[`1. key facts with title 1`] = `
       <div />
       <div>
         Example text 
-        <strong>
+        <b>
           this is bold 
-        </strong>
-        <em>
+        </b>
+        <i>
           this is in italics.
-        </em>
+        </i>
       </div>
     </div>
   </div>
@@ -77,12 +77,12 @@ exports[`2. key facts without title 1`] = `
       <div />
       <div>
         Example text 
-        <strong>
+        <b>
           this is bold 
-        </strong>
-        <em>
+        </b>
+        <i>
           this is in italics.
-        </em>
+        </i>
       </div>
     </div>
   </div>

--- a/packages/markup/README.md
+++ b/packages/markup/README.md
@@ -10,9 +10,11 @@ functions from `markup-forest`, which iterates over and renders with the given
 * bold
 * block
 * break
+* emphasis
 * inline
 * italic
 * paragraph
+* strong
 * text
 
 This package should only have core renderers with no dependencies beyond

--- a/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
+++ b/packages/markup/__tests__/android/__snapshots__/markup.android.test.js.snap
@@ -36,15 +36,27 @@ exports[`3. break 1`] = `
 </Text>
 `;
 
-exports[`4. image tag 1`] = `<View />`;
+exports[`4. emphasis 1`] = `
+<Text
+  style={
+    Object {
+      "fontStyle": "italic",
+    }
+  }
+>
+  some emphasised text here
+</Text>
+`;
 
-exports[`5. inline 1`] = `
+exports[`5. image tag 1`] = `<View />`;
+
+exports[`6. inline 1`] = `
 <Text>
   some other text here
 </Text>
 `;
 
-exports[`6. italic 1`] = `
+exports[`7. italic 1`] = `
 <Text
   style={
     Object {
@@ -56,10 +68,22 @@ exports[`6. italic 1`] = `
 </Text>
 `;
 
-exports[`7. paragraph 1`] = `
+exports[`8. paragraph 1`] = `
 <Text>
   This is the text for paragraph one
 </Text>
 `;
 
-exports[`8. does not render a script tag 1`] = `<View />`;
+exports[`9. strong 1`] = `
+<Text
+  style={
+    Object {
+      "fontWeight": "bold",
+    }
+  }
+>
+  some strong text here
+</Text>
+`;
+
+exports[`10. does not render a script tag 1`] = `<View />`;

--- a/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
+++ b/packages/markup/__tests__/ios/__snapshots__/markup.ios.test.js.snap
@@ -36,15 +36,27 @@ exports[`3. break 1`] = `
 </Text>
 `;
 
-exports[`4. image tag 1`] = `<View />`;
+exports[`4. emphasis 1`] = `
+<Text
+  style={
+    Object {
+      "fontStyle": "italic",
+    }
+  }
+>
+  some emphasised text here
+</Text>
+`;
 
-exports[`5. inline 1`] = `
+exports[`5. image tag 1`] = `<View />`;
+
+exports[`6. inline 1`] = `
 <Text>
   some other text here
 </Text>
 `;
 
-exports[`6. italic 1`] = `
+exports[`7. italic 1`] = `
 <Text
   style={
     Object {
@@ -56,10 +68,22 @@ exports[`6. italic 1`] = `
 </Text>
 `;
 
-exports[`7. paragraph 1`] = `
+exports[`8. paragraph 1`] = `
 <Text>
   This is the text for paragraph one
 </Text>
 `;
 
-exports[`8. does not render a script tag 1`] = `<View />`;
+exports[`9. strong 1`] = `
+<Text
+  style={
+    Object {
+      "fontWeight": "bold",
+    }
+  }
+>
+  some strong text here
+</Text>
+`;
+
+exports[`10. does not render a script tag 1`] = `<View />`;

--- a/packages/markup/__tests__/shared.base.js
+++ b/packages/markup/__tests__/shared.base.js
@@ -6,11 +6,13 @@ import coreRenderers from "../src/markup";
 import paragraph from "../fixtures/paragraph.json";
 import block from "../fixtures/block.json";
 import bold from "../fixtures/bold.json";
+import emphasis from "../fixtures/emphasis.json";
 import inline from "../fixtures/inline.json";
 import image from "../fixtures/image.json";
 import italic from "../fixtures/italic.json";
 import lineBreak from "../fixtures/break.json";
 import script from "../fixtures/script.json";
+import strong from "../fixtures/strong.json";
 
 export default renderComponent => {
   const tests = [
@@ -34,6 +36,14 @@ export default renderComponent => {
       name: "break",
       test: () => {
         const output = renderComponent(renderTree(lineBreak, coreRenderers));
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "emphasis",
+      test: () => {
+        const output = renderComponent(renderTree(emphasis, coreRenderers));
 
         expect(output).toMatchSnapshot();
       }
@@ -68,6 +78,14 @@ export default renderComponent => {
       name: "paragraph",
       test: () => {
         const output = renderComponent(renderTree(paragraph, coreRenderers));
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "strong",
+      test: () => {
+        const output = renderComponent(renderTree(strong, coreRenderers));
 
         expect(output).toMatchSnapshot();
       }

--- a/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
+++ b/packages/markup/__tests__/web/__snapshots__/markup.web.test.js.snap
@@ -18,31 +18,43 @@ exports[`1. block 1`] = `
 `;
 
 exports[`2. bold 1`] = `
-<strong>
+<b>
   some text here
-</strong>
+</b>
 `;
 
 exports[`3. break 1`] = `<br />`;
 
-exports[`4. image tag 1`] = `<div />`;
+exports[`4. emphasis 1`] = `
+<em>
+  some emphasised text here
+</em>
+`;
 
-exports[`5. inline 1`] = `
+exports[`5. image tag 1`] = `<div />`;
+
+exports[`6. inline 1`] = `
 <span>
   some other text here
 </span>
 `;
 
-exports[`6. italic 1`] = `
-<em>
+exports[`7. italic 1`] = `
+<i>
    some more text here
-</em>
+</i>
 `;
 
-exports[`7. paragraph 1`] = `
+exports[`8. paragraph 1`] = `
 <p>
   This is the text for paragraph one
 </p>
 `;
 
-exports[`8. does not render a script tag 1`] = `<div />`;
+exports[`9. strong 1`] = `
+<strong>
+  some strong text here
+</strong>
+`;
+
+exports[`10. does not render a script tag 1`] = `<div />`;

--- a/packages/markup/fixtures/emphasis.json
+++ b/packages/markup/fixtures/emphasis.json
@@ -1,0 +1,13 @@
+{
+  "name": "emphasis",
+  "attributes": {},
+  "children": [
+    {
+      "name": "text",
+      "attributes": {
+        "value": "some emphasised text here"
+      },
+      "children": []
+    }
+  ]
+}

--- a/packages/markup/fixtures/strong.json
+++ b/packages/markup/fixtures/strong.json
@@ -1,0 +1,13 @@
+{
+  "name": "strong",
+  "attributes": {},
+  "children": [
+    {
+      "name": "text",
+      "attributes": {
+        "value": "some strong text here"
+      },
+      "children": []
+    }
+  ]
+}

--- a/packages/markup/fixtures/tag-mixture.json
+++ b/packages/markup/fixtures/tag-mixture.json
@@ -47,6 +47,25 @@
       "attributes": {},
       "children": [
         {
+          "name": "strong",
+          "attributes": {},
+          "children": [
+            {
+              "name": "text",
+              "attributes": {
+                "value": " some text there"
+              },
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "block",
+      "attributes": {},
+      "children": [
+        {
           "name": "italic",
           "attributes": {},
           "children": [
@@ -54,6 +73,25 @@
               "name": "text",
               "attributes": {
                 "value": " some more text here"
+              },
+              "children": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "block",
+      "attributes": {},
+      "children": [
+        {
+          "name": "strong",
+          "attributes": {},
+          "children": [
+            {
+              "name": "text",
+              "attributes": {
+                "value": " some more text there"
               },
               "children": []
             }

--- a/packages/markup/src/markup.js
+++ b/packages/markup/src/markup.js
@@ -30,6 +30,15 @@ export default {
       element: <Text key={key}>{"\n"}</Text>
     };
   },
+  emphasis(key, attributes, renderedChildren) {
+    return {
+      element: (
+        <Text key={key} style={styles.italic}>
+          {renderedChildren}
+        </Text>
+      )
+    };
+  },
   inline(key, attributes, renderedChildren) {
     return {
       element: <Text key={key}>{renderedChildren}</Text>
@@ -47,6 +56,15 @@ export default {
   paragraph(key, attributes, renderedChildren) {
     return {
       element: <Text key={key}>{renderedChildren}</Text>
+    };
+  },
+  strong(key, attributes, renderedChildren) {
+    return {
+      element: (
+        <Text key={key} style={styles.bold}>
+          {renderedChildren}
+        </Text>
+      )
     };
   },
   text(key, { value }) {

--- a/packages/markup/src/markup.web.js
+++ b/packages/markup/src/markup.web.js
@@ -8,7 +8,7 @@ export default {
   },
   bold(key, attributes, renderedChildren) {
     return {
-      element: <strong key={key}>{renderedChildren}</strong>
+      element: <b key={key}>{renderedChildren}</b>
     };
   },
   break(key) {
@@ -16,9 +16,14 @@ export default {
       element: <br key={key} />
     };
   },
-  italic(key, attributes, renderedChildren) {
+  emphasis(key, attributes, renderedChildren) {
     return {
       element: <em key={key}>{renderedChildren}</em>
+    };
+  },
+  italic(key, attributes, renderedChildren) {
+    return {
+      element: <i key={key}>{renderedChildren}</i>
     };
   },
   inline(key, attributes, renderedChildren) {
@@ -29,6 +34,11 @@ export default {
   paragraph(key, attributes, renderedChildren) {
     return {
       element: <p key={key}>{renderedChildren}</p>
+    };
+  },
+  strong(key, attributes, renderedChildren) {
+    return {
+      element: <strong key={key}>{renderedChildren}</strong>
     };
   },
   text(key, { value }) {

--- a/packages/topic/__tests__/web/__snapshots__/topic-with-style.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-with-style.web.test.js.snap
@@ -123,12 +123,12 @@ exports[`1. an article list header 1`] = `
       className="S2"
     >
       Test 
-      <em>
+      <i>
         italic 
-      </em>
-      <strong>
+      </i>
+      <b>
         bold
-      </strong>
+      </b>
        text.
     </div>
   </div>

--- a/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic.web.test.js.snap
@@ -264,12 +264,12 @@ exports[`6. an article list header 1`] = `
     <div />
     <div>
       Test 
-      <em>
+      <i>
         italic 
-      </em>
-      <strong>
+      </i>
+      <b>
         bold
-      </strong>
+      </b>
        text.
     </div>
   </div>


### PR DESCRIPTION
This feature is an update to the markup package so that is can support the content elements,
- `emphasis`,
- `strong`,

that will soon be returned by the Times Public API, once Methode Parser is updated ([#15](https://github.com/newsuk/times-methode-parser/pull/15)).