### PR TITLE
fix: ssr publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   "useWorkspaces": true,
   "command": {
     "publish": {
-      "ignoreChanges": ["ssr/"]
+      "ignoreChanges": ["packages/ssr/**"]
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,11 +1,11 @@
 {
-  "lerna": "3.0.0-rc.0",
+  "lerna": "3.2.1",
   "packages": ["packages/*", "android-app", "ios-app"],
   "version": "independent",
   "useWorkspaces": true,
   "command": {
     "publish": {
-      "ignoreChanges": ["packages/ssr"]
+      "ignoreChanges": ["ssr/"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cinstall": "./lib/custom_install.sh",
     "postinstall": "lerna run postinstall && lerna run transpile",
     "packages:publish": "lerna publish --conventional-commits --yes --concurrency=1 --exact",
-    "packages:publish-dry-run": "yarn packages:publish --skip-git --skip-npm",
+    "packages:publish-dry-run": "yarn packages:publish --no-git-tag-version --no-push",
     "clean-snaps": "rm -rf dextrose/snappy/*.png",
     "commit": "git-cz"
   },

--- a/packages/ssr/index.js
+++ b/packages/ssr/index.js
@@ -23,10 +23,6 @@ const makeClient = () =>
     cache: new Cache({ addTypename: true, fragmentMatcher })
   });
 
-
-
-
-
 const makeHtml = (
   client,
   identifier,

--- a/packages/ssr/index.js
+++ b/packages/ssr/index.js
@@ -23,11 +23,6 @@ const makeClient = () =>
     cache: new Cache({ addTypename: true, fragmentMatcher })
   });
 
-
-
-
-
-
 const makeHtml = (
   client,
   identifier,

--- a/packages/ssr/index.js
+++ b/packages/ssr/index.js
@@ -23,6 +23,11 @@ const makeClient = () =>
     cache: new Cache({ addTypename: true, fragmentMatcher })
   });
 
+
+
+
+
+
 const makeHtml = (
   client,
   identifier,

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -52,5 +52,8 @@
     "react-native": "0.55.4",
     "react-native-web": "0.5.1",
     "styled-components": "3.4.0"
+  },
+  "publishConfig": {
+    "access": "private"
   }
 }

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@times-components/ssr",
+  "private": true,
   "version": "0.1.3",
   "scripts": {
     "cleanup-dist": "rm -rf dist",
@@ -52,8 +53,5 @@
     "react-native": "0.55.4",
     "react-native-web": "0.5.1",
     "styled-components": "3.4.0"
-  },
-  "publishConfig": {
-    "access": "private"
   }
 }


### PR DESCRIPTION
For a package to be ignored by the lerna npm publish step, it needs to be set to `private`. The `publish.ignoreChanges` glob is to simply ignore that package for the purposes of change detection.

fix: revert testing change
chore: update out of date script flags