### PR TITLE
Fix: Label title should not be required field

### DIFF
--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -82,7 +82,7 @@ const ArticleSummary = props => {
 
 ArticleSummary.propTypes = {
   labelProps: PropTypes.shape({
-    title: PropTypes.string.isRequired,
+    title: PropTypes.string,
     color: PropTypes.string,
     isVideo: PropTypes.bool
   }),


### PR DESCRIPTION
- `Article-summary` label proptypes update to stop warnings in client.