### PR TITLE
feat: add server-side paging

### DIFF
--- a/packages/article-label/__tests__/web/__snapshots__/article-label.web.test.js.snap
+++ b/packages/article-label/__tests__/web/__snapshots__/article-label.web.test.js.snap
@@ -6,11 +6,6 @@ exports[`Article Label test on web renders ArticleLabel 1`] = `
   style={
     Object {
       "color": "rgba(0,131,71,1)",
-      "fontFamily": "GillSansMTStd-Medium",
-      "fontSize": "12px",
-      "fontWeight": "400",
-      "letterSpacing": "1.2px",
-      "lineHeight": "14px",
     }
   }
 >

--- a/packages/article-label/src/style/index.js
+++ b/packages/article-label/src/style/index.js
@@ -1,7 +1,8 @@
+import { StyleSheet } from "react-native";
 import styleguide from "@times-components/styleguide";
 
 const { fontFactory } = styleguide();
-const styles = {
+const styles = StyleSheet.create({
   title: {
     ...fontFactory({
       font: "supporting",
@@ -11,6 +12,6 @@ const styles = {
     letterSpacing: 1.2,
     marginBottom: 0
   }
-};
+});
 
 export default styles;

--- a/packages/article-list/src/article-list-pagination.web.js
+++ b/packages/article-list/src/article-list-pagination.web.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import Pagination from "@times-components/pagination";
+import PropTypes from "prop-types";
 import styles from "./styles";
 
 const ArticleListPagination = props => (
@@ -11,6 +12,13 @@ const ArticleListPagination = props => (
   </View>
 );
 
-ArticleListPagination.propTypes = Pagination.propTypes;
+ArticleListPagination.propTypes = {
+  count: PropTypes.number.isRequired,
+  onNext: PropTypes.func.isRequired,
+  onPrev: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  hideResults: PropTypes.bool.isRequired
+};
 
 export default ArticleListPagination;

--- a/packages/article-list/src/article-list-prop-types.web.js
+++ b/packages/article-list/src/article-list-prop-types.web.js
@@ -1,14 +1,17 @@
 import PropTypes from "prop-types";
-import Pagination from "@times-components/pagination";
 import {
   propTypes as basePropTypes,
   defaultProps
 } from "./article-list-prop-types-base";
 
 export const propTypes = {
-  adConfig: PropTypes.shape({}).isRequired,
   ...basePropTypes,
-  ...Pagination.propTypes
+  adConfig: PropTypes.shape({}).isRequired,
+  count: PropTypes.number,
+  onNext: PropTypes.func,
+  onPrev: PropTypes.func,
+  page: PropTypes.number,
+  pageSize: PropTypes.number
 };
 
 export { defaultProps };

--- a/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -407,11 +407,6 @@ exports[`full article with style 1`] = `
   },
   "IS2": {
     "color": "rgba(51,51,51,1)",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": "12px",
-    "fontWeight": "400",
-    "letterSpacing": "1.2px",
-    "lineHeight": "14px",
   },
   "IS3": {
     "justifyContent": "flex-start",
@@ -469,6 +464,8 @@ exports[`full article with style 1`] = `
     "padding-top": "0px",
   },
   "S2": {
+    "font-weight": "400",
+    "line-height": "14px",
     "margin-bottom": "0px",
     "margin-top": "0px",
     "padding-bottom": "0px",

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
@@ -178,7 +178,7 @@ exports[`1. renders 1`] = `
     >
       <a
         className="IS1"
-        href="./1"
+        href="?mock-1"
       >
         <div
           className="S5"
@@ -206,7 +206,7 @@ exports[`1. renders 1`] = `
     >
       <a
         className="IS2"
-        href="./3"
+        href="?mock-3"
       >
         <div
           className="S5"

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-wrapper.web.test.js.snap
@@ -7,3 +7,15 @@ exports[`1. inner component with page 1`] = `
 }
 </div>
 `;
+
+exports[`does not update the page state when the history changes without a page 1`] = `
+<div>
+  2
+</div>
+`;
+
+exports[`updates the page state when the history changes 1`] = `
+<div>
+  4
+</div>
+`;

--- a/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination.web.test.js.snap
@@ -10,7 +10,7 @@ exports[`1. renders results, previous and next 1`] = `
   <div>
     <div>
       <a
-        href="./4"
+        href="?mock-4"
       >
         <div>
           <svg
@@ -39,7 +39,7 @@ exports[`1. renders results, previous and next 1`] = `
     </div>
     <div>
       <a
-        href="./6"
+        href="?mock-6"
       >
         <div>
           <div>
@@ -75,7 +75,7 @@ exports[`2. renders with no results 1`] = `
   <div>
     <div>
       <a
-        href="./4"
+        href="?mock-4"
       >
         <div>
           <svg
@@ -104,7 +104,7 @@ exports[`2. renders with no results 1`] = `
     </div>
     <div>
       <a
-        href="./6"
+        href="?mock-6"
       >
         <div>
           <div>
@@ -159,7 +159,7 @@ exports[`4. limits the starting result to the total count 1`] = `
   <div>
     <div>
       <a
-        href="./3"
+        href="?mock-3"
       >
         <div>
           <svg
@@ -196,7 +196,7 @@ exports[`5. renders previous and not next 1`] = `
   <div>
     <div>
       <a
-        href="./4"
+        href="?mock-4"
       >
         <div>
           <svg
@@ -234,7 +234,7 @@ exports[`6. renders next and not previous 1`] = `
     <div />
     <div>
       <a
-        href="./2"
+        href="?mock-2"
       >
         <div>
           <div>

--- a/packages/pagination/__tests__/web/pagination-with-styles.web.test.js
+++ b/packages/pagination/__tests__/web/pagination-with-styles.web.test.js
@@ -44,12 +44,15 @@ addSerializers(
 // eslint-disable-next-line global-require
 require("jest-styled-components");
 
+const mockGenerateLink = page => `?mock-${page}`;
+
 const tests = [
   {
     name: "renders",
     test: () => {
       const props = {
         count: 21,
+        generatePageLink: mockGenerateLink,
         page: 2,
         pageSize: 3
       };
@@ -64,6 +67,7 @@ const tests = [
     test: () => {
       const props = {
         count: 0,
+        generatePageLink: mockGenerateLink,
         hideResults: true,
         page: 0,
         pageSize: 0

--- a/packages/pagination/__tests__/web/pagination-wrapper.web.test.js
+++ b/packages/pagination/__tests__/web/pagination-wrapper.web.test.js
@@ -1,4 +1,125 @@
+/* eslint-env browser */
+
+import React, { Component } from "react";
+import { Text } from "react-native";
+import TestRenderer from "react-test-renderer";
 import shared from "../shared.web";
 import withPageState from "../../src/pagination-wrapper";
 
 shared(withPageState);
+
+test("replaces history state when mounted", () => {
+  const TestComponent = () => <Text>Hello world</Text>;
+  const PageChanger = withPageState(TestComponent);
+
+  const props = {
+    page: 2
+  };
+
+  const pushState = jest.spyOn(window.history, "pushState");
+  const replaceState = jest.spyOn(window.history, "replaceState");
+
+  TestRenderer.create(<PageChanger {...props} />);
+
+  expect(pushState).not.toHaveBeenCalled();
+  expect(replaceState.mock.calls).toEqual([[{ page: 2 }, null, "?page=2"]]);
+
+  window.history.pushState.mockClear();
+  window.history.replaceState.mockClear();
+});
+
+test("adds history state when the page changes", () => {
+  let onNext;
+  class TestComponent extends Component {
+    constructor(props) {
+      super(props);
+
+      // eslint-disable-next-line
+      onNext = props.onNext;
+    }
+
+    render() {
+      return null;
+    }
+  }
+
+  const PageChanger = withPageState(TestComponent);
+
+  const props = {
+    page: 2
+  };
+
+  TestRenderer.create(<PageChanger {...props} />);
+
+  const pushState = jest.spyOn(window.history, "pushState");
+  const replaceState = jest.spyOn(window.history, "replaceState");
+
+  onNext({ preventDefault() {} }, 3);
+
+  expect(replaceState).toHaveBeenCalledTimes(1);
+  expect(pushState.mock.calls).toEqual([[{ page: 3 }, null, "?page=3"]]);
+
+  window.history.pushState.mockClear();
+  window.history.replaceState.mockClear();
+});
+
+test("updates the page state when the history changes", () => {
+  // eslint-disable-next-line
+  const TestComponent = ({ page }) => <Text>{page}</Text>;
+  const PageChanger = withPageState(TestComponent);
+
+  const props = {
+    page: 2
+  };
+
+  const testRenderer = TestRenderer.create(<PageChanger {...props} />);
+
+  window.onpopstate({
+    state: {
+      page: 4
+    }
+  });
+
+  expect(testRenderer).toMatchSnapshot();
+
+  window.history.pushState.mockClear();
+  window.history.replaceState.mockClear();
+});
+
+test("does not update the page state when the history changes without a page", () => {
+  // eslint-disable-next-line
+  const TestComponent = ({ page }) => <Text>{page}</Text>;
+  const PageChanger = withPageState(TestComponent);
+
+  const props = {
+    page: 2
+  };
+
+  const testRenderer = TestRenderer.create(<PageChanger {...props} />);
+
+  window.onpopstate({});
+
+  expect(testRenderer).toMatchSnapshot();
+
+  window.history.pushState.mockClear();
+  window.history.replaceState.mockClear();
+});
+
+test("removes the onpopstate customisation when unmounted", () => {
+  // eslint-disable-next-line
+  const TestComponent = ({ page }) => <Text>{page}</Text>;
+  const PageChanger = withPageState(TestComponent);
+
+  const props = {
+    page: 2
+  };
+
+  const testRenderer = TestRenderer.create(<PageChanger {...props} />);
+
+  testRenderer.unmount();
+
+  expect(window.onpopstate).toEqual(null);
+
+  window.history.pushState.mockClear();
+  window.history.replaceState.mockClear();
+});

--- a/packages/pagination/__tests__/web/pagination.web.test.js
+++ b/packages/pagination/__tests__/web/pagination.web.test.js
@@ -29,12 +29,15 @@ addSerializers(
   )
 );
 
+const mockGenerateLink = page => `?mock-${page}`;
+
 const tests = [
   {
     name: "renders results, previous and next",
     test: () => {
       const props = {
         count: 20,
+        generatePageLink: mockGenerateLink,
         page: 5,
         pageSize: 3
       };
@@ -49,6 +52,7 @@ const tests = [
     test: () => {
       const props = {
         count: 20,
+        generatePageLink: mockGenerateLink,
         page: 5,
         pageSize: 3,
         hideResults: true
@@ -64,6 +68,7 @@ const tests = [
     test: () => {
       const props = {
         count: 20,
+        generatePageLink: mockGenerateLink,
         page: 1,
         pageSize: 25
       };
@@ -78,6 +83,7 @@ const tests = [
     test: () => {
       const props = {
         count: 20,
+        generatePageLink: mockGenerateLink,
         page: 4,
         pageSize: 10
       };
@@ -92,6 +98,7 @@ const tests = [
     test: () => {
       const props = {
         count: 20,
+        generatePageLink: mockGenerateLink,
         page: 5,
         pageSize: 4,
         hideResults: true
@@ -107,6 +114,7 @@ const tests = [
     test: () => {
       const props = {
         count: 20,
+        generatePageLink: mockGenerateLink,
         page: 1,
         pageSize: 4,
         hideResults: true
@@ -121,9 +129,12 @@ const tests = [
     name: "tracks next page interaction",
     test: () => {
       const stream = jest.fn();
-      const wrapper = shallow(<Pagination count={21} page={1} />, {
-        context: { tracking: { analytics: stream } }
-      });
+      const wrapper = shallow(
+        <Pagination count={21} generatePageLink={mockGenerateLink} page={1} />,
+        {
+          context: { tracking: { analytics: stream } }
+        }
+      );
 
       wrapper
         .dive()
@@ -144,9 +155,12 @@ const tests = [
     name: "tracks previous page interaction",
     test: () => {
       const stream = jest.fn();
-      const wrapper = shallow(<Pagination count={21} page={2} />, {
-        context: { tracking: { analytics: stream } }
-      });
+      const wrapper = shallow(
+        <Pagination count={21} generatePageLink={mockGenerateLink} page={2} />,
+        {
+          context: { tracking: { analytics: stream } }
+        }
+      );
 
       wrapper
         .dive()

--- a/packages/pagination/src/pagination-wrapper.js
+++ b/packages/pagination/src/pagination-wrapper.js
@@ -1,9 +1,23 @@
+/* eslint-env browser */
+
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import getDisplayName from "react-display-name";
 
 export default PaginatedComponent => {
   class Helper extends Component {
+    static addHistory(page) {
+      if (typeof window !== "undefined" && window.history) {
+        window.history.pushState({ page }, null, `?page=${page}`);
+      }
+    }
+
+    static replaceHistory(page) {
+      if (typeof window !== "undefined" && window.history) {
+        window.history.replaceState({ page }, null, `?page=${page}`);
+      }
+    }
+
     static getDerivedStateFromProps(props, state) {
       return {
         ...props,
@@ -18,8 +32,28 @@ export default PaginatedComponent => {
       this.handleChangePage = this.handleChangePage.bind(this);
     }
 
+    componentDidMount() {
+      if (typeof window !== "undefined") {
+        window.onpopstate = event => {
+          if (event.state) {
+            this.setState({
+              page: event.state.page
+            });
+          }
+        };
+      }
+
+      Helper.replaceHistory(this.state.page);
+    }
+
+    componentWillUnmount() {
+      if (typeof window !== "undefined") {
+        window.onpopstate = null;
+      }
+    }
+
     handleChangePage(event, page) {
-      this.setState({ page });
+      this.setState({ page }, () => Helper.addHistory(page));
       event.preventDefault();
     }
 

--- a/packages/pagination/src/pagination.web.js
+++ b/packages/pagination/src/pagination.web.js
@@ -74,7 +74,7 @@ const Pagination = ({
 
 Pagination.propTypes = {
   count: PropTypes.number,
-  generatePageLink: PropTypes.func,
+  generatePageLink: PropTypes.func.isRequired,
   onNext: PropTypes.func,
   onPrev: PropTypes.func,
   page: PropTypes.number,
@@ -84,7 +84,6 @@ Pagination.propTypes = {
 
 Pagination.defaultProps = {
   count: 0,
-  generatePageLink: page => `./${page}`,
   onNext: () => {},
   onPrev: () => {},
   page: 1,

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -166,13 +166,6 @@ exports[`default styles 1`] = `
 
 <style>
 {
-  "IS1": {
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": "12px",
-    "fontWeight": "400",
-    "letterSpacing": "1.2px",
-    "lineHeight": "14px",
-  },
   "S1": {
     "border-bottom-width": "0px",
     "border-top-width": "0px",
@@ -217,6 +210,10 @@ exports[`default styles 1`] = `
     "border-top-width": "0px",
     "color": "rgba(51,51,51,1)",
     "display": "inline",
+    "font-family": "GillSansMTStd-Medium",
+    "font-size": "12px",
+    "font-weight": "400",
+    "line-height": "14px",
     "margin-bottom": "0px",
     "margin-top": "0px",
   },
@@ -322,7 +319,7 @@ exports[`default styles 1`] = `
                   className="S4"
                 >
                   <div
-                    className="S3 IS1"
+                    className="S3"
                   >
                     TEST LABEL
                   </div>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -193,11 +193,6 @@ exports[`default styles 1`] = `
 {
   "IS1": {
     "color": "rgba(19,53,78,1)",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": "12px",
-    "fontWeight": "400",
-    "letterSpacing": "1.2px",
-    "lineHeight": "14px",
   },
   "IS2": {
     "color": "rgba(19,53,78,1)",
@@ -245,6 +240,10 @@ exports[`default styles 1`] = `
     "border-bottom-width": "0px",
     "border-top-width": "0px",
     "display": "inline",
+    "font-family": "GillSansMTStd-Medium",
+    "font-size": "12px",
+    "font-weight": "400",
+    "line-height": "14px",
     "margin-bottom": "0px",
     "margin-top": "0px",
   },

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -136,11 +136,6 @@ exports[`default styles 1`] = `
 {
   "IS1": {
     "color": "rgba(219,19,59,1)",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": "12px",
-    "fontWeight": "400",
-    "letterSpacing": "1.2px",
-    "lineHeight": "14px",
   },
   "IS2": {
     "color": "rgba(219,19,59,1)",
@@ -191,6 +186,10 @@ exports[`default styles 1`] = `
     "border-bottom-width": "0px",
     "border-top-width": "0px",
     "display": "inline",
+    "font-family": "GillSansMTStd-Medium",
+    "font-size": "12px",
+    "font-weight": "400",
+    "line-height": "14px",
     "margin-bottom": "0px",
     "margin-top": "0px",
   },

--- a/packages/ssr/author-profile.client.js
+++ b/packages/ssr/author-profile.client.js
@@ -4,4 +4,6 @@ const authorProfile = require("./author-profile");
 const apolloClient = require("./make-client-ac");
 const runClient = require("./run-client");
 
-runClient(authorProfile(apolloClient(), window.nuk.identifier));
+runClient(
+  authorProfile(apolloClient(), window.nuk.identifier, window.nuk.page)
+);

--- a/packages/ssr/author-profile.js
+++ b/packages/ssr/author-profile.js
@@ -5,7 +5,7 @@ const { ApolloProvider } = require("react-apollo");
 const { AuthorProfileProvider } = require("@times-components/provider/rnw");
 const AuthorProfile = require("@times-components/author-profile/rnw").default;
 
-module.exports = (client, slug) =>
+module.exports = (client, slug, page) =>
   React.createElement(
     ApolloProvider,
     { client },
@@ -24,7 +24,7 @@ module.exports = (client, slug) =>
           error,
           onTwitterLinkPress: () => {},
           onArticlePress: () => {},
-          page: 1,
+          page,
           refetch,
           slug
         })

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -7,9 +7,9 @@
     "bundle:dev": "webpack --config=webpack.config.dev.js",
     "bundle:prod": "NODE_ENV=production webpack --config=webpack.config.prod.js -p",
     "bundle:profile": "webpack --config=webpack.config.prod.js --profile --json > dist/stats.json",
-    "depcheck": "depcheck --ignores='eslint,prettier,webpack*' --skip-missing",
+    "depcheck": "depcheck --ignores='depcheck,eslint,prettier,webpack*' --skip-missing",
     "fmt": "eslint . --fix && prettier --write '**/*.*'",
-    "lint": "eslint . && yarn prettier:diff && yarn depcheck && jest-lint",
+    "lint": "eslint . && yarn prettier:diff && yarn depcheck",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "start": "node index.js"
   },
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.0",
+    "depcheck": "0.6.9",
     "eslint": "4.9.0",
     "prettier": "1.8.2",
     "webpack": "4.6.0",

--- a/packages/ssr/topic.client.js
+++ b/packages/ssr/topic.client.js
@@ -4,4 +4,4 @@ const topic = require("./topic");
 const apolloClient = require("./make-client-ac");
 const runClient = require("./run-client");
 
-runClient(topic(apolloClient(), window.nuk.identifier));
+runClient(topic(apolloClient(), window.nuk.identifier, window.nuk.page));

--- a/packages/ssr/topic.js
+++ b/packages/ssr/topic.js
@@ -5,7 +5,7 @@ const { ApolloProvider } = require("react-apollo");
 const { TopicProvider } = require("@times-components/provider/rnw");
 const Topic = require("@times-components/topic/rnw").default;
 
-module.exports = (client, slug) =>
+module.exports = (client, slug, page) =>
   React.createElement(
     ApolloProvider,
     { client },
@@ -23,7 +23,7 @@ module.exports = (client, slug) =>
           error,
           onTwitterLinkPress: () => {},
           onArticlePress: () => {},
-          page: 1,
+          page,
           refetch,
           slug,
           topic


### PR DESCRIPTION
The current UX is a bit naff when you navigate to a list item and then hit back in the browser, we effectively broke the web experience :-(

This PR updates history state and provides a server-side implementation

chore: refactor prop-types and the way they were shared. We should always provide a no-js fallback for paging and sharing prop-types made this brittle