### PR TITLE
Add slicename to relatedArticleSlice query

### DIFF
--- a/packages/provider-queries/src/article.js
+++ b/packages/provider-queries/src/article.js
@@ -25,6 +25,7 @@ export default gql`
       }
       relatedArticleSlice {
         ... on StandardSlice {
+          sliceName: __typename
           items {
             article {
               ...relatedProps
@@ -32,6 +33,7 @@ export default gql`
           }
         }
         ... on LeadOneAndTwoSlice {
+          sliceName: __typename
           lead {
             article {
               ...relatedProps
@@ -49,6 +51,7 @@ export default gql`
           }
         }
         ... on OpinionOneAndTwoSlice {
+          sliceName: __typename
           opinion {
             article {
               ...relatedProps

--- a/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
@@ -110,6 +110,7 @@ Object {
         Symbol(id): "$Article:198c4b2f-ecec-4f34-be53-c89f83bc1b44.relatedArticleSlice.items.0",
       },
     ],
+    "sliceName": "StandardSlice",
     Symbol(id): "$Article:198c4b2f-ecec-4f34-be53-c89f83bc1b44.relatedArticleSlice",
   },
   "section": "business",


### PR DESCRIPTION
SliceName was missing in the query. Added it in so related articles can be rendered when using the provider.