### PR TITLE
fix: dont display head image placeholder when no author image

### DIFF
--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.android.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.android.test.js.snap
@@ -97,7 +97,7 @@ exports[`4. an article list without images 1`] = `
         jobTitle="Job Title"
         name="Name"
         twitter="twitter"
-        uri="https://image.io"
+        uri=""
       />
     }
     articles={
@@ -307,10 +307,6 @@ exports[`10. an article list header only changes on loading state change 2`] = `
     <View
       pointerEvents="box-none"
     >
-      <Image
-        aspectRatio={1}
-        uri=""
-      />
       <Text
         accessibilityRole="heading"
         aria-level="2"
@@ -330,10 +326,6 @@ exports[`10. an article list header only changes on loading state change 3`] = `
     <View
       pointerEvents="box-none"
     >
-      <Image
-        aspectRatio={1}
-        uri=""
-      />
       <Text
         accessibilityRole="heading"
         aria-level="2"

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.ios.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.ios.test.js.snap
@@ -97,7 +97,7 @@ exports[`4. an article list without images 1`] = `
         jobTitle="Job Title"
         name="Name"
         twitter="twitter"
-        uri="https://image.io"
+        uri=""
       />
     }
     articles={
@@ -307,10 +307,6 @@ exports[`10. an article list header only changes on loading state change 2`] = `
     <View
       pointerEvents="box-none"
     >
-      <Image
-        aspectRatio={1}
-        uri=""
-      />
       <Text
         accessibilityRole="heading"
         aria-level="2"
@@ -330,10 +326,6 @@ exports[`10. an article list header only changes on loading state change 3`] = `
     <View
       pointerEvents="box-none"
     >
-      <Image
-        aspectRatio={1}
-        uri=""
-      />
       <Text
         accessibilityRole="heading"
         aria-level="2"

--- a/packages/author-profile/__tests__/shared.base.js
+++ b/packages/author-profile/__tests__/shared.base.js
@@ -54,7 +54,7 @@ export default (props, platformTests = []) => {
         const testInstance = TestRenderer.create(
           <AuthorProfile
             {...props}
-            author={{ ...props.author, hasLeadAssets: false }}
+            author={{ ...props.author, hasLeadAssets: false, image: "" }}
             isLoading={false}
             pageSize={12}
           />

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -97,7 +97,7 @@ exports[`4. an article list without images 1`] = `
         jobTitle="Job Title"
         name="Name"
         twitter="twitter"
-        uri="https://image.io"
+        uri=""
       />
     }
     articles={
@@ -307,12 +307,6 @@ exports[`10. an article list header only changes on loading state change 2`] = `
 >
   <div>
     <div>
-      <div>
-        <Image
-          aspectRatio={1}
-          uri=""
-        />
-      </div>
       <h2
         aria-level="2"
         role="heading"
@@ -330,12 +324,6 @@ exports[`10. an article list header only changes on loading state change 3`] = `
 >
   <div>
     <div>
-      <div>
-        <Image
-          aspectRatio={1}
-          uri=""
-        />
-      </div>
       <h2
         aria-level="2"
         role="heading"

--- a/packages/author-profile/src/author-profile-head-base.js
+++ b/packages/author-profile/src/author-profile-head-base.js
@@ -19,7 +19,7 @@ export class AuthorProfileHeadBase extends Component {
       jobTitle,
       onTwitterLinkPress,
       renderBiography,
-      image,
+      renderImage,
       renderName,
       twitter
     } = this.props;
@@ -53,7 +53,7 @@ export class AuthorProfileHeadBase extends Component {
           style={styles.authorHeadWrapper}
           testID="author-head"
         >
-          {image}
+          {renderImage()}
           {renderName()}
           {renderJobTitle()}
           {renderTwitterLink()}
@@ -69,7 +69,7 @@ AuthorProfileHeadBase.propTypes = {
   jobTitle: PropTypes.string,
   onTwitterLinkPress: PropTypes.func,
   renderBiography: PropTypes.func.isRequired,
-  image: PropTypes.node.isRequired,
+  renderImage: PropTypes.func.isRequired,
   renderName: PropTypes.func.isRequired,
   twitter: PropTypes.string
 };

--- a/packages/author-profile/src/author-profile-head.js
+++ b/packages/author-profile/src/author-profile-head.js
@@ -24,7 +24,10 @@ const AuthorProfileHead = ({
     );
   };
 
-  const image = <AuthorProfileHeadImage uri={uri} />;
+  const renderImage = () => {
+    if (!uri) return null;
+    return <AuthorProfileHeadImage uri={uri} />;
+  };
 
   const renderName = () => {
     if (!name) return null;
@@ -45,11 +48,11 @@ const AuthorProfileHead = ({
       style={[styles.authorHeadContainer, styles.authorHeadContainerNative]}
     >
       <AuthorProfileHeadBaseWithTracking
-        image={image}
         isLoading={isLoading}
         jobTitle={jobTitle}
         onTwitterLinkPress={onTwitterLinkPress}
         renderBiography={renderBiography}
+        renderImage={renderImage}
         renderName={renderName}
         twitter={twitter}
       />

--- a/packages/author-profile/src/author-profile-head.web.js
+++ b/packages/author-profile/src/author-profile-head.web.js
@@ -28,11 +28,14 @@ const AuthorProfileHead = ({
     );
   };
 
-  const image = (
-    <ImageContainer>
-      <AuthorProfileHeadImage uri={uri} />
-    </ImageContainer>
-  );
+  const renderImage = () => {
+    if (!uri) return null;
+    return (
+      <ImageContainer>
+        <AuthorProfileHeadImage uri={uri} />
+      </ImageContainer>
+    );
+  };
 
   const renderName = () => {
     if (!name) return null;
@@ -53,10 +56,10 @@ const AuthorProfileHead = ({
       style={styles.authorHeadContainer}
     >
       <AuthorProfileHeadBaseWithTracking
-        image={image}
         isLoading={isLoading}
         jobTitle={jobTitle}
         renderBiography={renderBiography}
+        renderImage={renderImage}
         renderName={renderName}
         twitter={twitter}
       />

--- a/packages/provider-test-tools/src/fixture-generator.js
+++ b/packages/provider-test-tools/src/fixture-generator.js
@@ -132,6 +132,7 @@ const makeAuthor = ({ count = 20, withImages } = {}) => {
 
   return {
     ...authorProfileFixture.data.author,
+    image: "",
     hasLeadAssets: false,
     articles: {
       count,


### PR DESCRIPTION
- the new image render function matches the render functions for all of the other parts of the author profile head