### PR TITLE
fix: ad error, and mock fragment for storybook

### DIFF
--- a/packages/ad/__tests__/utils/ad-init-gpt.js
+++ b/packages/ad/__tests__/utils/ad-init-gpt.js
@@ -73,6 +73,14 @@ export default () => {
     expect(mock.googletag.destroySlots).toHaveBeenCalled();
   });
 
+  it("destroys all slots only if they exist", () => {
+    const init = adInit(initOptions);
+
+    delete mock.googletag.destroySlots;
+
+    expect(init.gpt.destroySlots()).toEqual(false);
+  });
+
   it("throws if defineSlot returns null", () => {
     const init = adInit(initOptions);
     mock.googletag.defineSlot.mockImplementation(() => null);

--- a/packages/ad/src/utils/ad-init.js
+++ b/packages/ad/src/utils/ad-init.js
@@ -153,7 +153,7 @@ const adInit = args => {
       },
 
       destroySlots() {
-        window.googletag.destroySlots && window.googletag.destroySlots();
+        if (window.googletag.destroySlots) window.googletag.destroySlots();
       }
     },
 

--- a/packages/ad/src/utils/ad-init.js
+++ b/packages/ad/src/utils/ad-init.js
@@ -153,7 +153,11 @@ const adInit = args => {
       },
 
       destroySlots() {
-        if (window.googletag.destroySlots) window.googletag.destroySlots();
+        if (window.googletag.destroySlots) {
+          window.googletag.destroySlots();
+          return true;
+        }
+        return false;
       }
     },
 

--- a/packages/ad/src/utils/ad-init.js
+++ b/packages/ad/src/utils/ad-init.js
@@ -153,7 +153,7 @@ const adInit = args => {
       },
 
       destroySlots() {
-        window.googletag.destroySlots();
+        window.googletag.destroySlots && window.googletag.destroySlots();
       }
     },
 

--- a/packages/storybook/src/showcase-to-storybook.js
+++ b/packages/storybook/src/showcase-to-storybook.js
@@ -6,7 +6,7 @@ React.Fragment = ({ children }) => children;
 React.Fragment.propTypes = {
   children: PropTypes.node.isRequired
 };
-React.Fragment.displayName = 'React.Fragment';
+React.Fragment.displayName = "React.Fragment";
 
 // eslint-disable-next-line react/prop-types
 const StrictWrapper = ({ children }) => <StrictMode>{children}</StrictMode>;

--- a/packages/storybook/src/showcase-to-storybook.js
+++ b/packages/storybook/src/showcase-to-storybook.js
@@ -1,5 +1,12 @@
 import React, { StrictMode } from "react";
+import PropTypes from "prop-types";
 import { Platform } from "react-native";
+
+React.Fragment = ({ children }) => children;
+React.Fragment.propTypes = {
+  children: PropTypes.node.isRequired
+};
+React.Fragment.displayName = 'React.Fragment';
 
 // eslint-disable-next-line react/prop-types
 const StrictWrapper = ({ children }) => <StrictMode>{children}</StrictMode>;


### PR DESCRIPTION
- fixes the broken ad stories which try to destroy slots when they are not there. The sympton was an empty page with ad blocker turned on, and a RN screen of death when traversing between stories with ads
- mock `<Fragment>` for storybook which does not recognise them, and gives prop type warnings from the [info add-on](https://github.com/storybooks/storybook/tree/master/addons/info). Seen in the `Ad Loading State` story