### PR TITLE
fix: ad blocked layout in article list

### DIFF
--- a/packages/article-list/__tests__/web/__snapshots__/article-list-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-with-styles.web.test.js.snap
@@ -68,6 +68,12 @@ exports[`1. article list 1`] = `
 
 <style>
 {
+  "IS1": {
+    "borderBottomWidth": 1,
+    "borderColor": "#DBDBDB",
+    "borderTopWidth": 1,
+    "paddingVertical": "10px",
+  },
   "S1": {
     "-ms-flex": "1",
     "-ms-flex-align": "stretch",
@@ -160,27 +166,6 @@ exports[`1. article list 1`] = `
     "min-height": "0px",
     "padding-bottom": "0px",
     "padding-top": "0px",
-    "position": "relative",
-  },
-  "S5": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "1px",
-    "border-top-width": "1px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "10px",
-    "padding-top": "10px",
     "position": "relative",
   },
 }
@@ -298,36 +283,9 @@ exports[`1. article list 1`] = `
         </Link>
       </div>
     </div>
-    <div>
-      <div
-        className="c0 S3"
-      >
-        <div
-          className="c2 S3"
-        >
-          <div
-            className="S4"
-          />
-        </div>
-        <Link>
-          <div
-            className="c1 S3"
-          >
-            <Card
-              contentContainerClass="articleListContent"
-              imageContainerClass="articleListImage"
-            >
-              <ArticleSummary />
-            </Card>
-          </div>
-        </Link>
-      </div>
-    </div>
-    <div
-      className="S5"
-    >
-      <Ad />
-    </div>
+    <Ad
+      className="IS1"
+    />
     <div
       className="S2"
     >

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -231,71 +231,9 @@ exports[`1. article list 1`] = `
         </Link>
       </div>
     </div>
-    <div
-      accessibility-label="ca00422e-8e6f-11e8-9eb6-529269fb1459.4"
-      id="ca00422e-8e6f-11e8-9eb6-529269fb1459.4"
-    >
-      <div>
-        <div>
-          <div />
-        </div>
-        <Link
-          url="https://article5.io"
-        >
-          <div>
-            <Card
-              fadeImageIn={true}
-              highResSize={1440}
-              imageRatio={1}
-              imageUri="https://lead5.io"
-              lowResSize={100}
-              showImage={true}
-            >
-              <ArticleSummary
-                bylineProps={
-                  Object {
-                    "ast": Array [
-                      Object {
-                        "attributes": Object {},
-                        "children": Array [
-                          Object {
-                            "attributes": Object {
-                              "value": "Byline 5",
-                            },
-                            "children": Array [],
-                            "name": "text",
-                          },
-                        ],
-                        "name": "paragraph",
-                      },
-                    ],
-                    "color": "#333333",
-                  }
-                }
-                datePublicationProps={
-                  Object {
-                    "date": "2017-11-17T00:01:00.000Z",
-                    "publication": "SUNDAYTIMES",
-                  }
-                }
-                labelProps={
-                  Object {
-                    "color": "#333333",
-                    "isVideo": false,
-                    "title": "Label 5",
-                  }
-                }
-              />
-            </Card>
-          </div>
-        </Link>
-      </div>
-    </div>
-    <div>
-      <Ad
-        slotName="inline-ad"
-      />
-    </div>
+    <Ad
+      slotName="inline-ad"
+    />
     <div>
       <div>
         <Pagination

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -168,12 +168,14 @@ class ArticleList extends Component {
       </ListContentContainer>
     );
 
-    const AdComponent = (
-      <View style={styles.adContainer}>
-        <AdComposer adConfig={adConfig}>
-          <Ad isLoading={articlesLoading} slotName="inline-ad" />
-        </AdComposer>
-      </View>
+    const renderAdComponent = ({ key }) => (
+      <AdComposer adConfig={adConfig} key={key}>
+        <Ad
+          isLoading={articlesLoading}
+          slotName="inline-ad"
+          style={styles.adContainer}
+        />
+      </AdComposer>
     );
 
     const data = articlesLoading
@@ -201,13 +203,9 @@ class ArticleList extends Component {
             data.map((article, index) => {
               const { elementId } = article;
 
-              const renderAd = () => {
-                if (index !== this.advertPosition || !hasAdvertConfig) {
-                  return null;
-                }
-
-                return AdComponent;
-              };
+              if (index === this.advertPosition && hasAdvertConfig) {
+                return renderAdComponent({ key: `advert${index}` });
+              }
 
               const renderSeperator = () => {
                 if (index === 0 || index === this.advertPosition + 1) {
@@ -245,7 +243,6 @@ class ArticleList extends Component {
                       }
                     </ErrorView>
                   </div>
-                  {renderAd()}
                 </Fragment>
               );
             })}


### PR DESCRIPTION
- pass layout style (with keyline borders) to `Ad` so `Ad` can decide whether to show these keylines or not (when it fails due to ad blocker, in this example)