### PR TITLE
fix: Add zindex on play icon overlay

### DIFF
--- a/packages/video/__tests__/android/__snapshots__/video-with-style.android.test.js.snap
+++ b/packages/video/__tests__/android/__snapshots__/video-with-style.android.test.js.snap
@@ -28,6 +28,7 @@ exports[`1. video 1`] = `
         "position": "absolute",
         "top": 0,
         "width": 300,
+        "zIndex": 2,
       }
     }
   >
@@ -71,6 +72,7 @@ exports[`2. video without a poster image 1`] = `
         "position": "absolute",
         "top": 0,
         "width": 300,
+        "zIndex": 2,
       }
     }
   >

--- a/packages/video/__tests__/ios/__snapshots__/video-with-style.ios.test.js.snap
+++ b/packages/video/__tests__/ios/__snapshots__/video-with-style.ios.test.js.snap
@@ -35,6 +35,7 @@ exports[`1. video 1`] = `
           "position": "absolute",
           "top": 0,
           "width": 300,
+          "zIndex": 2,
         }
       }
     >
@@ -86,6 +87,7 @@ exports[`2. video without a poster image 1`] = `
           "position": "absolute",
           "top": 0,
           "width": 300,
+          "zIndex": 2,
         }
       }
     >

--- a/packages/video/src/styles/shared.js
+++ b/packages/video/src/styles/shared.js
@@ -26,7 +26,8 @@ const styles = {
     left: 0,
     flex: 1,
     justifyContent: "center",
-    alignItems: "center"
+    alignItems: "center",
+    zIndex: 2
   }
 };
 


### PR DESCRIPTION
Lead asset image has a zIndex:1, so we need play icon to have a higher zIndex. 