### PR TITLE
fix: android ad id

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -19,7 +19,7 @@ const ArticlePageView = Article(config)(fetch);
 
 const platformAdConfig = {
   adUnit: "d.thetimes.co.uk",
-  networkId: "25436805",
+  networkId: config.adNetworkId,
   testMode: "",
   appVersion: config.appVersion,
   operatingSystem: "Android",

--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -18,7 +18,7 @@ const {
 const ArticlePageView = Article(config)(fetch);
 
 const platformAdConfig = {
-  adUnit: "d.thetimes.co.uk",
+  adUnit: "thetimes.mob.android",
   networkId: config.adNetworkId,
   testMode: "",
   appVersion: config.appVersion,

--- a/ios-app/pages/article.js
+++ b/ios-app/pages/article.js
@@ -15,7 +15,7 @@ const { fetch } = NativeModules.NativeModuleFetch;
 const { track } = NativeModules.NativeModuleAnalytics;
 
 const platformAdConfig = {
-  adUnit: "d.thetimes.co.uk",
+  adUnit: "thetimes.mob.ios",
   networkId: "25436805",
   testMode: "",
   sectionId: "",


### PR DESCRIPTION
- Use mobile ad units on apps.
- Use networkId passed by the app, based on the build flavour