### PR TITLE
fix: missing props article

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -50,7 +50,7 @@ const ArticleView = ({ articleId, omitErrors, scale, sectionName }) => {
       onTopicPress={onTopicPress}
       platformAdConfig={adConfig}
       scale={scale}
-      section={sectionName}
+      sectionName={sectionName}
     />
   );
 };

--- a/packages/article/src/article-meta/article-meta-base.js
+++ b/packages/article/src/article-meta/article-meta-base.js
@@ -54,14 +54,16 @@ const ArticleMetaBase = ({
 
 const TextNode = PropTypes.shape({ text: PropTypes.string });
 
-const nodeShape = {
+const childNode = {
   name: PropTypes.string.isRequired,
   attributes: PropTypes.object.isRequired
 };
 
-nodeShape.children = PropTypes.arrayOf(
-  PropTypes.oneOfType([PropTypes.shape(nodeShape), TextNode])
-).isRequired;
+const nodeShape = {
+  children: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.shape(childNode), TextNode])
+  ).isRequired
+};
 
 ArticleMetaBase.propTypes = {
   byline: PropTypes.arrayOf(PropTypes.shape(nodeShape)),

--- a/packages/provider-queries/src/article.js
+++ b/packages/provider-queries/src/article.js
@@ -97,6 +97,7 @@ export default gql`
     publicationName
     publishedTime
     section
+    shortHeadline
     shortIdentifier
     slug
     url

--- a/packages/provider-test-tools/fixtures/article.js
+++ b/packages/provider-test-tools/fixtures/article.js
@@ -536,7 +536,7 @@ const defaultRelatedArticleSlice = {
     {
       id: "ea16d744-cb4a-11e4-a202-50ac5def393a",
       headline: "TMS: Pratchett’s law of the jungle - Disable Saving",
-      shortHeadline: "TMS: Pratchett’s law of the jungle - Disable Saving",
+      shortHeadline: "TMS: Pratchett’s law of the jungle",
       section: "sport",
       byline: [
         {
@@ -1138,7 +1138,7 @@ const defaultRelatedArticleSlice = {
   ]
 };
 const defaultSection = "business";
-const defaultShortHeadline = "Supplement In Depth Template (Style)";
+const defaultShortHeadline = "Supplement In Depth Template";
 const defaultStandfirst =
   "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life";
 const defaultTopics = [

--- a/packages/provider-test-tools/fixtures/article.js
+++ b/packages/provider-test-tools/fixtures/article.js
@@ -536,6 +536,7 @@ const defaultRelatedArticleSlice = {
     {
       id: "ea16d744-cb4a-11e4-a202-50ac5def393a",
       headline: "TMS: Pratchett’s law of the jungle - Disable Saving",
+      shortHeadline: "TMS: Pratchett’s law of the jungle - Disable Saving",
       section: "sport",
       byline: [
         {
@@ -798,6 +799,7 @@ const defaultRelatedArticleSlice = {
       id: "b09fc422-cb53-11e4-81dd-064fe933cd41",
       headline:
         "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+      shortHeadline: "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
       section: "comment",
       byline: [
         {
@@ -980,6 +982,7 @@ const defaultRelatedArticleSlice = {
     {
       id: "8557a3d2-cb55-11e4-81dd-064fe933cd41",
       headline: "Syndicated url: At long last, a burial place fit for a king",
+      shortHeadline: "Syndicated url: At long last, a burial place fit for a king",
       section: "thedish",
       byline: [
         {
@@ -1133,6 +1136,7 @@ const defaultRelatedArticleSlice = {
   ]
 };
 const defaultSection = "business";
+const defaultShortHeadline = "Supplement In Depth Template (Style)";
 const defaultStandfirst =
   "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life";
 const defaultTopics = [
@@ -1165,6 +1169,7 @@ export default (
     leadAsset = defaultLeadAsset,
     relatedArticleSlice = defaultRelatedArticleSlice,
     section = defaultSection,
+    shortHeadline = defaultShortHeadline,
     shortIdentifier = defaultShortIdentifier,
     slug = defaultSlug,
     standfirst = defaultStandfirst,
@@ -1189,6 +1194,7 @@ export default (
       publishedTime: "2015-03-13T18:54:58.000Z",
       relatedArticleSlice,
       section,
+      shortHeadline,
       shortIdentifier,
       slug,
       standfirst,

--- a/packages/provider-test-tools/fixtures/article.js
+++ b/packages/provider-test-tools/fixtures/article.js
@@ -799,7 +799,8 @@ const defaultRelatedArticleSlice = {
       id: "b09fc422-cb53-11e4-81dd-064fe933cd41",
       headline:
         "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
-      shortHeadline: "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
+      shortHeadline:
+        "Rise of centenarian drivers as elderly push on - V5 Premoderated Comments",
       section: "comment",
       byline: [
         {
@@ -982,7 +983,8 @@ const defaultRelatedArticleSlice = {
     {
       id: "8557a3d2-cb55-11e4-81dd-064fe933cd41",
       headline: "Syndicated url: At long last, a burial place fit for a king",
-      shortHeadline: "Syndicated url: At long last, a burial place fit for a king",
+      shortHeadline:
+        "Syndicated url: At long last, a burial place fit for a king",
       section: "thedish",
       byline: [
         {

--- a/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
@@ -93,6 +93,7 @@ Object {
           "publicationName": "TIMES",
           "publishedTime": "2015-03-23T19:39:39.000Z",
           "section": "related",
+          "shortHeadline": "Related Short Headline",
           "shortIdentifier": "37b27qd2s",
           "slug": "france-defies-may-over-russia",
           "summary125": Array [
@@ -114,6 +115,7 @@ Object {
     Symbol(id): "$Article:198c4b2f-ecec-4f34-be53-c89f83bc1b44.relatedArticleSlice",
   },
   "section": "business",
+  "shortHeadline": "Supplement In Depth Template (Style)",
   "shortIdentifier": "37b27qd2s",
   "slug": "france-defies-may-over-russia",
   "standfirst": "Standfirst",

--- a/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/article-provider.test.js.snap
@@ -115,7 +115,7 @@ Object {
     Symbol(id): "$Article:198c4b2f-ecec-4f34-be53-c89f83bc1b44.relatedArticleSlice",
   },
   "section": "business",
-  "shortHeadline": "Supplement In Depth Template (Style)",
+  "shortHeadline": "Supplement In Depth Template",
   "shortIdentifier": "37b27qd2s",
   "slug": "france-defies-may-over-russia",
   "standfirst": "Standfirst",

--- a/packages/provider/__tests__/article-provider.test.js
+++ b/packages/provider/__tests__/article-provider.test.js
@@ -63,6 +63,7 @@ const mocks = [
             article: {
               id: "ea16d744-cb4a-11e4-a202-50ac5def393a",
               headline: "Related Headline",
+              shortHeadline: "Related Short Headline",
               section: "related",
               shortIdentifier: "37b27qd2s",
               slug: "france-defies-may-over-russia",

--- a/packages/related-articles/src/related-article-item-prop-types-base.js
+++ b/packages/related-articles/src/related-article-item-prop-types-base.js
@@ -7,8 +7,8 @@ const { style: ViewPropTypesStyle } = ViewPropTypes;
 export const sharedPropTypes = {
   article: PropTypes.shape({
     byline: PropTypes.arrayOf(treePropType),
-    headline: PropTypes.string.isRequired,
-    shortHeadline: PropTypes.string.isRequired,
+    headline: PropTypes.string,
+    shortHeadline: PropTypes.string,
     label: PropTypes.string,
     publishedTime: PropTypes.string.isRequired,
     summary105: PropTypes.arrayOf(treePropType),


### PR DESCRIPTION
Fixing a few prop-type warning inside the native app

- Added shortheadline to articles and related articles, and set optional in related articles
- Section name was passed to the wrong prop in android-app
- Byline prop-type definition fixed in article-meta