### PR TITLE
chore: Update emulator script to provide a better warning

### DIFF
--- a/lib/start_android_emulator.sh
+++ b/lib/start_android_emulator.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 {
+  if [ -z "$ANDROID_HOME" ]
+  then
+    echo "Please set ANDROID_HOME directory"
+    exit 1
+  fi
+
   adb_cmd="$ANDROID_HOME/platform-tools/adb"
   device=$($adb_cmd devices | tail -n +2)
   if [[ ! -z $device ]]


### PR DESCRIPTION
Adds a warning to emulator launch script for ANDROID_HOME env var