### PR TITLE
fix: Remove unused dependency from TimesReactIOS podspec

### DIFF
--- a/TimesReactIOS.podspec
+++ b/TimesReactIOS.podspec
@@ -33,7 +33,6 @@ Pod::Spec.new do |s|
   # React is split into a set of subspecs, these are the essentials
   
   s.dependency 'React/Core'
-  s.dependency 'React/Fabric'
   s.dependency 'React/CxxBridge'
   s.dependency 'React/RCTAnimation'
   s.dependency 'React/RCTImage'


### PR DESCRIPTION
React as imported by the iOS project must have changed and fails to satisfy this dependency, so we cannot install any cocoa pods until we fix this podspec.