### PR TITLE
fix: Use whatwg-url for creating urls in android

### DIFF
--- a/android-app/index.android.js
+++ b/android-app/index.android.js
@@ -1,7 +1,12 @@
 import { AppRegistry } from "react-native";
+import { URL, URLSearchParams } from "whatwg-url";
 import AuthorProfileView from "./pages/author-profile";
 import ArticleView from "./pages/article";
 import TopicView from "./pages/topic";
+
+// see https://github.com/facebook/react-native/issues/16434
+global.URL = URL;
+global.URLSearchParams = URLSearchParams;
 
 AppRegistry.registerComponent("AuthorProfile", () => AuthorProfileView);
 AppRegistry.registerComponent("Article", () => ArticleView);

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -19,7 +19,8 @@
     "prop-types": "15.6.2",
     "react": "16.4.2",
     "react-native": "0.55.4",
-    "react-native-device-info": "0.13.0"
+    "react-native-device-info": "0.13.0",
+    "whatwg-url": "7.0.0"
   },
   "devDependencies": {
     "babel-preset-react-native": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16216,6 +16216,14 @@ whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
+whatwg-url@7.0.0, whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
 whatwg-url@^4.3.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
@@ -16226,14 +16234,6 @@ whatwg-url@^4.3.0:
 whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
-
-whatwg-url@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"


### PR DESCRIPTION
React-native Android is overwriting URL class, which causes an error in our image component. 

Applied the following fix to polyfill URL using whatwg-url: https://github.com/facebook/react-native/issues/16434#issuecomment-392147974