### PR TITLE
feat: Add test mode to ad configs for easier testing

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -20,7 +20,6 @@ const ArticlePageView = Article(config)(fetch);
 const platformAdConfig = {
   adUnit: "thetimes.mob.android",
   networkId: config.adNetworkId,
-  testMode: "",
   appVersion: config.appVersion,
   operatingSystem: "Android",
   operatingSystemVersion: config.operatingSystemVersion,
@@ -33,8 +32,14 @@ const platformAdConfig = {
   platform: "mobile"
 };
 
-const ArticleView = ({ articleId, omitErrors, scale, sectionName }) => {
-  const adConfig = { ...platformAdConfig, sectionName };
+const ArticleView = ({
+  adTestMode,
+  articleId,
+  omitErrors,
+  scale,
+  sectionName
+}) => {
+  const adConfig = { ...platformAdConfig, sectionName, testMode: adTestMode };
 
   return (
     <ArticlePageView
@@ -56,6 +61,7 @@ const ArticleView = ({ articleId, omitErrors, scale, sectionName }) => {
 };
 
 ArticleView.propTypes = {
+  adTestMode: PropTypes.string.isRequired,
   articleId: PropTypes.string.isRequired,
   omitErrors: PropTypes.bool.isRequired,
   scale: PropTypes.string.isRequired,

--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -61,11 +61,15 @@ const ArticleView = ({
 };
 
 ArticleView.propTypes = {
-  adTestMode: PropTypes.string.isRequired,
+  adTestMode: PropTypes.string,
   articleId: PropTypes.string.isRequired,
   omitErrors: PropTypes.bool.isRequired,
   scale: PropTypes.string.isRequired,
   sectionName: PropTypes.string.isRequired
+};
+
+ArticleView.defaultProps = {
+  adTestMode: ""
 };
 
 export default ArticleView;


### PR DESCRIPTION
Passes advertising testmode from the native app to the config. This allows us to put a custom debug field into the app for easier ad testing