### PR TITLE
Fix omitErrors usage in pages

### DIFF
--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -39,7 +39,7 @@ const ArticleDetailsPage = ({
             analyticsStream={analyticsStream}
             article={article}
             error={omitErrors ? null : error}
-            isLoading={isLoading || (omitErrors && error !== undefined)}
+            isLoading={isLoading || (omitErrors && error != null)}
             onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
             onCommentGuidelinesPress={() => onCommentGuidelinesPress()}
             onCommentsPress={(event, { articleId: id, url }) =>

--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -39,7 +39,7 @@ const ArticleDetailsPage = ({
             analyticsStream={analyticsStream}
             article={article}
             error={omitErrors ? null : error}
-            isLoading={isLoading || (omitErrors && error !== null)}
+            isLoading={isLoading || (omitErrors && error !== undefined)}
             onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
             onCommentGuidelinesPress={() => onCommentGuidelinesPress()}
             onCommentsPress={(event, { articleId: id, url }) =>

--- a/packages/pages/src/article.js
+++ b/packages/pages/src/article.js
@@ -39,7 +39,7 @@ const ArticleDetailsPage = ({
             analyticsStream={analyticsStream}
             article={article}
             error={omitErrors ? null : error}
-            isLoading={isLoading || (omitErrors && error != null)}
+            isLoading={isLoading || (omitErrors && error)}
             onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
             onCommentGuidelinesPress={() => onCommentGuidelinesPress()}
             onCommentsPress={(event, { articleId: id, url }) =>


### PR DESCRIPTION
Article page was hanging in loading when `omitErrors` flag was set. This should only happen if there is an error.