### PR TITLE
fix: Center align topic headline

### DIFF
--- a/packages/topic/__tests__/android/__snapshots__/topic-with-style.android.test.js.snap
+++ b/packages/topic/__tests__/android/__snapshots__/topic-with-style.android.test.js.snap
@@ -31,6 +31,7 @@ exports[`1. an article list header 1`] = `
           "fontSize": 40,
           "lineHeight": 40,
           "paddingBottom": 25,
+          "textAlign": "center",
         }
       }
     >

--- a/packages/topic/__tests__/ios/__snapshots__/topic-with-style.ios.test.js.snap
+++ b/packages/topic/__tests__/ios/__snapshots__/topic-with-style.ios.test.js.snap
@@ -31,6 +31,7 @@ exports[`1. an article list header 1`] = `
           "fontSize": 40,
           "lineHeight": 40,
           "paddingBottom": 20,
+          "textAlign": "center",
         }
       }
     >

--- a/packages/topic/src/styles/shared.js
+++ b/packages/topic/src/styles/shared.js
@@ -19,7 +19,8 @@ const styles = {
   },
   name: {
     ...fontFactory({ font: "headline", fontSize: "pageHeadline" }),
-    color: colours.functional.brandColour
+    color: colours.functional.brandColour,
+    textAlign: "center"
   },
   description: {
     ...fontFactory({ font: "body", fontSize: "tertiary" }),


### PR DESCRIPTION
Two line topic headlines were left aligned by default. Now forced them to center align always:


Before:
![screen shot 2018-09-17 at 11 32 38](https://user-images.githubusercontent.com/1849590/45618524-e7ebec00-ba6d-11e8-8c1d-af188377d1b4.png)

After:
![screen shot 2018-09-17 at 11 32 02](https://user-images.githubusercontent.com/1849590/45618534-ecb0a000-ba6d-11e8-8276-f1f33d017b8e.png)
