### PR TITLE
fix: variable ad height on articlie list pages

### DIFF
--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. multiple ad slots 1`] = `
 <style>
 {
   "IS1": {
-    "height": 250,
+    "height": "auto",
     "overflow": "hidden",
     "width": 970,
   },
@@ -13,7 +13,7 @@ exports[`1. multiple ad slots 1`] = `
     "flex": 1,
   },
   "IS3": {
-    "height": 1,
+    "height": "auto",
     "overflow": "hidden",
     "width": 1,
   },
@@ -22,7 +22,7 @@ exports[`1. multiple ad slots 1`] = `
     "flex": 1,
   },
   "IS5": {
-    "height": 250,
+    "height": "auto",
     "overflow": "hidden",
     "width": 970,
   },
@@ -218,7 +218,7 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
 <style>
 {
   "IS1": {
-    "height": 0,
+    "height": "auto",
     "overflow": "hidden",
     "width": 0,
   },

--- a/packages/ad/src/dom-context-prop-types-base.js
+++ b/packages/ad/src/dom-context-prop-types-base.js
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+
+export const propTypes = {
+  data: PropTypes.shape({}),
+  height: PropTypes.number.isRequired,
+  init: PropTypes.func.isRequired,
+  onRenderComplete: PropTypes.func,
+  onRenderError: PropTypes.func,
+  width: PropTypes.number.isRequired
+};
+
+export const defaultProps = {
+  data: {},
+  height: 0,
+  onRenderComplete: () => {},
+  onRenderError: () => {}
+};

--- a/packages/ad/src/dom-context-prop-types.js
+++ b/packages/ad/src/dom-context-prop-types.js
@@ -1,17 +1,3 @@
-import PropTypes from "prop-types";
+import { propTypes, defaultProps } from "./dom-context-prop-types-base";
 
-export const propTypes = {
-  data: PropTypes.shape({}),
-  height: PropTypes.number,
-  init: PropTypes.func.isRequired,
-  onRenderComplete: PropTypes.func,
-  onRenderError: PropTypes.func,
-  width: PropTypes.number.isRequired
-};
-
-export const defaultProps = {
-  data: {},
-  height: 0,
-  onRenderComplete: () => {},
-  onRenderError: () => {}
-};
+export { propTypes, defaultProps };

--- a/packages/ad/src/dom-context-prop-types.js
+++ b/packages/ad/src/dom-context-prop-types.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 export const propTypes = {
   data: PropTypes.shape({}),
-  height: PropTypes.number.isRequired,
+  height: PropTypes.number,
   init: PropTypes.func.isRequired,
   onRenderComplete: PropTypes.func,
   onRenderError: PropTypes.func,
@@ -11,6 +11,7 @@ export const propTypes = {
 
 export const defaultProps = {
   data: {},
+  height: 0,
   onRenderComplete: () => {},
   onRenderError: () => {}
 };

--- a/packages/ad/src/dom-context-prop-types.web.js
+++ b/packages/ad/src/dom-context-prop-types.web.js
@@ -1,0 +1,17 @@
+import PropTypes from "prop-types";
+import {
+  propTypes as sharedPropTypes,
+  defaultProps as sharedDefaultProps
+} from "./dom-context-prop-types-base";
+
+const propTypes = {
+  ...sharedPropTypes,
+  height: PropTypes.number
+};
+
+const defaultProps = {
+  ...sharedDefaultProps,
+  height: 0
+};
+
+export { propTypes, defaultProps };

--- a/packages/ad/src/dom-context.web.js
+++ b/packages/ad/src/dom-context.web.js
@@ -57,13 +57,13 @@ class DOMContext extends Component {
   };
 
   render() {
-    const { height, width } = this.props;
+    const { width } = this.props;
     return (
       <div
         ref={div => {
           this.div = div;
         }}
-        style={{ height, overflow: "hidden", width }}
+        style={{ height: "auto", overflow: "hidden", width }}
       />
     );
   }


### PR DESCRIPTION
https://nidigitalsolutions.jira.com/browse/REPLAT-3836

This should not adversely affect ads on any of the pages as the height is just set to be "auto", although this was difficult to test as ads seems to be very flakey. It shows intermittently and on some stories, not at all