### PR TITLE
Use url-polyfill instead of whatwg-url

### DIFF
--- a/.storybook.native/index.js
+++ b/.storybook.native/index.js
@@ -1,5 +1,6 @@
 import url from "url";
 import { AppRegistry, NativeModules, Platform } from "react-native";
+import { URL, URLSearchParams } from "url-polyfill";
 import {
   getStorybookUI,
   configure,
@@ -8,6 +9,10 @@ import {
 import { withKnobs } from '@storybook/addon-knobs';
 import { BarSpacingDecorator, WhiteBgColorDecorator } from "@times-components/storybook";
 import { loadStories } from "./story-loader";
+
+// see https://github.com/facebook/react-native/issues/16434
+global.URL = URL;
+global.URLSearchParams = URLSearchParams;
 
 if (Platform.OS === "ios") {
   addDecorator(BarSpacingDecorator);

--- a/android-app/index.android.js
+++ b/android-app/index.android.js
@@ -1,5 +1,5 @@
 import { AppRegistry } from "react-native";
-import { URL, URLSearchParams } from "whatwg-url";
+import { URL, URLSearchParams } from "url-polyfill";
 import AuthorProfileView from "./pages/author-profile";
 import ArticleView from "./pages/article";
 import TopicView from "./pages/topic";

--- a/android-app/package.json
+++ b/android-app/package.json
@@ -20,7 +20,7 @@
     "react": "16.4.2",
     "react-native": "0.55.4",
     "react-native-device-info": "0.13.0",
-    "whatwg-url": "7.0.0"
+    "url-polyfill": "1.1.0"
   },
   "devDependencies": {
     "babel-preset-react-native": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "sort-pkg": "1.1.0",
     "subcommander": "1.0.0",
     "url": "0.11.0",
+    "url-polyfill": "1.1.0",
     "wd": "1.4.1",
     "webpack": "3.12.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15676,6 +15676,10 @@ url-parse@^1.1.8, url-parse@^1.1.9, url-parse@^1.4.3:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-polyfill@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.0.tgz#d34e1a596d954b864bc8608f84c592820df422db"
+
 url-regex@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-3.2.0.tgz#dbad1e0c9e29e105dd0b1f09f6862f7fdb482724"
@@ -16216,14 +16220,6 @@ whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
 
-whatwg-url@7.0.0, whatwg-url@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
-
 whatwg-url@^4.3.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
@@ -16234,6 +16230,14 @@ whatwg-url@^4.3.0:
 whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"


### PR DESCRIPTION
The url polyfill we used for Android seem to only work when js debug is turned on, but crashing on release builds. Replaced with "url-polyfill" instead. Also added the same polyfill to storybook