### PR TITLE
fix: Split article view event from track event

### DIFF
--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -5,7 +5,7 @@ import { Article } from "@times-components/pages";
 
 const config = NativeModules.ReactConfig;
 const { fetch } = NativeModules.NativeFetch;
-const { onArticleView, track } = NativeModules.ReactAnalytics;
+const { track } = NativeModules.ReactAnalytics;
 const {
   onArticlePress,
   onArticleLoaded,
@@ -45,7 +45,7 @@ const ArticleView = ({
   return (
     <ArticlePageView
       articleId={articleId}
-      analyticsStream={(event) => {
+      analyticsStream={event => {
         if (event.object === "Article" && event.action === "Viewed") {
           onArticleLoaded(event.attrs.articleId, event);
         } else {

--- a/android-app/pages/article.js
+++ b/android-app/pages/article.js
@@ -5,9 +5,10 @@ import { Article } from "@times-components/pages";
 
 const config = NativeModules.ReactConfig;
 const { fetch } = NativeModules.NativeFetch;
-const { track } = NativeModules.ReactAnalytics;
+const { onArticleView, track } = NativeModules.ReactAnalytics;
 const {
   onArticlePress,
+  onArticleLoaded,
   onAuthorPress,
   onCommentsPress,
   onCommentGuidelinesPress,
@@ -44,7 +45,13 @@ const ArticleView = ({
   return (
     <ArticlePageView
       articleId={articleId}
-      analyticsStream={track}
+      analyticsStream={(event) => {
+        if (event.object === "Article" && event.action === "Viewed") {
+          onArticleLoaded(event.attrs.articleId, event);
+        } else {
+          track(event);
+        }
+      }}
       omitErrors={omitErrors}
       onArticlePress={onArticlePress}
       onAuthorPress={onAuthorPress}


### PR DESCRIPTION
Part of the android analytics fix (REPLAT-1706). Splitted article page view event from track event so the native app can treat these events separately. 