### PR TITLE
chore: Update related articles snapshots

### DIFF
--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -14,6 +14,11 @@ exports[`1. has video 1`] = `
     <View>
       <View>
         <Link
+          linkStyle={
+            Object {
+              "padding": 10,
+            }
+          }
           url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
         >
           <Card

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -14,6 +14,11 @@ exports[`1. has video 1`] = `
     <View>
       <View>
         <Link
+          linkStyle={
+            Object {
+              "padding": 10,
+            }
+          }
           url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
         >
           <Card

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -15,6 +15,11 @@ exports[`1. has video 1`] = `
       <div>
         <div>
           <Link
+            linkStyle={
+              Object {
+                "padding": 10,
+              }
+            }
             url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
           >
             <Card


### PR DESCRIPTION
Snapshot tests for related articles are breaking due to an out-of-date snapshot. Updated