### PR TITLE
fix: Change object name so that it works

### DIFF
--- a/packages/article/fixtures/full-article.js
+++ b/packages/article/fixtures/full-article.js
@@ -241,7 +241,7 @@ export const longContent = [
     attributes: {
       id: "d2f83305-d558-4f78-f582-32115c659355",
       display: "secondary",
-      metadata: {
+      element: {
         value: "times-datawrapper",
         attributes: { "chart-id": "csmgb" }
       },
@@ -1055,7 +1055,7 @@ const defaultContent = [
     attributes: {
       id: "d2f83305-d558-4f78-f582-32115c659355",
       display: "secondary",
-      metadata: {
+      element: {
         value: "times-datawrapper",
         attributes: { "chart-id": "csmgb" }
       },

--- a/packages/article/src/article-body/article-body-row.web.js
+++ b/packages/article/src/article-body/article-body-row.web.js
@@ -138,8 +138,8 @@ const ArticleRow = ({ content: { data, index } }) =>
         )
       };
     },
-    interactive(key, { url, metadata }) {
-      const { attributes, value } = metadata;
+    interactive(key, { url, element }) {
+      const { attributes, value } = element;
       return {
         element: (
           <InteractiveContainer>


### PR DESCRIPTION
Object naming for Interactives in TC compared to TPA didn't match. This fixes the integration of Interactives.