### PR TITLE
fix: storybooks

### DIFF
--- a/.storybook.native/webpack.haul.storybook.js
+++ b/.storybook.native/webpack.haul.storybook.js
@@ -24,7 +24,7 @@ module.exports = ({ platform }, { module, resolve, plugins }) => ({
   },
   resolve: {
     ...resolve,
-    extensions: [`.${platform}.js`, ".native.js", ".js", ".webpack.js", ".web.js", ".mjs", ".js"],
+    extensions: [`.${platform}.js`, ".native.js", ".js", ".webpack.js", ".mjs", ".js"],
     mainFields: ["devModule", "dev", "react-native", "browser", "module", "main"],
   },
 });

--- a/.storybook.native/webpack.haul.storybook.js
+++ b/.storybook.native/webpack.haul.storybook.js
@@ -15,11 +15,16 @@ module.exports = ({ platform }, { module, resolve, plugins }) => ({
         },
         exclude: /node_modules\/(?!react|@expo|svgs|pretty-format|haul|metro)/,
       },
+      {
+        include: /node_modules/,
+        test: /\.mjs$/,
+        type: "javascript/auto",
+      },
     ]
   },
   resolve: {
     ...resolve,
-    extensions: [`.${platform}.js`, ".native.js", ".js"],
+    extensions: [`.${platform}.js`, ".native.js", ".js", ".webpack.js", ".web.js", ".mjs", ".js"],
     mainFields: ["devModule", "dev", "react-native", "browser", "module", "main"],
   },
 });

--- a/packages/lazy-load/lazy-load.showcase.web.js
+++ b/packages/lazy-load/lazy-load.showcase.web.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import styled from "styled-components";
-import LazyLoad from "./src/lazy-load";
+import LazyLoad from "@times-components/lazy-load/src/lazy-load";
 
 const list = new Array(50).fill(0).map((_, indx) => `node-${indx}`);
 const ListElement = styled.li`

--- a/packages/lazy-load/lazy-load.showcase.web.js
+++ b/packages/lazy-load/lazy-load.showcase.web.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import styled from "styled-components";
-import LazyLoad from "@times-components/lazy-load/src/lazy-load";
+import LazyLoad from "./src/lazy-load";
 
 const list = new Array(50).fill(0).map((_, indx) => `node-${indx}`);
 const ListElement = styled.li`

--- a/packages/lazy-load/lazy-load.stories.web.js
+++ b/packages/lazy-load/lazy-load.stories.web.js
@@ -1,4 +1,4 @@
 import { showcaseConverter } from "@times-components/storybook";
-import showcase from "@times-components/lazy-load/lazy-load.showcase";
+import showcase from "./lazy-load.showcase";
 
 showcaseConverter(module, showcase);

--- a/packages/lazy-load/lazy-load.stories.web.js
+++ b/packages/lazy-load/lazy-load.stories.web.js
@@ -1,4 +1,4 @@
 import { showcaseConverter } from "@times-components/storybook";
-import showcase from "./lazy-load.showcase";
+import showcase from "@times-components/lazy-load/lazy-load.showcase";
 
 showcaseConverter(module, showcase);


### PR DESCRIPTION
Native storybooks are broken because of two issues, this PR fixes both:

- Graphql transpilation problems. Added mjs to list of extensions: (see https://github.com/graphql/graphql-js/issues/1272)
- Lazy load stories are converted to web only