### PR TITLE
fix: Ads not loading - Enqueue window post messages until it's ready

### DIFF
--- a/packages/ad/src/utils/webview-event-callback-setup.js
+++ b/packages/ad/src/utils/webview-event-callback-setup.js
@@ -34,7 +34,6 @@ const webviewEventCallbackSetup = options => {
   }
 
   window.eventCallback = (type, detail) => {
-    // delay until next frame as React Native message bridge is not set up immediately
     window.postMessage(
       JSON.stringify({
         isTngMessage: true,

--- a/packages/ad/src/utils/webview-event-callback-setup.js
+++ b/packages/ad/src/utils/webview-event-callback-setup.js
@@ -5,19 +5,43 @@
 
 const webviewEventCallbackSetup = options => {
   const { window } = options;
+
+  // Enqueue window messages until it's ready - See https://github.com/facebook/react-native/issues/11594#issuecomment-274689549 for details
+  let isReactNativePostMessageReady = !!window.originalPostMessage;
+  const queue = [];
+  let currentPostMessageFn = function store(message) {
+    if (queue.length > 100) queue.shift();
+    queue.push(message);
+  };
+
+  const sendQueue = () => {
+    while (queue.length > 0) window.postMessage(queue.shift());
+  };
+
+  if (!isReactNativePostMessageReady) {
+    Object.defineProperty(window, "postMessage", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return currentPostMessageFn;
+      },
+      set(fn) {
+        currentPostMessageFn = fn;
+        isReactNativePostMessageReady = true;
+        window.setTimeout(sendQueue, 0);
+      }
+    });
+  }
+
   window.eventCallback = (type, detail) => {
     // delay until next frame as React Native message bridge is not set up immediately
-    window.setTimeout(() => {
-      const method = window.reactBridgePostMessage || window.postMessage;
-      method(
-        JSON.stringify({
-          isTngMessage: true,
-          type,
-          detail
-        }),
-        "*"
-      );
-    }, 300);
+    window.postMessage(
+      JSON.stringify({
+        isTngMessage: true,
+        type,
+        detail
+      })
+    );
   };
   window.addEventListener("error", ev => {
     const file = (ev.filename || "").substring(0, 100);


### PR DESCRIPTION
window.postMessage doesn't work until the webView is loaded. Our previous fix for this was to add a timeout to postMessages, but that's not 100% reliable. Implemented a separate approach where the window enqueues messages until post message is ready:

Based on: https://github.com/facebook/react-native/issues/11594#issuecomment-274689549
