### PR TITLE
fix: topic page scroll fix

### DIFF
--- a/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
@@ -56,6 +56,7 @@ exports[`4. loading state 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url={null}
       >
         <View>
@@ -76,6 +77,7 @@ exports[`4. loading state 1`] = `
     </View>
     <View>
       <Link
+        delayPressIn={50}
         url={null}
       >
         <View>
@@ -96,6 +98,7 @@ exports[`4. loading state 1`] = `
     </View>
     <View>
       <Link
+        delayPressIn={50}
         url={null}
       >
         <View>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -5,6 +5,7 @@ exports[`1. article list 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -39,6 +40,7 @@ exports[`1. article list 1`] = `
     </View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article2.io"
       >
         <View>
@@ -107,6 +109,7 @@ exports[`2. article list with no images 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -156,6 +159,7 @@ exports[`3. a retry button when load more fails 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -204,6 +208,7 @@ exports[`4. no footer with data equalling the count 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -369,6 +374,7 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
@@ -56,6 +56,7 @@ exports[`4. loading state 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url={null}
       >
         <View>
@@ -76,6 +77,7 @@ exports[`4. loading state 1`] = `
     </View>
     <View>
       <Link
+        delayPressIn={50}
         url={null}
       >
         <View>
@@ -96,6 +98,7 @@ exports[`4. loading state 1`] = `
     </View>
     <View>
       <Link
+        delayPressIn={50}
         url={null}
       >
         <View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -5,6 +5,7 @@ exports[`1. article list 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -39,6 +40,7 @@ exports[`1. article list 1`] = `
     </View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article2.io"
       >
         <View>
@@ -107,6 +109,7 @@ exports[`2. article list with no images 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -156,6 +159,7 @@ exports[`3. a retry button when load more fails 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -204,6 +208,7 @@ exports[`4. no footer with data equalling the count 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>
@@ -369,6 +374,7 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
   <View>
     <View>
       <Link
+        delayPressIn={50}
         url="https://article1.io"
       >
         <View>

--- a/packages/article-list/src/article-list-item.js
+++ b/packages/article-list/src/article-list-item.js
@@ -36,7 +36,7 @@ const ArticleListItem = props => {
   const content = showImage ? summary : shortSummary;
 
   return (
-    <Link onPress={onPress} url={url}>
+    <Link delayPressIn={50} onPress={onPress} url={url}>
       <View style={styles.listItemContainer}>
         <Card
           highResSize={highResSize}

--- a/packages/link/src/link.android.js
+++ b/packages/link/src/link.android.js
@@ -2,9 +2,9 @@ import React from "react";
 import { TouchableNativeFeedback, View, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-const Link = ({ children, linkStyle, onPress }) => (
+const Link = ({ children, delayPressIn, linkStyle, onPress }) => (
   <TouchableNativeFeedback
-    delayPressIn={0}
+    delayPressIn={delayPressIn}
     onPress={onPress}
     useForeground={TouchableNativeFeedback.canUseNativeForeground()}
   >
@@ -18,11 +18,13 @@ const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
+  delayPressIn: PropTypes.number,
   linkStyle: ViewPropTypesStyle,
   onPress: PropTypes.func.isRequired
 };
 
 Link.defaultProps = {
+  delayPressIn: 0,
   linkStyle: {}
 };
 

--- a/packages/link/src/link.js
+++ b/packages/link/src/link.js
@@ -2,8 +2,12 @@ import React from "react";
 import { TouchableOpacity, ViewPropTypes } from "react-native";
 import PropTypes from "prop-types";
 
-const Link = ({ children, linkStyle, onPress }) => (
-  <TouchableOpacity onPress={onPress} style={linkStyle}>
+const Link = ({ children, delayPressIn, linkStyle, onPress }) => (
+  <TouchableOpacity
+    delayPressIn={delayPressIn}
+    onPress={onPress}
+    style={linkStyle}
+  >
     {children}
   </TouchableOpacity>
 );
@@ -12,11 +16,13 @@ const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
+  delayPressIn: PropTypes.number,
   linkStyle: ViewPropTypesStyle,
   onPress: PropTypes.func.isRequired
 };
 
 Link.defaultProps = {
+  delayPressIn: 0,
   linkStyle: {}
 };
 


### PR DESCRIPTION
When scrolling on Topic pages on iOS and Android, the feedback animation happens when you scroll. This adds a small delay on the onPress to help counteract this.

Waiting on @tuncaulubilge to speak with Jake.