### PR TITLE
fix: article flag layout

### DIFF
--- a/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
+++ b/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. red article flag 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 1,
+        "marginBottom": -1,
         "marginRight": 5,
       }
     }
@@ -28,6 +28,7 @@ exports[`1. red article flag 1`] = `
         "fontWeight": "400",
         "letterSpacing": 1.4,
         "lineHeight": 12,
+        "marginTop": 5,
       }
     }
   >

--- a/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
+++ b/packages/article-flag/__tests__/android/__snapshots__/article-flag-with-style.android.test.js.snap
@@ -12,7 +12,6 @@ exports[`1. red article flag 1`] = `
   <View
     style={
       Object {
-        "marginBottom": -1,
         "marginRight": 5,
       }
     }

--- a/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
+++ b/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. red article flag 1`] = `
   <View
     style={
       Object {
-        "marginBottom": 1,
+        "marginBottom": -1,
         "marginRight": 5,
       }
     }

--- a/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
+++ b/packages/article-flag/__tests__/ios/__snapshots__/article-flag-with-style.ios.test.js.snap
@@ -12,7 +12,6 @@ exports[`1. red article flag 1`] = `
   <View
     style={
       Object {
-        "marginBottom": -1,
         "marginRight": 5,
       }
     }

--- a/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
+++ b/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
@@ -4,7 +4,6 @@ exports[`1. red article flag 1`] = `
 <style>
 {
   "IS1": {
-    "marginBottom": "-1px",
     "marginRight": "5px",
   },
   "IS2": {
@@ -36,6 +35,7 @@ exports[`1. red article flag 1`] = `
     "-webkit-flex-direction": "column",
     "align-items": "stretch",
     "flex-direction": "column",
+    "margin-bottom": "0px",
   },
   "S2": {
     "margin-bottom": "0px",

--- a/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
+++ b/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. red article flag 1`] = `
 <style>
 {
   "IS1": {
-    "marginBottom": "1px",
+    "marginBottom": "-1px",
     "marginRight": "5px",
   },
   "IS2": {

--- a/packages/article-flag/src/style/index.android.js
+++ b/packages/article-flag/src/style/index.android.js
@@ -5,7 +5,8 @@ const styles = {
   ...sharedStyles,
   title: {
     ...sharedStyles.title,
-    fontSize: fontSizes.meta
+    fontSize: fontSizes.meta,
+    marginTop: 5
   }
 };
 

--- a/packages/article-flag/src/style/shared.js
+++ b/packages/article-flag/src/style/shared.js
@@ -7,8 +7,8 @@ const styles = {
     alignItems: "center"
   },
   diamond: {
-    marginRight: 5,
-    marginBottom: 1
+    marginBottom: -1,
+    marginRight: 5
   },
   title: {
     ...fontFactory({

--- a/packages/article-flag/src/style/shared.js
+++ b/packages/article-flag/src/style/shared.js
@@ -7,7 +7,6 @@ const styles = {
     alignItems: "center"
   },
   diamond: {
-    marginBottom: -1,
     marginRight: 5
   },
   title: {


### PR DESCRIPTION
Part of https://nidigitalsolutions.jira.com/browse/REPLAT-3472

NB: margins here are for layout _vis a vis_ font, rather than vertical rhythm, hence, did not use `spacing`
