### PR TITLE
docs: provide instructions for building for iOS using Xcode 10

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -178,7 +178,7 @@ Follow these steps to deploy storybook native to a real android device.
 * Run `yarn android:device` (to enable Times API)
 * Open [storybook native](http:localhost:7007) on your computer and load a story
 
-#### Troublshooting
+#### Troubleshooting
 
 * If your device is complaining about about `story-loader.js` not existing - run
   `yarn storybook-native` before `yarn android`. This should generate the
@@ -190,11 +190,30 @@ Follow these steps to deploy storybook native to a real android device.
   on your computer for more info on the error
 * If you're still struggling verify that you are able to run `yarn storybook`
   and that it works in web view.
-* If you receive a `":CFBundleIdentifier", Does Not Exist` error when trying to
-  run `yarn ios`, try clearing your React Native cache with `rm -r ~/.rncache`
-  and clearing third part libraries `rm -r
-  <your-project>/node_modules/react-native/third_party`. This happens when React
-  Native caches third party tools for previous versions of React Native.
+
+### iOS
+
+#### Building on Xcode 10
+
+We are currently using React Native 0.55.4 which does not fully support
+Xcode
+10<sup>[1](https://github.com/facebook/react-native/issues/14382#issuecomment-313163119),
+[2](https://github.com/facebook/react-native/issues/19569#issuecomment-399652331)</sup>.
+If you need to build with Xcode 10, you will need to run the below command,
+**only after you have installed dependencies**.
+
+```
+$ yarn ios; pushd node_modules/react-native/third-party/glog-*; ../../scripts/ios-configure-glog.sh; popd; cp ios/build/Build/Products/Debug-iphonesimulator/libfishhook.a node_modules/react-native/Libraries/WebSocket/;
+```
+
+#### Other iOS Build Issues
+
+If when trying to run `yarn ios` you receive a `":CFBundleIdentifier", Does Not
+Exist` error, either on XCode 10 after attempting the above instructions, or on
+a previous version of Xcode, try clearing your React Native cache with `rm -r
+~/.rncache` and clearing third part libraries `rm -r
+<your-project>/node_modules/react-native/third_party`. This happens when React
+Native caches third party tools for previous versions of React Native.
 
 ### Font Naming Conventions
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -195,8 +195,7 @@ Follow these steps to deploy storybook native to a real android device.
 
 #### Building on Xcode 10
 
-We are currently using React Native 0.55.4 which does not fully support
-Xcode
+We are currently using React Native 0.55.4 which does not fully support Xcode
 10<sup>[1](https://github.com/facebook/react-native/issues/14382#issuecomment-313163119),
 [2](https://github.com/facebook/react-native/issues/19569#issuecomment-399652331)</sup>.
 If you need to build with Xcode 10, you will need to run the below command,
@@ -210,10 +209,20 @@ $ yarn ios; pushd node_modules/react-native/third-party/glog-*; ../../scripts/io
 
 If when trying to run `yarn ios` you receive a `":CFBundleIdentifier", Does Not
 Exist` error, either on XCode 10 after attempting the above instructions, or on
-a previous version of Xcode, try clearing your React Native cache with `rm -r
-~/.rncache` and clearing third part libraries `rm -r
-<your-project>/node_modules/react-native/third_party`. This happens when React
-Native caches third party tools for previous versions of React Native.
+a previous version of Xcode, try clearing your React Native cache with
+
+```
+rm -r ~/.rncache
+```
+
+and clearing third party libraries
+
+```
+rm -r node_modules/react-native/third_party
+```
+
+This happens when React Native caches third party tools for previous versions of
+React Native.
 
 ### Font Naming Conventions
 


### PR DESCRIPTION
Building on Xcode 10 doesn't currently work. I figured out a work around that worked for me – thought it should be in the CONTRIBUTING.md so others do not have to stab in the dark. 