### PR TITLE
feat: expose tracking events to native storybook

### DIFF
--- a/packages/tealium-utils/package.json
+++ b/packages/tealium-utils/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
-    "@storybook/addon-actions": "3.4.10",
     "@times-components/eslint-config-thetimes": "0.8.0",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
@@ -40,6 +39,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
+    "@storybook/addon-actions": "3.4.10",
     "@times-components/tealium": "1.6.3"
   },
   "peerDependencies": {

--- a/packages/tealium-utils/src/storybook.js
+++ b/packages/tealium-utils/src/storybook.js
@@ -1,1 +1,4 @@
-export default () => {};
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { action } from "@storybook/addon-actions";
+
+export default e => action("analytics-event")(e);

--- a/packages/tealium-utils/src/storybook.js
+++ b/packages/tealium-utils/src/storybook.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { action } from "@storybook/addon-actions";
 
 export default e => action("analytics-event")(e);

--- a/packages/tealium-utils/src/storybook.web.js
+++ b/packages/tealium-utils/src/storybook.web.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { action } from "@storybook/addon-actions";
 import tealiumReporter, {
   TealiumSendScheduler

--- a/packages/tealium-utils/src/storybook.web.js
+++ b/packages/tealium-utils/src/storybook.web.js
@@ -22,5 +22,5 @@ const reporter = tealiumReporter(tealiumSendScheduler);
 export default e => {
   if (reporter) reporter.analytics(e);
 
-  if (!global.storiesOf) action("analytics-event")(e);
+  return action("analytics-event")(e);
 };


### PR DESCRIPTION
Call the action logger from the native storybook `tealium-util`. Looks like it was just an oversight that it wasn't added.

`if (!global.storiesOf)` has been removed which was a previous hack when `fructose` first started