### PR TITLE
chore: ensure PureComponent is destructed from React

### DIFF
--- a/packages/eslint-config-thetimes/index.js
+++ b/packages/eslint-config-thetimes/index.js
@@ -45,6 +45,11 @@ module.exports = {
         object: "React",
         property: "Component",
         message: "Please destruct Component from React."
+      },
+      {
+        object: "React",
+        property: "PureComponent",
+        message: "Please destruct Component from React."
       }
     ]
   },


### PR DESCRIPTION
We do the same thing with `Component`