### PR TITLE
chore: stop using media queries on native platforms

### DIFF
--- a/packages/card/card-wrapper.js
+++ b/packages/card/card-wrapper.js
@@ -1,0 +1,2 @@
+export const CardWrapper = ({ children }) => children;
+export const ReversedCardWrapper = ({ children }) => children;

--- a/packages/card/card-wrapper.web.js
+++ b/packages/card/card-wrapper.web.js
@@ -1,0 +1,33 @@
+import { View } from "react-native";
+import styled from "styled-components";
+import { breakpoints } from "../styleguide";
+
+export const CardWrapper = styled(View)`
+  @media (min-width: ${breakpoints.medium}px) {
+    .exampleCardImage {
+      flex-grow: 2 !important;
+      margin-bottom: 0;
+      min-width: 360px;
+      padding-right: 15px;
+    }
+    .exampleCardContent {
+      flex-grow: 2.7 !important;
+      min-width: 380px;
+    }
+  }
+`;
+
+export const ReversedCardWrapper = styled(View)`
+  @media (min-width: ${breakpoints.medium}px) {
+    .exampleCardImage {
+      flex-grow: 2 !important;
+      margin-bottom: 0;
+      min-width: 360px;
+      padding-left: 15px;
+    }
+    .exampleCardContent {
+      flex-grow: 2.7 !important;
+      min-width: 380px;
+    }
+  }
+`;

--- a/packages/card/card.showcase.js
+++ b/packages/card/card.showcase.js
@@ -1,8 +1,7 @@
 import React from "react";
 import { Text, View } from "react-native";
-import styled from "styled-components";
-import { breakpoints } from "@times-components/styleguide";
 import Card from "./src/card";
+import { CardWrapper, ReversedCardWrapper } from "./card-wrapper";
 
 const cardProps = {
   image: {
@@ -12,36 +11,6 @@ const cardProps = {
   imageRatio: 1.5,
   imageSize: 360
 };
-
-const CardWrapper = styled(View)`
-  @media (min-width: ${breakpoints.medium}px) {
-    .exampleCardImage {
-      flex-grow: 2 !important;
-      margin-bottom: 0;
-      min-width: 360px;
-      padding-right: 15px;
-    }
-    .exampleCardContent {
-      flex-grow: 2.7 !important;
-      min-width: 380px;
-    }
-  }
-`;
-
-const ReversedCardWrapper = styled(View)`
-  @media (min-width: ${breakpoints.medium}px) {
-    .exampleCardImage {
-      flex-grow: 2 !important;
-      margin-bottom: 0;
-      min-width: 360px;
-      padding-left: 15px;
-    }
-    .exampleCardContent {
-      flex-grow: 2.7 !important;
-      min-width: 380px;
-    }
-  }
-`;
 
 const childStyle = {
   borderColor: "black",


### PR DESCRIPTION
Styled components doesn't support media queries on native platforms, but the error you get is very non-descriptive and without any kind of stack trace

```
node of type at rule not supported as an inline style
```

After investigating, this was tracked down to the use of media queries in two showcases that did not have native specific versions.

**You should avoid using media queries on native platforms as they will not work, and give you very confusing errors with no information to track them down**