### PR TITLE
fix: Convert div to view in related-articles

### DIFF
--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one lead related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,7 +62,7 @@ exports[`1. one lead related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one lead and one support related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. one lead and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -107,7 +107,7 @@ exports[`1. one lead and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one lead and two support related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. one lead and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -107,12 +107,12 @@ exports[`1. one lead and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -152,7 +152,7 @@ exports[`1. one lead and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. no short headline 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,7 +62,7 @@ exports[`1. no short headline 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -49,7 +49,7 @@ exports[`default styles 1`] = `
           }
         }
       >
-        <div>
+        <View>
           <Link>
             <Card>
               <View>
@@ -152,7 +152,7 @@ exports[`default styles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one opinion related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,7 +72,7 @@ exports[`1. one opinion related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one opinion and one support related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,12 +72,12 @@ exports[`1. one opinion and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -117,7 +117,7 @@ exports[`1. one opinion and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one opinion and two support related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,12 +72,12 @@ exports[`1. one opinion and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -117,12 +117,12 @@ exports[`1. one opinion and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -162,7 +162,7 @@ exports[`1. one opinion and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. no short headline 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,7 +72,7 @@ exports[`1. no short headline 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
           }
         }
       >
-        <div>
+        <View>
           <Link>
             <Card>
               <View>
@@ -162,7 +162,7 @@ exports[`default styles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. has video 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -217,7 +217,7 @@ exports[`1. has video 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -49,7 +49,7 @@ exports[`default styles 1`] = `
           }
         }
       >
-        <div>
+        <View>
           <Link>
             <Card>
               <View>
@@ -165,7 +165,7 @@ exports[`default styles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. a single related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -65,7 +65,7 @@ exports[`1. a single related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. two related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. two related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -116,7 +116,7 @@ exports[`1. two related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. three related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. three related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -116,12 +116,12 @@ exports[`1. three related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -170,7 +170,7 @@ exports[`1. three related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. no short headline 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -65,7 +65,7 @@ exports[`1. no short headline 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one lead related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,7 +62,7 @@ exports[`1. one lead related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one lead and one support related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. one lead and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -107,7 +107,7 @@ exports[`1. one lead and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one lead and two support related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. one lead and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -107,12 +107,12 @@ exports[`1. one lead and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -152,7 +152,7 @@ exports[`1. one lead and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. no short headline 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,7 +62,7 @@ exports[`1. no short headline 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -49,7 +49,7 @@ exports[`default styles 1`] = `
           }
         }
       >
-        <div>
+        <View>
           <Link>
             <Card>
               <View>
@@ -152,7 +152,7 @@ exports[`default styles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one opinion related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,7 +72,7 @@ exports[`1. one opinion related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one opinion and one support related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,12 +72,12 @@ exports[`1. one opinion and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -117,7 +117,7 @@ exports[`1. one opinion and one support related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. one opinion and two support related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,12 +72,12 @@ exports[`1. one opinion and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -117,12 +117,12 @@ exports[`1. one opinion and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -162,7 +162,7 @@ exports[`1. one opinion and two support related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. no short headline 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -72,7 +72,7 @@ exports[`1. no short headline 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
           }
         }
       >
-        <div>
+        <View>
           <Link>
             <Card>
               <View>
@@ -162,7 +162,7 @@ exports[`default styles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. a single related article 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -65,7 +65,7 @@ exports[`1. a single related article 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. two related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. two related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -116,7 +116,7 @@ exports[`1. two related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. three related articles 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -62,12 +62,12 @@ exports[`1. three related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -116,12 +116,12 @@ exports[`1. three related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -170,7 +170,7 @@ exports[`1. three related articles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. has video 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -217,7 +217,7 @@ exports[`1. has video 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -13,7 +13,7 @@ exports[`1. no short headline 1`] = `
   <View>
     <View>
       <View>
-        <div>
+        <View>
           <Link
             linkStyle={
               Object {
@@ -65,7 +65,7 @@ exports[`1. no short headline 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -49,7 +49,7 @@ exports[`default styles 1`] = `
           }
         }
       >
-        <div>
+        <View>
           <Link>
             <Card>
               <View>
@@ -165,7 +165,7 @@ exports[`default styles 1`] = `
               </View>
             </Card>
           </Link>
-        </div>
+        </View>
       </View>
     </View>
   </View>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -317,7 +317,9 @@ exports[`default styles 1`] = `
         <div
           className="c6 c7 c8 S4"
         >
-          <div>
+          <div
+            className="S4"
+          >
             <Link>
               <Card>
                 <div

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -346,7 +346,9 @@ exports[`default styles 1`] = `
         <div
           className="c6 c7 c8 S4"
         >
-          <div>
+          <div
+            className="S4"
+          >
             <Link>
               <Card>
                 <div

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -292,7 +292,9 @@ exports[`default styles 1`] = `
         <div
           className="c7 S4"
         >
-          <div>
+          <div
+            className="S4"
+          >
             <Link>
               <Card>
                 <div

--- a/packages/related-articles/src/related-article-item.js
+++ b/packages/related-articles/src/related-article-item.js
@@ -76,7 +76,7 @@ class RelatedArticleItem extends Component {
         : get(leadAsset, `crop${cropSize}.url`);
 
     return (
-      <div
+      <View
         ref={node => {
           this.node = node;
         }}
@@ -144,7 +144,7 @@ class RelatedArticleItem extends Component {
             />
           </Card>
         </Link>
-      </div>
+      </View>
     );
   }
 }


### PR DESCRIPTION
A rogue `<div>` inside native components have been caught and eliminated. 