### PR TITLE
fix: prop type warnings in article

### DIFF
--- a/packages/article/__tests__/comments.base.js
+++ b/packages/article/__tests__/comments.base.js
@@ -38,6 +38,7 @@ export default () =>
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         );
 
@@ -66,6 +67,7 @@ export default () =>
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         );
 

--- a/packages/article/__tests__/comments.native.js
+++ b/packages/article/__tests__/comments.native.js
@@ -76,6 +76,7 @@ export default () => {
         onTopicPress={() => {}}
         onTwitterLinkPress={() => {}}
         onVideoPress={() => {}}
+        refetch={() => {}}
       />
     );
 

--- a/packages/article/__tests__/images.base.js
+++ b/packages/article/__tests__/images.base.js
@@ -49,6 +49,7 @@ export default () =>
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         );
 
@@ -87,6 +88,7 @@ export default () =>
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         );
 

--- a/packages/article/__tests__/scaling.base.js
+++ b/packages/article/__tests__/scaling.base.js
@@ -25,6 +25,7 @@ export default renderComponent => [
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         </Context.Provider>
       );
@@ -51,6 +52,7 @@ export default renderComponent => [
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         </Context.Provider>
       );
@@ -77,6 +79,7 @@ export default renderComponent => [
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         </Context.Provider>
       );

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -31,6 +31,7 @@ export default () => {
         onTwitterLinkPress={() => {}}
         onVideoPress={() => {}}
         pageSection="News"
+        refetch={() => {}}
       />
     );
     const [[call]] = stream.mock.calls;

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -54,6 +54,7 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -148,6 +149,7 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -177,6 +179,7 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -202,6 +205,7 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -234,6 +238,7 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -257,6 +262,7 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -308,6 +314,7 @@ export const snapshotTests = renderComponent => [
                 onTopicPress={() => {}}
                 onTwitterLinkPress={() => {}}
                 onVideoPress={() => {}}
+                refetch={() => {}}
               />
             </Context.Provider>
           )}
@@ -343,6 +350,7 @@ const negativeTests = [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -367,6 +375,7 @@ const negativeTests = [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -391,6 +400,7 @@ const negativeTests = [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -418,6 +428,7 @@ const negativeTests = [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 
@@ -458,6 +469,7 @@ const negativeTests = [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          refetch={() => {}}
         />
       );
 

--- a/packages/article/__tests__/shared.native.js
+++ b/packages/article/__tests__/shared.native.js
@@ -82,6 +82,7 @@ export default () => {
                 onTopicPress={() => {}}
                 onTwitterLinkPress={() => {}}
                 onVideoPress={() => {}}
+                refetch={() => {}}
               />
             )}
           </Wrapper>
@@ -134,6 +135,7 @@ export default () => {
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            refetch={() => {}}
           />
         );
 

--- a/packages/article/src/article-prop-types.js
+++ b/packages/article/src/article-prop-types.js
@@ -3,7 +3,6 @@ import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
 
 const articlePropTypes = {
-  adConfig: PropTypes.shape({}).isRequired,
   analyticsStream: PropTypes.func.isRequired,
   data: PropTypes.shape({
     ...ArticleHeader.propTypes,


### PR DESCRIPTION
- ad config
- refetch method

prop type warnings fixed in story book and test runner. Ad config is on the `ArticlePage` level, not `Article` anymore
