### PR TITLE
fix: Remove div in related articles and use view instead

### DIFF
--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one lead related article 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. one lead related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one lead and one support related article 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. one lead and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. one lead and one support related article 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -106,7 +106,7 @@ exports[`1. one lead and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one lead and two support related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. one lead and two support related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -106,7 +106,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -120,7 +120,7 @@ exports[`1. one lead and two support related articles 1`] = `
           }
           url="https://third.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -151,7 +151,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. no short headline 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. no short headline 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
         }
       >
         <Link>
-          <div>
+          <View>
             <Card>
               <View>
                 <View
@@ -151,7 +151,7 @@ exports[`default styles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one opinion related article 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. one opinion related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one opinion and one support related article 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -85,7 +85,7 @@ exports[`1. one opinion and one support related article 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -116,7 +116,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one opinion and two support related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -85,7 +85,7 @@ exports[`1. one opinion and two support related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -116,7 +116,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -130,7 +130,7 @@ exports[`1. one opinion and two support related articles 1`] = `
           }
           url="https://third.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -161,7 +161,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. no short headline 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. no short headline 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -51,7 +51,7 @@ exports[`default styles 1`] = `
         }
       >
         <Link>
-          <div>
+          <View>
             <Card>
               <View>
                 <View
@@ -161,7 +161,7 @@ exports[`default styles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. has video 1`] = `
           }
           url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -216,7 +216,7 @@ exports[`1. has video 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
         }
       >
         <Link>
-          <div>
+          <View>
             <Card>
               <View>
                 <View
@@ -164,7 +164,7 @@ exports[`default styles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. a single related article 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -64,7 +64,7 @@ exports[`1. a single related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. two related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. two related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. two related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -115,7 +115,7 @@ exports[`1. two related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. three related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. three related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. three related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -115,7 +115,7 @@ exports[`1. three related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -129,7 +129,7 @@ exports[`1. three related articles 1`] = `
           }
           url="https://third.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -169,7 +169,7 @@ exports[`1. three related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. no short headline 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -64,7 +64,7 @@ exports[`1. no short headline 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one lead related article 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. one lead related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one lead and one support related article 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. one lead and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. one lead and one support related article 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -106,7 +106,7 @@ exports[`1. one lead and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one lead and two support related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. one lead and two support related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -106,7 +106,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -120,7 +120,7 @@ exports[`1. one lead and two support related articles 1`] = `
           }
           url="https://third.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -151,7 +151,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. no short headline 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. no short headline 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
         }
       >
         <Link>
-          <div>
+          <View>
             <Card>
               <View>
                 <View
@@ -151,7 +151,7 @@ exports[`default styles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one opinion related article 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. one opinion related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one opinion and one support related article 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -85,7 +85,7 @@ exports[`1. one opinion and one support related article 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -116,7 +116,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. one opinion and two support related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -85,7 +85,7 @@ exports[`1. one opinion and two support related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -116,7 +116,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -130,7 +130,7 @@ exports[`1. one opinion and two support related articles 1`] = `
           }
           url="https://third.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -161,7 +161,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. no short headline 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={0.6135458167330677}
@@ -71,7 +71,7 @@ exports[`1. no short headline 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -51,7 +51,7 @@ exports[`default styles 1`] = `
         }
       >
         <Link>
-          <div>
+          <View>
             <Card>
               <View>
                 <View
@@ -161,7 +161,7 @@ exports[`default styles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. a single related article 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -64,7 +64,7 @@ exports[`1. a single related article 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. two related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. two related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. two related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -115,7 +115,7 @@ exports[`1. two related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. three related articles 1`] = `
           }
           url="https://first.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -61,7 +61,7 @@ exports[`1. three related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -75,7 +75,7 @@ exports[`1. three related articles 1`] = `
           }
           url="https://second.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -115,7 +115,7 @@ exports[`1. three related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>
@@ -129,7 +129,7 @@ exports[`1. three related articles 1`] = `
           }
           url="https://third.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -169,7 +169,7 @@ exports[`1. three related articles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. has video 1`] = `
           }
           url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -216,7 +216,7 @@ exports[`1. has video 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -21,7 +21,7 @@ exports[`1. no short headline 1`] = `
           }
           url="https://test.io"
         >
-          <div>
+          <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
@@ -64,7 +64,7 @@ exports[`1. no short headline 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
         }
       >
         <Link>
-          <div>
+          <View>
             <Card>
               <View>
                 <View
@@ -164,7 +164,7 @@ exports[`default styles 1`] = `
                 </Text>
               </View>
             </Card>
-          </div>
+          </View>
         </Link>
       </View>
     </View>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -318,7 +318,9 @@ exports[`default styles 1`] = `
           className="c6 c7 c8 S4"
         >
           <Link>
-            <div>
+            <div
+              className="S4"
+            >
               <Card>
                 <div
                   className="S4"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -347,7 +347,9 @@ exports[`default styles 1`] = `
           className="c6 c7 c8 S4"
         >
           <Link>
-            <div>
+            <div
+              className="S4"
+            >
               <Card>
                 <div
                   className="S4"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -293,7 +293,9 @@ exports[`default styles 1`] = `
           className="c7 S4"
         >
           <Link>
-            <div>
+            <div
+              className="S4"
+            >
               <Card>
                 <div
                   className="S4"

--- a/packages/related-articles/src/related-article-item.base.js
+++ b/packages/related-articles/src/related-article-item.base.js
@@ -77,7 +77,7 @@ class RelatedArticleItem extends Component {
     return children({
       article: this.props.article,
       card: (
-        <div
+        <View
           ref={node => {
             this.node = node;
           }}
@@ -139,7 +139,7 @@ class RelatedArticleItem extends Component {
               }}
             />
           </Card>
-        </div>
+        </View>
       ),
       onPress
     });


### PR DESCRIPTION
The div in related-articles came back through another refactor pr. So this pr removes it once again, same as https://github.com/newsuk/times-components/pull/1406