### PR TITLE
refactor: remove unrequired adConfig prop type

### DIFF
--- a/packages/article/src/article-prop-types.js
+++ b/packages/article/src/article-prop-types.js
@@ -3,7 +3,6 @@ import ArticleHeader from "./article-header/article-header";
 import ArticleMeta from "./article-meta/article-meta";
 
 const articlePropTypes = {
-  adConfig: PropTypes.shape({}).isRequired,
   analyticsStream: PropTypes.func.isRequired,
   data: PropTypes.shape({
     ...ArticleHeader.propTypes,


### PR DESCRIPTION
- remove `adConfig` prop type - Ad config is on the ArticlePage level, not Article anymore