### PR TITLE
test: remove prop type warnings in article

### DIFF
--- a/packages/article/__tests__/comments.base.js
+++ b/packages/article/__tests__/comments.base.js
@@ -4,6 +4,7 @@ import TestRenderer from "react-test-renderer";
 import Article from "../src/article";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 const emptyArticle = {
   byline: null,
@@ -27,6 +28,7 @@ export default () =>
 
         const testInstance = TestRenderer.create(
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={article}
@@ -55,6 +57,7 @@ export default () =>
 
         const testInstance = TestRenderer.create(
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={article}

--- a/packages/article/__tests__/comments.native.js
+++ b/packages/article/__tests__/comments.native.js
@@ -12,6 +12,7 @@ import shared from "./comments.base";
 import Article from "../src/article";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 const findViewByText = (testInstance, text) =>
   testInstance.root.find(
@@ -65,6 +66,7 @@ export default () => {
 
     const testInstance = TestRenderer.create(
       <Article
+        {...articleProps}
         adConfig={adConfig}
         analyticsStream={() => {}}
         article={article}

--- a/packages/article/__tests__/images.base.js
+++ b/packages/article/__tests__/images.base.js
@@ -4,6 +4,7 @@ import TestRenderer from "react-test-renderer";
 import Article from "../src/article";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 const emptyArticle = {
   byline: null,
@@ -22,6 +23,7 @@ export default () =>
       test() {
         const output = TestRenderer.create(
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={articleFixture({
@@ -60,6 +62,7 @@ export default () =>
       test() {
         const output = TestRenderer.create(
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={articleFixture({

--- a/packages/article/__tests__/scaling.base.js
+++ b/packages/article/__tests__/scaling.base.js
@@ -4,6 +4,7 @@ import { scales } from "@times-components/styleguide";
 import Article from "../src/article";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 export default renderComponent => [
   {
@@ -12,6 +13,7 @@ export default renderComponent => [
       const output = renderComponent(
         <Context.Provider value={{ theme: { scale: scales.medium } }}>
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={articleFixture({
@@ -38,6 +40,7 @@ export default renderComponent => [
       const output = renderComponent(
         <Context.Provider value={{ theme: { scale: scales.large } }}>
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={articleFixture({
@@ -64,6 +67,7 @@ export default renderComponent => [
       const output = renderComponent(
         <Context.Provider value={{ theme: { scale: scales.xlarge } }}>
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={articleFixture({

--- a/packages/article/__tests__/shared-article-props.js
+++ b/packages/article/__tests__/shared-article-props.js
@@ -1,0 +1,3 @@
+export default {
+    refetch: () => {}
+};

--- a/packages/article/__tests__/shared-article-props.js
+++ b/packages/article/__tests__/shared-article-props.js
@@ -1,3 +1,3 @@
 export default {
-    refetch: () => {}
+  refetch: () => {}
 };

--- a/packages/article/__tests__/shared-article-props.web.js
+++ b/packages/article/__tests__/shared-article-props.web.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/article/__tests__/shared-tracking.js
+++ b/packages/article/__tests__/shared-tracking.js
@@ -4,6 +4,7 @@ import mockDate from "mockdate";
 import Article from "../src/article";
 import { adConfig } from "./ad-mock";
 import articleFixture from "../fixtures/full-article";
+import articleProps from "./shared-article-props";
 
 export default () => {
   beforeEach(() => {
@@ -19,6 +20,7 @@ export default () => {
 
     renderer.create(
       <Article
+        {...articleProps}
         adConfig={adConfig}
         analyticsStream={stream}
         article={articleFixture()}

--- a/packages/article/__tests__/shared-with-style.web.js
+++ b/packages/article/__tests__/shared-with-style.web.js
@@ -15,6 +15,7 @@ import "./mocks.web";
 import Article from "../src/article";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 const styles = [
   "alignItems",
@@ -149,6 +150,7 @@ export default () => {
 
     const output = TestRenderer.create(
       <Article
+        {...articleProps}
         adConfig={adConfig}
         analyticsStream={() => {}}
         article={article}

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -12,6 +12,7 @@ import articleFixture, {
   videoLeadAsset
 } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 const findComponents = (testInstance, componentName) =>
   testInstance.root.findAll(node => {
@@ -44,6 +45,7 @@ export const snapshotTests = renderComponent => [
       const output = renderComponent(
         <Article
           {...props}
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           onAuthorPress={() => {}}
@@ -54,7 +56,6 @@ export const snapshotTests = renderComponent => [
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
-          refetch={() => {}}
         />
       );
 
@@ -138,6 +139,7 @@ export const snapshotTests = renderComponent => [
 
       const output = renderComponent(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={article}
@@ -160,6 +162,7 @@ export const snapshotTests = renderComponent => [
     test() {
       const output = renderComponent(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({
@@ -189,6 +192,7 @@ export const snapshotTests = renderComponent => [
     test() {
       const output = renderComponent(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({
@@ -214,6 +218,7 @@ export const snapshotTests = renderComponent => [
     test() {
       const output = renderComponent(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({
@@ -246,6 +251,7 @@ export const snapshotTests = renderComponent => [
     test() {
       const testInstance = TestRenderer.create(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture()}
@@ -294,6 +300,7 @@ export const snapshotTests = renderComponent => [
               }}
             >
               <Article
+                {...articleProps}
                 adConfig={adConfig}
                 analyticsStream={() => {}}
                 article={articleFixture({
@@ -330,6 +337,7 @@ const negativeTests = [
     test() {
       const testInstance = TestRenderer.create(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({
@@ -357,6 +365,7 @@ const negativeTests = [
     test() {
       const testInstance = TestRenderer.create(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({ ...testFixture, byline: null })}
@@ -381,6 +390,7 @@ const negativeTests = [
     test() {
       const testInstance = TestRenderer.create(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({ ...testFixture, label: null })}
@@ -405,6 +415,7 @@ const negativeTests = [
     test() {
       const testInstance = TestRenderer.create(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({
@@ -442,6 +453,7 @@ const negativeTests = [
     test() {
       const testInstance = TestRenderer.create(
         <Article
+          {...articleProps}
           adConfig={adConfig}
           analyticsStream={() => {}}
           article={articleFixture({

--- a/packages/article/__tests__/shared.native.js
+++ b/packages/article/__tests__/shared.native.js
@@ -13,6 +13,7 @@ import shared from "./shared.base";
 import Article from "../src/article";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import { adConfig } from "./ad-mock";
+import articleProps from "./shared-article-props";
 
 jest.mock("../src/article-comments/article-comments", () => "ArticleComments");
 
@@ -61,6 +62,7 @@ export default () => {
           <Wrapper>
             {(byline, isLoading) => (
               <Article
+                {...articleProps}
                 adConfig={adConfig}
                 analyticsStream={() => {}}
                 article={articleFixture({
@@ -103,6 +105,7 @@ export default () => {
 
         const testInstance = TestRenderer.create(
           <Article
+            {...articleProps}
             adConfig={adConfig}
             analyticsStream={() => {}}
             article={articleFixture({


### PR DESCRIPTION
This prepares the ground for article prop types to be further separated out into web vs native. It removes the `refetch` required prop type warnings in native in the tests.

future pr: move more common prop types into the `shared-article-props` files in the `tests` directory