### PR TITLE
chore: output CSS in react native style serialisers. Fixes #1031

### DIFF
--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
@@ -2,114 +2,122 @@
 
 exports[`advert placeholder 1`] = `
 <style>
-{
-  "IS1": {
-    "left": 0,
-    "position": "absolute",
-    "top": 0,
-  },
-  "IS2": {
-    "backgroundColor": "#F9F9F9",
-    "borderColor": "#DBDBDB",
-    "borderStyle": "solid",
-    "borderWidth": 1,
-    "color": "#696969",
-    "fontFamily": "TimesDigitalW04",
-    "fontSize": 11,
-    "letterSpacing": 1.5,
-    "lineHeight": 15,
-    "paddingBottom": "5px",
-    "paddingLeft": "10px",
-    "paddingRight": "10px",
-    "paddingTop": "5px",
-    "zIndex": 1,
-  },
-  "IS3": {
-    "height": "300px",
-    "width": "970px",
-  },
-  "IS4": {
-    "alignItems": "center",
-    "backgroundColor": "#F9F9F9",
-    "borderColor": "#DBDBDB",
-    "borderStyle": "solid",
-    "borderWidth": 1,
-    "height": 300,
-    "justifyContent": "center",
-    "overflow": "hidden",
-    "width": 970,
-  },
-  "IS5": {
-    "backgroundColor": "rgba(255,0,0,1.00)",
-  },
-  "IS6": {
-    "alignItems": "center",
-    "backgroundColor": "red",
-    "flex": 1,
-    "justifyContent": "center",
-  },
-  "IS7": {
-    "backgroundColor": "red",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "align-items": "stretch",
-    "left": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-    "position": "absolute",
-    "top": "0px",
-    "z-index": "0",
-  },
-  "S2": {
-    "background-color": "rgba(249,249,249,1.00)",
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "TimesDigitalW04",
-    "font-size": "11px",
-    "letter-spacing": "1.5px",
-    "padding-bottom": "5px",
-    "padding-left": "10px",
-    "padding-right": "10px",
-    "padding-top": "5px",
-    "z-index": "1",
-  },
-  "S3": {
-    "-ms-flex-align": "center",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-pack": "center",
-    "-webkit-justify-content": "center",
-    "align-items": "center",
-    "background-color": "rgba(249,249,249,1.00)",
-    "justify-content": "center",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-    "z-index": "0",
-  },
-  "S4": {
-    "-ms-flex-align": "center",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-pack": "center",
-    "-webkit-justify-content": "center",
-    "align-items": "center",
-    "justify-content": "center",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-    "z-index": "0",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  left: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  position: absolute;
+  top: 0px;
+  z-index: 0;
+}
+
+.S2 {
+  background-color: rgba(249,249,249,1.00);
+  color: rgba(105,105,105,1.00);
+  font-family: TimesDigitalW04;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  padding-bottom: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 5px;
+  z-index: 1;
+}
+
+.S3 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  background-color: rgba(249,249,249,1.00);
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  position: relative;
+  z-index: 0;
+}
+
+.S4 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  position: relative;
+  z-index: 0;
+}
+
+.IS1 {
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
+.IS2 {
+  background-color: #F9F9F9;
+  border-color: #DBDBDB;
+  border-style: solid;
+  border-width: 1;
+  color: #696969;
+  font-family: TimesDigitalW04;
+  font-size: 11;
+  line-height: 15;
+  letter-spacing: 1.5;
+  padding-bottom: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 5px;
+  z-index: 1;
+}
+
+.IS3 {
+  height: 300px;
+  width: 970px;
+}
+
+.IS4 {
+  align-items: center;
+  background-color: #F9F9F9;
+  border-color: #DBDBDB;
+  border-style: solid;
+  border-width: 1;
+  justify-content: center;
+  overflow: hidden;
+  height: 300;
+  width: 970;
+}
+
+.IS5 {
+  background-color: rgba(255,0,0,1.00);
+}
+
+.IS6 {
+  align-items: center;
+  flex: 1;
+  justify-content: center;
+  background-color: red;
+}
+
+.IS7 {
+  background-color: red;
 }
 </style>
 

--- a/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-placeholder-with-style.web.test.js.snap
@@ -66,21 +66,30 @@ exports[`advert placeholder 1`] = `
 }
 
 .IS1 {
-  left: 0;
+  left: 0px;
   position: absolute;
-  top: 0;
+  top: 0px;
 }
 
 .IS2 {
-  background-color: #F9F9F9;
-  border-color: #DBDBDB;
-  border-style: solid;
-  border-width: 1;
-  color: #696969;
+  background-color: rgba(249,249,249,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  color: rgba(105,105,105,1.00);
   font-family: TimesDigitalW04;
-  font-size: 11;
-  line-height: 15;
-  letter-spacing: 1.5;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  line-height: 15px;
   padding-bottom: 5px;
   padding-left: 10px;
   padding-right: 10px;
@@ -94,15 +103,31 @@ exports[`advert placeholder 1`] = `
 }
 
 .IS4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
   align-items: center;
-  background-color: #F9F9F9;
-  border-color: #DBDBDB;
-  border-style: solid;
-  border-width: 1;
+  background-color: rgba(249,249,249,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  height: 300px;
   justify-content: center;
-  overflow: hidden;
-  height: 300;
-  width: 970;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 970px;
 }
 
 .IS5 {
@@ -110,14 +135,24 @@ exports[`advert placeholder 1`] = `
 }
 
 .IS6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  -webkit-flex: 1;
+  -webkit-justify-content: center;
   align-items: center;
-  flex: 1;
+  background-color: rgba(255,0,0,1.00);
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
   justify-content: center;
-  background-color: red;
+  -ms-flex: 1;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
 }
 
 .IS7 {
-  background-color: red;
+  background-color: rgba(255,0,0,1.00);
 }
 </style>
 

--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -2,34 +2,37 @@
 
 exports[`1. multiple ad slots 1`] = `
 <style>
-{
-  "IS1": {
-    "height": "auto",
-    "overflow": "hidden",
-    "width": 970,
-  },
-  "IS2": {
-    "alignItems": "center",
-    "flex": 1,
-  },
-  "IS3": {
-    "height": "auto",
-    "overflow": "hidden",
-    "width": 1,
-  },
-  "IS4": {
-    "alignItems": "center",
-    "flex": 1,
-  },
-  "IS5": {
-    "height": "auto",
-    "overflow": "hidden",
-    "width": 970,
-  },
-  "IS6": {
-    "alignItems": "center",
-    "flex": 1,
-  },
+.IS1 {
+  height: auto;
+  overflow: hidden;
+  width: 970;
+}
+
+.IS2 {
+  align-items: center;
+  flex: 1;
+}
+
+.IS3 {
+  height: auto;
+  overflow: hidden;
+  width: 1;
+}
+
+.IS4 {
+  align-items: center;
+  flex: 1;
+}
+
+.IS5 {
+  height: auto;
+  overflow: hidden;
+  width: 970;
+}
+
+.IS6 {
+  align-items: center;
+  flex: 1;
 }
 </style>
 
@@ -108,55 +111,59 @@ exports[`1. multiple ad slots 1`] = `
 
 exports[`2. placeholder when isloading 1`] = `
 <style>
-{
-  "IS1": {
-    "left": 0,
-    "position": "absolute",
-    "top": 0,
-  },
-  "IS2": {
-    "backgroundColor": "#F9F9F9",
-    "borderColor": "#DBDBDB",
-    "borderStyle": "solid",
-    "borderWidth": 1,
-    "color": "#696969",
-    "fontFamily": "TimesDigitalW04",
-    "fontSize": 11,
-    "letterSpacing": 1.5,
-    "lineHeight": 15,
-    "paddingBottom": "5px",
-    "paddingLeft": "10px",
-    "paddingRight": "10px",
-    "paddingTop": "5px",
-    "zIndex": 1,
-  },
-  "IS3": {
-    "height": "250px",
-    "width": "970px",
-  },
-  "IS4": {
-    "alignItems": "center",
-    "backgroundColor": "#F9F9F9",
-    "borderColor": "#DBDBDB",
-    "borderStyle": "solid",
-    "borderWidth": 1,
-    "height": 250,
-    "justifyContent": "center",
-    "overflow": "hidden",
-    "width": 970,
-  },
-  "IS5": {
-    "alignItems": "center",
-    "flex": 1,
-    "justifyContent": "center",
-  },
-  "IS6": {
-    "flex": 1,
-  },
-  "IS7": {
-    "alignItems": "center",
-    "flex": 1,
-  },
+.IS1 {
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
+.IS2 {
+  background-color: #F9F9F9;
+  border-color: #DBDBDB;
+  border-style: solid;
+  border-width: 1;
+  color: #696969;
+  font-family: TimesDigitalW04;
+  font-size: 11;
+  line-height: 15;
+  letter-spacing: 1.5;
+  padding-bottom: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 5px;
+  z-index: 1;
+}
+
+.IS3 {
+  height: 250px;
+  width: 970px;
+}
+
+.IS4 {
+  align-items: center;
+  background-color: #F9F9F9;
+  border-color: #DBDBDB;
+  border-style: solid;
+  border-width: 1;
+  justify-content: center;
+  overflow: hidden;
+  height: 250;
+  width: 970;
+}
+
+.IS5 {
+  align-items: center;
+  flex: 1;
+  justify-content: center;
+}
+
+.IS6 {
+  flex: 1;
+}
+
+.IS7 {
+  align-items: center;
+  flex: 1;
 }
 </style>
 
@@ -218,60 +225,65 @@ exports[`2. placeholder when isloading 1`] = `
 
 exports[`3. nothing if there is an error in the loading of scripts 1`] = `
 <style>
-{
-  "IS1": {
-    "height": "auto",
-    "overflow": "hidden",
-    "width": 0,
-  },
-  "IS2": {
-    "left": 0,
-    "position": "absolute",
-    "top": 0,
-  },
-  "IS3": {
-    "backgroundColor": "#F9F9F9",
-    "borderColor": "#DBDBDB",
-    "borderStyle": "solid",
-    "borderWidth": 1,
-    "color": "#696969",
-    "fontFamily": "TimesDigitalW04",
-    "fontSize": 11,
-    "letterSpacing": 1.5,
-    "lineHeight": 15,
-    "paddingBottom": "5px",
-    "paddingLeft": "10px",
-    "paddingRight": "10px",
-    "paddingTop": "5px",
-    "zIndex": 1,
-  },
-  "IS4": {
-    "height": "250px",
-    "width": "970px",
-  },
-  "IS5": {
-    "alignItems": "center",
-    "backgroundColor": "#F9F9F9",
-    "borderColor": "#DBDBDB",
-    "borderStyle": "solid",
-    "borderWidth": 1,
-    "height": 250,
-    "justifyContent": "center",
-    "overflow": "hidden",
-    "width": 970,
-  },
-  "IS6": {
-    "alignItems": "center",
-    "flex": 1,
-    "justifyContent": "center",
-  },
-  "IS7": {
-    "flex": 1,
-  },
-  "IS8": {
-    "alignItems": "center",
-    "flex": 1,
-  },
+.IS1 {
+  height: auto;
+  overflow: hidden;
+  width: 0;
+}
+
+.IS2 {
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
+.IS3 {
+  background-color: #F9F9F9;
+  border-color: #DBDBDB;
+  border-style: solid;
+  border-width: 1;
+  color: #696969;
+  font-family: TimesDigitalW04;
+  font-size: 11;
+  line-height: 15;
+  letter-spacing: 1.5;
+  padding-bottom: 5px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 5px;
+  z-index: 1;
+}
+
+.IS4 {
+  height: 250px;
+  width: 970px;
+}
+
+.IS5 {
+  align-items: center;
+  background-color: #F9F9F9;
+  border-color: #DBDBDB;
+  border-style: solid;
+  border-width: 1;
+  justify-content: center;
+  overflow: hidden;
+  height: 250;
+  width: 970;
+}
+
+.IS6 {
+  align-items: center;
+  flex: 1;
+  justify-content: center;
+}
+
+.IS7 {
+  flex: 1;
+}
+
+.IS8 {
+  align-items: center;
+  flex: 1;
 }
 </style>
 

--- a/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
+++ b/packages/ad/__tests__/web/__snapshots__/ad-with-style.web.test.js.snap
@@ -4,35 +4,59 @@ exports[`1. multiple ad slots 1`] = `
 <style>
 .IS1 {
   height: auto;
-  overflow: hidden;
-  width: 970;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 970px;
 }
 
 .IS2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-flex: 1;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
+  -ms-flex-align: center;
 }
 
 .IS3 {
   height: auto;
-  overflow: hidden;
-  width: 1;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 1px;
 }
 
 .IS4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-flex: 1;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
+  -ms-flex-align: center;
 }
 
 .IS5 {
   height: auto;
-  overflow: hidden;
-  width: 970;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 970px;
 }
 
 .IS6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-flex: 1;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
+  -ms-flex-align: center;
 }
 </style>
 
@@ -112,21 +136,30 @@ exports[`1. multiple ad slots 1`] = `
 exports[`2. placeholder when isloading 1`] = `
 <style>
 .IS1 {
-  left: 0;
+  left: 0px;
   position: absolute;
-  top: 0;
+  top: 0px;
 }
 
 .IS2 {
-  background-color: #F9F9F9;
-  border-color: #DBDBDB;
-  border-style: solid;
-  border-width: 1;
-  color: #696969;
+  background-color: rgba(249,249,249,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  color: rgba(105,105,105,1.00);
   font-family: TimesDigitalW04;
-  font-size: 11;
-  line-height: 15;
-  letter-spacing: 1.5;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  line-height: 15px;
   padding-bottom: 5px;
   padding-left: 10px;
   padding-right: 10px;
@@ -140,30 +173,67 @@ exports[`2. placeholder when isloading 1`] = `
 }
 
 .IS4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
   align-items: center;
-  background-color: #F9F9F9;
-  border-color: #DBDBDB;
-  border-style: solid;
-  border-width: 1;
+  background-color: rgba(249,249,249,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  height: 250px;
   justify-content: center;
-  overflow: hidden;
-  height: 250;
-  width: 970;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 970px;
 }
 
 .IS5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  -webkit-flex: 1;
+  -webkit-justify-content: center;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
   justify-content: center;
+  -ms-flex: 1;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
 }
 
 .IS6 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-flex: 1;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
+  -ms-flex-align: center;
 }
 </style>
 
@@ -227,26 +297,36 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
 <style>
 .IS1 {
   height: auto;
-  overflow: hidden;
-  width: 0;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 0px;
 }
 
 .IS2 {
-  left: 0;
+  left: 0px;
   position: absolute;
-  top: 0;
+  top: 0px;
 }
 
 .IS3 {
-  background-color: #F9F9F9;
-  border-color: #DBDBDB;
-  border-style: solid;
-  border-width: 1;
-  color: #696969;
+  background-color: rgba(249,249,249,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  color: rgba(105,105,105,1.00);
   font-family: TimesDigitalW04;
-  font-size: 11;
-  line-height: 15;
-  letter-spacing: 1.5;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  line-height: 15px;
   padding-bottom: 5px;
   padding-left: 10px;
   padding-right: 10px;
@@ -260,30 +340,67 @@ exports[`3. nothing if there is an error in the loading of scripts 1`] = `
 }
 
 .IS5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
   align-items: center;
-  background-color: #F9F9F9;
-  border-color: #DBDBDB;
-  border-style: solid;
-  border-width: 1;
+  background-color: rgba(249,249,249,1.00);
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-style: solid;
+  border-right-style: solid;
+  border-bottom-style: solid;
+  border-left-style: solid;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  height: 250px;
   justify-content: center;
-  overflow: hidden;
-  height: 250;
-  width: 970;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 970px;
 }
 
 .IS6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  -webkit-flex: 1;
+  -webkit-justify-content: center;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
   justify-content: center;
+  -ms-flex: 1;
+  -ms-flex-align: center;
+  -ms-flex-pack: center;
 }
 
 .IS7 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-flex: 1;
   align-items: center;
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
+  -ms-flex-align: center;
 }
 </style>
 

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-style.web.test.js.snap
@@ -2,25 +2,24 @@
 
 exports[`1. with a single author 1`] = `
 <style>
-{
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "color": "rgba(0,102,153,1.00)",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  color: rgba(0,102,153,1.00);
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
 }
 </style>
 
@@ -37,27 +36,27 @@ exports[`1. with a single author 1`] = `
 
 exports[`2. with a given section colour 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+.IS1 {
+  color: rgba(0,0,255,1.00);
 }
 </style>
 
@@ -74,28 +73,28 @@ exports[`2. with a given section colour 1`] = `
 
 exports[`3. with given styles 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(255,0,0,1.00)",
-    "textDecoration": "underline",
-  },
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+.IS1 {
+  color: rgba(255,0,0,1.00);
+  text-decoration: underline;
 }
 </style>
 
@@ -112,42 +111,47 @@ exports[`3. with given styles 1`] = `
 
 exports[`4. with a a very long byline 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS2": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS3": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS4": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS5": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS6": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+.IS1 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS2 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS3 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS4 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS5 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS6 {
+  color: rgba(0,0,255,1.00);
 }
 </style>
 

--- a/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
+++ b/packages/article-byline/__tests__/web/__snapshots__/article-byline-with-links-style.web.test.js.snap
@@ -2,25 +2,24 @@
 
 exports[`1. with a single author 1`] = `
 <style>
-{
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "color": "rgba(0,102,153,1.00)",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  color: rgba(0,102,153,1.00);
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
 }
 </style>
 
@@ -39,27 +38,27 @@ exports[`1. with a single author 1`] = `
 
 exports[`2. with a given section colour 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+.IS1 {
+  color: rgba(0,0,255,1.00);
 }
 </style>
 
@@ -78,27 +77,27 @@ exports[`2. with a given section colour 1`] = `
 
 exports[`3. with given styles 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(255,0,0,1.00)",
-  },
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+.IS1 {
+  color: rgba(255,0,0,1.00);
 }
 </style>
 
@@ -117,42 +116,47 @@ exports[`3. with given styles 1`] = `
 
 exports[`4. with a a very long byline 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS2": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS3": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS4": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS5": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "IS6": {
-    "color": "rgba(0,0,255,1.00)",
-  },
-  "S1": {
-    "-ms-flex-direction": "row",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "flex-direction": "row",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "15px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-  },
+.S1 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 15px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+.IS1 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS2 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS3 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS4 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS5 {
+  color: rgba(0,0,255,1.00);
+}
+
+.IS6 {
+  color: rgba(0,0,255,1.00);
 }
 </style>
 

--- a/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
+++ b/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
@@ -2,45 +2,47 @@
 
 exports[`1. red article flag 1`] = `
 <style>
-{
-  "IS1": {
-    "marginRight": "5px",
-  },
-  "IS2": {
-    "color": "rgba(255,0,0,1.00)",
-    "fontFamily": "TimesDigitalW04-RegularSC",
-    "fontSize": "12px",
-    "fontWeight": "400",
-    "letterSpacing": "1.4px",
-    "lineHeight": "12px",
-  },
-  "IS3": {
-    "WebkitAlignItems": "center",
-    "WebkitBoxAlign": "center",
-    "WebkitBoxDirection": "normal",
-    "WebkitBoxOrient": "horizontal",
-    "WebkitFlexDirection": "row",
-    "alignItems": "center",
-    "flexDirection": "row",
-    "msFlexAlign": "center",
-    "msFlexDirection": "row",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-  },
-  "S2": {
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  margin-right: 0px;
+  margin-bottom: 0px;
+}
+
+.IS1 {
+  margin-right: 5px;
+}
+
+.IS2 {
+  color: rgba(255,0,0,1.00);
+  font-family: TimesDigitalW04-RegularSC;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 1.4px;
+  line-height: 12px;
+}
+
+.IS3 {
+  -webkit-align-items: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  ms-flex-direction: row;
+  flex-direction: row;
+  ms-flex-align: center;
+  -webkit-box-align: center;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
 }
 </style>
 

--- a/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
+++ b/packages/article-flag/__tests__/web/__snapshots__/article-flag-with-style.web.test.js.snap
@@ -35,14 +35,14 @@ exports[`1. red article flag 1`] = `
 
 .IS3 {
   -webkit-align-items: center;
-  align-items: center;
-  -webkit-flex-direction: row;
-  ms-flex-direction: row;
-  flex-direction: row;
-  ms-flex-align: center;
   -webkit-box-align: center;
-  -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  align-items: center;
+  flex-direction: row;
+  -ms-flex-align: center;
+  -ms-flex-direction: row;
 }
 </style>
 

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
@@ -73,96 +73,100 @@ exports[`1. page error 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS2": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "110%",
-  },
-  "IS3": {
-    "alignSelf": "center",
-    "marginBottom": "10px",
-    "marginTop": "40px",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "bottom": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "absolute",
-    "right": "0px",
-  },
-  "S3": {
-    "-ms-flex-item-align": "center",
-    "-webkit-align-self": "center",
-    "align-self": "center",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(29,29,27,1.00)",
-    "font-family": "TimesModern-Bold",
-    "font-size": "26px",
-    "margin-bottom": "10px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "20px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "text-align": "center",
-  },
-  "S4": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "TimesDigitalW04-Regular",
-    "font-size": "18px",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "text-align": "center",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  bottom: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: absolute;
+  right: 0px;
+}
+
+.S3 {
+  -ms-flex-item-align: center;
+  -webkit-align-self: center;
+  align-self: center;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(29,29,27,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 26px;
+  margin-right: 0px;
+  margin-left: 0px;
+  margin-bottom: 10px;
+  margin-top: 20px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  text-align: center;
+}
+
+.S4 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  font-family: TimesDigitalW04-Regular;
+  font-size: 18px;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  text-align: center;
+}
+
+.IS1 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS2 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 110%;
+}
+
+.IS3 {
+  align-self: center;
+  margin-bottom: 10px;
+  margin-top: 40px;
 }
 </style>
 
@@ -339,88 +343,89 @@ exports[`2. article list 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "15px",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "4px",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
-  "S3": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "max-width": "760px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "center",
-    "-webkit-flex-direction": "row",
-    "-webkit-justify-content": "center",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "row",
-    "justify-content": "center",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
+.S1 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 15px;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  padding-bottom: 0px;
+  padding-top: 4px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.S3 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  max-width: 760px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
 }
 </style>
 

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-error-with-styles.web.test.js.snap
@@ -153,20 +153,23 @@ exports[`1. page error 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS2 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 110%;
 }
 
 .IS3 {
+  -webkit-align-self: center;
   align-self: center;
   margin-bottom: 10px;
   margin-top: 40px;
+  -ms-flex-item-align: center;
 }
 </style>
 

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-with-styles.web.test.js.snap
@@ -72,105 +72,107 @@ exports[`1. article list 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "borderBottomWidth": 1,
-    "borderColor": "#DBDBDB",
-    "borderTopWidth": 1,
-    "paddingVertical": "10px",
-    "top": 1,
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "max-width": "760px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "center",
-    "-webkit-flex-direction": "row",
-    "-webkit-justify-content": "center",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "row",
-    "justify-content": "center",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
-  "S3": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "background-color": "rgba(219,219,219,1.00)",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "height": "1px",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "min-height": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-    "position": "relative",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  max-width: 760px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.S3 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  background-color: rgba(219,219,219,1.00);
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 1px;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.IS1 {
+  border-bottom-width: 1;
+  border-color: #DBDBDB;
+  border-top-width: 1;
+  padding-vertical: 10px;
+  top: 1;
 }
 </style>
 

--- a/packages/article-list/__tests__/web/__snapshots__/article-list-with-styles.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list-with-styles.web.test.js.snap
@@ -168,11 +168,15 @@ exports[`1. article list 1`] = `
 }
 
 .IS1 {
-  border-bottom-width: 1;
-  border-color: #DBDBDB;
-  border-top-width: 1;
-  padding-vertical: 10px;
-  top: 1;
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-right-color: rgba(219,219,219,1.00);
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-left-color: rgba(219,219,219,1.00);
+  border-top-width: 1px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  top: 1px;
 }
 </style>
 

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -2,46 +2,48 @@
 
 exports[`1. article summary component with a single paragraph 1`] = `
 <style>
-{
-  "S1": {
-    "margin-bottom": "0px",
-  },
-  "S2": {
-    "color": "rgba(51,51,51,1.00)",
-    "font-family": "TimesModern-Bold",
-    "font-size": "22px",
-    "font-weight": "400",
-    "line-height": "27px",
-    "margin-bottom": "5px",
-  },
-  "S3": {
-    "color": "inherit",
-    "font-family": "inherit",
-    "font-size": "inherit",
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-  },
-  "S4": {
-    "-ms-flex-wrap": "wrap",
-    "-webkit-box-lines": "multiple",
-    "-webkit-flex-wrap": "wrap",
-    "color": "rgba(105,105,105,1.00)",
-    "flex-wrap": "wrap",
-    "font-family": "TimesDigitalW04",
-    "font-size": "14px",
-    "font-weight": "inherit",
-    "line-height": "20px",
-    "margin-bottom": "10px",
-  },
-  "S5": {
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "5px",
-  },
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 5px;
+}
+
+.S3 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.S5 {
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-bottom: 5px;
 }
 </style>
 
@@ -126,27 +128,26 @@ exports[`1. article summary component with a single paragraph 1`] = `
 
 exports[`2. article summary content component with the given style 1`] = `
 <style>
-{
-  "S1": {
-    "color": "inherit",
-    "font-family": "inherit",
-    "font-size": "inherit",
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-  },
-  "S2": {
-    "-ms-flex-wrap": "wrap",
-    "-webkit-box-lines": "multiple",
-    "-webkit-flex-wrap": "wrap",
-    "color": "rgba(105,105,105,1.00)",
-    "flex-wrap": "wrap",
-    "font-family": "TimesDigitalW04",
-    "font-size": "14px",
-    "font-weight": "inherit",
-    "line-height": "20px",
-    "margin-bottom": "10px",
-  },
+.S1 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-bottom: 10px;
 }
 </style>
 

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
@@ -2,72 +2,74 @@
 
 exports[`1. group of topics 1`] = `
 <style>
-{
-  "IS1": {
-    "textDecoration": "none",
-  },
-  "S1": {
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "2.5px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "12px",
-    "padding-left": "15px",
-    "padding-right": "15px",
-    "padding-top": "12px",
-  },
-  "S3": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-right": "10px",
-    "margin-top": "10px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
-  "S4": {
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "center",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "center",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "center",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "justify-content": "center",
-    "margin-bottom": "10px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-top: 2.5px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 12px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 12px;
+}
+
+.S3 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  margin-right: 10px;
+  margin-top: 10px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S4 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 10px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.IS1 {
+  text-decoration: none;
 }
 </style>
 
@@ -96,72 +98,74 @@ exports[`1. group of topics 1`] = `
 
 exports[`2. group of topics at large scale 1`] = `
 <style>
-{
-  "IS1": {
-    "textDecoration": "none",
-  },
-  "S1": {
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "2.5px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "12px",
-    "padding-left": "15px",
-    "padding-right": "15px",
-    "padding-top": "12px",
-  },
-  "S3": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-right": "10px",
-    "margin-top": "10px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
-  "S4": {
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "center",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "center",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "center",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "justify-content": "center",
-    "margin-bottom": "10px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-top: 2.5px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 12px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 12px;
+}
+
+.S3 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  margin-right: 10px;
+  margin-top: 10px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S4 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 10px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.IS1 {
+  text-decoration: none;
 }
 </style>
 
@@ -190,72 +194,74 @@ exports[`2. group of topics at large scale 1`] = `
 
 exports[`3. group of topics at xlarge scale 1`] = `
 <style>
-{
-  "IS1": {
-    "textDecoration": "none",
-  },
-  "S1": {
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "2.5px",
-  },
-  "S2": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "12px",
-    "padding-left": "15px",
-    "padding-right": "15px",
-    "padding-top": "12px",
-  },
-  "S3": {
-    "-ms-flex-direction": "column",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-right": "10px",
-    "margin-top": "10px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
-  "S4": {
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "center",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "center",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "center",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "justify-content": "center",
-    "margin-bottom": "10px",
-    "margin-right": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-top: 2.5px;
+}
+
+.S2 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 12px;
+  padding-left: 15px;
+  padding-right: 15px;
+  padding-top: 12px;
+}
+
+.S3 {
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  margin-right: 10px;
+  margin-top: 10px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S4 {
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 10px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+}
+
+.IS1 {
+  text-decoration: none;
 }
 </style>
 

--- a/packages/article/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -171,60 +171,63 @@ exports[`1. a secondary image 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "marginBottom": 0,
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S2": {
-    "font-weight": "inherit",
-    "line-height": "30px",
-    "margin-bottom": "7px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S3": {
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S4": {
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "5px",
-    "padding-top": "5px",
-  },
-  "S5": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "20px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "9px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S2 {
+  font-weight: inherit;
+  line-height: 30px;
+  margin-top: 0px;
+  margin-bottom: 7px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S3 {
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S4 {
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+
+.S5 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 20px;
+  padding-bottom: 0px;
+  padding-top: 9px;
+}
+
+.IS1 {
+  margin-bottom: 0;
 }
 </style>
 
@@ -465,60 +468,63 @@ exports[`2. an inline image 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "marginBottom": 0,
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S2": {
-    "font-weight": "inherit",
-    "line-height": "30px",
-    "margin-bottom": "7px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S3": {
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S4": {
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "5px",
-    "padding-top": "5px",
-  },
-  "S5": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "20px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "9px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S2 {
+  font-weight: inherit;
+  line-height: 30px;
+  margin-top: 0px;
+  margin-bottom: 7px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S3 {
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S4 {
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+
+.S5 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 20px;
+  padding-bottom: 0px;
+  padding-top: 9px;
+}
+
+.IS1 {
+  margin-bottom: 0;
 }
 </style>
 

--- a/packages/article/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -227,7 +227,7 @@ exports[`1. a secondary image 1`] = `
 }
 
 .IS1 {
-  margin-bottom: 0;
+  margin-bottom: 0px;
 }
 </style>
 
@@ -524,7 +524,7 @@ exports[`2. an inline image 1`] = `
 }
 
 .IS1 {
-  margin-bottom: 0;
+  margin-bottom: 0px;
 }
 </style>
 

--- a/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -372,176 +372,198 @@ exports[`full article with style 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "marginBottom": 0,
-  },
-  "IS10": {
-    "height": "100%",
-    "width": "100%",
-  },
-  "IS11": {
-    "height": "100%",
-    "position": "absolute",
-    "width": "100%",
-  },
-  "IS12": {
-    "paddingBottom": "56.25%",
-  },
-  "IS13": {
-    "margin": 0,
-  },
-  "IS14": {
-    "borderBottomColor": "#DBDBDB",
-    "borderBottomWidth": 1,
-    "borderTopColor": "#DBDBDB",
-    "borderTopWidth": 1,
-    "marginBottom": "30px",
-    "marginTop": "30px",
-    "paddingHorizontal": "10px",
-    "paddingVertical": "10px",
-  },
-  "IS15": {
-    "borderTopColor": "#DBDBDB",
-    "borderTopWidth": 1,
-  },
-  "IS2": {
-    "justifyContent": "flex-start",
-  },
-  "IS3": {
-    "height": "100%",
-    "position": "absolute",
-    "width": "100%",
-  },
-  "IS4": {
-    "paddingBottom": "56.25%",
-  },
-  "IS5": {
-    "margin": 0,
-  },
-  "IS6": {
-    "color": "#333333",
-    "fontFamily": "TimesDigitalW04",
-    "fontSize": 17,
-    "lineHeight": 26,
-    "marginBottom": "25px",
-    "marginTop": 0,
-  },
-  "IS7": {
-    "paddingLeft": "10px",
-    "paddingRight": "10px",
-  },
-  "IS8": {
-    "height": "100%",
-    "width": "100%",
-  },
-  "IS9": {
-    "position": "relative",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S10": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-top": "0px",
-  },
-  "S2": {
-    "font-weight": "400",
-    "line-height": "14px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S3": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "5px",
-    "padding-top": "5px",
-  },
-  "S4": {
-    "font-weight": "inherit",
-    "line-height": "30px",
-    "margin-bottom": "7px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S5": {
-    "font-weight": "inherit",
-    "line-height": "26px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "10px",
-    "padding-top": "0px",
-  },
-  "S6": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "10px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S7": {
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "0px",
-  },
-  "S8": {
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-    "padding-bottom": "5px",
-    "padding-top": "5px",
-  },
-  "S9": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-preferred-size": "auto",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-flex-basis": "auto",
-    "align-items": "stretch",
-    "flex-basis": "auto",
-    "margin-bottom": "20px",
-    "margin-top": "0px",
-    "padding-bottom": "0px",
-    "padding-top": "9px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S2 {
+  font-weight: 400;
+  line-height: 14px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S3 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+
+.S4 {
+  font-weight: inherit;
+  line-height: 30px;
+  margin-top: 0px;
+  margin-bottom: 7px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S5 {
+  font-weight: inherit;
+  line-height: 26px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 10px;
+}
+
+.S6 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 10px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S7 {
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.S8 {
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+}
+
+.S9 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 20px;
+  padding-bottom: 0px;
+  padding-top: 9px;
+}
+
+.S10 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-preferred-size: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+}
+
+.IS1 {
+  margin-bottom: 0;
+}
+
+.IS2 {
+  justify-content: flex-start;
+}
+
+.IS3 {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+
+.IS4 {
+  padding-bottom: 56.25%;
+}
+
+.IS5 {
+  margin: 0;
+}
+
+.IS6 {
+  font-family: TimesDigitalW04;
+  font-size: 17;
+  line-height: 26;
+  color: #333333;
+  margin-bottom: 25px;
+  margin-top: 0;
+}
+
+.IS7 {
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.IS8 {
+  height: 100%;
+  width: 100%;
+}
+
+.IS9 {
+  position: relative;
+}
+
+.IS10 {
+  height: 100%;
+  width: 100%;
+}
+
+.IS11 {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+
+.IS12 {
+  padding-bottom: 56.25%;
+}
+
+.IS13 {
+  margin: 0;
+}
+
+.IS14 {
+  border-bottom-color: #DBDBDB;
+  border-bottom-width: 1;
+  border-top-color: #DBDBDB;
+  border-top-width: 1;
+  margin-bottom: 30px;
+  padding-horizontal: 10px;
+  padding-vertical: 10px;
+  margin-top: 30px;
+}
+
+.IS15 {
+  border-top-color: #DBDBDB;
+  border-top-width: 1;
 }
 </style>
 

--- a/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -487,11 +487,14 @@ exports[`full article with style 1`] = `
 }
 
 .IS1 {
-  margin-bottom: 0;
+  margin-bottom: 0px;
 }
 
 .IS2 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
+  -ms-flex-pack: start;
 }
 
 .IS3 {
@@ -505,16 +508,19 @@ exports[`full article with style 1`] = `
 }
 
 .IS5 {
-  margin: 0;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
 }
 
 .IS6 {
+  color: rgba(51,51,51,1.00);
   font-family: TimesDigitalW04;
-  font-size: 17;
-  line-height: 26;
-  color: #333333;
+  font-size: 17px;
+  line-height: 26px;
   margin-bottom: 25px;
-  margin-top: 0;
+  margin-top: 0px;
 }
 
 .IS7 {
@@ -547,23 +553,28 @@ exports[`full article with style 1`] = `
 }
 
 .IS13 {
-  margin: 0;
+  margin-top: 0px;
+  margin-right: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
 }
 
 .IS14 {
-  border-bottom-color: #DBDBDB;
-  border-bottom-width: 1;
-  border-top-color: #DBDBDB;
-  border-top-width: 1;
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-top-width: 1px;
   margin-bottom: 30px;
-  padding-horizontal: 10px;
-  padding-vertical: 10px;
   margin-top: 30px;
+  padding-right: 10px;
+  padding-left: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .IS15 {
-  border-top-color: #DBDBDB;
-  border-top-width: 1;
+  border-top-color: rgba(219,219,219,1.00);
+  border-top-width: 1px;
 }
 </style>
 

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-with-style.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-with-style.web.test.js.snap
@@ -60,63 +60,69 @@ exports[`1. an article list header 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "borderColor": "#FFFFFF",
-    "borderRadius": 50,
-    "marginBottom": "20px",
-    "marginLeft": "auto",
-    "marginRight": "auto",
-    "overflow": "hidden",
-    "width": 100,
-  },
-  "IS2": {
-    "color": "#006699",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": 15,
-    "lineHeight": 17,
-    "paddingLeft": "5px",
-    "textDecorationLine": "none",
-  },
-  "S1": {},
-  "S2": {
-    "font-family": "system-ui, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Ubuntu, \\"Helvetica Neue\\", sans-serif",
-    "font-size": "14px",
-    "line-height": "inherit",
-  },
-  "S3": {
-    "-webkit-font-smoothing": "antialiased",
-    "font-family": "TimesDigitalW04-RegularSC",
-    "font-size": "14px",
-    "line-height": "14px",
-  },
-  "S4": {
-    "-ms-flex-item-align": "center",
-    "-webkit-align-self": "center",
-    "align-self": "center",
-  },
-  "S5": {
-    "-ms-flex-align": "end",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "flex-end",
-    "-webkit-box-align": "end",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "flex-end",
-    "flex-direction": "row",
-    "padding-bottom": "10px",
-    "padding-top": "15px",
-  },
-  "S6": {
-    "font-family": "TimesDigitalW04",
-    "font-size": "16px",
-    "line-height": "27px",
-    "text-align": "center",
-  },
-  "S7": {
-    "background-color": "rgba(0,0,0,0.00)",
-  },
+
+
+.S2 {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  line-height: inherit;
+}
+
+.S3 {
+  -webkit-font-smoothing: antialiased;
+  font-family: TimesDigitalW04-RegularSC;
+  font-size: 14px;
+  line-height: 14px;
+}
+
+.S4 {
+  -ms-flex-item-align: center;
+  -webkit-align-self: center;
+  align-self: center;
+}
+
+.S5 {
+  -ms-flex-align: end;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: end;
+  align-items: flex-end;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  padding-bottom: 10px;
+  padding-top: 15px;
+}
+
+.S6 {
+  font-family: TimesDigitalW04;
+  font-size: 16px;
+  line-height: 27px;
+  text-align: center;
+}
+
+.S7 {
+  background-color: rgba(0,0,0,0.00);
+}
+
+.IS1 {
+  border-color: #FFFFFF;
+  border-radius: 50;
+  margin-bottom: 20px;
+  margin-left: auto;
+  margin-right: auto;
+  overflow: hidden;
+  width: 100;
+}
+
+.IS2 {
+  color: #006699;
+  font-family: GillSansMTStd-Medium;
+  font-size: 15;
+  line-height: 17;
+  padding-left: 5px;
+  text-decoration-line: none;
 }
 </style>
 
@@ -188,21 +194,22 @@ exports[`2. an article list header loading 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "flex": 1,
-  },
-  "S1": {
-    "border-bottom-color": "rgba(255,255,255,1.00)",
-    "height": "100px",
-    "position": "absolute",
-    "top": "30px",
-    "width": "100px",
-  },
-  "S2": {
-    "min-height": "264px",
-  },
-  "S3": {},
+.S1 {
+  border-bottom-color: rgba(255,255,255,1.00);
+  height: 100px;
+  position: absolute;
+  top: 30px;
+  width: 100px;
+}
+
+.S2 {
+  min-height: 264px;
+}
+
+
+
+.IS1 {
+  flex: 1;
 }
 </style>
 

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile-with-style.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile-with-style.web.test.js.snap
@@ -107,22 +107,30 @@ exports[`1. an article list header 1`] = `
 }
 
 .IS1 {
-  border-color: #FFFFFF;
-  border-radius: 50;
+  border-top-color: rgba(255,255,255,1.00);
+  border-right-color: rgba(255,255,255,1.00);
+  border-bottom-color: rgba(255,255,255,1.00);
+  border-left-color: rgba(255,255,255,1.00);
+  border-top-left-radius: 50px;
+  border-top-right-radius: 50px;
+  border-bottom-right-radius: 50px;
+  border-bottom-left-radius: 50px;
   margin-bottom: 20px;
   margin-left: auto;
   margin-right: auto;
-  overflow: hidden;
-  width: 100;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  width: 100px;
 }
 
 .IS2 {
-  color: #006699;
+  -webkit-text-decoration-line: none;
+  color: rgba(0,102,153,1.00);
   font-family: GillSansMTStd-Medium;
-  font-size: 15;
-  line-height: 17;
+  font-size: 15px;
+  line-height: 17px;
   padding-left: 5px;
-  text-decoration-line: none;
+  text-decoration: none;
 }
 </style>
 
@@ -209,7 +217,11 @@ exports[`2. an article list header loading 1`] = `
 
 
 .IS1 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 </style>
 

--- a/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
@@ -2,37 +2,41 @@
 
 exports[`caption with specific styles 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(0,128,0,1.00)",
-  },
-  "IS2": {
-    "color": "rgba(0,128,0,1.00)",
-  },
-  "IS3": {
-    "backgroundColor": "rgba(255,0,0,1.00)",
-  },
-  "S1": {
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "17px",
-    "padding-top": "0px",
-  },
-  "S2": {
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "9px",
-    "font-weight": "400",
-    "letter-spacing": "1px",
-    "line-height": "17px",
-    "padding-top": "0px",
-  },
-  "S3": {
-    "padding-top": "10px",
-  },
-  "S4": {
-    "padding-top": "0px",
-  },
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 17px;
+  padding-top: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 1px;
+  line-height: 17px;
+  padding-top: 0px;
+}
+
+.S3 {
+  padding-top: 10px;
+}
+
+.S4 {
+  padding-top: 0px;
+}
+
+.IS1 {
+  color: rgba(0,128,0,1.00);
+}
+
+.IS2 {
+  color: rgba(0,128,0,1.00);
+}
+
+.IS3 {
+  background-color: rgba(255,0,0,1.00);
 }
 </style>
 

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -27,189 +27,210 @@ exports[`1. card loading state 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS10": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS11": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS12": {
-    "backgroundImage": "linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS13": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS14": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS15": {
-    "backgroundImage": "linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS16": {
-    "height": 10,
-    "marginBottom": 0,
-    "maxWidth": 240,
-  },
-  "IS17": {
-    "height": 10,
-    "marginBottom": 0,
-    "maxWidth": 240,
-  },
-  "IS2": {
-    "flex": 1,
-  },
-  "IS3": {
-    "flex": 1,
-  },
-  "IS4": {
-    "bottom": 0,
-    "left": 0,
-    "position": "absolute",
-    "right": 0,
-    "top": 0,
-    "zIndex": 0,
-  },
-  "IS5": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "150%",
-  },
-  "IS6": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS7": {
-    "height": 24,
-    "marginBottom": "10px",
-    "maxWidth": 300,
-  },
-  "IS8": {
-    "height": 24,
-    "marginBottom": "10px",
-    "maxWidth": 300,
-  },
-  "IS9": {
-    "backgroundImage": "linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "10px",
-    "min-width": "100%",
-  },
-  "S3": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "height": "24px",
-    "margin-bottom": "10px",
-    "max-width": "300px",
-    "min-width": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "height": "10px",
-    "margin-bottom": "10px",
-    "min-width": "0px",
-  },
-  "S5": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "height": "10px",
-    "margin-bottom": "0px",
-    "max-width": "240px",
-    "min-width": "0px",
-  },
-  "S6": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "100%",
-  },
-  "S7": {
-    "-ms-flex-align": "start",
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "end",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-align-items": "flex-start",
-    "-webkit-box-align": "start",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "end",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "flex-end",
-    "align-items": "flex-start",
-    "display": "flex",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "justify-content": "flex-end",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 10px;
+  min-width: 100%;
+}
+
+.S3 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  margin-bottom: 10px;
+  max-width: 300px;
+  min-width: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  margin-bottom: 10px;
+  min-width: 0px;
+}
+
+.S5 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  margin-bottom: 0px;
+  max-width: 240px;
+  min-width: 0px;
+}
+
+.S6 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 100%;
+}
+
+.S7 {
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
+  display: flex;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-pack: end;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.IS1 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS2 {
+  flex: 1;
+}
+
+.IS3 {
+  flex: 1;
+}
+
+.IS4 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
+}
+
+.IS5 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 150%;
+}
+
+.IS6 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS7 {
+  height: 24;
+  margin-bottom: 10px;
+  max-width: 300;
+}
+
+.IS8 {
+  height: 24;
+  margin-bottom: 10px;
+  max-width: 300;
+}
+
+.IS9 {
+  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS10 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS11 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS12 {
+  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS13 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS14 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS15 {
+  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS16 {
+  height: 10;
+  margin-bottom: 0;
+  max-width: 240;
+}
+
+.IS17 {
+  height: 10;
+  margin-bottom: 0;
+  max-width: 240;
 }
 </style>
 
@@ -285,190 +306,211 @@ exports[`2. card with reversed loading state 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS10": {
-    "backgroundImage": "linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS11": {
-    "height": 10,
-    "marginBottom": 0,
-    "maxWidth": 240,
-  },
-  "IS12": {
-    "height": 10,
-    "marginBottom": 0,
-    "maxWidth": 240,
-  },
-  "IS13": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS14": {
-    "flex": 1,
-  },
-  "IS15": {
-    "flex": 1,
-  },
-  "IS16": {
-    "bottom": 0,
-    "left": 0,
-    "position": "absolute",
-    "right": 0,
-    "top": 0,
-    "zIndex": 0,
-  },
-  "IS17": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "150%",
-  },
-  "IS2": {
-    "height": 24,
-    "marginBottom": "10px",
-    "maxWidth": 300,
-  },
-  "IS3": {
-    "height": 24,
-    "marginBottom": "10px",
-    "maxWidth": 300,
-  },
-  "IS4": {
-    "backgroundImage": "linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS5": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS6": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS7": {
-    "backgroundImage": "linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS8": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "IS9": {
-    "height": 10,
-    "marginBottom": "10px",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "height": "24px",
-    "margin-bottom": "10px",
-    "max-width": "300px",
-    "min-width": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "height": "10px",
-    "margin-bottom": "10px",
-    "min-width": "0px",
-  },
-  "S3": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "height": "10px",
-    "margin-bottom": "0px",
-    "max-width": "240px",
-    "min-width": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "10px",
-    "min-width": "100%",
-  },
-  "S5": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
-  "S6": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "100%",
-  },
-  "S7": {
-    "-ms-flex-align": "start",
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "end",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-align-items": "flex-start",
-    "-webkit-box-align": "start",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "end",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "flex-end",
-    "align-items": "flex-start",
-    "display": "flex",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "height": "auto",
-    "justify-content": "flex-end",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 24px;
+  margin-bottom: 10px;
+  max-width: 300px;
+  min-width: 0px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  margin-bottom: 10px;
+  min-width: 0px;
+}
+
+.S3 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  height: 10px;
+  margin-bottom: 0px;
+  max-width: 240px;
+  min-width: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 10px;
+  min-width: 100%;
+}
+
+.S5 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.S6 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 100%;
+}
+
+.S7 {
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
+  display: flex;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  height: auto;
+  -ms-flex-pack: end;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.IS1 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS2 {
+  height: 24;
+  margin-bottom: 10px;
+  max-width: 300;
+}
+
+.IS3 {
+  height: 24;
+  margin-bottom: 10px;
+  max-width: 300;
+}
+
+.IS4 {
+  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS5 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS6 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS7 {
+  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS8 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS9 {
+  height: 10;
+  margin-bottom: 10px;
+}
+
+.IS10 {
+  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS11 {
+  height: 10;
+  margin-bottom: 0;
+  max-width: 240;
+}
+
+.IS12 {
+  height: 10;
+  margin-bottom: 0;
+  max-width: 240;
+}
+
+.IS13 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS14 {
+  flex: 1;
+}
+
+.IS15 {
+  flex: 1;
+}
+
+.IS16 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
+}
+
+.IS17 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 150%;
 }
 </style>
 

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -146,91 +146,100 @@ exports[`1. card loading state 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS2 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS3 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS4 {
-  bottom: 0;
-  left: 0;
+  bottom: 0px;
+  left: 0px;
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 0px;
+  top: 0px;
   z-index: 0;
 }
 
 .IS5 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 150%;
 }
 
 .IS6 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS7 {
-  height: 24;
+  height: 24px;
   margin-bottom: 10px;
-  max-width: 300;
+  max-width: 300px;
 }
 
 .IS8 {
-  height: 24;
+  height: 24px;
   margin-bottom: 10px;
-  max-width: 300;
+  max-width: 300px;
 }
 
 .IS9 {
-  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS10 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS11 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS12 {
-  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS13 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS14 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS15 {
-  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS16 {
-  height: 10;
-  margin-bottom: 0;
-  max-width: 240;
+  height: 10px;
+  margin-bottom: 0px;
+  max-width: 240px;
 }
 
 .IS17 {
-  height: 10;
-  margin-bottom: 0;
-  max-width: 240;
+  height: 10px;
+  margin-bottom: 0px;
+  max-width: 240px;
 }
 </style>
 
@@ -426,90 +435,99 @@ exports[`2. card with reversed loading state 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS2 {
-  height: 24;
+  height: 24px;
   margin-bottom: 10px;
-  max-width: 300;
+  max-width: 300px;
 }
 
 .IS3 {
-  height: 24;
+  height: 24px;
   margin-bottom: 10px;
-  max-width: 300;
+  max-width: 300px;
 }
 
 .IS4 {
-  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS5 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS6 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS7 {
-  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS8 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS9 {
-  height: 10;
+  height: 10px;
   margin-bottom: 10px;
 }
 
 .IS10 {
-  background-image: linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(267deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS11 {
-  height: 10;
-  margin-bottom: 0;
-  max-width: 240;
+  height: 10px;
+  margin-bottom: 0px;
+  max-width: 240px;
 }
 
 .IS12 {
-  height: 10;
-  margin-bottom: 0;
-  max-width: 240;
+  height: 10px;
+  margin-bottom: 0px;
+  max-width: 240px;
 }
 
 .IS13 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS14 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS15 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS16 {
-  bottom: 0;
-  left: 0;
+  bottom: 0px;
+  left: 0px;
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 0px;
+  top: 0px;
   z-index: 0;
 }
 
 .IS17 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 150%;
 }
 </style>

--- a/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
@@ -22,98 +22,105 @@ exports[`card with default layout 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS2": {
-    "flex": 1,
-  },
-  "IS3": {
-    "flex": 1,
-  },
-  "IS4": {
-    "bottom": 0,
-    "left": 0,
-    "position": "absolute",
-    "right": 0,
-    "top": 0,
-    "zIndex": 0,
-  },
-  "IS5": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "150%",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "10px",
-    "min-width": "100%",
-  },
-  "S3": {
-    "display": "inline",
-    "margin-bottom": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "100%",
-  },
-  "S5": {
-    "-ms-flex-align": "start",
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "end",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-align-items": "flex-start",
-    "-webkit-box-align": "start",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "end",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "flex-end",
-    "align-items": "flex-start",
-    "display": "flex",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "justify-content": "flex-end",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 10px;
+  min-width: 100%;
+}
+
+.S3 {
+  display: inline;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 100%;
+}
+
+.S5 {
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
+  display: flex;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -ms-flex-pack: end;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.IS1 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS2 {
+  flex: 1;
+}
+
+.IS3 {
+  flex: 1;
+}
+
+.IS4 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
+}
+
+.IS5 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 150%;
 }
 </style>
 

--- a/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-render-style.test.js.snap
@@ -96,30 +96,39 @@ exports[`card with default layout 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS2 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS3 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS4 {
-  bottom: 0;
-  left: 0;
+  bottom: 0px;
+  left: 0px;
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 0px;
+  top: 0px;
   z-index: 0;
 }
 
 .IS5 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 150%;
 }
 </style>

--- a/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
@@ -22,99 +22,106 @@ exports[`card with reversed layout 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "IS2": {
-    "flex": 1,
-  },
-  "IS3": {
-    "flex": 1,
-  },
-  "IS4": {
-    "bottom": 0,
-    "left": 0,
-    "position": "absolute",
-    "right": 0,
-    "top": 0,
-    "zIndex": 0,
-  },
-  "IS5": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "150%",
-  },
-  "S1": {
-    "display": "inline",
-    "margin-bottom": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "10px",
-    "min-width": "100%",
-  },
-  "S3": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-width": "100%",
-  },
-  "S5": {
-    "-ms-flex-align": "start",
-    "-ms-flex-direction": "row",
-    "-ms-flex-pack": "end",
-    "-ms-flex-wrap": "wrap",
-    "-webkit-align-items": "flex-start",
-    "-webkit-box-align": "start",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-lines": "multiple",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-box-pack": "end",
-    "-webkit-flex-direction": "row",
-    "-webkit-flex-wrap": "wrap",
-    "-webkit-justify-content": "flex-end",
-    "align-items": "flex-start",
-    "display": "flex",
-    "flex-direction": "row",
-    "flex-wrap": "wrap",
-    "height": "auto",
-    "justify-content": "flex-end",
-    "margin-bottom": "0px",
-    "min-width": "0px",
-  },
+.S1 {
+  display: inline;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 10px;
+  min-width: 100%;
+}
+
+.S3 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-width: 100%;
+}
+
+.S5 {
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: start;
+  align-items: flex-start;
+  display: flex;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  height: auto;
+  -ms-flex-pack: end;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  margin-bottom: 0px;
+  min-width: 0px;
+}
+
+.IS1 {
+  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+}
+
+.IS2 {
+  flex: 1;
+}
+
+.IS3 {
+  flex: 1;
+}
+
+.IS4 {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 0;
+}
+
+.IS5 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 150%;
 }
 </style>
 

--- a/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-reverse-style.test.js.snap
@@ -97,30 +97,39 @@ exports[`card with reversed layout 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(264deg, #F9F9F9 0%, #EDEDED 100%);
 }
 
 .IS2 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS3 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS4 {
-  bottom: 0;
-  left: 0;
+  bottom: 0px;
+  left: 0px;
   position: absolute;
-  right: 0;
-  top: 0;
+  right: 0px;
+  top: 0px;
   z-index: 0;
 }
 
 .IS5 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 150%;
 }
 </style>

--- a/packages/gradient/__tests__/web/__snapshots__/gradient-with-styles.web.test.js.snap
+++ b/packages/gradient/__tests__/web/__snapshots__/gradient-with-styles.web.test.js.snap
@@ -2,13 +2,12 @@
 
 exports[`1. gradient with style 1`] = `
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(30deg, #F9F9F9 0%, #EDEDED 100%)",
-  },
-  "S1": {
-    "background-color": "rgba(255,0,0,1.00)",
-  },
+.S1 {
+  background-color: rgba(255,0,0,1.00);
+}
+
+.IS1 {
+  background-image: linear-gradient(30deg, #F9F9F9 0%, #EDEDED 100%);
 }
 </style>
 

--- a/packages/gradient/__tests__/web/__snapshots__/gradient-with-styles.web.test.js.snap
+++ b/packages/gradient/__tests__/web/__snapshots__/gradient-with-styles.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. gradient with style 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(30deg, #F9F9F9 0%, #EDEDED 100%);
+  background-image: -webkit-linear-gradient(30deg, #F9F9F9 0%, #EDEDED 100%),-moz-linear-gradient(30deg, #F9F9F9 0%, #EDEDED 100%),linear-gradient(30deg, #F9F9F9 0%, #EDEDED 100%);
 }
 </style>
 

--- a/packages/gradient/__tests__/web/__snapshots__/overlay-gradient-with-styles.web.test.js.snap
+++ b/packages/gradient/__tests__/web/__snapshots__/overlay-gradient-with-styles.web.test.js.snap
@@ -2,13 +2,12 @@
 
 exports[`1. overlay gradient with style 1`] = `
 <style>
-{
-  "IS1": {
-    "backgroundImage": "linear-gradient(30deg, rgba(1, 1, 1, 0.9) 0%, rgba(0, 0, 0, 0) 100%)",
-  },
-  "S1": {
-    "background-color": "rgba(255,0,0,1.00)",
-  },
+.S1 {
+  background-color: rgba(255,0,0,1.00);
+}
+
+.IS1 {
+  background-image: linear-gradient(30deg, rgba(1, 1, 1, 0.9) 0%, rgba(0, 0, 0, 0) 100%);
 }
 </style>
 

--- a/packages/gradient/__tests__/web/__snapshots__/overlay-gradient-with-styles.web.test.js.snap
+++ b/packages/gradient/__tests__/web/__snapshots__/overlay-gradient-with-styles.web.test.js.snap
@@ -7,7 +7,7 @@ exports[`1. overlay gradient with style 1`] = `
 }
 
 .IS1 {
-  background-image: linear-gradient(30deg, rgba(1, 1, 1, 0.9) 0%, rgba(0, 0, 0, 0) 100%);
+  background-image: -webkit-linear-gradient(30deg, rgba(1, 1, 1, 0.9) 0%, rgba(0, 0, 0, 0) 100%),-moz-linear-gradient(30deg, rgba(1, 1, 1, 0.9) 0%, rgba(0, 0, 0, 0) 100%),linear-gradient(30deg, rgba(1, 1, 1, 0.9) 0%, rgba(0, 0, 0, 0) 100%);
 }
 </style>
 

--- a/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
@@ -12,54 +12,55 @@ exports[`1. default image 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "flex": 1,
-  },
-  "IS2": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "66.66666666666667%",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-ms-flex-positive": "1",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-flex": "1",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "-webkit-flex-grow": "1",
-    "align-items": "stretch",
-    "bottom": "0px",
-    "display": "flex",
-    "flex-direction": "column",
-    "flex-grow": "1",
-    "left": "0px",
-    "padding-bottom": "0px",
-    "position": "absolute",
-    "right": "0px",
-    "top": "0px",
-    "z-index": "0",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "padding-bottom": "0px",
-    "position": "relative",
-    "z-index": "0",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  bottom: 0px;
+  display: flex;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  left: 0px;
+  padding-bottom: 0px;
+  position: absolute;
+  right: 0px;
+  top: 0px;
+  z-index: 0;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 0px;
+  position: relative;
+  z-index: 0;
+}
+
+.IS1 {
+  flex: 1;
+}
+
+.IS2 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 66.66666666666667%;
 }
 </style>
 
@@ -95,54 +96,55 @@ exports[`2. default modal 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "flex": 1,
-  },
-  "IS2": {
-    "display": "table",
-    "height": 0,
-    "overflow": "hidden",
-    "paddingBottom": "66.66666666666667%",
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-ms-flex-positive": "1",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-flex": "1",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "-webkit-flex-grow": "1",
-    "align-items": "stretch",
-    "bottom": "0px",
-    "display": "flex",
-    "flex-direction": "column",
-    "flex-grow": "1",
-    "left": "0px",
-    "padding-bottom": "0px",
-    "position": "absolute",
-    "right": "0px",
-    "top": "0px",
-    "z-index": "0",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "display": "flex",
-    "flex-direction": "column",
-    "padding-bottom": "0px",
-    "position": "relative",
-    "z-index": "0",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  bottom: 0px;
+  display: flex;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  left: 0px;
+  padding-bottom: 0px;
+  position: absolute;
+  right: 0px;
+  top: 0px;
+  z-index: 0;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  padding-bottom: 0px;
+  position: relative;
+  z-index: 0;
+}
+
+.IS1 {
+  flex: 1;
+}
+
+.IS2 {
+  display: table;
+  height: 0;
+  overflow: hidden;
+  padding-bottom: 66.66666666666667%;
 }
 </style>
 

--- a/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image-with-style.web.test.js.snap
@@ -53,13 +53,18 @@ exports[`1. default image 1`] = `
 }
 
 .IS1 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS2 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 66.66666666666667%;
 }
 </style>
@@ -137,13 +142,18 @@ exports[`2. default modal 1`] = `
 }
 
 .IS1 {
-  flex: 1;
+  -webkit-flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+  -ms-flex: 1;
 }
 
 .IS2 {
   display: table;
-  height: 0;
-  overflow: hidden;
+  height: 0px;
+  overflow-x: hidden;
+  overflow-y: hidden;
   padding-bottom: 66.66666666666667%;
 }
 </style>

--- a/packages/jest-serializer/.eslintignore
+++ b/packages/jest-serializer/.eslintignore
@@ -2,3 +2,5 @@
 **/coverage/*
 dist
 rnw.js
+hoist-style.js
+printers.js

--- a/packages/jest-serializer/__tests__/web/__snapshots__/composed.test.js.snap
+++ b/packages/jest-serializer/__tests__/web/__snapshots__/composed.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`The serializers should minimalise and create styles 1`] = `
 <style>
-{
-  "S1": {
-    "color": "rgba(255,0,0,1.00)",
-  },
+.S1 {
+  color: rgba(255,0,0,1.00);
 }
 </style>
 

--- a/packages/jest-serializer/__tests__/web/__snapshots__/hoist-style.test.js.snap
+++ b/packages/jest-serializer/__tests__/web/__snapshots__/hoist-style.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`hoist-style should hoist a style and leave existing props untouched 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(255,0,0,1.00)",
-  },
+.IS1 {
+  color: rgba(255,0,0,1.00);
 }
 </style>
 
@@ -20,13 +18,12 @@ exports[`hoist-style should hoist a style and leave existing props untouched 1`]
 
 exports[`hoist-style should hoist a style as well as an rnw class 1`] = `
 <style>
-{
-  "IS1": {
-    "color": "rgba(255,0,0,1.00)",
-  },
-  "S1": {
-    "border-top-width": "0px",
-  },
+.S1 {
+  border-top-width: 0px;
+}
+
+.IS1 {
+  color: rgba(255,0,0,1.00);
 }
 </style>
 

--- a/packages/jest-serializer/__tests__/web/__snapshots__/rnw.test.js.snap
+++ b/packages/jest-serializer/__tests__/web/__snapshots__/rnw.test.js.snap
@@ -2,10 +2,8 @@
 
 exports[`The React Native Web serializer should effect children 1`] = `
 <style>
-{
-  "S1": {
-    "font-size": "9px",
-  },
+.S1 {
+  font-size: 9px;
 }
 </style>
 
@@ -21,16 +19,16 @@ exports[`The React Native Web serializer should effect children 1`] = `
 
 exports[`The React Native Web serializer should effect multiple children 1`] = `
 <style>
-{
-  "S1": {
-    "font-size": "9px",
-  },
-  "S2": {
-    "font-size": "10px",
-  },
-  "S3": {
-    "font-size": "11px",
-  },
+.S1 {
+  font-size: 9px;
+}
+
+.S2 {
+  font-size: 10px;
+}
+
+.S3 {
+  font-size: 11px;
 }
 </style>
 
@@ -66,10 +64,8 @@ exports[`The React Native Web serializer should effect render props 1`] = `
 
 exports[`The React Native Web serializer should remove rnw-classnames and hoist the styles 1`] = `
 <style>
-{
-  "S1": {
-    "color": "rgba(255,0,0,1.00)",
-  },
+.S1 {
+  color: rgba(255,0,0,1.00);
 }
 </style>
 
@@ -82,10 +78,8 @@ exports[`The React Native Web serializer should remove rnw-classnames and hoist 
 
 exports[`The React Native Web serializer should squash identical styles 1`] = `
 <style>
-{
-  "S1": {
-    "font-size": "10px",
-  },
+.S1 {
+  font-size: 10px;
 }
 </style>
 

--- a/packages/jest-serializer/src/hoist-style.js
+++ b/packages/jest-serializer/src/hoist-style.js
@@ -1,6 +1,13 @@
 import traverse from "./traverse";
 import { stylePrinter } from "./printers";
 
+const getNormalisedCSSPropertyName = property => property.replace(/([A-Z])/g, "-$1").toLowerCase();
+
+const normaliseCSSPropertyNames = (transformed, [propertyName, value]) => ({
+  ...transformed,
+  [getNormalisedCSSPropertyName(propertyName)]: value
+});
+
 export const hoistStyleTransform = (accum, node, props, children) => {
   const { style, className, ...other } = props;
 
@@ -36,12 +43,14 @@ export const hoistStyleTransform = (accum, node, props, children) => {
     ? `${className} ${inlineStyleClass}`
     : inlineStyleClass;
 
+  const transformedStyle = Object.entries(style).reduce(normaliseCSSPropertyNames, {});
+
   return {
     accum: {
       ...accum,
       inlineStyles: {
         ...accum.inlineStyles,
-        [inlineStyleClass]: style
+        [inlineStyleClass]: transformedStyle
       }
     },
     children,

--- a/packages/jest-serializer/src/hoist-style.js
+++ b/packages/jest-serializer/src/hoist-style.js
@@ -1,12 +1,21 @@
+import hyphenateStyleName from "hyphenate-style-name";
+import normalizeValue from "react-native-web/dist/cjs/exports/StyleSheet/normalizeValue";
+import createReactDOMStyle from "react-native-web/dist/cjs/exports/StyleSheet/createReactDOMStyle";
+import prefixStyles from "react-native-web/dist/cjs/modules/prefixStyles";
+
 import traverse from "./traverse";
 import { stylePrinter } from "./printers";
 
-const getNormalisedCSSPropertyName = property => property.replace(/([A-Z])/g, "-$1").toLowerCase();
-
-const normaliseCSSPropertyNames = (transformed, [propertyName, value]) => ({
-  ...transformed,
-  [getNormalisedCSSPropertyName(propertyName)]: value
+const transformRNStyleProperty = (acc, [propertyName, value]) => ({
+  ...acc,
+  [hyphenateStyleName(propertyName)]: normalizeValue(propertyName, value)
 });
+
+const transformRNStylesForWeb = style =>
+  Object.entries(createReactDOMStyle(prefixStyles({ ...style }))).reduce(
+    transformRNStyleProperty,
+    {}
+  );
 
 export const hoistStyleTransform = (accum, node, props, children) => {
   const { style, className, ...other } = props;
@@ -43,7 +52,7 @@ export const hoistStyleTransform = (accum, node, props, children) => {
     ? `${className} ${inlineStyleClass}`
     : inlineStyleClass;
 
-  const transformedStyle = Object.entries(style).reduce(normaliseCSSPropertyNames, {});
+  const transformedStyle = transformRNStylesForWeb(style);
 
   return {
     accum: {

--- a/packages/jest-serializer/src/printers.js
+++ b/packages/jest-serializer/src/printers.js
@@ -1,24 +1,26 @@
-import css from 'css';
+import css from "css";
 
 export default (serialize, accum, element) => serialize(element);
 
-const getDeclarationsAst = rules => Object.entries(rules).map(([property, value]) => ({
-  property,
-  type: "declaration",
-  value
-}));
+const getDeclarationsAst = rules =>
+  Object.entries(rules).map(([property, value]) => ({
+    property,
+    type: "declaration",
+    value
+  }));
 
-const getRulesAst = jss => Object.entries(jss).map(([selector, rules]) => ({
-  declarations: getDeclarationsAst(rules),
-  selectors: [`.${selector}`],
-  type: "rule",
-}));
+const getRulesAst = jss =>
+  Object.entries(jss).map(([selector, rules]) => ({
+    declarations: getDeclarationsAst(rules),
+    selectors: [`.${selector}`],
+    type: "rule"
+  }));
 
 const getStylesheetAst = jss => ({
   stylesheet: {
     rules: getRulesAst(jss)
   },
-  type: "stylesheet",
+  type: "stylesheet"
 });
 
 const stringifyJss = jss => css.stringify(getStylesheetAst(jss));

--- a/packages/jest-serializer/src/printers.js
+++ b/packages/jest-serializer/src/printers.js
@@ -1,4 +1,27 @@
+import css from 'css';
+
 export default (serialize, accum, element) => serialize(element);
+
+const getDeclarationsAst = rules => Object.entries(rules).map(([property, value]) => ({
+  property,
+  type: "declaration",
+  value
+}));
+
+const getRulesAst = jss => Object.entries(jss).map(([selector, rules]) => ({
+  declarations: getDeclarationsAst(rules),
+  selectors: [`.${selector}`],
+  type: "rule",
+}));
+
+const getStylesheetAst = jss => ({
+  stylesheet: {
+    rules: getRulesAst(jss)
+  },
+  type: "stylesheet",
+});
+
+const stringifyJss = jss => css.stringify(getStylesheetAst(jss));
 
 export const stylePrinter = (serialize, accum, element) => {
   const mergedStyles = {
@@ -8,7 +31,7 @@ export const stylePrinter = (serialize, accum, element) => {
   const styleBlock =
     Object.keys(mergedStyles).length > 0
       ? `<style>
-${serialize(mergedStyles).replace(/Object\s{/g, "{")}
+${stringifyJss(mergedStyles)}
 </style>
 
 `

--- a/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
+++ b/packages/pagination/__tests__/web/__snapshots__/pagination-with-styles.web.test.js.snap
@@ -89,71 +89,76 @@ exports[`1. renders 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "textDecoration": "none",
-  },
-  "IS2": {
-    "textDecoration": "none",
-  },
-  "S1": {
-    "color": "rgba(105,105,105,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "15px",
-    "margin-right": "0px",
-    "padding-top": "4px",
-  },
-  "S2": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "flex-direction": "column",
-    "margin-right": "0px",
-    "padding-top": "0px",
-  },
-  "S3": {
-    "color": "inherit",
-    "font-family": "inherit",
-    "font-size": "inherit",
-    "margin-right": "0px",
-    "padding-top": "0px",
-  },
-  "S4": {
-    "color": "rgba(0,102,153,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "15px",
-    "height": "15px",
-    "margin-right": "0px",
-    "padding-top": "0px",
-    "text-align": "left",
-  },
-  "S5": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "center",
-    "flex-direction": "row",
-    "margin-right": "0px",
-    "padding-top": "10px",
-  },
-  "S6": {
-    "color": "rgba(0,102,153,1.00)",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "15px",
-    "height": "15px",
-    "margin-right": "10px",
-    "padding-top": "0px",
-    "text-align": "right",
-  },
+.S1 {
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 15px;
+  margin-right: 0px;
+  padding-top: 4px;
+}
+
+.S2 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-right: 0px;
+  padding-top: 0px;
+}
+
+.S3 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  margin-right: 0px;
+  padding-top: 0px;
+}
+
+.S4 {
+  color: rgba(0,102,153,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 15px;
+  height: 15px;
+  margin-right: 0px;
+  padding-top: 0px;
+  text-align: left;
+}
+
+.S5 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  margin-right: 0px;
+  padding-top: 10px;
+}
+
+.S6 {
+  color: rgba(0,102,153,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 15px;
+  height: 15px;
+  margin-right: 10px;
+  padding-top: 0px;
+  text-align: right;
+}
+
+.IS1 {
+  text-decoration: none;
+}
+
+.IS2 {
+  text-decoration: none;
 }
 </style>
 
@@ -277,20 +282,18 @@ exports[`2. renders with no results 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "flex-direction": "column",
-    "margin-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-right: 0px;
+  padding-top: 0px;
 }
 </style>
 

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
@@ -16,109 +16,115 @@ exports[`different colours 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "color": "rgba(133,0,41,1.00)",
-  },
-  "IS2": {
-    "color": "rgba(133,0,41,1.00)",
-  },
-  "IS3": {
-    "color": "#006699",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": 13,
-    "lineHeight": 13,
-    "marginLeft": 3,
-    "textDecorationLine": "none",
-  },
-  "S1": {
-    "border-left-width": "0px",
-    "display": "inline",
-    "font-family": "TimesModern-Regular",
-    "font-size": "75px",
-    "line-height": "inherit",
-    "margin-bottom": "-40px",
-    "margin-left": "0px",
-    "margin-top": "0px",
-    "padding-left": "0px",
-  },
-  "S2": {
-    "border-left-width": "0px",
-    "color": "inherit",
-    "display": "inline",
-    "font-family": "system-ui, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Ubuntu, \\"Helvetica Neue\\", sans-serif",
-    "font-size": "14px",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-top": "0px",
-    "padding-left": "0px",
-  },
-  "S3": {
-    "border-left-width": "0px",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "line-height": "13px",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-top": "0px",
-    "padding-left": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "center",
-    "border-left-color": "rgba(219,219,219,1.00)",
-    "border-left-width": "1px",
-    "display": "flex",
-    "flex-direction": "row",
-    "height": "15px",
-    "margin-bottom": "0px",
-    "margin-left": "7px",
-    "margin-top": "0px",
-    "padding-left": "7px",
-  },
-  "S5": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "center",
-    "border-left-width": "0px",
-    "display": "flex",
-    "flex-direction": "row",
-    "height": "20px",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "margin-top": "10px",
-    "padding-left": "0px",
-  },
-  "S6": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-left-width": "0px",
-    "display": "flex",
-    "flex-direction": "column",
-    "margin-bottom": "15px",
-    "margin-left": "0px",
-    "margin-top": "0px",
-    "padding-left": "0px",
-  },
+.S1 {
+  border-left-width: 0px;
+  display: inline;
+  font-family: TimesModern-Regular;
+  font-size: 75px;
+  line-height: inherit;
+  margin-left: 0px;
+  margin-bottom: -40px;
+  margin-top: 0px;
+  padding-left: 0px;
+}
+
+.S2 {
+  border-left-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  padding-left: 0px;
+}
+
+.S3 {
+  border-left-width: 0px;
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 13px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S4 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  border-left-color: rgba(219,219,219,1.00);
+  border-left-width: 1px;
+  display: flex;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 7px;
+  padding-left: 7px;
+}
+
+.S5 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  border-left-width: 0px;
+  display: flex;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  height: 20px;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  margin-top: 10px;
+  padding-left: 0px;
+}
+
+.S6 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-left-width: 0px;
+  display: flex;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-left: 0px;
+  margin-bottom: 15px;
+  margin-top: 0px;
+  padding-left: 0px;
+}
+
+.IS1 {
+  color: rgba(133,0,41,1.00);
+}
+
+.IS2 {
+  color: rgba(133,0,41,1.00);
+}
+
+.IS3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 13;
+  line-height: 13;
+  color: #006699;
+  margin-left: 3;
+  text-decoration-line: none;
 }
 </style>
 

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
@@ -119,12 +119,13 @@ exports[`different colours 1`] = `
 }
 
 .IS3 {
+  -webkit-text-decoration-line: none;
+  color: rgba(0,102,153,1.00);
   font-family: GillSansMTStd-Medium;
-  font-size: 13;
-  line-height: 13;
-  color: #006699;
-  margin-left: 3;
-  text-decoration-line: none;
+  font-size: 13px;
+  line-height: 13px;
+  margin-left: 3px;
+  text-decoration: none;
 }
 </style>
 

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -165,131 +165,138 @@ exports[`default styles 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "25px",
-    "font-weight": "inherit",
-    "line-height": "27px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S10": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "center",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-pack": "center",
-    "-webkit-justify-content": "center",
-    "align-items": "center",
-    "border-bottom-color": "rgba(219,219,219,1.00)",
-    "border-bottom-width": "1px",
-    "border-top-color": "rgba(219,219,219,1.00)",
-    "border-top-width": "1px",
-    "display": "flex",
-    "justify-content": "center",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S3": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "12px",
-    "font-weight": "400",
-    "line-height": "14px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "flex",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S5": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "22px",
-    "font-weight": "400",
-    "line-height": "27px",
-    "margin-bottom": "5px",
-    "margin-top": "0px",
-  },
-  "S6": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "inherit",
-    "display": "inline",
-    "font-family": "inherit",
-    "font-size": "inherit",
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S7": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "TimesDigitalW04",
-    "font-size": "14px",
-    "font-weight": "inherit",
-    "line-height": "20px",
-    "margin-bottom": "10px",
-    "margin-top": "0px",
-  },
-  "S8": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "5px",
-    "margin-top": "0px",
-  },
-  "S9": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
+.S1 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 25px;
+  font-weight: inherit;
+  line-height: 27px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-top-width: 1px;
+  display: flex;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: flex;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 5px;
+  margin-top: 0px;
+}
+
+.S6 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S7 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-top: 0px;
+  margin-bottom: 10px;
+}
+
+.S8 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 5px;
+}
+
+.S9 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 </style>
 

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -190,135 +190,144 @@ exports[`default styles 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "color": "rgba(19,53,78,1.00)",
-  },
-  "IS2": {
-    "color": "rgba(19,53,78,1.00)",
-  },
-  "S1": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "25px",
-    "font-weight": "inherit",
-    "line-height": "27px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S10": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "5px",
-    "margin-top": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "center",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-pack": "center",
-    "-webkit-justify-content": "center",
-    "align-items": "center",
-    "border-bottom-color": "rgba(219,219,219,1.00)",
-    "border-bottom-width": "1px",
-    "border-top-color": "rgba(219,219,219,1.00)",
-    "border-top-width": "1px",
-    "display": "flex",
-    "justify-content": "center",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S3": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "12px",
-    "font-weight": "400",
-    "line-height": "14px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "flex",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S5": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S6": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(133,0,41,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "22px",
-    "font-weight": "400",
-    "line-height": "24px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S7": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "22px",
-    "font-weight": "400",
-    "line-height": "27px",
-    "margin-bottom": "5px",
-    "margin-top": "0px",
-  },
-  "S8": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "inherit",
-    "display": "inline",
-    "font-family": "inherit",
-    "font-size": "inherit",
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S9": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "TimesDigitalW04",
-    "font-size": "14px",
-    "font-weight": "inherit",
-    "line-height": "20px",
-    "margin-bottom": "10px",
-    "margin-top": "0px",
-  },
+.S1 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 25px;
+  font-weight: inherit;
+  line-height: 27px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-top-width: 1px;
+  display: flex;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: flex;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S6 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(133,0,41,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 24px;
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
+.S7 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 5px;
+  margin-top: 0px;
+}
+
+.S8 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S9 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-top: 0px;
+  margin-bottom: 10px;
+}
+
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 5px;
+}
+
+.IS1 {
+  color: rgba(19,53,78,1.00);
+}
+
+.IS2 {
+  color: rgba(19,53,78,1.00);
 }
 </style>
 

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -133,138 +133,148 @@ exports[`default styles 1`] = `
 }
 
 <style>
-{
-  "IS1": {
-    "color": "rgba(219,19,59,1.00)",
-  },
-  "IS2": {
-    "color": "rgba(219,19,59,1.00)",
-  },
-  "IS3": {
-    "color": "rgba(219,19,59,1.00)",
-  },
-  "S1": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "25px",
-    "font-weight": "inherit",
-    "line-height": "27px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S10": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S2": {
-    "-ms-flex-align": "center",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-pack": "center",
-    "-webkit-justify-content": "center",
-    "align-items": "center",
-    "border-bottom-color": "rgba(219,219,219,1.00)",
-    "border-bottom-width": "1px",
-    "border-top-color": "rgba(219,219,219,1.00)",
-    "border-top-width": "1px",
-    "display": "flex",
-    "justify-content": "center",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S3": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "12px",
-    "font-weight": "400",
-    "line-height": "14px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S4": {
-    "-ms-flex-align": "stretch",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "flex",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S5": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "22px",
-    "font-weight": "400",
-    "line-height": "27px",
-    "margin-bottom": "5px",
-    "margin-top": "0px",
-  },
-  "S6": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "inherit",
-    "display": "inline",
-    "font-family": "inherit",
-    "font-size": "inherit",
-    "font-weight": "inherit",
-    "line-height": "inherit",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
-  "S7": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "TimesDigitalW04",
-    "font-size": "14px",
-    "font-weight": "inherit",
-    "line-height": "20px",
-    "margin-bottom": "10px",
-    "margin-top": "0px",
-  },
-  "S8": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(105,105,105,1.00)",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "5px",
-    "margin-top": "0px",
-  },
-  "S9": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "display": "inline",
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "13px",
-    "font-weight": "inherit",
-    "line-height": "15px",
-    "margin-bottom": "0px",
-    "margin-top": "0px",
-  },
+.S1 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 25px;
+  font-weight: inherit;
+  line-height: 27px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  border-bottom-color: rgba(219,219,219,1.00);
+  border-bottom-width: 1px;
+  border-top-color: rgba(219,219,219,1.00);
+  border-top-width: 1px;
+  display: flex;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S4 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: flex;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 5px;
+  margin-top: 0px;
+}
+
+.S6 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S7 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-top: 0px;
+  margin-bottom: 10px;
+}
+
+.S8 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 5px;
+}
+
+.S9 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 15px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.IS1 {
+  color: rgba(219,19,59,1.00);
+}
+
+.IS2 {
+  color: rgba(219,19,59,1.00);
+}
+
+.IS3 {
+  color: rgba(219,19,59,1.00);
 }
 </style>
 

--- a/packages/slice/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/slice/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -165,14 +165,12 @@ exports[`1. a single child element 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 
@@ -428,14 +426,12 @@ exports[`2. two child elements 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 
@@ -747,14 +743,12 @@ exports[`3. three child elements 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 

--- a/packages/slice/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/slice/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -190,14 +190,12 @@ exports[`1. a single child element 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 
@@ -526,14 +524,12 @@ exports[`2. two child elements 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 
@@ -940,14 +936,12 @@ exports[`3. three child elements 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 

--- a/packages/slice/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/slice/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -135,14 +135,12 @@ exports[`2. a single child element 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 
@@ -305,14 +303,12 @@ exports[`3. two child elements 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 
@@ -489,14 +485,12 @@ exports[`4. three child elements 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "border-bottom-width": "0px",
-    "padding-bottom": "0px",
-    "padding-left": "0px",
-    "padding-right": "0px",
-    "padding-top": "0px",
-  },
+.S1 {
+  border-bottom-width: 0px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
 }
 </style>
 

--- a/packages/topic/__tests__/web/__snapshots__/topic-with-style.web.test.js.snap
+++ b/packages/topic/__tests__/web/__snapshots__/topic-with-style.web.test.js.snap
@@ -55,53 +55,53 @@ exports[`1. an article list header 1`] = `
 }
 
 <style>
-{
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-height": "0px",
-    "padding-top": "0px",
-  },
-  "S2": {
-    "border-bottom-width": "0px",
-    "border-top-width": "0px",
-    "color": "rgba(51,51,51,1.00)",
-    "font-family": "TimesDigitalW04",
-    "font-size": "15px",
-    "line-height": "26px",
-    "margin-bottom": "0px",
-    "padding-top": "0px",
-    "text-align": "center",
-  },
-  "S3": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "center",
-    "background-color": "rgba(249,249,249,1.00)",
-    "border-bottom-color": "rgba(240,240,240,1.00)",
-    "border-bottom-width": "1px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-height": "90px",
-    "padding-top": "40px",
-    "width": "100%",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-height: 0px;
+  padding-top: 0px;
+}
+
+.S2 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: rgba(51,51,51,1.00);
+  font-family: TimesDigitalW04;
+  font-size: 15px;
+  line-height: 26px;
+  margin-bottom: 0px;
+  padding-top: 0px;
+  text-align: center;
+}
+
+.S3 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  background-color: rgba(249,249,249,1.00);
+  border-bottom-color: rgba(240,240,240,1.00);
+  border-bottom-width: 1px;
+  border-top-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-height: 90px;
+  padding-top: 40px;
+  width: 100%;
 }
 </style>
 
@@ -137,26 +137,24 @@ exports[`1. an article list header 1`] = `
 
 exports[`2. an article list header loading 1`] = `
 <style>
-{
-  "S1": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "center",
-    "background-color": "rgba(249,249,249,1.00)",
-    "border-bottom-color": "rgba(240,240,240,1.00)",
-    "border-bottom-width": "1px",
-    "border-top-width": "0px",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "min-height": "90px",
-    "padding-top": "40px",
-    "width": "100%",
-  },
+.S1 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  background-color: rgba(249,249,249,1.00);
+  border-bottom-color: rgba(240,240,240,1.00);
+  border-bottom-width: 1px;
+  border-top-width: 0px;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  min-height: 90px;
+  padding-top: 40px;
+  width: 100%;
 }
 </style>
 

--- a/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
@@ -2,72 +2,76 @@
 
 exports[`1. video label with a title 1`] = `
 <style>
-{
-  "IS1": {
-    "paddingBottom": 3,
-  },
-  "IS2": {
-    "color": "rgba(0,131,71,1.00)",
-  },
-  "IS3": {
-    "color": "#008347",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": 12,
-    "fontWeight": "400",
-    "letterSpacing": 1.2,
-    "lineHeight": 11,
-    "marginLeft": 5,
-    "padding": 0,
-    "position": "relative",
-    "top": 2,
-  },
-  "IS4": {
-    "alignItems": "center",
-    "flexDirection": "row",
-    "marginBottom": 3,
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "padding-bottom": "3px",
-    "position": "relative",
-  },
-  "S2": {
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "12px",
-    "font-weight": "400",
-    "letter-spacing": "1.2px",
-    "line-height": "11px",
-    "margin-bottom": "0px",
-    "margin-left": "5px",
-    "padding-bottom": "0px",
-    "position": "relative",
-    "top": "2px",
-  },
-  "S3": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "center",
-    "flex-direction": "row",
-    "margin-bottom": "3px",
-    "margin-left": "0px",
-    "padding-bottom": "0px",
-    "position": "relative",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  padding-bottom: 3px;
+  position: relative;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 1.2px;
+  line-height: 11px;
+  margin-bottom: 0px;
+  margin-left: 5px;
+  padding-bottom: 0px;
+  position: relative;
+  top: 2px;
+}
+
+.S3 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  margin-left: 0px;
+  margin-bottom: 3px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.IS1 {
+  padding-bottom: 3;
+}
+
+.IS2 {
+  color: rgba(0,131,71,1.00);
+}
+
+.IS3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12;
+  line-height: 11;
+  font-weight: 400;
+  letter-spacing: 1.2;
+  margin-left: 5;
+  padding: 0;
+  position: relative;
+  top: 2;
+  color: #008347;
+}
+
+.IS4 {
+  align-items: center;
+  flex-direction: row;
+  margin-bottom: 3;
 }
 </style>
 
@@ -97,72 +101,76 @@ exports[`1. video label with a title 1`] = `
 
 exports[`2. video label without a title shows video 1`] = `
 <style>
-{
-  "IS1": {
-    "paddingBottom": 3,
-  },
-  "IS2": {
-    "color": "rgba(0,131,71,1.00)",
-  },
-  "IS3": {
-    "color": "#008347",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": 12,
-    "fontWeight": "400",
-    "letterSpacing": 1.2,
-    "lineHeight": 11,
-    "marginLeft": 5,
-    "padding": 0,
-    "position": "relative",
-    "top": 2,
-  },
-  "IS4": {
-    "alignItems": "center",
-    "flexDirection": "row",
-    "marginBottom": 3,
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "padding-bottom": "3px",
-    "position": "relative",
-  },
-  "S2": {
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "12px",
-    "font-weight": "400",
-    "letter-spacing": "1.2px",
-    "line-height": "11px",
-    "margin-bottom": "0px",
-    "margin-left": "5px",
-    "padding-bottom": "0px",
-    "position": "relative",
-    "top": "2px",
-  },
-  "S3": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "center",
-    "flex-direction": "row",
-    "margin-bottom": "3px",
-    "margin-left": "0px",
-    "padding-bottom": "0px",
-    "position": "relative",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  padding-bottom: 3px;
+  position: relative;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 1.2px;
+  line-height: 11px;
+  margin-bottom: 0px;
+  margin-left: 5px;
+  padding-bottom: 0px;
+  position: relative;
+  top: 2px;
+}
+
+.S3 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  margin-left: 0px;
+  margin-bottom: 3px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.IS1 {
+  padding-bottom: 3;
+}
+
+.IS2 {
+  color: rgba(0,131,71,1.00);
+}
+
+.IS3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12;
+  line-height: 11;
+  font-weight: 400;
+  letter-spacing: 1.2;
+  margin-left: 5;
+  padding: 0;
+  position: relative;
+  top: 2;
+  color: #008347;
+}
+
+.IS4 {
+  align-items: center;
+  flex-direction: row;
+  margin-bottom: 3;
 }
 </style>
 
@@ -192,72 +200,76 @@ exports[`2. video label without a title shows video 1`] = `
 
 exports[`3. video label with the black default colour 1`] = `
 <style>
-{
-  "IS1": {
-    "paddingBottom": 3,
-  },
-  "IS2": {
-    "color": "rgba(0,0,0,1.00)",
-  },
-  "IS3": {
-    "color": "black",
-    "fontFamily": "GillSansMTStd-Medium",
-    "fontSize": 12,
-    "fontWeight": "400",
-    "letterSpacing": 1.2,
-    "lineHeight": 11,
-    "marginLeft": 5,
-    "padding": 0,
-    "position": "relative",
-    "top": 2,
-  },
-  "IS4": {
-    "alignItems": "center",
-    "flexDirection": "row",
-    "marginBottom": 3,
-  },
-  "S1": {
-    "-ms-flex-align": "stretch",
-    "-ms-flex-direction": "column",
-    "-webkit-align-items": "stretch",
-    "-webkit-box-align": "stretch",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "vertical",
-    "-webkit-flex-direction": "column",
-    "align-items": "stretch",
-    "flex-direction": "column",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
-    "padding-bottom": "3px",
-    "position": "relative",
-  },
-  "S2": {
-    "font-family": "GillSansMTStd-Medium",
-    "font-size": "12px",
-    "font-weight": "400",
-    "letter-spacing": "1.2px",
-    "line-height": "11px",
-    "margin-bottom": "0px",
-    "margin-left": "5px",
-    "padding-bottom": "0px",
-    "position": "relative",
-    "top": "2px",
-  },
-  "S3": {
-    "-ms-flex-align": "center",
-    "-ms-flex-direction": "row",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-direction": "normal",
-    "-webkit-box-orient": "horizontal",
-    "-webkit-flex-direction": "row",
-    "align-items": "center",
-    "flex-direction": "row",
-    "margin-bottom": "3px",
-    "margin-left": "0px",
-    "padding-bottom": "0px",
-    "position": "relative",
-  },
+.S1 {
+  -ms-flex-align: stretch;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  align-items: stretch;
+  -ms-flex-direction: column;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: vertical;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  padding-bottom: 3px;
+  position: relative;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 1.2px;
+  line-height: 11px;
+  margin-bottom: 0px;
+  margin-left: 5px;
+  padding-bottom: 0px;
+  position: relative;
+  top: 2px;
+}
+
+.S3 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  -ms-flex-direction: row;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+  margin-left: 0px;
+  margin-bottom: 3px;
+  padding-bottom: 0px;
+  position: relative;
+}
+
+.IS1 {
+  padding-bottom: 3;
+}
+
+.IS2 {
+  color: rgba(0,0,0,1.00);
+}
+
+.IS3 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12;
+  line-height: 11;
+  font-weight: 400;
+  letter-spacing: 1.2;
+  margin-left: 5;
+  padding: 0;
+  position: relative;
+  top: 2;
+  color: black;
+}
+
+.IS4 {
+  align-items: center;
+  flex-direction: row;
+  margin-bottom: 3;
 }
 </style>
 

--- a/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label-with-style.web.test.js.snap
@@ -48,7 +48,7 @@ exports[`1. video label with a title 1`] = `
 }
 
 .IS1 {
-  padding-bottom: 3;
+  padding-bottom: 3px;
 }
 
 .IS2 {
@@ -56,22 +56,32 @@ exports[`1. video label with a title 1`] = `
 }
 
 .IS3 {
+  color: rgba(0,131,71,1.00);
   font-family: GillSansMTStd-Medium;
-  font-size: 12;
-  line-height: 11;
+  font-size: 12px;
   font-weight: 400;
-  letter-spacing: 1.2;
-  margin-left: 5;
-  padding: 0;
+  letter-spacing: 1.2px;
+  line-height: 11px;
+  margin-left: 5px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
   position: relative;
-  top: 2;
-  color: #008347;
+  top: 2px;
 }
 
 .IS4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
   align-items: center;
   flex-direction: row;
-  margin-bottom: 3;
+  margin-bottom: 3px;
+  -ms-flex-align: center;
+  -ms-flex-direction: row;
 }
 </style>
 
@@ -147,7 +157,7 @@ exports[`2. video label without a title shows video 1`] = `
 }
 
 .IS1 {
-  padding-bottom: 3;
+  padding-bottom: 3px;
 }
 
 .IS2 {
@@ -155,22 +165,32 @@ exports[`2. video label without a title shows video 1`] = `
 }
 
 .IS3 {
+  color: rgba(0,131,71,1.00);
   font-family: GillSansMTStd-Medium;
-  font-size: 12;
-  line-height: 11;
+  font-size: 12px;
   font-weight: 400;
-  letter-spacing: 1.2;
-  margin-left: 5;
-  padding: 0;
+  letter-spacing: 1.2px;
+  line-height: 11px;
+  margin-left: 5px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
   position: relative;
-  top: 2;
-  color: #008347;
+  top: 2px;
 }
 
 .IS4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
   align-items: center;
   flex-direction: row;
-  margin-bottom: 3;
+  margin-bottom: 3px;
+  -ms-flex-align: center;
+  -ms-flex-direction: row;
 }
 </style>
 
@@ -246,7 +266,7 @@ exports[`3. video label with the black default colour 1`] = `
 }
 
 .IS1 {
-  padding-bottom: 3;
+  padding-bottom: 3px;
 }
 
 .IS2 {
@@ -254,22 +274,32 @@ exports[`3. video label with the black default colour 1`] = `
 }
 
 .IS3 {
+  color: rgba(0,0,0,1.00);
   font-family: GillSansMTStd-Medium;
-  font-size: 12;
-  line-height: 11;
+  font-size: 12px;
   font-weight: 400;
-  letter-spacing: 1.2;
-  margin-left: 5;
-  padding: 0;
+  letter-spacing: 1.2px;
+  line-height: 11px;
+  margin-left: 5px;
+  padding-top: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
   position: relative;
-  top: 2;
-  color: black;
+  top: 2px;
 }
 
 .IS4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -webkit-box-direction: normal;
+  -webkit-box-orient: horizontal;
+  -webkit-flex-direction: row;
   align-items: center;
   flex-direction: row;
-  margin-bottom: 3;
+  margin-bottom: 3px;
+  -ms-flex-align: center;
+  -ms-flex-direction: row;
 }
 </style>
 

--- a/packages/video/__tests__/web/__snapshots__/video-error-with-style.web.test.js.snap
+++ b/packages/video/__tests__/web/__snapshots__/video-error-with-style.web.test.js.snap
@@ -2,45 +2,46 @@
 
 exports[`1. video with error 1`] = `
 <style>
-{
-  "IS1": {
-    "height": "100px",
-    "width": "100px",
-  },
-  "S1": {
-    "color": "rgba(255,255,255,1.00)",
-    "display": "inline",
-    "font-family": "TimesModern-Bold",
-    "font-size": "20px",
-    "height": "auto",
-    "margin-bottom": "10px",
-    "text-align": "center",
-    "width": "auto",
-  },
-  "S2": {
-    "color": "rgba(255,255,255,0.80)",
-    "display": "inline",
-    "font-family": "TimesDigitalW04",
-    "font-size": "14px",
-    "height": "auto",
-    "margin-bottom": "0px",
-    "max-width": "80%",
-    "text-align": "center",
-    "width": "410px",
-  },
-  "S3": {
-    "-ms-flex-align": "center",
-    "-ms-flex-pack": "center",
-    "-webkit-align-items": "center",
-    "-webkit-box-align": "center",
-    "-webkit-box-pack": "center",
-    "-webkit-justify-content": "center",
-    "align-items": "center",
-    "background-color": "rgba(0,0,0,0.60)",
-    "display": "flex",
-    "justify-content": "center",
-    "margin-bottom": "0px",
-  },
+.S1 {
+  color: rgba(255,255,255,1.00);
+  display: inline;
+  font-family: TimesModern-Bold;
+  font-size: 20px;
+  height: auto;
+  margin-bottom: 10px;
+  text-align: center;
+  width: auto;
+}
+
+.S2 {
+  color: rgba(255,255,255,0.80);
+  display: inline;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  height: auto;
+  margin-bottom: 0px;
+  max-width: 80%;
+  text-align: center;
+  width: 410px;
+}
+
+.S3 {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  align-items: center;
+  background-color: rgba(0,0,0,0.60);
+  display: flex;
+  -ms-flex-pack: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin-bottom: 0px;
+}
+
+.IS1 {
+  height: 100px;
+  width: 100px;
 }
 </style>
 


### PR DESCRIPTION
- Modifies `hoist-style.js` to make use of `react-native-web` internals & dependencies to make outputted inline styles more inline with outputted style sheets. (Unfortunately there was not a single method that did everything we needed so had to use a couple)
- Modifies the style printer to output styles as CSS in web snapshots rather than as JSS objects 
- Updates all existing snapshots to use CSS rather than JSS in web snapshots 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
