### PR TITLE
chore: show filename of mocked image paths in native snapshots.

### DIFF
--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -6,7 +6,11 @@ exports[`1. an error 1`] = `
     <Image
       accessibilityLabel="Server error"
       resizeMode="contain"
-      source={1}
+      source={
+        Object {
+          "testUri": "../../../packages/article/assets/article-error.png",
+        }
+      }
     />
     <Text>
       Something's gone wrong

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -6,7 +6,11 @@ exports[`1. an error 1`] = `
     <Image
       accessibilityLabel="Server error"
       resizeMode="contain"
-      source={1}
+      source={
+        Object {
+          "testUri": "../../../packages/article/assets/article-error.png",
+        }
+      }
     />
     <Text>
       Something's gone wrong

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -14,7 +14,11 @@ exports[`1. modal image 1`] = `
         >
           <Image
             resizeMode="contain"
-            source={1}
+            source={
+              Object {
+                "testUri": "../../../packages/image/assets/close-button.png",
+              }
+            }
           />
         </View>
       </View>

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -12,7 +12,11 @@ exports[`1. modal image 1`] = `
         <View>
           <Image
             resizeMode="contain"
-            source={1}
+            source={
+              Object {
+                "testUri": "../../../packages/image/assets/close-button.png",
+              }
+            }
           />
         </View>
       </View>

--- a/packages/jest-configurator/__tests__/jest-configurator.test.js
+++ b/packages/jest-configurator/__tests__/jest-configurator.test.js
@@ -27,7 +27,7 @@ describe("Jest Configurator Tests", () => {
     it("should include times-components in transform ignore patterns", () => {
       const config = jestConfigurator("android", dir);
       expect(config.transformIgnorePatterns).toContain(
-        "node_modules/(?!(react-native|react-native-linear-gradient|react-native-iphone-x-helper|@times-components)/)"
+        "node_modules/(?!(react-native|react-native-linear-gradient|react-native-iphone-x-helper|@times-components|@storybook/react-native)/)"
       );
     });
 

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -93,11 +93,12 @@ export default (
     testURL: "http://localhost",
     transform: {
       // @todo Remove this when upgrading to above react 0.56.0 (blocked by expo-sdk as of 2018/10/18)
-      "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/node_modules/react-native/jest/assetFileTransformer.js",
+      "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$":
+        "<rootDir>/node_modules/react-native/jest/assetFileTransformer.js",
       "^.+\\.js$": path.resolve(__dirname, "source-loader.js")
     },
     transformIgnorePatterns: [
-      "node_modules/(?!(react-native|react-native-linear-gradient|react-native-iphone-x-helper|@times-components|@storybook/react-native)/)",
+      "node_modules/(?!(react-native|react-native-linear-gradient|react-native-iphone-x-helper|@times-components|@storybook/react-native)/)"
     ]
   };
 

--- a/packages/jest-configurator/src/jest-configurator.js
+++ b/packages/jest-configurator/src/jest-configurator.js
@@ -13,9 +13,6 @@ const nativeSpecific = (platform: Platform) => ({
     defaultPlatform: platform,
     platforms: [platform],
     providesModuleNodeModules: ["react", "react-native"]
-  },
-  moduleNameMapper: {
-    "\\.(png)$": "RelativeImageStub"
   }
 });
 
@@ -95,10 +92,12 @@ export default (
     ],
     testURL: "http://localhost",
     transform: {
+      // @todo Remove this when upgrading to above react 0.56.0 (blocked by expo-sdk as of 2018/10/18)
+      "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/node_modules/react-native/jest/assetFileTransformer.js",
       "^.+\\.js$": path.resolve(__dirname, "source-loader.js")
     },
     transformIgnorePatterns: [
-      "node_modules/(?!(react-native|react-native-linear-gradient|react-native-iphone-x-helper|@times-components)/)"
+      "node_modules/(?!(react-native|react-native-linear-gradient|react-native-iphone-x-helper|@times-components|@storybook/react-native)/)",
     ]
   };
 


### PR DESCRIPTION
Fixes #1102

Uses the `react-native` provided transformer for showing the filename of mocked image paths in native snapshots.

Unfortunately, we use an old version of `react-native`, and in this version the jest preset has the bug of not applying to scoped packages. Unfortunately, we're blocked on updating `react-native` by Expo. Therefore, I've temporarily copied the patch https://github.com/facebook/react-native/commit/216bce31632480ce70cc03b1b2a57ec12440afd7 into `jest-configurator`.

I've also whitelisted `@storybook/react-native` from the transform as it requires a png transform to work. 