### PR TITLE
fix: Properly handle null titles in the video label component

### DIFF
--- a/packages/video-label/__tests__/android/__snapshots__/video-label.android.test.js.snap
+++ b/packages/video-label/__tests__/android/__snapshots__/video-label.android.test.js.snap
@@ -28,7 +28,21 @@ exports[`2. video label without a title shows video 1`] = `
 </View>
 `;
 
-exports[`3. video label with the black default colour 1`] = `
+exports[`3. video label with null title shows video 1`] = `
+<View>
+  <View>
+    <IconVideo
+      fillColour="#008347"
+      height={8}
+    />
+  </View>
+  <Text>
+    VIDEO
+  </Text>
+</View>
+`;
+
+exports[`4. video label with the black default colour 1`] = `
 <View>
   <View>
     <IconVideo

--- a/packages/video-label/__tests__/ios/__snapshots__/video-label.ios.test.js.snap
+++ b/packages/video-label/__tests__/ios/__snapshots__/video-label.ios.test.js.snap
@@ -28,7 +28,21 @@ exports[`2. video label without a title shows video 1`] = `
 </View>
 `;
 
-exports[`3. video label with the black default colour 1`] = `
+exports[`3. video label with null title shows video 1`] = `
+<View>
+  <View>
+    <IconVideo
+      fillColour="#008347"
+      height={8}
+    />
+  </View>
+  <Text>
+    VIDEO
+  </Text>
+</View>
+`;
+
+exports[`4. video label with the black default colour 1`] = `
 <View>
   <View>
     <IconVideo

--- a/packages/video-label/__tests__/video-label.native.js
+++ b/packages/video-label/__tests__/video-label.native.js
@@ -44,6 +44,16 @@ export default () => {
       }
     },
     {
+      name: "video label with null title shows VIDEO",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <VideoLabel color="#008347" title={null} />
+        );
+
+        expect(testInstance).toMatchSnapshot();
+      }
+    },
+    {
       name: "video label with the black default colour",
       test: () => {
         const testInstance = TestRenderer.create(<VideoLabel />);

--- a/packages/video-label/__tests__/web/__snapshots__/video-label.web.test.js.snap
+++ b/packages/video-label/__tests__/web/__snapshots__/video-label.web.test.js.snap
@@ -38,7 +38,26 @@ exports[`2. video label without a title shows video 1`] = `
 </VideoLabel>
 `;
 
-exports[`3. video label with the black default colour 1`] = `
+exports[`3. video label with null title shows video 1`] = `
+<VideoLabel
+  color="#008347"
+  title={null}
+>
+  <div>
+    <div>
+      <IconVideo
+        fillColour="#008347"
+        height={8}
+      />
+    </div>
+    <div>
+      VIDEO
+    </div>
+  </div>
+</VideoLabel>
+`;
+
+exports[`4. video label with the black default colour 1`] = `
 <VideoLabel
   color="black"
   title=""

--- a/packages/video-label/__tests__/web/video-label.web.test.js
+++ b/packages/video-label/__tests__/web/video-label.web.test.js
@@ -49,6 +49,14 @@ const tests = [
     }
   },
   {
+    name: "video label with null title shows VIDEO",
+    test: () => {
+      const wrapper = mount(<VideoLabel color="#008347" title={null} />);
+
+      expect(wrapper).toMatchSnapshot();
+    }
+  },
+  {
     name: "video label with the black default colour",
     test: () => {
       const wrapper = mount(<VideoLabel />);

--- a/packages/video-label/src/video-label.js
+++ b/packages/video-label/src/video-label.js
@@ -10,7 +10,7 @@ const VideoLabel = ({ color, title }) => (
       <IconVideo fillColour={color} height={8} />
     </View>
     <Text style={[styles.title, { color }]}>
-      {title.toUpperCase() || "VIDEO"}
+      {title ? title.toUpperCase() : "VIDEO"}
     </Text>
   </View>
 );


### PR DESCRIPTION
Titles are optional in the `VideoLabel` component, but if you pass null the component breaks due to how it checks whether the title has been passed or not. This is a regression that was introduced when the "beautifier" was inlined in be5a458be5d3679f959edb1598c5397b4834d098, so I have added tests to prevent this occurring again. 