### PR TITLE
chore: Sort keys in template

### DIFF
--- a/lib/cli/templates.js
+++ b/lib/cli/templates.js
@@ -17,14 +17,14 @@ const showcaseFile = handlebars.compile(`import React from "react";
 import {{{component}}} from "./src/{{{packageName}}}";
 
 export default {
-  name: "{{{component}}}",
   children: [
     {
-      type: "story",
+      component: () => <{{{component}}} />,
       name: "{{{component}}}",
-      component: () => <{{{component}}} />
+      type: "story"
     }
-  ]
+  ],
+  name: "{{{component}}}"
 };
 `);
 


### PR DESCRIPTION
The keys in our create component script are not sorted, this pr fixes it