### PR TITLE
chore: lint snaps

### DIFF
--- a/packages/article-image/.jestlint
+++ b/packages/article-image/.jestlint
@@ -1,0 +1,3 @@
+{
+  "maxAttributes": 7
+}

--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. primary image with caption and credits 1`] = `
       aspectRatio={1.25}
       caption="Some caption"
       credits="Some credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View>
@@ -84,7 +84,7 @@ exports[`2. secondary image with caption and credits 1`] = `
       aspectRatio={1.5}
       caption="Another caption"
       credits="Other credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View
@@ -160,7 +160,7 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
       aspectRatio={1.5}
       caption="Landscape caption"
       credits="Landscape credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View
@@ -236,7 +236,7 @@ exports[`4. inline image (portrait) with caption and credits 1`] = `
       aspectRatio={0.6666666666666666}
       caption="Portrait caption"
       credits="Portrait credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View

--- a/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image.android.test.js.snap
@@ -30,7 +30,7 @@ exports[`5. image with no caption 1`] = `
       aspectRatio={1.7777777777777777}
       caption={null}
       credits={null}
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
 </View>
@@ -71,7 +71,7 @@ exports[`8. primary image renders with caption and credits 1`] = `
       aspectRatio={1.7777777777777777}
       caption="Some caption"
       credits="Some credit"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View>
@@ -98,7 +98,7 @@ exports[`9. primary image with given resolutions 1`] = `
       credits="Some credit"
       highResSize={900}
       lowResSize={50}
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View>

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -15,7 +15,7 @@ exports[`1. primary image with caption and credits 1`] = `
       aspectRatio={1.25}
       caption="Some caption"
       credits="Some credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View>
@@ -84,7 +84,7 @@ exports[`2. secondary image with caption and credits 1`] = `
       aspectRatio={1.5}
       caption="Another caption"
       credits="Other credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View
@@ -160,7 +160,7 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
       aspectRatio={1.5}
       caption="Landscape caption"
       credits="Landscape credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View
@@ -236,7 +236,7 @@ exports[`4. inline image (portrait) with caption and credits 1`] = `
       aspectRatio={0.6666666666666666}
       caption="Portrait caption"
       credits="Portrait credits"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image.ios.test.js.snap
@@ -30,7 +30,7 @@ exports[`5. image with no caption 1`] = `
       aspectRatio={1.7777777777777777}
       caption={null}
       credits={null}
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
 </View>
@@ -71,7 +71,7 @@ exports[`8. primary image renders with caption and credits 1`] = `
       aspectRatio={1.7777777777777777}
       caption="Some caption"
       credits="Some credit"
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View>
@@ -98,7 +98,7 @@ exports[`9. primary image with given resolutions 1`] = `
       credits="Some credit"
       highResSize={900}
       lowResSize={50}
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </View>
   <View>

--- a/packages/article-image/__tests__/shared-with-style.base.js
+++ b/packages/article-image/__tests__/shared-with-style.base.js
@@ -6,7 +6,7 @@ import secondaryImageFixture from "../fixtures/secondary-image";
 import landscapeInlineImageFixture from "../fixtures/landscape-inline-image";
 import portraitInlineImageFixture from "../fixtures/portrait-inline-image";
 
-const testImageUrl = "https://imageserver/someImage";
+const testImageUrl = "https://img/someImage";
 const primaryImage = primaryImageFixture(
   testImageUrl,
   "Some caption",

--- a/packages/article-image/__tests__/shared.base.js
+++ b/packages/article-image/__tests__/shared.base.js
@@ -2,7 +2,7 @@ import React from "react";
 import { iterator } from "@times-components/test-utils";
 import ArticleImage from "../src/article-image";
 
-const testImageUrl = "https://imageserver/someImage";
+const testImageUrl = "https://img/someImage";
 
 export default makeTest => {
   const tests = [

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -30,7 +30,7 @@ Array [
       fadeImageIn={false}
       highResSize={null}
       lowResSize={null}
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </div>,
   <div>
@@ -74,7 +74,7 @@ Array [
       fadeImageIn={false}
       highResSize={null}
       lowResSize={null}
-      uri="https://imageserver/someImage"
+      uri="https://img/someImage"
     />
   </div>,
   <div>
@@ -169,7 +169,7 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
-        uri="https://imageserver/someImage"
+        uri="https://img/someImage"
       />
     </div>
   </responsiveweb__InsetImageStyle>
@@ -271,7 +271,7 @@ exports[`4. inline image (portrait) with caption and credits 1`] = `
         fadeImageIn={false}
         highResSize={null}
         lowResSize={null}
-        uri="https://imageserver/someImage"
+        uri="https://img/someImage"
       />
     </div>
   </responsiveweb__InsetImageStyle>

--- a/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image.web.test.js.snap
@@ -29,7 +29,7 @@ exports[`5. image with no caption 1`] = `
     <div>
       <img
         alt=""
-        src="https://imageserver/someImage"
+        src="https://img/someImage"
       />
       <div>
         <div />
@@ -70,7 +70,7 @@ Array [
       <div>
         <img
           alt=""
-          src="https://imageserver/someImage"
+          src="https://img/someImage"
         />
         <div>
           <div />
@@ -102,11 +102,11 @@ Array [
       <div>
         <img
           alt=""
-          src="https://imageserver/someImage?resize=900"
+          src="https://img/someImage?resize=900"
         />
         <img
           alt=""
-          src="https://imageserver/someImage?resize=50"
+          src="https://img/someImage?resize=50"
         />
         <div>
           <div />

--- a/packages/article-list/.jestlint
+++ b/packages/article-list/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributeStringLength": 38,
-  "maxAttributes": 6,
+  "maxAttributes": 7,
   "maxFileSize": 19320,
   "maxLines": 823
 }

--- a/packages/article-list/__tests__/shared.base.web.js
+++ b/packages/article-list/__tests__/shared.base.web.js
@@ -1,10 +1,12 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 import Context from "@times-components/context";
-import { iterator, makeArticleUrl } from "@times-components/test-utils";
+import { iterator } from "@times-components/test-utils";
 import ArticleList from "../src/article-list";
 import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
+
+const makeArticleUrl = () => "https://test.io";
 
 export default (additionalTests = []) => {
   const realIntl = Intl;

--- a/packages/article-list/__tests__/shared.web.js
+++ b/packages/article-list/__tests__/shared.web.js
@@ -7,7 +7,6 @@ import {
   print
 } from "@times-components/jest-serializer";
 import Context from "@times-components/context";
-import { makeArticleUrl } from "@times-components/test-utils";
 import TestRenderer from "react-test-renderer";
 import "./mocks";
 import { omitWeb as omitProps } from "./utils";
@@ -15,6 +14,8 @@ import articlesFixture from "../fixtures/articles.json";
 import adConfig from "../fixtures/article-ad-config.json";
 import ArticleList from "../src/article-list";
 import shared from "./shared.base.web";
+
+const makeArticleUrl = () => "https://test.io";
 
 export default () => {
   addSerializers(

--- a/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
+++ b/packages/article-list/__tests__/web/__snapshots__/article-list.web.test.js.snap
@@ -19,7 +19,7 @@ exports[`1. article list 1`] = `
     >
       <div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
+          url="https://test.io"
         >
           <div>
             <Card
@@ -63,7 +63,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-2-968n7tdck2"
+          url="https://test.io"
         >
           <div>
             <Card
@@ -126,7 +126,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-3-968n7tdck3"
+          url="https://test.io"
         >
           <div>
             <Card
@@ -189,7 +189,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-4-968n7tdck4"
+          url="https://test.io"
         >
           <div>
             <Card
@@ -252,7 +252,7 @@ exports[`1. article list 1`] = `
           <div />
         </div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-5-968n7tdck5"
+          url="https://test.io"
         >
           <div>
             <Card
@@ -340,7 +340,7 @@ exports[`2. article list with no images 1`] = `
     >
       <div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
+          url="https://test.io"
         >
           <div>
             <Card
@@ -426,7 +426,7 @@ exports[`3. article list with missing image 1`] = `
     >
       <div>
         <Link
-          url="https://www.thetimes.co.uk/article/this-is-slug-1-968n7tdck1"
+          url="https://test.io"
         >
           <div>
             <Card

--- a/packages/article/.jestlint
+++ b/packages/article/.jestlint
@@ -2,5 +2,5 @@
   "maxAttributes": 8,
   "maxAttributeStringLength": 36,
   "maxFileSize": 19253,
-  "maxLines": 746
+  "maxLines": 780
 }

--- a/packages/article/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -8,16 +8,11 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     width={970}
   >
     <g
-      fill="none"
-      fillRule="evenodd"
       id="watermark"
       opacity="0.07"
-      stroke="none"
-      strokeWidth="1"
     >
       <path
         d="53a8dae08c4e492d934bf2f094a46ab4"
-        fill="#1D1D1B"
         id="shape"
       />
     </g>
@@ -48,9 +43,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       <title>
         Diamond Icon
       </title>
-      <g
-        fill="#E34605"
-      >
+      <g>
         <path
           d="90928a4d6e9b702222e7187e68c282b7"
         />
@@ -125,7 +118,6 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       </title>
       <path
         d="ebf51b280a2c9ea0e632fdbf86606550"
-        fill="#006699"
       />
     </svg>
     <a
@@ -169,7 +161,7 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       Related articles
     </h3>
     <a
-      href="https://www.thetimes.co.uk/article/this-is-slug-2k629tpvh"
+      href="https://some-url.io"
     >
       <img
         alt=""
@@ -195,16 +187,11 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     width={1}
   >
     <g
-      fill="none"
-      fillRule="evenodd"
       id="watermark"
       opacity="0.07"
-      stroke="none"
-      strokeWidth="1"
     >
       <path
         d="53a8dae08c4e492d934bf2f094a46ab4"
-        fill="#1D1D1B"
         id="shape"
       />
     </g>
@@ -216,16 +203,11 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     width={1}
   >
     <g
-      fill="none"
-      fillRule="evenodd"
       id="watermark"
       opacity="0.07"
-      stroke="none"
-      strokeWidth="1"
     >
       <path
         d="53a8dae08c4e492d934bf2f094a46ab4"
-        fill="#1D1D1B"
         id="shape"
       />
     </g>
@@ -237,16 +219,11 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     width={1}
   >
     <g
-      fill="none"
-      fillRule="evenodd"
       id="watermark"
       opacity="0.07"
-      stroke="none"
-      strokeWidth="1"
     >
       <path
         d="53a8dae08c4e492d934bf2f094a46ab4"
-        fill="#1D1D1B"
         id="shape"
       />
     </g>

--- a/packages/article/__tests__/web/semantic.web.test.js
+++ b/packages/article/__tests__/web/semantic.web.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import { hash, iterator, makeArticleUrl } from "@times-components/test-utils";
+import { hash, iterator } from "@times-components/test-utils";
 import {
   addSerializers,
   compose,
@@ -17,6 +17,15 @@ import Article from "../../src/article";
 import articleFixture, { testFixture } from "../../fixtures/full-article";
 import { adConfig } from "../ad-mock";
 
+const omitProps = new Set([
+  "className",
+  "fill",
+  "fillRule",
+  "stroke",
+  "strokeWidth",
+  "style"
+]);
+
 addSerializers(
   expect,
   compose(
@@ -26,7 +35,7 @@ addSerializers(
       div: justChildren
     }),
     replacePropTransform((value, key) => (key === "d" ? hash(value) : value)),
-    minimaliseTransform((value, key) => key === "className" || key === "style")
+    minimaliseTransform((value, key) => omitProps.has(key))
   )
 );
 
@@ -110,7 +119,10 @@ const tests = [
       const sectionColour = "#FFFFFF";
       const testInstance = TestRenderer.create(
         <Context.Provider
-          value={{ makeArticleUrl, theme: { scale, sectionColour } }}
+          value={{
+            makeArticleUrl: () => "https://some-url.io",
+            theme: { scale, sectionColour }
+          }}
         >
           <Article
             adConfig={adConfig}

--- a/packages/interactive-wrapper/.jestlint
+++ b/packages/interactive-wrapper/.jestlint
@@ -1,0 +1,3 @@
+{
+  "maxAttributeStringLength": 144
+}

--- a/packages/interactive-wrapper/__tests__/android/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/android/__snapshots__/interactive-wrapper.test.js.snap
@@ -16,30 +16,17 @@ exports[`renders correctly 1`] = `
     }
   >
     <RCTWebView
-      javaScriptEnabled={true}
-      messagingEnabled={true}
-      onLoadingError={[Function]}
-      onLoadingFinish={[Function]}
-      onLoadingStart={[Function]}
-      onMessage={[Function]}
-      saveFormDataDisabled={false}
-      scalesPageToFit={true}
       source={
         Object {
           "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79",
         }
       }
       style={
-        Array [
-          Object {
-            "flex": 1,
-          },
-          Object {
-            "height": 0,
-          },
-        ]
+        Object {
+          "flex": 1,
+          "height": 0,
+        }
       }
-      thirdPartyCookiesEnabled={true}
     />
   </View>
 </View>

--- a/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
@@ -17,29 +17,17 @@ exports[`renders correctly 1`] = `
   >
     <RCTWebView
       injectedJavaScript="window.reactBridgePostMessage = window.postMessage; window.postMessage = String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage');"
-      messagingEnabled={true}
-      onLoadingError={[Function]}
-      onLoadingFinish={[Function]}
-      onLoadingStart={[Function]}
-      onMessage={[Function]}
-      scalesPageToFit={true}
       source={
         Object {
           "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79",
         }
       }
       style={
-        Array [
-          Object {
-            "flex": 1,
-          },
-          Object {
-            "backgroundColor": "#ffffff",
-          },
-          Object {
-            "height": 0,
-          },
-        ]
+        Object {
+          "backgroundColor": "#ffffff",
+          "flex": 1,
+          "height": 0,
+        }
       }
     />
   </View>

--- a/packages/interactive-wrapper/__tests__/shared.base.js
+++ b/packages/interactive-wrapper/__tests__/shared.base.js
@@ -1,0 +1,22 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+import InteractiveWrapper from "../src/interactive-wrapper";
+
+export default () => {
+  it("renders correctly", () => {
+    const props = {
+      attributes: {
+        chaptercounter: "Chapter%20one",
+        heading: "A heading",
+        standfirst: "A standfirst"
+      },
+      element: "chapter-header",
+      id: "a0534eee-682e-4955-8e1e-84b428ef1e79",
+      source:
+        "//components.timesdev.tools/lib2/times-chapter-header-1.0.0/chapter-header.html"
+    };
+    const testInstance = TestRenderer.create(<InteractiveWrapper {...props} />);
+
+    expect(testInstance.toJSON()).toMatchSnapshot();
+  });
+};

--- a/packages/interactive-wrapper/__tests__/shared.js
+++ b/packages/interactive-wrapper/__tests__/shared.js
@@ -1,23 +1,29 @@
-import React from "react";
-import TestRenderer from "react-test-renderer";
-import InteractiveWrapper from "../src/interactive-wrapper";
+import {
+  addSerializers,
+  compose,
+  flattenStyleTransform,
+  minimaliseTransform,
+  minimalNativeTransform,
+  print
+} from "@times-components/jest-serializer";
+import shared from "./shared.base";
 
-export default () => {
-  it("renders correctly", () => {
-    const props = {
-      attributes: {
-        chaptercounter: "Chapter%20one",
-        heading: "Xxxx%20xxxxxx%20xxxx%20xxxxx%20",
-        standfirst:
-          "Xxxx%20xxxxxx%20xxxx%20xxxxx%20xxxxxxxx%20xxxxxx%20xxxx%20xx%20xxxxxxxx"
-      },
-      element: "chapter-header",
-      id: "a0534eee-682e-4955-8e1e-84b428ef1e79",
-      source:
-        "//components.timesdev.tools/lib2/times-chapter-header-1.0.0/chapter-header.html"
-    };
-    const testInstance = TestRenderer.create(<InteractiveWrapper {...props} />);
+const omitProps = new Set([
+  "javaScriptEnabled",
+  "messagingEnabled",
+  "saveFormDataDisabled",
+  "scalesPageToFit",
+  "thirdPartyCookiesEnabled"
+]);
 
-    expect(testInstance.toJSON()).toMatchSnapshot();
-  });
-};
+addSerializers(
+  expect,
+  compose(
+    print,
+    flattenStyleTransform,
+    minimalNativeTransform,
+    minimaliseTransform((value, key) => omitProps.has(key))
+  )
+);
+
+export default () => shared();

--- a/packages/interactive-wrapper/__tests__/shared.web.js
+++ b/packages/interactive-wrapper/__tests__/shared.web.js
@@ -1,0 +1,19 @@
+import {
+  addSerializers,
+  compose,
+  flattenStyleTransform,
+  minimalWebTransform,
+  print
+} from "@times-components/jest-serializer";
+import shared from "./shared.base";
+
+addSerializers(
+  expect,
+  compose(
+    print,
+    flattenStyleTransform,
+    minimalWebTransform
+  )
+);
+
+export default () => shared();

--- a/packages/interactive-wrapper/__tests__/web/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/web/__snapshots__/interactive-wrapper.test.js.snap
@@ -8,8 +8,8 @@ Array [
   />,
   <chapter-header
     chaptercounter="Chapter%20one"
-    heading="Xxxx%20xxxxxx%20xxxx%20xxxxx%20"
-    standfirst="Xxxx%20xxxxxx%20xxxx%20xxxxx%20xxxxxxxx%20xxxxxx%20xxxx%20xx%20xxxxxxxx"
+    heading="A heading"
+    standfirst="A standfirst"
   />,
 ]
 `;

--- a/packages/interactive-wrapper/package.json
+++ b/packages/interactive-wrapper/package.json
@@ -40,6 +40,7 @@
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.4",
     "@times-components/jest-configurator": "2.1.12",
+    "@times-components/jest-serializer": "3.1.6",
     "@times-components/storybook": "3.1.19",
     "@times-components/webpack-configurator": "2.0.10",
     "babel-cli": "6.26.0",

--- a/packages/related-articles/.jestlint
+++ b/packages/related-articles/.jestlint
@@ -1,4 +1,6 @@
 {
+  "maxAttributes": 7,
   "maxAttributeStringLength": 44,
+  "maxDepth": 11,
   "maxLines": 431
 }

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. one lead related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#333333"
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. one lead and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#005B8D"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. one lead and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#006469"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. one lead and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#7B0046"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. one lead and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#FF1D25"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -131,9 +133,10 @@ exports[`1. one lead and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    THIRD LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#C04605"
+                    title="third label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. no short headline 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#333333"
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -42,9 +42,10 @@ exports[`1. one opinion related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#00313B"
+                    title="test label"
+                  />
                 </View>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -42,9 +42,10 @@ exports[`1. one opinion and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#8D724D"
+                    title="first label"
+                  />
                 </View>
                 <Text>
                   <Text>
@@ -96,9 +97,10 @@ exports[`1. one opinion and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004E45"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -42,9 +42,10 @@ exports[`1. one opinion and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#691D26"
+                    title="first label"
+                  />
                 </View>
                 <Text>
                   <Text>
@@ -96,9 +97,10 @@ exports[`1. one opinion and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#333333"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -141,9 +143,10 @@ exports[`1. one opinion and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    THIRD LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#006A74"
+                    title="third label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -35,16 +35,17 @@ exports[`1. no short headline 1`] = `
                   "right": 0,
                 }
               }
-              imageUri="https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0"
+              imageUri="https://crop23.io"
               isReversed={true}
               lowResSize={100}
               showImage={true}
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004D6D"
+                    title="test label"
+                  />
                 </View>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -19,186 +19,36 @@ exports[`1. has video 1`] = `
               "padding": 10,
             }
           }
-          url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+          url="https://test.io"
         >
           <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
-              imageUri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104"
+              imageUri="https://crop169.io"
               isReversed={false}
               lowResSize={100}
               showImage={true}
             >
               <View>
                 <View>
-                  <View>
-                    <View>
-                      <ARTSurfaceView>
-                        <ARTGroup
-                          opacity={1}
-                          transform={
-                            Array [
-                              0.5982608695652174,
-                              0,
-                              0,
-                              0.5982608695652174,
-                              0,
-                              0,
-                            ]
-                          }
-                        >
-                          <ARTShape
-                            d={
-                              Array [
-                                0,
-                                0.154639175,
-                                0.139754386,
-                                2,
-                                15.609649475,
-                                0.139754386,
-                                2,
-                                15.609649475,
-                                13.711894786,
-                                2,
-                                0.1546391749999998,
-                                13.711894786,
-                                2,
-                                0.1546391749999998,
-                                0.1397543859999999,
-                              ]
-                            }
-                            fill={
-                              Array [
-                                0,
-                                0.8588235294117647,
-                                0.07450980392156863,
-                                0.23137254901960785,
-                                1,
-                              ]
-                            }
-                            opacity={1}
-                            stroke={null}
-                            strokeCap={1}
-                            strokeDash={null}
-                            strokeJoin={1}
-                            strokeWidth={1}
-                            transform={
-                              Array [
-                                1,
-                                0,
-                                0,
-                                1,
-                                0,
-                                0,
-                              ]
-                            }
-                          />
-                          <ARTShape
-                            d={
-                              Array [
-                                0,
-                                16.3405361,
-                                4.14989474,
-                                2,
-                                16.3405361,
-                                9.66442105,
-                                2,
-                                22.0216082,
-                                12.8146667,
-                                2,
-                                22.0216082,
-                                0.999894737,
-                              ]
-                            }
-                            fill={
-                              Array [
-                                0,
-                                0.8588235294117647,
-                                0.07450980392156863,
-                                0.23137254901960785,
-                                1,
-                              ]
-                            }
-                            opacity={1}
-                            stroke={null}
-                            strokeCap={1}
-                            strokeDash={null}
-                            strokeJoin={1}
-                            strokeWidth={1}
-                            transform={
-                              Array [
-                                1,
-                                0,
-                                0,
-                                1,
-                                0,
-                                0,
-                              ]
-                            }
-                          />
-                          <ARTShape
-                            d={
-                              Array [
-                                0,
-                                23.7538144,
-                                0.0496140351,
-                                2,
-                                22.7616495,
-                                0.643508772,
-                                2,
-                                22.7616495,
-                                13.1902105,
-                                2,
-                                23.7538144,
-                                13.7782105,
-                              ]
-                            }
-                            fill={
-                              Array [
-                                0,
-                                0.8588235294117647,
-                                0.07450980392156863,
-                                0.23137254901960785,
-                                1,
-                              ]
-                            }
-                            opacity={1}
-                            stroke={null}
-                            strokeCap={1}
-                            strokeDash={null}
-                            strokeJoin={1}
-                            strokeWidth={1}
-                            transform={
-                              Array [
-                                1,
-                                0,
-                                0,
-                                1,
-                                0,
-                                0,
-                              ]
-                            }
-                          />
-                        </ARTGroup>
-                      </ARTSurfaceView>
-                    </View>
-                    <Text>
-                      BAYEUX TAPESTRY
-                    </Text>
-                  </View>
+                  <VideoLabel
+                    color="#DB133B"
+                    isVideo={true}
+                    title="BAYEUX TAPESTRY"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"
                 >
-                  Bringing the fragile masterpiece over safely
+                  Test Headline
                 </Text>
                 <View>
                   <Text>
                     <Text>
                       
-                      Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab it for Nazi Germany
+                      Summary 125
                       ...
                     </Text>
                   </Text>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -32,9 +32,11 @@ exports[`1. a single related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004D6D"
+                    isVideo={false}
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. two related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#C74600"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. two related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#6C6C69"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. three related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#A31D24"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. three related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#008347"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -140,9 +142,10 @@ exports[`1. three related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    THIRD LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#1A1F24"
+                    title="third label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -32,9 +32,11 @@ exports[`1. no short headline 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004D6D"
+                    isVideo={false}
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. one lead related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#333333"
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. one lead and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#005B8D"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. one lead and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#006469"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. one lead and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#7B0046"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. one lead and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#FF1D25"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -131,9 +133,10 @@ exports[`1. one lead and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    THIRD LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#C04605"
+                    title="third label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. no short headline 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#333333"
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -42,9 +42,10 @@ exports[`1. one opinion related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#00313B"
+                    title="test label"
+                  />
                 </View>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -42,9 +42,10 @@ exports[`1. one opinion and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#8D724D"
+                    title="first label"
+                  />
                 </View>
                 <Text>
                   <Text>
@@ -96,9 +97,10 @@ exports[`1. one opinion and one support related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004E45"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -42,9 +42,10 @@ exports[`1. one opinion and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#691D26"
+                    title="first label"
+                  />
                 </View>
                 <Text>
                   <Text>
@@ -96,9 +97,10 @@ exports[`1. one opinion and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#333333"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -141,9 +143,10 @@ exports[`1. one opinion and two support related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    THIRD LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#006A74"
+                    title="third label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -35,16 +35,17 @@ exports[`1. no short headline 1`] = `
                   "right": 0,
                 }
               }
-              imageUri="https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0"
+              imageUri="https://crop23.io"
               isReversed={true}
               lowResSize={100}
               showImage={true}
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004D6D"
+                    title="test label"
+                  />
                 </View>
                 <Text>
                   <Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -32,9 +32,11 @@ exports[`1. a single related article 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004D6D"
+                    isVideo={false}
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. two related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#C74600"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. two related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#6C6C69"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -32,9 +32,10 @@ exports[`1. three related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    FIRST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#A31D24"
+                    title="first label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -86,9 +87,10 @@ exports[`1. three related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    SECOND LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#008347"
+                    title="second label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
@@ -140,9 +142,10 @@ exports[`1. three related articles 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    THIRD LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#1A1F24"
+                    title="third label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -19,186 +19,36 @@ exports[`1. has video 1`] = `
               "padding": 10,
             }
           }
-          url="https://www.thetimes.co.uk/article/bayeux-tapestry-now-for-a-new-battle-bringing-fragile-masterpiece-to-britain-safely-2k629tpvh"
+          url="https://test.io"
         >
           <View>
             <Card
               highResSize={null}
               imageRatio={1.7777777777777777}
-              imageUri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104"
+              imageUri="https://crop169.io"
               isReversed={false}
               lowResSize={100}
               showImage={true}
             >
               <View>
                 <View>
-                  <View>
-                    <View>
-                      <ARTSurfaceView>
-                        <ARTGroup
-                          opacity={1}
-                          transform={
-                            Array [
-                              0.5982608695652174,
-                              0,
-                              0,
-                              0.5982608695652174,
-                              0,
-                              0,
-                            ]
-                          }
-                        >
-                          <ARTShape
-                            d={
-                              Array [
-                                0,
-                                0.154639175,
-                                0.139754386,
-                                2,
-                                15.609649475,
-                                0.139754386,
-                                2,
-                                15.609649475,
-                                13.711894786,
-                                2,
-                                0.1546391749999998,
-                                13.711894786,
-                                2,
-                                0.1546391749999998,
-                                0.1397543859999999,
-                              ]
-                            }
-                            fill={
-                              Array [
-                                0,
-                                0.8588235294117647,
-                                0.07450980392156863,
-                                0.23137254901960785,
-                                1,
-                              ]
-                            }
-                            opacity={1}
-                            stroke={null}
-                            strokeCap={1}
-                            strokeDash={null}
-                            strokeJoin={1}
-                            strokeWidth={1}
-                            transform={
-                              Array [
-                                1,
-                                0,
-                                0,
-                                1,
-                                0,
-                                0,
-                              ]
-                            }
-                          />
-                          <ARTShape
-                            d={
-                              Array [
-                                0,
-                                16.3405361,
-                                4.14989474,
-                                2,
-                                16.3405361,
-                                9.66442105,
-                                2,
-                                22.0216082,
-                                12.8146667,
-                                2,
-                                22.0216082,
-                                0.999894737,
-                              ]
-                            }
-                            fill={
-                              Array [
-                                0,
-                                0.8588235294117647,
-                                0.07450980392156863,
-                                0.23137254901960785,
-                                1,
-                              ]
-                            }
-                            opacity={1}
-                            stroke={null}
-                            strokeCap={1}
-                            strokeDash={null}
-                            strokeJoin={1}
-                            strokeWidth={1}
-                            transform={
-                              Array [
-                                1,
-                                0,
-                                0,
-                                1,
-                                0,
-                                0,
-                              ]
-                            }
-                          />
-                          <ARTShape
-                            d={
-                              Array [
-                                0,
-                                23.7538144,
-                                0.0496140351,
-                                2,
-                                22.7616495,
-                                0.643508772,
-                                2,
-                                22.7616495,
-                                13.1902105,
-                                2,
-                                23.7538144,
-                                13.7782105,
-                              ]
-                            }
-                            fill={
-                              Array [
-                                0,
-                                0.8588235294117647,
-                                0.07450980392156863,
-                                0.23137254901960785,
-                                1,
-                              ]
-                            }
-                            opacity={1}
-                            stroke={null}
-                            strokeCap={1}
-                            strokeDash={null}
-                            strokeJoin={1}
-                            strokeWidth={1}
-                            transform={
-                              Array [
-                                1,
-                                0,
-                                0,
-                                1,
-                                0,
-                                0,
-                              ]
-                            }
-                          />
-                        </ARTGroup>
-                      </ARTSurfaceView>
-                    </View>
-                    <Text>
-                      BAYEUX TAPESTRY
-                    </Text>
-                  </View>
+                  <VideoLabel
+                    color="#DB133B"
+                    isVideo={true}
+                    title="BAYEUX TAPESTRY"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"
                 >
-                  Bringing the fragile masterpiece over safely
+                  Test Headline
                 </Text>
                 <View>
                   <Text>
                     <Text>
                       
-                      Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab it for Nazi Germany
+                      Summary 125
                       ...
                     </Text>
                   </Text>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -32,9 +32,11 @@ exports[`1. no short headline 1`] = `
             >
               <View>
                 <View>
-                  <Text>
-                    TEST LABEL
-                  </Text>
+                  <ArticleLabel
+                    color="#004D6D"
+                    isVideo={false}
+                    title="test label"
+                  />
                 </View>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/shared-la2.base.js
+++ b/packages/related-articles/__tests__/shared-la2.base.js
@@ -11,6 +11,9 @@ import leadAndTwo1ArticleFixture from "../fixtures/leadandtwo/1-article";
 import leadAndTwo2ArticlesFixture from "../fixtures/leadandtwo/2-articles";
 import leadAndTwo3ArticlesFixture from "../fixtures/leadandtwo/3-articles";
 
+jest.mock("@times-components/video-label", () => "VideoLabel");
+jest.mock("@times-components/article-label", () => "ArticleLabel");
+
 const leadAndTwo0ArticleFixtureData = leadAndTwo0ArticleFixture.data;
 const leadAndTwo1ArticleFixtureData = leadAndTwo1ArticleFixture({
   crop169: "https://crop169.io",
@@ -24,6 +27,7 @@ const leadAndTwo1ArticleFixtureData = leadAndTwo1ArticleFixture({
 }).data;
 
 const leadAndTwoNoShortHeadlineFixtureData = leadAndTwo1ArticleFixture({
+  crop23: "https://crop23.io",
   crop169: "https://crop169.io",
   headline: "Test Headline",
   label: "test label",

--- a/packages/related-articles/__tests__/shared-oa2.base.js
+++ b/packages/related-articles/__tests__/shared-oa2.base.js
@@ -13,6 +13,9 @@ import opinionAndTwo2ArticlesFixture from "../fixtures/opinionandtwo/2-articles"
 import opinionAndTwo3ArticlesFixture from "../fixtures/opinionandtwo/3-articles";
 import opinionAndTwo3ArticlesLeadAssetOverrideFixture from "../fixtures/opinionandtwo/3-articles-lead-asset-override";
 
+jest.mock("@times-components/video-label", () => "VideoLabel");
+jest.mock("@times-components/article-label", () => "ArticleLabel");
+
 const opinionAndTwo0ArticleFixtureData = opinionAndTwo0ArticleFixture.data;
 const opinionAndTwo1ArticleFixtureData = opinionAndTwo1ArticleFixture({
   crop23: "https://crop23.io",
@@ -30,6 +33,7 @@ const opinionAndTwo1ArticleFixtureData = opinionAndTwo1ArticleFixture({
 }).data;
 
 const opinionAndTwoNoShortHeadlineFixtureData = opinionAndTwo1ArticleFixture({
+  crop23: "https://crop23.io",
   crop169: "https://crop.io",
   headline: "Test Headline",
   label: "test label",

--- a/packages/related-articles/__tests__/shared-std.base.js
+++ b/packages/related-articles/__tests__/shared-std.base.js
@@ -12,6 +12,9 @@ import standard1ArticleFixture from "../fixtures/standard/1-article";
 import standard2ArticlesFixture from "../fixtures/standard/2-articles";
 import standard3ArticlesFixture from "../fixtures/standard/3-articles";
 
+jest.mock("@times-components/video-label", () => "VideoLabel");
+jest.mock("@times-components/article-label", () => "ArticleLabel");
+
 const standard0ArticleFixtureData = standard0ArticleFixture.data;
 const standard1ArticleFixtureData = standard1ArticleFixture({
   crop169: "https://crop.io",
@@ -36,8 +39,13 @@ const standardNoShortHeadlineFixtureData = standard1ArticleFixture({
 }).data;
 
 const standardhasVideoFixtureData = standard1ArticleFixture({
+  crop169: "https://crop169.io",
   hasVideo: true,
-  slug: "test-slug"
+  headline: "Test Headline",
+  shortHeadline: "",
+  slug: "test-slug",
+  summary125: testSummary(125),
+  url: "https://test.io"
 }).data;
 
 const standard2ArticlesFixtureData = standard2ArticlesFixture({

--- a/packages/related-articles/__tests__/shared-util.base.js
+++ b/packages/related-articles/__tests__/shared-util.base.js
@@ -1,9 +1,11 @@
 import React from "react";
 import mockDate from "mockdate";
-import { iterator, makeArticleUrl } from "@times-components/test-utils";
+import { iterator } from "@times-components/test-utils";
 import Card from "@times-components/card";
 import Context from "@times-components/context";
 import RelatedArticles from "../src/related-articles";
+
+const makeArticleUrl = () => "https://some-url.io";
 
 export const testSummary = summary => [
   {

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. one lead related article 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      TEST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#333333"
+                      title="test label"
+                    />
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead and one support related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. one lead and one support related article 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      FIRST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#005B8D"
+                      title="first label"
+                    />
                   </div>
                   <h3
                     aria-level="3"
@@ -78,7 +79,7 @@ exports[`1. one lead and one support related article 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+              url="https://some-url.io"
             >
               <div>
                 <Card
@@ -91,9 +92,10 @@ exports[`1. one lead and one support related article 1`] = `
                 >
                   <div>
                     <div>
-                      <div>
-                        SECOND LABEL
-                      </div>
+                      <ArticleLabel
+                        color="#006469"
+                        title="second label"
+                      />
                     </div>
                     <h3
                       aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one lead and two support related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. one lead and two support related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      FIRST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#7B0046"
+                      title="first label"
+                    />
                   </div>
                   <h3
                     aria-level="3"
@@ -85,7 +86,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+              url="https://some-url.io"
             >
               <div>
                 <Card
@@ -98,9 +99,10 @@ exports[`1. one lead and two support related articles 1`] = `
                 >
                   <div>
                     <div>
-                      <div>
-                        SECOND LABEL
-                      </div>
+                      <ArticleLabel
+                        color="#FF1D25"
+                        title="second label"
+                      />
                     </div>
                     <h3
                       aria-level="3"
@@ -133,7 +135,7 @@ exports[`1. one lead and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+              url="https://some-url.io"
             >
               <div>
                 <Card
@@ -146,9 +148,10 @@ exports[`1. one lead and two support related articles 1`] = `
                 >
                   <div>
                     <div>
-                      <div>
-                        THIRD LABEL
-                      </div>
+                      <ArticleLabel
+                        color="#C04605"
+                        title="third label"
+                      />
                     </div>
                     <h3
                       aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. no short headline 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      TEST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#333333"
+                      title="test label"
+                    />
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. one opinion related article 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      TEST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#00313B"
+                      title="test label"
+                    />
                   </div>
                   <div>
                     <span>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion and one support related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. one opinion and one support related article 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      FIRST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#8D724D"
+                      title="first label"
+                    />
                   </div>
                   <div>
                     <span>
@@ -92,7 +93,7 @@ exports[`1. one opinion and one support related article 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+              url="https://some-url.io"
             >
               <div>
                 <Card
@@ -105,9 +106,10 @@ exports[`1. one opinion and one support related article 1`] = `
                 >
                   <div>
                     <div>
-                      <div>
-                        SECOND LABEL
-                      </div>
+                      <ArticleLabel
+                        color="#004E45"
+                        title="second label"
+                      />
                     </div>
                     <h3
                       aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. one opinion and two support related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      FIRST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#691D26"
+                      title="first label"
+                    />
                   </div>
                   <div>
                     <span>
@@ -85,7 +86,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+              url="https://some-url.io"
             >
               <div>
                 <Card
@@ -98,9 +99,10 @@ exports[`1. one opinion and two support related articles 1`] = `
                 >
                   <div>
                     <div>
-                      <div>
-                        SECOND LABEL
-                      </div>
+                      <ArticleLabel
+                        color="#333333"
+                        title="second label"
+                      />
                     </div>
                     <h3
                       aria-level="3"
@@ -133,7 +135,7 @@ exports[`1. one opinion and two support related articles 1`] = `
                   "padding": 10,
                 }
               }
-              url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+              url="https://some-url.io"
             >
               <div>
                 <Card
@@ -146,9 +148,10 @@ exports[`1. one opinion and two support related articles 1`] = `
                 >
                   <div>
                     <div>
-                      <div>
-                        THIRD LABEL
-                      </div>
+                      <ArticleLabel
+                        color="#006A74"
+                        title="third label"
+                      />
                     </div>
                     <h3
                       aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -20,22 +20,23 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
                 highResSize={null}
                 imageRatio={0.6135458167330677}
-                imageUri="https://www.uat-thetimes.co.uk/imageserver/image/opiniontwo_2x3crop.jpg?crop=354%2C580%2C0%2C0"
+                imageUri="https://crop23.io"
                 isReversed={true}
                 lowResSize={100}
                 showImage={true}
               >
                 <div>
                   <div>
-                    <div>
-                      TEST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#004D6D"
+                      title="test label"
+                    />
                   </div>
                   <div>
                     <span>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. a single related article 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,11 @@ exports[`1. a single related article 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      TEST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#004D6D"
+                      isVideo={false}
+                      title="test label"
+                    />
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. two related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. two related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      FIRST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#C74600"
+                      title="first label"
+                    />
                   </div>
                   <h3
                     aria-level="3"
@@ -77,7 +78,7 @@ exports[`1. two related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -90,9 +91,10 @@ exports[`1. two related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      SECOND LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#6C6C69"
+                      title="second label"
+                    />
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,10 @@ exports[`1. three related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      FIRST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#A31D24"
+                      title="first label"
+                    />
                   </div>
                   <h3
                     aria-level="3"
@@ -84,7 +85,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -97,9 +98,10 @@ exports[`1. three related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      SECOND LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#008347"
+                      title="second label"
+                    />
                   </div>
                   <h3
                     aria-level="3"
@@ -148,7 +150,7 @@ exports[`1. three related articles 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -161,9 +163,10 @@ exports[`1. three related articles 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      THIRD LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#1A1F24"
+                      title="third label"
+                    />
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -20,64 +20,36 @@ exports[`1. has video 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
                 highResSize={null}
                 imageRatio={1.7777777777777777}
-                imageUri="https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0547a7be-fb77-11e7-a987-7fcf5e9983dc.jpg?crop=2000%2C1125%2C0%2C104"
+                imageUri="https://crop169.io"
                 isReversed={false}
                 lowResSize={100}
                 showImage={true}
               >
                 <div>
                   <div>
-                    <div>
-                      <div>
-                        <svg
-                          aria-label="[title]"
-                          height={8}
-                          role="img"
-                          viewBox="0.15463916957378387 0.049614034593105316 23.59917640686035 13.728596687316895"
-                          width={13.76}
-                        >
-                          <title>
-                            Video Icon
-                          </title>
-                          <rect
-                            fill="#DB133B"
-                            height="13.5721404"
-                            width="15.4550103"
-                            x="0.154639175"
-                            y="0.139754386"
-                          />
-                          <polygon
-                            fill="#DB133B"
-                            points="16.3405361 4.14989474 16.3405361 9.66442105 22.0216082 12.8146667 22.0216082 0.999894737"
-                          />
-                          <polygon
-                            fill="#DB133B"
-                            points="23.7538144 0.0496140351 22.7616495 0.643508772 22.7616495 13.1902105 23.7538144 13.7782105"
-                          />
-                        </svg>
-                      </div>
-                      <div>
-                        BAYEUX TAPESTRY
-                      </div>
-                    </div>
+                    <VideoLabel
+                      color="#DB133B"
+                      isVideo={true}
+                      title="BAYEUX TAPESTRY"
+                    />
                   </div>
                   <h3
                     aria-level="3"
                     role="heading"
                   >
-                    Bringing the fragile masterpiece over safely
+                    Test Headline
                   </h3>
                   <div>
                     <div>
                       <span>
                         
-                        Napoleon Bonaparte flaunted it to whip up enthusiasm for invading England. Heinrich Himmler tried to grab it for Nazi Germany
+                        Summary 125
                         ...
                       </span>
                     </div>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -20,7 +20,7 @@ exports[`1. no short headline 1`] = `
                 "padding": 10,
               }
             }
-            url="https://www.thetimes.co.uk/article/test-slug-2k629tpvh"
+            url="https://some-url.io"
           >
             <div>
               <Card
@@ -33,9 +33,11 @@ exports[`1. no short headline 1`] = `
               >
                 <div>
                   <div>
-                    <div>
-                      TEST LABEL
-                    </div>
+                    <ArticleLabel
+                      color="#004D6D"
+                      isVideo={false}
+                      title="test label"
+                    />
                   </div>
                   <h3
                     aria-level="3"


### PR DESCRIPTION
There was a bug in `jest-lint` which meant that it didn't fail the CI. Have updated the offending snaps in preparation for the `jest-lint` update.