### PR TITLE
Fix/article headline fallback

### DIFF
--- a/packages/article/.jestlint
+++ b/packages/article/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
   "maxAttributeStringLength": 36,
-  "maxFileSize": 19253,
+  "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -531,7 +531,109 @@ exports[`4. an article with no lead asset 1`] = `
 </RCTScrollView>
 `;
 
-exports[`5. an article with ads 1`] = `
+exports[`5. an article with no headline falls back to use shortheadline 1`] = `
+<RCTScrollView>
+  <View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "400",
+              "lineHeight": 33,
+              "marginBottom": 15,
+              "marginTop": 15,
+            }
+          }
+        >
+          Some Short Headline
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 1,
+              "paddingBottom": 6,
+              "paddingTop": 7,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 21,
+              }
+            }
+          >
+            Friday March 13 2015, 6:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View />
+    <View>
+      <ArticleComments />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`6. an article with ads 1`] = `
 <RCTScrollView>
   <View>
     <View>
@@ -623,7 +725,7 @@ exports[`5. an article with ads 1`] = `
 </RCTScrollView>
 `;
 
-exports[`6. an article loading state 1`] = `
+exports[`7. an article loading state 1`] = `
 <View
   style={
     Object {
@@ -638,7 +740,7 @@ exports[`6. an article loading state 1`] = `
 </View>
 `;
 
-exports[`7. an article with updated byline 1`] = `
+exports[`8. an article with updated byline 1`] = `
 <RCTScrollView>
   <View>
     <View>
@@ -740,7 +842,7 @@ exports[`7. an article with updated byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`7. an article with updated byline 2`] = `
+exports[`8. an article with updated byline 2`] = `
 <RCTScrollView>
   <View>
     <View>

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -363,7 +363,58 @@ exports[`4. an article with no lead asset 1`] = `
 </RCTScrollView>
 `;
 
-exports[`5. an article with ads 1`] = `
+exports[`5. an article with no headline falls back to use shortheadline 1`] = `
+<RCTScrollView
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          selectable={true}
+        >
+          Some Short Headline
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View>
+        <View>
+          <Text>
+            Friday March 13 2015, 6:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View>
+        <Text
+          selectable={true}
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View />
+    <View>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        commentCount={65}
+        commentsEnabled={true}
+        url="https://url.io"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`6. an article with ads 1`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -412,7 +463,7 @@ exports[`5. an article with ads 1`] = `
 </RCTScrollView>
 `;
 
-exports[`6. an article loading state 1`] = `
+exports[`7. an article loading state 1`] = `
 <View>
   <ActivityIndicator
     animating={true}
@@ -422,7 +473,7 @@ exports[`6. an article loading state 1`] = `
 </View>
 `;
 
-exports[`7. an article with updated byline 1`] = `
+exports[`8. an article with updated byline 1`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -473,7 +524,7 @@ exports[`7. an article with updated byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`7. an article with updated byline 2`] = `
+exports[`8. an article with updated byline 2`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -548,7 +599,7 @@ exports[`7. an article with updated byline 2`] = `
 </RCTScrollView>
 `;
 
-exports[`8. an article that moves to a loading state 1`] = `
+exports[`9. an article that moves to a loading state 1`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -599,7 +650,7 @@ exports[`8. an article that moves to a loading state 1`] = `
 </RCTScrollView>
 `;
 
-exports[`8. an article that moves to a loading state 2`] = `
+exports[`9. an article that moves to a loading state 2`] = `
 <View>
   <ActivityIndicator
     animating={true}

--- a/packages/article/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -527,7 +527,106 @@ exports[`4. an article with no lead asset 1`] = `
 </RCTScrollView>
 `;
 
-exports[`5. an article with ads 1`] = `
+exports[`5. an article with no headline falls back to use shortheadline 1`] = `
+<RCTScrollView>
+  <View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "TimesModern-Bold",
+              "fontSize": 30,
+              "fontWeight": "700",
+              "lineHeight": 30,
+              "marginBottom": 7,
+              "marginTop": 15,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "marginBottom": 20,
+            "marginLeft": 10,
+            "marginRight": 10,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 9,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "borderTopColor": "#DBDBDB",
+              "borderTopWidth": 1,
+              "paddingBottom": 4,
+              "paddingTop": 9,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 15,
+              }
+            }
+          >
+            Friday March 13 2015, 6:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View />
+    <View>
+      <ArticleComments />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`6. an article with ads 1`] = `
 <RCTScrollView>
   <View>
     <View>
@@ -619,7 +718,7 @@ exports[`5. an article with ads 1`] = `
 </RCTScrollView>
 `;
 
-exports[`6. an article loading state 1`] = `
+exports[`7. an article loading state 1`] = `
 <View
   style={
     Object {
@@ -634,7 +733,7 @@ exports[`6. an article loading state 1`] = `
 </View>
 `;
 
-exports[`7. an article with updated byline 1`] = `
+exports[`8. an article with updated byline 1`] = `
 <RCTScrollView>
   <View>
     <View>
@@ -735,7 +834,7 @@ exports[`7. an article with updated byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`7. an article with updated byline 2`] = `
+exports[`8. an article with updated byline 2`] = `
 <RCTScrollView>
   <View>
     <View>

--- a/packages/article/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -551,7 +551,9 @@ exports[`5. an article with no headline falls back to use shortheadline 1`] = `
               "marginTop": 15,
             }
           }
-        />
+        >
+          Some Short Headline
+        </Text>
       </View>
     </View>
     <View>

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -378,7 +378,9 @@ exports[`5. an article with no headline falls back to use shortheadline 1`] = `
       <View>
         <Text
           selectable={true}
-        />
+        >
+          Some Short Headline
+        </Text>
       </View>
     </View>
     <View>

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -363,7 +363,56 @@ exports[`4. an article with no lead asset 1`] = `
 </RCTScrollView>
 `;
 
-exports[`5. an article with ads 1`] = `
+exports[`5. an article with no headline falls back to use shortheadline 1`] = `
+<RCTScrollView
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View>
+        <Text
+          selectable={true}
+        />
+      </View>
+    </View>
+    <View>
+      <View>
+        <View>
+          <Text>
+            Friday March 13 2015, 6:54pm, The Times
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View>
+        <Text
+          selectable={true}
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View />
+    <View>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        commentCount={65}
+        commentsEnabled={true}
+        url="https://url.io"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`6. an article with ads 1`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -412,7 +461,7 @@ exports[`5. an article with ads 1`] = `
 </RCTScrollView>
 `;
 
-exports[`6. an article loading state 1`] = `
+exports[`7. an article loading state 1`] = `
 <View>
   <ActivityIndicator
     animating={true}
@@ -423,7 +472,7 @@ exports[`6. an article loading state 1`] = `
 </View>
 `;
 
-exports[`7. an article with updated byline 1`] = `
+exports[`8. an article with updated byline 1`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -474,7 +523,7 @@ exports[`7. an article with updated byline 1`] = `
 </RCTScrollView>
 `;
 
-exports[`7. an article with updated byline 2`] = `
+exports[`8. an article with updated byline 2`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -549,7 +598,7 @@ exports[`7. an article with updated byline 2`] = `
 </RCTScrollView>
 `;
 
-exports[`8. an article that moves to a loading state 1`] = `
+exports[`9. an article that moves to a loading state 1`] = `
 <RCTScrollView
   initialNumToRender={10}
   maxToRenderPerBatch={10}
@@ -600,7 +649,7 @@ exports[`8. an article that moves to a loading state 1`] = `
 </RCTScrollView>
 `;
 
-exports[`8. an article that moves to a loading state 2`] = `
+exports[`9. an article that moves to a loading state 2`] = `
 <View>
   <ActivityIndicator
     animating={true}

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -224,7 +224,7 @@ export const snapshotTests = renderComponent => [
           article={articleFixture({
             ...testFixture,
             ...emptyArticle,
-            headline: null
+            headline: ""
           })}
           onAuthorPress={() => {}}
           onCommentGuidelinesPress={() => {}}

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -214,6 +214,39 @@ export const snapshotTests = renderComponent => [
     }
   },
   {
+    name: "an article with no headline falls back to use shortHeadline",
+    test() {
+
+      console.log(articleFixture({
+        ...testFixture,
+        ...emptyArticle,
+        headline: null
+      }));
+      const output = renderComponent(
+        <Article
+          {...articleProps}
+          adConfig={adConfig}
+          analyticsStream={() => {}}
+          article={articleFixture({
+            ...testFixture,
+            ...emptyArticle,
+            headline: null
+          })}
+          onAuthorPress={() => {}}
+          onCommentGuidelinesPress={() => {}}
+          onCommentsPress={() => {}}
+          onLinkPress={() => {}}
+          onRelatedArticlePress={() => {}}
+          onTopicPress={() => {}}
+          onTwitterLinkPress={() => {}}
+          onVideoPress={() => {}}
+        />
+      );
+
+      expect(output).toMatchSnapshot();
+    }
+  },
+  {
     name: "an article with ads",
     test() {
       const output = renderComponent(

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -216,12 +216,6 @@ export const snapshotTests = renderComponent => [
   {
     name: "an article with no headline falls back to use shortHeadline",
     test() {
-
-      console.log(articleFixture({
-        ...testFixture,
-        ...emptyArticle,
-        headline: null
-      }));
       const output = renderComponent(
         <Article
           {...articleProps}

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -433,7 +433,71 @@ exports[`4. an article with no lead asset 1`] = `
 </article>
 `;
 
-exports[`5. an article with ads 1`] = `
+exports[`5. an article with no headline falls back to use shortheadline 1`] = `
+<article>
+  <div>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="header"
+    />
+  </div>
+  <div>
+    <header>
+      <div>
+        <div>
+          <h1
+            aria-level="1"
+            role="heading"
+          >
+            Some Short Headline
+          </h1>
+        </div>
+      </div>
+      <div>
+        <div>
+          <div>
+            <span>
+              <DatePublication
+                date="2015-03-13T18:54:58.000Z"
+                publication="TIMES"
+              />
+            </span>
+          </div>
+        </div>
+      </div>
+      <div />
+    </header>
+    <div>
+      <div>
+        <p>
+          Some content
+        </p>
+      </div>
+    </div>
+  </div>
+  <aside
+    id="related-articles"
+  />
+  <Ad
+    contextUrl="https://url.io"
+    section="Some Section"
+    slotName="pixel"
+  />
+  <Ad
+    contextUrl="https://url.io"
+    section="Some Section"
+    slotName="pixelteads"
+  />
+  <Ad
+    contextUrl="https://url.io"
+    section="Some Section"
+    slotName="pixelskin"
+  />
+</article>
+`;
+
+exports[`6. an article with ads 1`] = `
 <article>
   <div>
     <Ad
@@ -497,13 +561,13 @@ exports[`5. an article with ads 1`] = `
 </article>
 `;
 
-exports[`6. an article loading state 1`] = `
+exports[`7. an article loading state 1`] = `
 <div>
   Loading ...
 </div>
 `;
 
-exports[`7. an article with updated byline 1`] = `
+exports[`8. an article with updated byline 1`] = `
 <article>
   <div>
     <Ad
@@ -567,7 +631,7 @@ exports[`7. an article with updated byline 1`] = `
 </article>
 `;
 
-exports[`7. an article with updated byline 2`] = `
+exports[`8. an article with updated byline 2`] = `
 <article>
   <div>
     <Ad

--- a/packages/article/fixtures/full-article.js
+++ b/packages/article/fixtures/full-article.js
@@ -1923,6 +1923,8 @@ const defaultRelatedArticleSlice = {
   ]
 };
 const defaultSection = "news";
+const defaultShortHeadline =
+  "Caribbean islands devastated by Hurricane Irma";
 const defaultShortIdentifier = "37b27qd2s";
 const defaultSlug = "france-defies-may-over-russia";
 const defaultStandfirst =
@@ -1981,6 +1983,7 @@ const makeDefaultConfig = ({
   leadAsset = defaultLeadAsset,
   relatedArticleSlice = defaultRelatedArticleSlice,
   section = defaultSection,
+  shortHeadline = defaultShortHeadline,
   shortIdentifier = defaultShortIdentifier,
   slug = defaultSlug,
   standfirst = defaultStandfirst,
@@ -1999,6 +2002,7 @@ const makeDefaultConfig = ({
   leadAsset,
   relatedArticleSlice,
   section,
+  shortHeadline,
   shortIdentifier,
   slug,
   standfirst,
@@ -2144,6 +2148,7 @@ export const testFixture = {
     ]
   },
   section: "Some Section",
+  shortHeadline: "Some Short Headline",
   shortIdentifier: "2k629tpvh",
   slug: "this-is-slug",
   standfirst: "Some Standfirst",

--- a/packages/article/fixtures/full-article.js
+++ b/packages/article/fixtures/full-article.js
@@ -1923,8 +1923,7 @@ const defaultRelatedArticleSlice = {
   ]
 };
 const defaultSection = "news";
-const defaultShortHeadline =
-  "Caribbean islands devastated by Hurricane Irma";
+const defaultShortHeadline = "Caribbean islands devastated by Hurricane Irma";
 const defaultShortIdentifier = "37b27qd2s";
 const defaultSlug = "france-defies-may-over-russia";
 const defaultStandfirst =

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -23,6 +23,7 @@ import {
 } from "./article-page-prop-types";
 import articleTrackingContext from "./article-tracking-context";
 import listViewDataHelper from "./data-helper";
+import getHeadline from "./utils";
 
 const listViewPageSize = 1;
 const listViewSize = 10;
@@ -54,13 +55,20 @@ const renderRow = (analyticsStream, width) => (
     }
 
     case "header": {
-      const { flags, hasVideo, headline, label, standfirst } = rowData.data;
+      const {
+        flags,
+        hasVideo,
+        headline,
+        label,
+        shortHeadline,
+        standfirst
+      } = rowData.data;
       const styles = stylesFactory();
       return (
         <ArticleHeader
           flags={flags}
           hasVideo={hasVideo}
-          headline={headline}
+          headline={getHeadline(headline, shortHeadline)}
           key={rowData.type}
           label={label}
           standfirst={standfirst}

--- a/packages/article/src/article.web.js
+++ b/packages/article/src/article.web.js
@@ -17,6 +17,7 @@ import {
   articlePagePropTypes,
   articlePageDefaultProps
 } from "./article-page-prop-types";
+import getHeadline from "./utils";
 
 import {
   MainContainer,
@@ -61,6 +62,7 @@ class Article extends Component {
         publicationName,
         content,
         section,
+        shortHeadline,
         url,
         topics,
         relatedArticleSlice
@@ -113,7 +115,7 @@ class Article extends Component {
               <ArticleHeader
                 flags={flags}
                 hasVideo={hasVideo}
-                headline={headline}
+                headline={getHeadline(headline, shortHeadline)}
                 label={label}
                 standfirst={standfirst}
               />

--- a/packages/article/src/data-helper.js
+++ b/packages/article/src/data-helper.js
@@ -36,6 +36,7 @@ const prepareDataForListView = articleData => {
     headline: articleData.headline,
     isVideo,
     label: articleData.label,
+    shortHeadline: articleData.shortHeadline,
     standfirst: articleData.standfirst
   };
   const articleMidContainerData = {

--- a/packages/article/src/utils/index.js
+++ b/packages/article/src/utils/index.js
@@ -1,0 +1,3 @@
+const getHeadline = (headline, shortHeadline) => headline || shortHeadline;
+
+export default getHeadline;


### PR DESCRIPTION
- sometimes the `headline` field in article is empty. This PR adds `shortHeadline` as a fallback.
- This is the cause of the missing headlines in render CI. Eg: http://cps-render-ci.elb.tnl-dev.ntch.co.uk/edition/news/british-trio-stopped-on-the-way-to-join-isis-57nwljmbn?react=1
- Increases `maxFileSize` in jest lint so as not to refactor too much in this PR as there is a big `article` refactor coming which would cause rebase issues. I'll create a Github issue to revert the change when this is merged.