### PR TITLE
fix: Undefined value in para wrapper

### DIFF
--- a/packages/article-paragraph/src/index.js
+++ b/packages/article-paragraph/src/index.js
@@ -9,11 +9,9 @@ import { propTypes, defaultProps } from "./drop-cap-prop-types";
 const ArticleParagraphWrapper = props => {
   const { ast, children, colour } = props;
   const { children: astChildren } = ast;
-  const {
-    name,
-    attributes: { value }
-  } = astChildren[0];
+  const { name, attributes } = astChildren[0];
   if (name === "dropCap") {
+    const { value } = attributes;
     const text = renderTreeAsText(ast).slice(1);
     return (
       <DropCapWrapper


### PR DESCRIPTION
Not all markups have attributes in it so the previous code was crashing. Updated to fix native articles