### PR TITLE
chore: Remove bundling from article error since it's native only

### DIFF
--- a/packages/article-error/package.json
+++ b/packages/article-error/package.json
@@ -14,8 +14,7 @@
     "test:all": "yarn test:android --coverage && yarn test:ios --coverage",
     "prepublishOnly": "yarn transpile && yarn bundle",
     "cleanup-dist": "rm -rf dist",
-    "transpile": "yarn cleanup-dist && babel src -d dist",
-    "bundle": "NODE_ENV=production webpack -p"
+    "transpile": "yarn cleanup-dist && babel src -d dist"
   },
   "repository": {
     "type": "git",
@@ -40,7 +39,6 @@
     "@times-components/jest-configurator": "2.1.12",
     "@times-components/jest-serializer": "3.1.6",
     "@times-components/storybook": "3.1.19",
-    "@times-components/webpack-configurator": "2.0.10",
     "babel-cli": "6.26.0",
     "eslint": "4.19.1",
     "jest": "23.3.0",
@@ -48,9 +46,7 @@
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "react-native": "0.55.4",
-    "react-test-renderer": "16.5.2",
-    "webpack": "4.6.0",
-    "webpack-cli": "2.1.4"
+    "react-test-renderer": "16.5.2"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-error/webpack.config.js
+++ b/packages/article-error/webpack.config.js
@@ -1,5 +1,0 @@
-/* eslint-disable import/no-extraneous-dependencies */
-module.exports = require("@times-components/webpack-configurator")(
-  __dirname,
-  "dev"
-);


### PR DESCRIPTION
Article error shouldn't be bundled for web as it's native only. Removed bundling as it was breaking releases