### PR TITLE
fix: Allow android storybook to load bundle from insecure webpack server

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
@tuncaulubilge & I paired on this.

This should make Android builds of the storybook work again. 

Android was blocking connections to the bundle webpack server because it is being served over HTTP instead of HTTPS. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
