### PR TITLE
feat: Zoom at centre of the two touches during pinch to zoom

### DIFF
--- a/packages/gestures/__tests__/android/__snapshots__/gestures.android.test.js.snap
+++ b/packages/gestures/__tests__/android/__snapshots__/gestures.android.test.js.snap
@@ -14,7 +14,31 @@ exports[`1. scale correctly when spreading fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 55,
+            },
+            Object {
+              "translateY": 15,
+            },
+            Object {
               "scale": 3,
+            },
+            Object {
+              "translateX": -55,
+            },
+            Object {
+              "translateY": -15,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "0 deg",
@@ -48,7 +72,31 @@ exports[`2. rotate anti-clockwise when turning fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 30,
+            },
+            Object {
+              "translateY": 15,
+            },
+            Object {
               "scale": 1,
+            },
+            Object {
+              "translateX": -30,
+            },
+            Object {
+              "translateY": -15,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "90 deg",
@@ -82,7 +130,31 @@ exports[`3. rotate clockwise when turning fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 30,
+            },
+            Object {
+              "translateY": 15,
+            },
+            Object {
               "scale": 1,
+            },
+            Object {
+              "translateX": -30,
+            },
+            Object {
+              "translateY": -15,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "270 deg",
@@ -116,7 +188,31 @@ exports[`4. scale and rotate when spreading and rotating fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 90,
+            },
+            Object {
+              "translateY": 45,
+            },
+            Object {
               "scale": 2.9154759474226504,
+            },
+            Object {
+              "translateX": -90,
+            },
+            Object {
+              "translateY": -45,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "-5.906 deg",
@@ -150,7 +246,31 @@ exports[`5. do nothing if a finger is removed while interacting 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": -20,
+            },
+            Object {
+              "translateY": -60,
+            },
+            Object {
               "scale": 1,
+            },
+            Object {
+              "translateX": 20,
+            },
+            Object {
+              "translateY": 60,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "0 deg",

--- a/packages/gestures/__tests__/ios/__snapshots__/gestures.ios.test.js.snap
+++ b/packages/gestures/__tests__/ios/__snapshots__/gestures.ios.test.js.snap
@@ -14,7 +14,31 @@ exports[`1. scale correctly when spreading fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 55,
+            },
+            Object {
+              "translateY": 15,
+            },
+            Object {
               "scale": 3,
+            },
+            Object {
+              "translateX": -55,
+            },
+            Object {
+              "translateY": -15,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "0 deg",
@@ -48,7 +72,31 @@ exports[`2. rotate anti-clockwise when turning fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 30,
+            },
+            Object {
+              "translateY": 15,
+            },
+            Object {
               "scale": 1,
+            },
+            Object {
+              "translateX": -30,
+            },
+            Object {
+              "translateY": -15,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "90 deg",
@@ -82,7 +130,31 @@ exports[`3. rotate clockwise when turning fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 30,
+            },
+            Object {
+              "translateY": 15,
+            },
+            Object {
               "scale": 1,
+            },
+            Object {
+              "translateX": -30,
+            },
+            Object {
+              "translateY": -15,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "270 deg",
@@ -116,7 +188,31 @@ exports[`4. scale and rotate when spreading and rotating fingers 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": 90,
+            },
+            Object {
+              "translateY": 45,
+            },
+            Object {
               "scale": 2.9154759474226504,
+            },
+            Object {
+              "translateX": -90,
+            },
+            Object {
+              "translateY": -45,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "-5.906 deg",
@@ -150,7 +246,31 @@ exports[`5. do nothing if a finger is removed while interacting 1`] = `
         Object {
           "transform": Array [
             Object {
+              "translateX": -15,
+            },
+            Object {
+              "translateY": -25,
+            },
+            Object {
+              "translateX": -20,
+            },
+            Object {
+              "translateY": -60,
+            },
+            Object {
               "scale": 1,
+            },
+            Object {
+              "translateX": 20,
+            },
+            Object {
+              "translateY": 60,
+            },
+            Object {
+              "translateX": 15,
+            },
+            Object {
+              "translateY": 25,
             },
             Object {
               "rotate": "0 deg",

--- a/packages/gestures/__tests__/shared.native.js
+++ b/packages/gestures/__tests__/shared.native.js
@@ -24,12 +24,12 @@ const makeTouchEvent = (active, history = []) => ({
 });
 
 const renderComponent = () => {
-  const component = TestRenderer.create(
+  const testRenderer = TestRenderer.create(
     <Gesture>
       <Text>Hello world!</Text>
     </Gesture>
   );
-  component.getInstance().onViewLayout({
+  testRenderer.getInstance().onViewLayout({
     nativeEvent: {
       layout: {
         height: 50,
@@ -39,7 +39,7 @@ const renderComponent = () => {
       }
     }
   });
-  return component;
+  return testRenderer;
 };
 
 const gestureHandlers = component => {

--- a/packages/gestures/__tests__/shared.native.js
+++ b/packages/gestures/__tests__/shared.native.js
@@ -23,12 +23,24 @@ const makeTouchEvent = (active, history = []) => ({
   }
 });
 
-const renderComponent = () =>
-  TestRenderer.create(
+const renderComponent = () => {
+  const component = TestRenderer.create(
     <Gesture>
       <Text>Hello world!</Text>
     </Gesture>
   );
+  component.getInstance().onViewLayout({
+    nativeEvent: {
+      layout: {
+        height: 50,
+        width: 30,
+        x: 20,
+        y: 60
+      }
+    }
+  });
+  return component;
+};
 
 const gestureHandlers = component => {
   const {

--- a/packages/gestures/src/gestures.js
+++ b/packages/gestures/src/gestures.js
@@ -34,6 +34,26 @@ const pointBetweenTwoTouches = ([
   pageY: (y1 + y2) / 2
 });
 
+
+const translate = ({ translateX, translateY }, transformations) => [
+  { translateX },
+  { translateY },
+  ...transformations,
+  { translateX: Animated.multiply(translateX, -1) },
+  { translateY: Animated.multiply(translateY, -1) }
+];
+
+const resetOrigin = ({ width, height }, transformations) =>
+  translate(
+    {
+      translateX: Animated.multiply(width, -0.5),
+      translateY: Animated.multiply(height, -0.5)
+    },
+    transformations
+  );
+
+const subtract = (a, b) => Animated.add(a, Animated.multiply(b, -1));
+
 class Gestures extends Component {
   constructor(props) {
     super(props);
@@ -110,26 +130,18 @@ class Gestures extends Component {
   }
 
   render() {
-    const translateX = Animated.add(
-      this.state.center.pageX,
-      Animated.multiply(this.state.viewLayout.x, -1)
-    );
-    const translateY = Animated.add(
-      this.state.center.pageY,
-      Animated.multiply(this.state.viewLayout.y, -1)
-    );
-
     const transformStyle = {
       transform: [
-        { translateX: Animated.multiply(this.state.viewLayout.width, -0.5) },
-        { translateY: Animated.multiply(this.state.viewLayout.height, -0.5) },
-        { translateX },
-        { translateY },
-        { scale: this.state.zoomRatio },
-        { translateX: Animated.multiply(translateX, -1) },
-        { translateY: Animated.multiply(translateY, -1) },
-        { translateX: Animated.divide(this.state.viewLayout.width, 2) },
-        { translateY: Animated.divide(this.state.viewLayout.height, 2) },
+        ...resetOrigin(
+          this.state.viewLayout,
+          translate(
+            {
+              translateX: subtract(this.state.center.pageX, this.state.viewLayout.x),
+              translateY: subtract(this.state.center.pageY, this.state.viewLayout.y),
+            },
+            [{ scale: this.state.zoomRatio }]
+          )
+        ),
         {
           rotate: this.state.angle.interpolate({
             inputRange: [0, 359],

--- a/packages/gestures/src/gestures.js
+++ b/packages/gestures/src/gestures.js
@@ -34,7 +34,6 @@ const pointBetweenTwoTouches = ([
   pageY: (y1 + y2) / 2
 });
 
-
 const translate = ({ translateX, translateY }, transformations) => [
   { translateX },
   { translateY },
@@ -136,8 +135,14 @@ class Gestures extends Component {
           this.state.viewLayout,
           translate(
             {
-              translateX: subtract(this.state.center.pageX, this.state.viewLayout.x),
-              translateY: subtract(this.state.center.pageY, this.state.viewLayout.y),
+              translateX: subtract(
+                this.state.center.pageX,
+                this.state.viewLayout.x
+              ),
+              translateY: subtract(
+                this.state.center.pageY,
+                this.state.viewLayout.y
+              )
             },
             [{ scale: this.state.zoomRatio }]
           )

--- a/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image-with-style.android.test.js.snap
@@ -53,7 +53,31 @@ exports[`1. default modal 1`] = `
               Object {
                 "transform": Array [
                   Object {
+                    "translateX": -0,
+                  },
+                  Object {
+                    "translateY": -0,
+                  },
+                  Object {
+                    "translateX": 0,
+                  },
+                  Object {
+                    "translateY": 0,
+                  },
+                  Object {
                     "scale": 1,
+                  },
+                  Object {
+                    "translateX": -0,
+                  },
+                  Object {
+                    "translateY": -0,
+                  },
+                  Object {
+                    "translateX": 0,
+                  },
+                  Object {
+                    "translateY": 0,
                   },
                   Object {
                     "rotate": "0 deg",

--- a/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image-with-style.ios.test.js.snap
@@ -59,7 +59,31 @@ exports[`1. default modal 1`] = `
               Object {
                 "transform": Array [
                   Object {
+                    "translateX": -0,
+                  },
+                  Object {
+                    "translateY": -0,
+                  },
+                  Object {
+                    "translateX": 0,
+                  },
+                  Object {
+                    "translateY": 0,
+                  },
+                  Object {
                     "scale": 1,
+                  },
+                  Object {
+                    "translateX": -0,
+                  },
+                  Object {
+                    "translateY": -0,
+                  },
+                  Object {
+                    "translateX": 0,
+                  },
+                  Object {
+                    "translateY": 0,
                   },
                   Object {
                     "rotate": "0 deg",


### PR DESCRIPTION
React Native doesn't support transform origin, so we have to use translations to emulate this. https://github.com/facebook/react-native/issues/1964

![nov-02-2018 12-17-57](https://user-images.githubusercontent.com/719814/47915009-6fb07d00-de99-11e8-8db5-d9516c7a47ad.gif)

First we apply a translation to reset the origin of the transformation to the top left of the gesture view, and then we apply another translation to move the origin to the offset from that to the centre of the two touches. Then, we apply the zoom transformation, and then undo the translations. Then the rotation is applied. 


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
