### PR TITLE
fix: Use screen width if highRes is not provided in images

### DIFF
--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -125,3 +125,22 @@ exports[`5. handle onload event 2`] = `
   />
 </View>
 `;
+
+exports[`7. use screen width if highressize is not provided 1`] = `
+<View
+  aspectRatio={1.5}
+>
+  <View>
+    <Gradient
+      degrees={264}
+    />
+  </View>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+      }
+    }
+  />
+</View>
+`;

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -125,3 +125,22 @@ exports[`5. handle onload event 2`] = `
   />
 </View>
 `;
+
+exports[`7. use screen width if highressize is not provided 1`] = `
+<View
+  aspectRatio={1.5}
+>
+  <View>
+    <Gradient
+      degrees={264}
+    />
+  </View>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+      }
+    }
+  />
+</View>
+`;

--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -75,6 +75,16 @@ export default () => {
             .source.uri
         ).toEqual(dataUri);
       }
+    },
+    {
+      name: "use screen width if highResSize is not provided",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Image {...props} highResSize={undefined} />
+        );
+
+        expect(testInstance).toMatchSnapshot();
+      }
     }
   ];
 

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -1,6 +1,10 @@
 import React, { Component } from "react";
 import { Image, View } from "react-native";
-import { addMissingProtocol } from "@times-components/utils";
+import {
+  addMissingProtocol,
+  normaliseWidth,
+  screenWidthInPixels
+} from "@times-components/utils";
 import appendSize from "./utils";
 import { defaultProps, propTypes } from "./image-prop-types";
 import Placeholder from "./placeholder";
@@ -11,7 +15,8 @@ class TimesImage extends Component {
     super(props);
 
     this.state = {
-      isLoaded: false
+      isLoaded: false,
+      width: normaliseWidth(screenWidthInPixels())
     };
     this.handleLoad = this.handleLoad.bind(this);
   }
@@ -22,13 +27,13 @@ class TimesImage extends Component {
 
   render() {
     const { aspectRatio, highResSize, style, uri } = this.props;
-    const { isLoaded } = this.state;
+    const { isLoaded, width } = this.state;
 
     const isDataImageUri = uri && uri.indexOf("data:") > -1;
 
     const srcUri = isDataImageUri
       ? uri
-      : addMissingProtocol(appendSize(uri, "resize", highResSize));
+      : addMissingProtocol(appendSize(uri, "resize", highResSize || width));
 
     const props = {
       onLoad: this.handleLoad,

--- a/packages/image/src/utils.js
+++ b/packages/image/src/utils.js
@@ -14,7 +14,6 @@ export default (uriString, key, value) => {
   try {
     url = new URL(uriString);
   } catch (e) {
-    console.error("Invalid URL", uriString);
     return uriString;
   }
 


### PR DESCRIPTION
Image resize was broken on native apps since highResSize is not passed at the moment. This pr uses screenWidth if highResSize is not available