### PR TITLE
Fix versions on article comments

### DIFF
--- a/packages/article-comments/package.json
+++ b/packages/article-comments/package.json
@@ -38,7 +38,7 @@
     "@times-components/button": "2.2.27",
     "@times-components/context": "0.5.4",
     "@times-components/link": "3.1.5",
-    "@times-components/provider": "1.6.4",
+    "@times-components/provider": "1.6.5",
     "@times-components/styleguide": "3.7.2",
     "prop-types": "15.6.2"
   },
@@ -47,7 +47,7 @@
     "@times-components/eslint-config-thetimes": "0.8.5",
     "@times-components/jest-configurator": "2.1.14",
     "@times-components/jest-serializer": "3.1.7",
-    "@times-components/provider-test-tools": "1.8.4",
+    "@times-components/provider-test-tools": "1.8.5",
     "@times-components/storybook": "3.1.21",
     "@times-components/test-utils": "2.0.0",
     "@times-components/webpack-configurator": "2.0.11",


### PR DESCRIPTION
Versions got messed up when we merged multiple PRs at the same time. Ran deps:fix to get it working 