### PR TITLE
fix: lazy loading for related articles slice

### DIFF
--- a/packages/related-articles/src/related-article-item.base.js
+++ b/packages/related-articles/src/related-article-item.base.js
@@ -37,16 +37,27 @@ class RelatedArticleItem extends Component {
     };
   }
 
+  componentDidMount() {
+    if (
+      this.props.imageConfig.showHiRes
+    ) {
+      this.setHighResSize();
+    }
+  }
+
   componentDidUpdate(prevProps) {
     if (
       prevProps.imageConfig.showHiRes !== this.props.imageConfig.showHiRes &&
       this.props.imageConfig.showHiRes
     ) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        highResSize: findNodeHandle(this.node.current).clientWidth
-      });
+      this.setHighResSize();
     }
+  }
+
+  setHighResSize() {
+    this.setState({
+      highResSize: findNodeHandle(this.node.current).clientWidth
+    });
   }
 
   render() {


### PR DESCRIPTION
`componentDidUpdate` is sufficient for setting the `highResSize` needed for lazy loading in related articles only within storybook. Because of this, lazy loading was not working on SSR. I've fixed this by adding a `componentDidMount` lifecycle instead.

**PS**: This kind of bug can be avoided in the future when React hooks are stable, using the `useEffect` hook. https://reactjs.org/docs/hooks-effect.html


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
