### PR TITLE
fix: button android default style

### DIFF
--- a/packages/article-error/__tests__/android/__snapshots__/article-error-style.test.js.snap
+++ b/packages/article-error/__tests__/android/__snapshots__/article-error-style.test.js.snap
@@ -84,7 +84,7 @@ exports[`renders correctly with style 1`] = `
               "color": "#FFFFFF",
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 16,
-              "lineHeight": 14,
+              "lineHeight": 16,
               "paddingTop": 0,
             }
           }

--- a/packages/button/__tests__/android/__snapshots__/button.android.test.js.snap
+++ b/packages/button/__tests__/android/__snapshots__/button.android.test.js.snap
@@ -24,7 +24,7 @@ exports[`1. button 1`] = `
         "color": "#FFFFFF",
         "fontFamily": "GillSansMTStd-Medium",
         "fontSize": 16,
-        "lineHeight": 14,
+        "lineHeight": 16,
         "paddingTop": 0,
       }
     }

--- a/packages/button/src/styles/index.android.js
+++ b/packages/button/src/styles/index.android.js
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
   },
   text: {
     ...sharedStyles.text,
-    lineHeight: 14,
     paddingTop: 0
   }
 });


### PR DESCRIPTION
Default style on android for buttons has the wrong lineHeight.

Before: 
![screenshot_1541607884](https://user-images.githubusercontent.com/1849590/48146557-2acb8280-e2ad-11e8-95a5-0d5ac00a1a00.png)

After:
![screenshot_1541607866](https://user-images.githubusercontent.com/1849590/48146566-2f903680-e2ad-11e8-8310-1f9606e070cb.png)
