### PR TITLE
fix: Use short headline in Related Articles on web

### DIFF
--- a/packages/provider-queries/src/article.web.js
+++ b/packages/provider-queries/src/article.web.js
@@ -106,6 +106,7 @@ export default addTypenameToDocument(gql`
     publishedTime
     section
     shortIdentifier
+    shortHeadline
     slug
     url
   }


### PR DESCRIPTION
The short headline isn't displaying in Related Articles slices on web, because its not included in the GraphQL query on web.