### PR TITLE
fix: Check if resize already exists in url

### DIFF
--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -85,6 +85,21 @@ export default () => {
 
         expect(testInstance).toMatchSnapshot();
       }
+    },
+    {
+      name: "do not append resize if url already contains resize",
+      test: () => {
+        const uri =
+          "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=100";
+        const testInstance = TestRenderer.create(
+          <Image aspectRatio={3 / 2} highResSize={999} uri={uri} />
+        );
+
+        expect(
+          testInstance.root.find(node => node.type === ReactNativeImage).props
+            .source.uri
+        ).toEqual(uri);
+      }
     }
   ];
 

--- a/packages/image/src/utils.js
+++ b/packages/image/src/utils.js
@@ -5,6 +5,10 @@ export default (uriString, key, value) => {
     return uriString;
   }
 
+  if (uriString.includes(`?${key}`) || uriString.includes(`&${key}`)) {
+    return uriString;
+  }
+
   if (typeof URL === "undefined") {
     return `${uriString}&${key}=${value}`;
   }


### PR DESCRIPTION
Author profile head image has a resize in the url received from tpa, so this PR checks before appending another "resize" at the end of that url, otherwise the image is not loaded at all.