### PR TITLE
fix: pages stories

### DIFF
--- a/android/app/src/main/java/com/storybooknative/MainApplication.java
+++ b/android/app/src/main/java/com/storybooknative/MainApplication.java
@@ -8,6 +8,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.facebook.stetho.Stetho;
+import com.storybooknative.stubs.StorybookStubPackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,7 +25,8 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
             return Arrays.asList(
                     new MainReactPackage(),
-                    new ComponentsPackage()
+                    new ComponentsPackage(),
+                    new StorybookStubPackage()
             );
         }
 

--- a/android/app/src/main/java/com/storybooknative/stubs/ArticleEvents.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/ArticleEvents.kt
@@ -1,0 +1,50 @@
+package com.storybooknative.stubs
+
+import android.util.Log
+import com.facebook.react.bridge.BaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+
+class ArticleEvents : BaseJavaModule() {
+    override fun getName() = "ArticleEvents"
+
+    @ReactMethod
+    fun onArticlePress(url: String) {
+        Log.d(name, "onArticlePress $url")
+    }
+
+    @ReactMethod
+    fun onArticleLoaded(articleId: String, extras: ReadableMap) {
+        Log.d(name, "onArticleLoaded $articleId $extras")
+    }
+
+    @ReactMethod
+    fun onAuthorPress(slug: String) {
+        Log.d(name, "onAuthorPress $slug")
+    }
+
+    @ReactMethod
+    fun onLinkPress(url: String) {
+        Log.d(name, "onLinkPress $url")
+    }
+
+    @ReactMethod
+    fun onVideoPress(info: ReadableMap) {
+        Log.d(name, "onVideoPress $info")
+    }
+
+    @ReactMethod
+    fun onTopicPress(url: String) {
+        Log.d(name, "onTopicPress $url")
+    }
+
+    @ReactMethod
+    fun onCommentsPress(articleId: String, url: String) {
+        Log.d(name, "onCommentsPress $articleId $url")
+    }
+
+    @ReactMethod
+    fun onCommentGuidelinesPress() {
+        Log.d(name, "onCommentGuidelinesPress")
+    }
+}

--- a/android/app/src/main/java/com/storybooknative/stubs/AuthorProfileEvents.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/AuthorProfileEvents.kt
@@ -1,0 +1,19 @@
+package com.storybooknative.stubs
+
+import android.util.Log
+import com.facebook.react.bridge.BaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class AuthorProfileEvents : BaseJavaModule() {
+    override fun getName() = "AuthorProfileEvents"
+
+    @ReactMethod
+    fun onArticlePress(url: String) {
+        Log.d(name, "onArticlePress $url")
+    }
+
+    @ReactMethod
+    fun onTwitterLinkPress(url: String) {
+        Log.d(name, "onTwitterLinkPress $url")
+    }
+}

--- a/android/app/src/main/java/com/storybooknative/stubs/ReactAnalytics.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/ReactAnalytics.kt
@@ -1,0 +1,16 @@
+package com.storybooknative.stubs
+
+import android.util.Log
+import com.facebook.react.bridge.BaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+
+
+class ReactAnalytics : BaseJavaModule() {
+    override fun getName() = "ReactAnalytics"
+
+    @ReactMethod
+    fun track(extras: ReadableMap) {
+        Log.d(name, "track $extras")
+    }
+}

--- a/android/app/src/main/java/com/storybooknative/stubs/ReactConfig.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/ReactConfig.kt
@@ -1,0 +1,27 @@
+package com.storybooknative.stubs
+
+import com.facebook.react.bridge.BaseJavaModule
+import java.util.*
+
+class ReactConfig : BaseJavaModule() {
+
+    override fun getName(): String {
+        return "ReactConfig"
+    }
+
+    override fun hasConstants(): Boolean {
+        return true
+    }
+
+    override fun getConstants(): Map<String, Any>? {
+        return HashMap<String, Any>().apply {
+            put("deviceId", "")
+            put("operatingSystemVersion", "")
+            put("cookieEid", "")
+            put("isLoggedIn", "")
+            put("graphqlEndPoint", "https://api.thetimes.co.uk/graphql")
+            put("adNetworkId", "")
+            put("timezone", "")
+        }
+    }
+}

--- a/android/app/src/main/java/com/storybooknative/stubs/StorybookStubPackage.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/StorybookStubPackage.kt
@@ -1,0 +1,20 @@
+package com.storybooknative.stubs
+
+import android.view.View
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ReactShadowNode
+import com.facebook.react.uimanager.ViewManager
+
+// Stub NativeModules for storybook
+class StorybookStubPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext) = listOf(
+            ArticleEvents(),
+            AuthorProfileEvents(),
+            ReactAnalytics(),
+            ReactConfig(),
+            TopicEvents()
+    )
+
+    override fun createViewManagers(reactContext: ReactApplicationContext) = emptyList<ViewManager<View, ReactShadowNode<*>>>()
+}

--- a/android/app/src/main/java/com/storybooknative/stubs/TopicEvents.kt
+++ b/android/app/src/main/java/com/storybooknative/stubs/TopicEvents.kt
@@ -1,0 +1,14 @@
+package com.storybooknative.stubs
+
+import android.util.Log
+import com.facebook.react.bridge.BaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class TopicEvents : BaseJavaModule() {
+    override fun getName() = "TopicEvents"
+
+    @ReactMethod
+    fun onArticlePress(url: String) {
+        Log.d(name, "onArticlePress $url")
+    }
+}

--- a/packages/pages/pages.showcase.native.js
+++ b/packages/pages/pages.showcase.native.js
@@ -10,30 +10,8 @@ export default {
           "Article id",
           "4938a3d4-8109-11e8-a645-f0478472c67b"
         );
-        const graphqlEndPoint = text(
-          "GraphQL Endpoint",
-          "https://api.thetimes.co.uk/graphql"
-        );
 
-        const config = {
-          graphqlEndPoint
-        };
-        const ArticlePageView = Article(config)();
-
-        return (
-          <ArticlePageView
-            analyticsStream={() => {}}
-            articleId={articleId}
-            onArticlePress={() => {}}
-            onAuthorPress={() => {}}
-            onCommentGuidelinesPress={() => {}}
-            onCommentsPress={() => {}}
-            onLinkPress={() => {}}
-            onTopicPress={() => {}}
-            onVideoPress={() => {}}
-            platformAdConfig={{ sectionName: "news" }}
-          />
-        );
+        return <Article articleId={articleId} />;
       },
       name: "Article",
       type: "story"
@@ -41,24 +19,8 @@ export default {
     {
       component: ({ text }) => {
         const authorSlug = text("Author slug", "deborah-haynes");
-        const graphqlEndPoint = text(
-          "GraphQL Endpoint",
-          "https://api.thetimes.co.uk/graphql"
-        );
 
-        const config = {
-          graphqlEndPoint
-        };
-        const AuthorProfilePageView = AuthorProfile(config)();
-
-        return (
-          <AuthorProfilePageView
-            analyticsStream={() => {}}
-            authorSlug={authorSlug}
-            onArticlePress={() => {}}
-            onTwitterLinkPress={() => {}}
-          />
-        );
+        return <AuthorProfile authorSlug={authorSlug} />;
       },
       name: "AuthorProfile",
       type: "story"
@@ -66,23 +28,8 @@ export default {
     {
       component: ({ text }) => {
         const topicSlug = text("Topic slug", "brexit");
-        const graphqlEndPoint = text(
-          "GraphQL Endpoint",
-          "https://api.thetimes.co.uk/graphql"
-        );
 
-        const config = {
-          graphqlEndPoint
-        };
-        const TopicPageView = Topic(config)();
-
-        return (
-          <TopicPageView
-            analyticsStream={() => {}}
-            onArticlePress={() => {}}
-            topicSlug={topicSlug}
-          />
-        );
+        return <Topic topicSlug={topicSlug} />;
       },
       name: "Topic",
       type: "story"

--- a/packages/pages/src/apollo-client.js
+++ b/packages/pages/src/apollo-client.js
@@ -4,8 +4,10 @@ import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { fragmentMatcher } from "@times-components/schema";
 
-const { graphqlEndPoint } = NativeModules.ReactConfig;
-const { fetch } = NativeModules.NativeFetch;
+const {
+  NativeFetch: { fetch } = {},
+  ReactConfig: { graphqlEndPoint }
+} = NativeModules;
 
 const link = fetch
   ? createHttpLink({


### PR DESCRIPTION
Pages package is directly using the NativeModules now, so we had to stub those out on storybook android app. 

- Fixed the NativeFetch callback, which uses the default react-native fetch when not provided (storybook uses this fallback)
- Fixed showcases
- Added stub modules into storybooks, which just logs any native method calls. 