### PR TITLE
fix: Add article section fallback on pages

### DIFF
--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -37,11 +37,11 @@ const ArticleBase = ({
       : adTargetConfig({
           adTestMode,
           article,
-          sectionName: pageSection || articleSection
+          sectionName: pageSection || articleSection || ""
         });
   const theme = {
     scale: scale || defaults.theme.scale,
-    sectionColour: colours.section[pageSection || articleSection]
+    sectionColour: colours.section[pageSection || articleSection || "default"]
   };
 
   return (


### PR DESCRIPTION
There are few articles which has an empty newsdesk value, which causes the app to crash. Added default values for these scenarios