### PR TITLE
fix: native resize append util

### DIFF
--- a/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
+++ b/packages/image/__tests__/web/__snapshots__/image.web.test.js.snap
@@ -132,7 +132,7 @@ exports[`5. no url in environment 1`] = `
   <div>
     <img
       alt=""
-      src="not-valid&resize=1400"
+      src="not-valid?resize=1400"
     />
     <div>
       <div />

--- a/packages/image/src/utils.js
+++ b/packages/image/src/utils.js
@@ -10,7 +10,8 @@ export default (uriString, key, value) => {
   }
 
   if (typeof URL === "undefined") {
-    return `${uriString}&${key}=${value}`;
+    const separator = uriString.includes("?") ? "&" : "?";
+    return `${uriString}${separator}${key}=${value}`;
   }
 
   let url;


### PR DESCRIPTION
Query param append util was broken on our fallback scenario. "URL" class is not defined in some android versions, so we had to fix our fallback scenario when URL is not defined.