### PR TITLE
fix: Add id to images inside author and topic articles queries

### DIFF
--- a/packages/provider-queries/src/author-articles-with-images.js
+++ b/packages/provider-queries/src/author-articles-with-images.js
@@ -23,6 +23,7 @@ export default addTypenameToDocument(gql`
               crop(ratio: $imageRatio) {
                 url
               }
+              id
               title
             }
             ... on Video {
@@ -30,6 +31,7 @@ export default addTypenameToDocument(gql`
                 crop(ratio: $imageRatio) {
                   url
                 }
+                id
                 title
               }
             }

--- a/packages/provider-queries/src/topic-articles.js
+++ b/packages/provider-queries/src/topic-articles.js
@@ -21,18 +21,19 @@ export default addTypenameToDocument(gql`
           shortIdentifier
           leadAsset {
             ... on Image {
-              id
-              title
               crop(ratio: $imageRatio) {
                 url
               }
+              id
+              title
             }
             ... on Video {
               posterImage {
-                title
                 crop(ratio: $imageRatio) {
                   url
                 }
+                id
+                title
               }
             }
           }

--- a/packages/provider-test-tools/src/author-profile.js
+++ b/packages/provider-test-tools/src/author-profile.js
@@ -118,7 +118,10 @@ export default ({
             imageIndex += 1;
             return {
               __typename: "Image",
-              title: `Some title ${imageIndex}`
+              title: `Some title ${imageIndex}`,
+              id: `e98c2${imageIndex
+                .toString()
+                .padStart(2)}c-cb16-11e7-b529-95e3fc05f40f`,
             };
           },
           Media: () => ({

--- a/packages/provider-test-tools/src/author-profile.js
+++ b/packages/provider-test-tools/src/author-profile.js
@@ -118,10 +118,10 @@ export default ({
             imageIndex += 1;
             return {
               __typename: "Image",
-              title: `Some title ${imageIndex}`,
               id: `e98c2${imageIndex
                 .toString()
                 .padStart(2)}c-cb16-11e7-b529-95e3fc05f40f`,
+              title: `Some title ${imageIndex}`
             };
           },
           Media: () => ({

--- a/packages/provider/__tests__/__snapshots__/author-articles-with-images.test.js.snap
+++ b/packages/provider/__tests__/__snapshots__/author-articles-with-images.test.js.snap
@@ -18,10 +18,11 @@ Object {
           "crop": Object {
             "__typename": "Crop",
             "url": "https://placeimg.com/300/200/tech",
-            Symbol(id): "$Article:d98c2 1c-cb16-11e7-b529-95e3fc05f40f.leadAsset.crop({\\"ratio\\":\\"3:2\\"})",
+            Symbol(id): "$Image:e98c2 1c-cb16-11e7-b529-95e3fc05f40f.crop({\\"ratio\\":\\"3:2\\"})",
           },
+          "id": "e98c2 1c-cb16-11e7-b529-95e3fc05f40f",
           "title": "Some title 1",
-          Symbol(id): "$Article:d98c2 1c-cb16-11e7-b529-95e3fc05f40f.leadAsset",
+          Symbol(id): "Image:e98c2 1c-cb16-11e7-b529-95e3fc05f40f",
         },
         "publicationName": "TIMES",
         "publishedTime": "2018-06-01",


### PR DESCRIPTION
Apollo normalised cache has an issue which fails the network request if an object has an id in one query and doesn't have it in another. Added id to all image objects inside topic and author articles

Here is the error we are receiving at the moment: 
```
Store error: the application attempted to write an object with no provided id but the store already contains an id of Image:d3494166-0c9b-4971-86c0-602892d5b11c for this object. The selectionSet that was trying to be written is:
```
Here is the related github issue for more details: https://github.com/apollographql/apollo-client/issues/2510