### PR TITLE
fix: Comma join topic names for analytics

### DIFF
--- a/packages/article-main-standard/__tests__/android/__snapshots__/tracking.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/tracking.android.test.js.snap
@@ -13,33 +13,7 @@ Object {
     "publishedTime": "2015-03-13T18:54:58.000Z",
     "section": "news",
     "template": "Default",
-    "topics": Array [
-      Object {
-        "__typename": "Topic",
-        "name": "Football",
-        "slug": "football",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Manchester United FC",
-        "slug": "manchester-united",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Chelsea FC",
-        "slug": "chelsea",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Arsenal",
-        "slug": "arsenal",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Rugby Union",
-        "slug": "rugby-union",
-      },
-    ],
+    "topics": "Football,Manchester United FC,Chelsea FC,Arsenal,Rugby Union",
   },
   "component": "Page",
   "object": "Article",

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/tracking.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/tracking.ios.test.js.snap
@@ -13,33 +13,7 @@ Object {
     "publishedTime": "2015-03-13T18:54:58.000Z",
     "section": "news",
     "template": "Default",
-    "topics": Array [
-      Object {
-        "__typename": "Topic",
-        "name": "Football",
-        "slug": "football",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Manchester United FC",
-        "slug": "manchester-united",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Chelsea FC",
-        "slug": "chelsea",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Arsenal",
-        "slug": "arsenal",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Rugby Union",
-        "slug": "rugby-union",
-      },
-    ],
+    "topics": "Football,Manchester United FC,Chelsea FC,Arsenal,Rugby Union",
   },
   "component": "Page",
   "object": "Article",

--- a/packages/article-main-standard/__tests__/web/__snapshots__/tracking.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/tracking.web.test.js.snap
@@ -13,33 +13,7 @@ Object {
     "publishedTime": "2015-03-13T18:54:58.000Z",
     "section": "news",
     "template": "Default",
-    "topics": Array [
-      Object {
-        "__typename": "Topic",
-        "name": "Football",
-        "slug": "football",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Manchester United FC",
-        "slug": "manchester-united",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Chelsea FC",
-        "slug": "chelsea",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Arsenal",
-        "slug": "arsenal",
-      },
-      Object {
-        "__typename": "Topic",
-        "name": "Rugby Union",
-        "slug": "rugby-union",
-      },
-    ],
+    "topics": "Football,Manchester United FC,Chelsea FC,Arsenal,Rugby Union",
   },
   "component": "Page",
   "object": "Article",

--- a/packages/article/src/article-tracking-context.js
+++ b/packages/article/src/article-tracking-context.js
@@ -12,7 +12,9 @@ export default Component =>
       publishedTime: get(data, "publishedTime", ""),
       section: pageSection || get(data, "section", ""),
       template: get(data, "template", "Default"),
-      topics: get(data, "topics")
+      topics: get(data, "topics", [])
+        .map(topic => topic.name)
+        .join(",")
     }),
     trackingObjectName: "Article"
   });


### PR DESCRIPTION
Right now we are sending the whole topic object, but the analytics team wants to see only the topic names. 

Part of Replat-4348