### PR TITLE
feat: Add referral url to article analytics

### DIFF
--- a/packages/article-main-standard/__tests__/android/__snapshots__/tracking.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/tracking.android.test.js.snap
@@ -11,6 +11,7 @@ Object {
     "label": "HURRICANE IRMA",
     "pageName": "france-defies-may-over-russia-37b27qd2s",
     "publishedTime": "2015-03-13T18:54:58.000Z",
+    "referralUrl": "thetimes.co.uk/article/dummy-article-url",
     "section": "news",
     "template": "Default",
     "topics": Array [

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/tracking.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/tracking.ios.test.js.snap
@@ -11,6 +11,7 @@ Object {
     "label": "HURRICANE IRMA",
     "pageName": "france-defies-may-over-russia-37b27qd2s",
     "publishedTime": "2015-03-13T18:54:58.000Z",
+    "referralUrl": "thetimes.co.uk/article/dummy-article-url",
     "section": "news",
     "template": "Default",
     "topics": Array [

--- a/packages/article-main-standard/__tests__/shared-tracking.js
+++ b/packages/article-main-standard/__tests__/shared-tracking.js
@@ -33,6 +33,7 @@ export default () => {
         onTwitterLinkPress={() => {}}
         onVideoPress={() => {}}
         pageSection="News"
+        referralUrl="thetimes.co.uk/article/dummy-article-url"
       />
     );
     const [[call]] = stream.mock.calls;

--- a/packages/article-main-standard/__tests__/web/__snapshots__/tracking.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/tracking.web.test.js.snap
@@ -11,6 +11,7 @@ Object {
     "label": "HURRICANE IRMA",
     "pageName": "france-defies-may-over-russia-37b27qd2s",
     "publishedTime": "2015-03-13T18:54:58.000Z",
+    "referralUrl": "",
     "section": "news",
     "template": "Default",
     "topics": Array [

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -88,7 +88,8 @@ class ArticlePage extends Component {
       onTwitterLinkPress,
       onVideoPress,
       onViewed,
-      receiveChildList
+      receiveChildList,
+      referralUrl
     } = this.props;
 
     return (
@@ -107,6 +108,7 @@ class ArticlePage extends Component {
         onVideoPress={onVideoPress}
         onViewableItemsChanged={onViewed ? this.onViewableItemsChanged : null}
         receiveChildList={receiveChildList}
+        referralUrl={referralUrl}
       />
     );
   }
@@ -120,8 +122,12 @@ ArticlePage.propTypes = {
   onLinkPress: PropTypes.func.isRequired,
   onTwitterLinkPress: PropTypes.func.isRequired,
   onVideoPress: PropTypes.func.isRequired,
+  referralUrl: PropTypes.string,
   refetch: PropTypes.func.isRequired
 };
-ArticlePage.defaultProps = articlePageDefaultProps;
+ArticlePage.defaultProps = {
+  ...articlePageDefaultProps,
+  referralUrl: null
+};
 
 export default ArticlePage;

--- a/packages/article/src/article-tracking-context.js
+++ b/packages/article/src/article-tracking-context.js
@@ -3,13 +3,14 @@ import { withTrackingContext } from "@times-components/tracking";
 
 export default Component =>
   withTrackingContext(Component, {
-    getAttrs: ({ data, pageSection }) => ({
+    getAttrs: ({ data, pageSection, referralUrl = "" }) => ({
       articleId: get(data, "id", ""),
       byline: get(data, "byline[0].children[0].attributes.value", ""),
       headline: get(data, "headline", ""),
       label: get(data, "label", ""),
       pageName: `${get(data, "slug", "")}-${get(data, "shortIdentifier", "")}`,
       publishedTime: get(data, "publishedTime", ""),
+      referralUrl,
       section: pageSection || get(data, "section", ""),
       template: get(data, "template", "Default"),
       topics: get(data, "topics")

--- a/packages/pages/__tests__/android/__snapshots__/pages.test.js.snap
+++ b/packages/pages/__tests__/android/__snapshots__/pages.test.js.snap
@@ -36,5 +36,6 @@ exports[`article page 1`] = `
   error={null}
   isLoading={true}
   pageSection="News"
+  referralUrl={null}
 />
 `;

--- a/packages/pages/__tests__/ios/__snapshots__/pages.test.js.snap
+++ b/packages/pages/__tests__/ios/__snapshots__/pages.test.js.snap
@@ -36,5 +36,6 @@ exports[`article page 1`] = `
   error={null}
   isLoading={true}
   pageSection="News"
+  referralUrl={null}
 />
 `;

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -36,10 +36,10 @@ const ArticleBase = ({
     isLoading || error
       ? {}
       : adTargetConfig({
-        adTestMode,
-        article,
-        sectionName: pageSection || articleSection || ""
-      });
+          adTestMode,
+          article,
+          sectionName: pageSection || articleSection || ""
+        });
   const theme = {
     scale: scale || defaults.theme.scale,
     sectionColour: colours.section[pageSection || articleSection || "default"]

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -24,6 +24,7 @@ const ArticleBase = ({
   article,
   error,
   isLoading,
+  referralUrl,
   refetch,
   omitErrors,
   scale,
@@ -35,10 +36,10 @@ const ArticleBase = ({
     isLoading || error
       ? {}
       : adTargetConfig({
-          adTestMode,
-          article,
-          sectionName: pageSection || articleSection || ""
-        });
+        adTestMode,
+        article,
+        sectionName: pageSection || articleSection || ""
+      });
   const theme = {
     scale: scale || defaults.theme.scale,
     sectionColour: colours.section[pageSection || articleSection || "default"]
@@ -77,6 +78,7 @@ const ArticleBase = ({
         onTwitterLinkPress={(_, { url }) => onLinkPress(url)}
         onVideoPress={(event, info) => onVideoPress(info)}
         pageSection={pageSection}
+        referralUrl={referralUrl}
         refetch={refetch}
       />
     </Context.Provider>

--- a/packages/pages/src/article/article-prop-types.js
+++ b/packages/pages/src/article/article-prop-types.js
@@ -5,6 +5,7 @@ export const propTypes = {
   error: PropTypes.shape({}),
   isLoading: PropTypes.bool,
   omitErrors: PropTypes.bool,
+  referralUrl: PropTypes.string,
   refetch: PropTypes.func,
   scale: PropTypes.string,
   sectionName: PropTypes.string,
@@ -16,7 +17,8 @@ export const defaultProps = {
   error: null,
   isLoading: false,
   omitErrors: false,
-  refetch: () => {},
+  referralUrl: null,
+  refetch: () => { },
   scale: null,
   sectionName: null,
   showInteractives: false

--- a/packages/pages/src/article/article-prop-types.js
+++ b/packages/pages/src/article/article-prop-types.js
@@ -18,7 +18,7 @@ export const defaultProps = {
   isLoading: false,
   omitErrors: false,
   referralUrl: null,
-  refetch: () => { },
+  refetch: () => {},
   scale: null,
   sectionName: null,
   showInteractives: false


### PR DESCRIPTION
Analytics team wants to get the referralUrl whenever user launches an article through deeplinking, especially to see query params such as utm_tracking etc.

This "referralUrl" is passed through the native apps into our article component. 
Part of the Replat-4348 ticket
