### PR TITLE
fix: pull quotes markup

### DIFF
--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -171,7 +171,9 @@ exports[`full article with style 1`] = `
     </View>
     <View>
       <View>
-        <PullQuote />
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -170,7 +170,9 @@ exports[`full article with style 1`] = `
     </View>
     <View>
       <View>
-        <PullQuote />
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article-main-comment/__tests__/shared-with-style.native.js
+++ b/packages/article-main-comment/__tests__/shared-with-style.native.js
@@ -75,11 +75,19 @@ export default () => {
           attributes: {
             caption: {
               name: "AName",
+              text: "a text",
               twitter: "@AName"
-            },
-            content: "A pull quote"
+            }
           },
-          children: [],
+          children: [
+            {
+              attributes: {
+                value: "The pull quote content"
+              },
+              children: [],
+              name: "text"
+            }
+          ],
           name: "pullQuote"
         },
         {

--- a/packages/article-main-comment/__tests__/shared-with-style.web.js
+++ b/packages/article-main-comment/__tests__/shared-with-style.web.js
@@ -98,11 +98,19 @@ export default () => {
           attributes: {
             caption: {
               name: "AName",
+              text: "a text",
               twitter: "@AName"
-            },
-            content: "A pull quote"
+            }
           },
-          children: [],
+          children: [
+            {
+              attributes: {
+                value: "The pull quote content"
+              },
+              children: [],
+              name: "text"
+            }
+          ],
           name: "pullQuote"
         },
         {

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -81,10 +81,11 @@ exports[`1. a full article 1`] = `
     url="https://twitter.com/@AName"
   >
     “
-    A pull quote
     <cite>
-      AName
+      The pull quote content
     </cite>
+    AName
+    , a text
     <svg
       aria-label="[title]"
       height={10}

--- a/packages/article-main-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-comment/__tests__/web/semantic.web.test.js
@@ -90,11 +90,19 @@ const tests = [
             attributes: {
               caption: {
                 name: "AName",
+                text: "a text",
                 twitter: "@AName"
-              },
-              content: "A pull quote"
+              }
             },
-            children: [],
+            children: [
+              {
+                attributes: {
+                  value: "The pull quote content"
+                },
+                children: [],
+                name: "text"
+              }
+            ],
             name: "pullQuote"
           },
           {

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-lead-asset.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-lead-asset.android.test.js.snap
@@ -116,9 +116,13 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       <View>
         <PullQuote
           caption="AName"
-          content="A pull quote"
+          captionColour="#333333"
+          quoteColour="#333333"
+          text="a text"
           twitter="@AName"
-        />
+        >
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -185,7 +185,9 @@ exports[`full article with style 1`] = `
     </View>
     <View>
       <View>
-        <PullQuote />
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-lead-asset.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-lead-asset.ios.test.js.snap
@@ -116,9 +116,13 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       <View>
         <PullQuote
           caption="AName"
-          content="A pull quote"
+          captionColour="#333333"
+          quoteColour="#333333"
+          text="a text"
           twitter="@AName"
-        />
+        >
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -183,7 +183,9 @@ exports[`full article with style 1`] = `
     </View>
     <View>
       <View>
-        <PullQuote />
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article-main-standard/__tests__/shared-lead-asset.base.js
+++ b/packages/article-main-standard/__tests__/shared-lead-asset.base.js
@@ -79,11 +79,11 @@ export const snapshotTests = renderComponent => [
             },
             children: [
               {
-                "name": "text",
-                "attributes": {
-                  "value": "The pull quote content"
+                attributes: {
+                  value: "The pull quote content"
                 },
-                "children": []
+                children: [],
+                name: "text"
               }
             ],
             name: "pullQuote"

--- a/packages/article-main-standard/__tests__/shared-lead-asset.base.js
+++ b/packages/article-main-standard/__tests__/shared-lead-asset.base.js
@@ -73,11 +73,19 @@ export const snapshotTests = renderComponent => [
             attributes: {
               caption: {
                 name: "AName",
+                text: "a text",
                 twitter: "@AName"
-              },
-              content: "A pull quote"
+              }
             },
-            children: [],
+            children: [
+              {
+                "name": "text",
+                "attributes": {
+                  "value": "The pull quote content"
+                },
+                "children": []
+              }
+            ],
             name: "pullQuote"
           },
           {

--- a/packages/article-main-standard/__tests__/shared-with-style.native.js
+++ b/packages/article-main-standard/__tests__/shared-with-style.native.js
@@ -73,11 +73,19 @@ export default () => {
           attributes: {
             caption: {
               name: "AName",
+              text: "a text",
               twitter: "@AName"
-            },
-            content: "A pull quote"
+            }
           },
-          children: [],
+          children: [
+            {
+              "name": "text",
+              "attributes": {
+                "value": "The pull quote content"
+              },
+              "children": []
+            }
+          ],
           name: "pullQuote"
         },
         {

--- a/packages/article-main-standard/__tests__/shared-with-style.native.js
+++ b/packages/article-main-standard/__tests__/shared-with-style.native.js
@@ -79,11 +79,11 @@ export default () => {
           },
           children: [
             {
-              "name": "text",
-              "attributes": {
-                "value": "The pull quote content"
+              attributes: {
+                value: "The pull quote content"
               },
-              "children": []
+              children: [],
+              name: "text"
             }
           ],
           name: "pullQuote"

--- a/packages/article-main-standard/__tests__/shared-with-style.web.js
+++ b/packages/article-main-standard/__tests__/shared-with-style.web.js
@@ -96,11 +96,19 @@ export default () => {
           attributes: {
             caption: {
               name: "AName",
+              text: "a text",
               twitter: "@AName"
-            },
-            content: "A pull quote"
+            }
           },
-          children: [],
+          children: [
+            {
+              "name": "text",
+              "attributes": {
+                "value": "The pull quote content"
+              },
+              "children": []
+            }
+          ],
           name: "pullQuote"
         },
         {

--- a/packages/article-main-standard/__tests__/shared-with-style.web.js
+++ b/packages/article-main-standard/__tests__/shared-with-style.web.js
@@ -102,11 +102,11 @@ export default () => {
           },
           children: [
             {
-              "name": "text",
-              "attributes": {
-                "value": "The pull quote content"
+              attributes: {
+                value: "The pull quote content"
               },
-              "children": []
+              children: [],
+              name: "text"
             }
           ],
           name: "pullQuote"

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-lead-asset.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-lead-asset.web.test.js.snap
@@ -146,9 +146,13 @@ exports[`1. a full article with an image as the lead asset 1`] = `
         <div>
           <PullQuote
             caption="AName"
-            content="A pull quote"
+            captionColour="#333333"
+            quoteColour="#333333"
+            text="a text"
             twitter="@AName"
-          />
+          >
+            The pull quote content
+          </PullQuote>
         </div>
       </div>
       <div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -688,7 +688,9 @@ exports[`full article with style 1`] = `
         <div
           className="c16 S1"
         >
-          <PullQuote />
+          <PullQuote>
+            The pull quote content
+          </PullQuote>
         </div>
       </div>
       <div

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -100,10 +100,11 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     url="https://twitter.com/@AName"
   >
     “
-    A pull quote
     <cite>
-      AName
+      The pull quote content
     </cite>
+    AName
+    , a text
     <svg
       aria-label="[title]"
       height={10}

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -96,11 +96,11 @@ const tests = [
             },
             children: [
               {
-                "name": "text",
-                "attributes": {
-                  "value": "The pull quote content"
+                attributes: {
+                  value: "The pull quote content"
                 },
-                "children": []
+                children: [],
+                name: "text"
               }
             ],
             name: "pullQuote"

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -90,11 +90,19 @@ const tests = [
             attributes: {
               caption: {
                 name: "AName",
+                text: "a text",
                 twitter: "@AName"
-              },
-              content: "A pull quote"
+              }
             },
-            children: [],
+            children: [
+              {
+                "name": "text",
+                "attributes": {
+                  "value": "The pull quote content"
+                },
+                "children": []
+              }
+            ],
             name: "pullQuote"
           },
           {

--- a/packages/article/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -76,7 +76,9 @@ exports[`1. a full article with all content items 1`] = `
     </View>
     <View>
       <View>
-        <PullQuote />
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -149,7 +149,8 @@ exports[`1. a full article with all content items 1`] = `
       <View>
         <PullQuote
           caption="AName"
-          content="A pull quote"
+          captionColour="#FF0000"
+          quoteColour="#FF0000"
           twitter="@AName"
         />
       </View>

--- a/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -151,8 +151,11 @@ exports[`1. a full article with all content items 1`] = `
           caption="AName"
           captionColour="#FF0000"
           quoteColour="#FF0000"
+          text="a text"
           twitter="@AName"
-        />
+        >
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -76,7 +76,9 @@ exports[`1. a full article with all content items 1`] = `
     </View>
     <View>
       <View>
-        <PullQuote />
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -149,7 +149,8 @@ exports[`1. a full article with all content items 1`] = `
       <View>
         <PullQuote
           caption="AName"
-          content="A pull quote"
+          captionColour="#FF0000"
+          quoteColour="#FF0000"
           twitter="@AName"
         />
       </View>

--- a/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -151,8 +151,11 @@ exports[`1. a full article with all content items 1`] = `
           caption="AName"
           captionColour="#FF0000"
           quoteColour="#FF0000"
+          text="a text"
           twitter="@AName"
-        />
+        >
+          The pull quote content
+        </PullQuote>
       </View>
     </View>
     <View>

--- a/packages/article/__tests__/shared-with-style.web.js
+++ b/packages/article/__tests__/shared-with-style.web.js
@@ -155,11 +155,19 @@ export default () => {
               attributes: {
                 caption: {
                   name: "AName",
+                  text: "a text",
                   twitter: "@AName"
-                },
-                content: "A pull quote"
+                }
               },
-              children: [],
+              children: [
+                {
+                  attributes: {
+                    value: "The pull quote content"
+                  },
+                  children: [],
+                  name: "text"
+                }
+              ],
               name: "pullQuote"
             },
             {

--- a/packages/article/__tests__/shared.base.js
+++ b/packages/article/__tests__/shared.base.js
@@ -143,11 +143,19 @@ export const snapshotTests = renderComponent => [
             attributes: {
               caption: {
                 name: "AName",
+                text: "a text",
                 twitter: "@AName"
-              },
-              content: "A pull quote"
+              }
             },
-            children: [],
+            children: [
+              {
+                attributes: {
+                  value: "The pull quote content"
+                },
+                children: [],
+                name: "text"
+              }
+            ],
             name: "pullQuote"
           },
           {

--- a/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -387,7 +387,9 @@ exports[`full article with style 1`] = `
           <div
             className="c10 S1"
           >
-            <PullQuote />
+            <PullQuote>
+              The pull quote content
+            </PullQuote>
           </div>
         </div>
         <div

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -117,8 +117,11 @@ exports[`1. a full article with all content items 1`] = `
             caption="AName"
             captionColour="#FF0000"
             quoteColour="#FF0000"
+            text="a text"
             twitter="@AName"
-          />
+          >
+            The pull quote content
+          </PullQuote>
         </div>
       </div>
       <div>

--- a/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -115,7 +115,8 @@ exports[`1. a full article with all content items 1`] = `
         <div>
           <PullQuote
             caption="AName"
-            content="A pull quote"
+            captionColour="#FF0000"
+            quoteColour="#FF0000"
             twitter="@AName"
           />
         </div>

--- a/packages/article/src/article-body/article-body-row.js
+++ b/packages/article/src/article-body/article-body-row.js
@@ -118,7 +118,6 @@ const ArticleRow = ({
                 <PullQuote
                   caption={name}
                   captionColour={sectionColour || colours.section.default}
-                  key={key}
                   onTwitterLinkPress={onTwitterLinkPress}
                   quoteColour={sectionColour || colours.section.default}
                   text={text}

--- a/packages/article/src/article-body/article-body-row.js
+++ b/packages/article/src/article-body/article-body-row.js
@@ -4,11 +4,13 @@ import PropTypes from "prop-types";
 import ArticleImage from "@times-components/article-image";
 import ArticleParagraph from "@times-components/article-paragraph";
 import Ad from "@times-components/ad";
+import Context from "@times-components/context";
 import InteractiveWrapper from "@times-components/interactive-wrapper";
 import KeyFacts from "@times-components/key-facts";
 import { renderTree } from "@times-components/markup-forest";
 import coreRenderers from "@times-components/markup";
 import PullQuote from "@times-components/pull-quote";
+import { colours } from "@times-components/styleguide";
 import Video from "@times-components/video";
 import ArticleLink from "./article-link";
 import InsetCaption from "./inset-caption";
@@ -104,21 +106,29 @@ const ArticleRow = ({
     pullQuote(
       key,
       {
-        content,
-        caption: { name, twitter }
-      }
+        caption: { name, text, twitter }
+      },
+      children
     ) {
       return {
         element: (
-          <View key={key}>
-            <PullQuote
-              caption={name}
-              content={content}
-              key={key}
-              onTwitterLinkPress={onTwitterLinkPress}
-              twitter={twitter}
-            />
-          </View>
+          <Context.Consumer>
+            {({ theme: { sectionColour } }) => (
+              <View key={key}>
+                <PullQuote
+                  caption={name}
+                  captionColour={sectionColour || colours.section.default}
+                  key={key}
+                  onTwitterLinkPress={onTwitterLinkPress}
+                  quoteColour={sectionColour || colours.section.default}
+                  text={text}
+                  twitter={twitter}
+                >
+                  {children}
+                </PullQuote>
+              </View>
+            )}
+          </Context.Consumer>
         )
       };
     },

--- a/packages/article/src/article-body/article-body-row.js
+++ b/packages/article/src/article-body/article-body-row.js
@@ -78,7 +78,7 @@ const ArticleRow = ({
       return {
         element: (
           <ArticleLink
-            key={index}
+            key={key}
             onPress={e =>
               onLinkPress(e, {
                 canonicalId: attributes.canonicalId,
@@ -97,7 +97,7 @@ const ArticleRow = ({
     paragraph(key, attributes, children, indx, node) {
       return {
         element: (
-          <ArticleParagraph ast={node} key={index} uid={index}>
+          <ArticleParagraph ast={node} key={key} uid={index}>
             {children}
           </ArticleParagraph>
         )
@@ -112,9 +112,9 @@ const ArticleRow = ({
     ) {
       return {
         element: (
-          <Context.Consumer>
+          <Context.Consumer key={key}>
             {({ theme: { sectionColour } }) => (
-              <View key={key}>
+              <View>
                 <PullQuote
                   caption={name}
                   captionColour={sectionColour || colours.section.default}

--- a/packages/article/src/article-body/article-body.web.js
+++ b/packages/article/src/article-body/article-body.web.js
@@ -49,12 +49,9 @@ const renderers = ({ observed, registerNode }) => ({
   dropCap(key, { value }) {
     return {
       element: (
-        <Context.Consumer>
+        <Context.Consumer key={key}>
           {({ theme: { sectionColour } }) => (
-            <DropCapView
-              colour={sectionColour || colours.section.default}
-              key={key}
-            >
+            <DropCapView colour={sectionColour || colours.section.default}>
               {value}
             </DropCapView>
           )}
@@ -143,9 +140,9 @@ const renderers = ({ observed, registerNode }) => ({
   ) {
     return {
       element: (
-        <Context.Consumer>
+        <Context.Consumer key={key}>
           {({ theme: { sectionColour } }) => (
-            <PullQuoteContainer key={key}>
+            <PullQuoteContainer>
               <PullQuoteResp>
                 <PullQuote
                   caption={name}

--- a/packages/article/src/article-body/article-body.web.js
+++ b/packages/article/src/article-body/article-body.web.js
@@ -137,17 +137,29 @@ const renderers = ({ observed, registerNode }) => ({
   pullQuote(
     key,
     {
-      content,
-      caption: { name, twitter }
-    }
+      caption: { name, text, twitter }
+    },
+    children
   ) {
     return {
       element: (
-        <PullQuoteContainer key={key}>
-          <PullQuoteResp>
-            <PullQuote caption={name} content={content} twitter={twitter} />
-          </PullQuoteResp>
-        </PullQuoteContainer>
+        <Context.Consumer>
+          {({ theme: { sectionColour } }) => (
+            <PullQuoteContainer key={key}>
+              <PullQuoteResp>
+                <PullQuote
+                  caption={name}
+                  captionColour={sectionColour || colours.section.default}
+                  quoteColour={sectionColour || colours.section.default}
+                  text={text}
+                  twitter={twitter}
+                >
+                  {children}
+                </PullQuote>
+              </PullQuoteResp>
+            </PullQuoteContainer>
+          )}
+        </Context.Consumer>
       )
     };
   },

--- a/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes-with-style.android.test.js.snap
+++ b/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes-with-style.android.test.js.snap
@@ -60,6 +60,19 @@ exports[`different colours 1`] = `
     >
       A caption
     </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 13,
+          "lineHeight": 13,
+          "marginBottom": 0,
+        }
+      }
+    >
+      
+    </Text>
     <View
       style={
         Object {

--- a/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes.android.test.js.snap
+++ b/packages/pull-quote/__tests__/android/__snapshots__/pull-quotes.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. with a caption 1`] = `
+exports[`1. with a caption and a text 1`] = `
 <View>
   <Text>
     “
@@ -12,11 +12,14 @@ exports[`1. with a caption 1`] = `
     <Text>
       A caption
     </Text>
+    <Text>
+      , Some extra text
+    </Text>
   </View>
 </View>
 `;
 
-exports[`2. without a caption 1`] = `
+exports[`2. with a caption but no text 1`] = `
 <View>
   <Text>
     “
@@ -28,11 +31,52 @@ exports[`2. without a caption 1`] = `
     <Text>
       
     </Text>
+    <Text>
+      Some extra text
+    </Text>
   </View>
 </View>
 `;
 
-exports[`3. with a twitter handle 1`] = `
+exports[`3. with a text but no caption 1`] = `
+<View>
+  <Text>
+    “
+  </Text>
+  <Text>
+    Some content
+  </Text>
+  <View>
+    <Text>
+      
+    </Text>
+    <Text>
+      Some extra text
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`4. without a caption or a text 1`] = `
+<View>
+  <Text>
+    “
+  </Text>
+  <Text>
+    Some content
+  </Text>
+  <View>
+    <Text>
+      
+    </Text>
+    <Text>
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`5. with a twitter handle 1`] = `
 <View>
   <Text>
     “
@@ -43,6 +87,9 @@ exports[`3. with a twitter handle 1`] = `
   <View>
     <Text>
       A caption
+    </Text>
+    <Text>
+      
     </Text>
     <View>
       <IconTwitter

--- a/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes-with-style.ios.test.js.snap
+++ b/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes-with-style.ios.test.js.snap
@@ -63,6 +63,20 @@ exports[`different colours 1`] = `
     >
       A caption
     </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 13,
+          "lineHeight": 13,
+          "marginBottom": 0,
+          "paddingTop": 4,
+        }
+      }
+    >
+      
+    </Text>
     <View
       style={
         Object {

--- a/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes.ios.test.js.snap
+++ b/packages/pull-quote/__tests__/ios/__snapshots__/pull-quotes.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. with a caption 1`] = `
+exports[`1. with a caption and a text 1`] = `
 <View>
   <Text>
     “
@@ -12,11 +12,14 @@ exports[`1. with a caption 1`] = `
     <Text>
       A caption
     </Text>
+    <Text>
+      , Some extra text
+    </Text>
   </View>
 </View>
 `;
 
-exports[`2. without a caption 1`] = `
+exports[`2. with a caption but no text 1`] = `
 <View>
   <Text>
     “
@@ -28,11 +31,52 @@ exports[`2. without a caption 1`] = `
     <Text>
       
     </Text>
+    <Text>
+      Some extra text
+    </Text>
   </View>
 </View>
 `;
 
-exports[`3. with a twitter handle 1`] = `
+exports[`3. with a text but no caption 1`] = `
+<View>
+  <Text>
+    “
+  </Text>
+  <Text>
+    Some content
+  </Text>
+  <View>
+    <Text>
+      
+    </Text>
+    <Text>
+      Some extra text
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`4. without a caption or a text 1`] = `
+<View>
+  <Text>
+    “
+  </Text>
+  <Text>
+    Some content
+  </Text>
+  <View>
+    <Text>
+      
+    </Text>
+    <Text>
+      
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`5. with a twitter handle 1`] = `
 <View>
   <Text>
     “
@@ -43,6 +87,9 @@ exports[`3. with a twitter handle 1`] = `
   <View>
     <Text>
       A caption
+    </Text>
+    <Text>
+      
     </Text>
     <View>
       <IconTwitter

--- a/packages/pull-quote/__tests__/shared-with-style.base.js
+++ b/packages/pull-quote/__tests__/shared-with-style.base.js
@@ -11,11 +11,12 @@ export default renderComponent => {
       <PullQuotes
         caption={caption}
         captionColour="#850029"
-        content={content}
         onTwitterLinkPress={() => null}
         quoteColour="#850029"
         twitter={twitter}
-      />
+      >
+        {content}
+      </PullQuotes>
     );
 
     expect(output).toMatchSnapshot();

--- a/packages/pull-quote/__tests__/shared.base.js
+++ b/packages/pull-quote/__tests__/shared.base.js
@@ -6,29 +6,56 @@ import PullQuoteTwitterLink from "../src/pull-quote-twitter-link";
 
 const content = "Some content";
 const caption = "A caption";
+const text = "Some extra text";
 const twitter = "@twitter";
 
 export default renderComponent => {
   const tests = [
     {
-      name: "with a caption",
+      name: "with a caption and a text",
       test() {
         const output = renderComponent(
           <PullQuotes
             caption={caption}
-            content={content}
             onTwitterLinkPress={() => null}
-          />
+            text={text}
+          >
+            {content}
+          </PullQuotes>
         );
 
         expect(output).toMatchSnapshot();
       }
     },
     {
-      name: "without a caption",
+      name: "with a caption but no text",
       test() {
         const output = renderComponent(
-          <PullQuotes content={content} onTwitterLinkPress={() => null} />
+          <PullQuotes onTwitterLinkPress={() => null} text={text}>
+            {content}
+          </PullQuotes>
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "with a text but no caption",
+      test() {
+        const output = renderComponent(
+          <PullQuotes onTwitterLinkPress={() => null} text={text}>
+            {content}
+          </PullQuotes>
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "without a caption or a text",
+      test() {
+        const output = renderComponent(
+          <PullQuotes onTwitterLinkPress={() => null}>{content}</PullQuotes>
         );
 
         expect(output).toMatchSnapshot();
@@ -40,10 +67,11 @@ export default renderComponent => {
         const output = renderComponent(
           <PullQuotes
             caption={caption}
-            content={content}
             onTwitterLinkPress={() => null}
             twitter={twitter}
-          />
+          >
+            {content}
+          </PullQuotes>
         );
 
         expect(output).toMatchSnapshot();

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
@@ -54,6 +54,19 @@ exports[`different colours 1`] = `
 }
 
 .S4 {
+  border-left-width: 0px;
+  color: rgba(105,105,105,1.00);
+  display: inline;
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  line-height: 13px;
+  margin-top: 0px;
+  margin-left: 0px;
+  margin-bottom: 0px;
+  padding-left: 0px;
+}
+
+.S5 {
   -ms-flex-align: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -73,7 +86,7 @@ exports[`different colours 1`] = `
   padding-left: 7px;
 }
 
-.S5 {
+.S6 {
   -ms-flex-align: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -92,7 +105,7 @@ exports[`different colours 1`] = `
   padding-left: 0px;
 }
 
-.S6 {
+.S7 {
   -ms-flex-align: stretch;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -132,7 +145,7 @@ exports[`different colours 1`] = `
   url="https://twitter.com/@twitter"
 >
   <div
-    className="S6"
+    className="S7"
   >
     <div
       className="IS1 S1"
@@ -142,20 +155,25 @@ exports[`different colours 1`] = `
     <div
       className="c0 S2"
     >
-      Some content
+      <cite>
+        Some content
+      </cite>
     </div>
     <div
-      className="S5"
+      className="S6"
     >
       <div
         className="IS2 S3"
       >
-        <cite>
-          A caption
-        </cite>
+        A caption
       </div>
       <div
         className="S4"
+      >
+        
+      </div>
+      <div
+        className="S5"
       >
         <IconTwitter
           height={10}

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. with a caption 1`] = `
+exports[`1. with a caption and a text 1`] = `
 <blockquote
   url=""
 >
@@ -9,20 +9,23 @@ exports[`1. with a caption 1`] = `
       “
     </div>
     <div>
-      Some content
+      <cite>
+        Some content
+      </cite>
     </div>
     <div>
       <div>
-        <cite>
-          A caption
-        </cite>
+        A caption
+      </div>
+      <div>
+        , Some extra text
       </div>
     </div>
   </div>
 </blockquote>
 `;
 
-exports[`2. without a caption 1`] = `
+exports[`2. with a caption but no text 1`] = `
 <blockquote
   url=""
 >
@@ -31,20 +34,73 @@ exports[`2. without a caption 1`] = `
       “
     </div>
     <div>
-      Some content
+      <cite>
+        Some content
+      </cite>
     </div>
     <div>
       <div>
-        <cite>
-          
-        </cite>
+        
+      </div>
+      <div>
+        Some extra text
       </div>
     </div>
   </div>
 </blockquote>
 `;
 
-exports[`3. with a twitter handle 1`] = `
+exports[`3. with a text but no caption 1`] = `
+<blockquote
+  url=""
+>
+  <div>
+    <div>
+      “
+    </div>
+    <div>
+      <cite>
+        Some content
+      </cite>
+    </div>
+    <div>
+      <div>
+        
+      </div>
+      <div>
+        Some extra text
+      </div>
+    </div>
+  </div>
+</blockquote>
+`;
+
+exports[`4. without a caption or a text 1`] = `
+<blockquote
+  url=""
+>
+  <div>
+    <div>
+      “
+    </div>
+    <div>
+      <cite>
+        Some content
+      </cite>
+    </div>
+    <div>
+      <div>
+        
+      </div>
+      <div>
+        
+      </div>
+    </div>
+  </div>
+</blockquote>
+`;
+
+exports[`5. with a twitter handle 1`] = `
 <blockquote
   url="https://twitter.com/@twitter"
 >
@@ -53,13 +109,16 @@ exports[`3. with a twitter handle 1`] = `
       “
     </div>
     <div>
-      Some content
+      <cite>
+        Some content
+      </cite>
     </div>
     <div>
       <div>
-        <cite>
-          A caption
-        </cite>
+        A caption
+      </div>
+      <div>
+        
       </div>
       <div>
         <IconTwitter

--- a/packages/pull-quote/pull-quote.showcase.js
+++ b/packages/pull-quote/pull-quote.showcase.js
@@ -13,6 +13,7 @@ const preventDefaultedAction = decorateAction =>
 const content =
   "[The judgement was] taken because of the evidence available in the court today, that the grandmother is an appropriate carer for the child";
 const caption = "Judge Sapnara";
+const title = "Author";
 const twitter = "@henrywinter";
 
 export default {
@@ -22,13 +23,15 @@ export default {
         <PullQuotes
           caption={text("Caption: ", caption)}
           captionColour={color("Caption Colour: ", "#850029")}
-          content={text("Content: ", content)}
           onTwitterLinkPress={preventDefaultedAction(decorateAction)(
             "onTwitterLinkPress"
           )}
           quoteColour={color("Quote Colour: ", "#850029")}
+          text={text("Title: ", title)}
           twitter={text("Twitter Link: ", twitter)}
-        />
+        >
+          {text("Content: ", content)}
+        </PullQuotes>
       ),
       name: "Default",
       type: "story"

--- a/packages/pull-quote/src/pull-quote-content.js
+++ b/packages/pull-quote/src/pull-quote-content.js
@@ -8,7 +8,7 @@ const PullQuoteContent = ({ children }) => (
 );
 
 PullQuoteContent.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired
 };
 
 export default PullQuoteContent;

--- a/packages/pull-quote/src/pull-quote-content.js
+++ b/packages/pull-quote/src/pull-quote-content.js
@@ -8,7 +8,7 @@ const PullQuoteContent = ({ children }) => (
 );
 
 PullQuoteContent.propTypes = {
-  children: PropTypes.string.isRequired
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
 };
 
 export default PullQuoteContent;

--- a/packages/pull-quote/src/pull-quote-prop-types.js
+++ b/packages/pull-quote/src/pull-quote-prop-types.js
@@ -8,9 +8,10 @@ import {
 export const propTypes = {
   caption: PropTypes.string,
   captionColour: PropTypes.string,
-  content: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
   onTwitterLinkPress: twitterPropTypes.onTwitterLinkPress,
   quoteColour: PropTypes.string,
+  text: PropTypes.string,
   twitter: twitterPropTypes.twitter
 };
 
@@ -18,5 +19,6 @@ export const defaultProps = {
   caption: "",
   captionColour: colours.functional.secondary,
   quoteColour: colours.functional.secondary,
+  text: "",
   twitter: twitterDefaultTypes.twitter
 };

--- a/packages/pull-quote/src/pull-quote.base.js
+++ b/packages/pull-quote/src/pull-quote.base.js
@@ -6,18 +6,20 @@ import { propTypes, defaultProps } from "./pull-quote-prop-types";
 import styles from "./styles";
 
 const PullQuotes = ({
+  caption,
   captionColour,
   children,
-  content,
   onTwitterLinkPress,
   quoteColour,
+  text,
   twitter
 }) => (
   <View style={styles.container}>
     <Text style={[styles.quotes, { color: quoteColour }]}>&ldquo;</Text>
-    <PullQuoteContent>{content}</PullQuoteContent>
+    <PullQuoteContent>{children}</PullQuoteContent>
     <View style={styles.captionContainer}>
-      <Text style={[styles.caption, { color: captionColour }]}>{children}</Text>
+      <Text style={[styles.caption, { color: captionColour }]}>{caption}</Text>
+      <Text style={styles.text}>{caption && text ? `, ${text}` : text}</Text>
       <PullQuoteTwitterLink
         onTwitterLinkPress={onTwitterLinkPress}
         twitter={twitter}

--- a/packages/pull-quote/src/pull-quote.js
+++ b/packages/pull-quote/src/pull-quote.js
@@ -2,8 +2,8 @@ import React from "react";
 import PullQuoteBase from "./pull-quote.base";
 import { propTypes, defaultProps } from "./pull-quote-prop-types";
 
-const PullQuote = ({ caption, ...props }) => (
-  <PullQuoteBase {...props}>{caption}</PullQuoteBase>
+const PullQuote = ({ children, ...props }) => (
+  <PullQuoteBase {...props}>{children}</PullQuoteBase>
 );
 
 PullQuote.propTypes = propTypes;

--- a/packages/pull-quote/src/pull-quote.js
+++ b/packages/pull-quote/src/pull-quote.js
@@ -1,12 +1,3 @@
-import React from "react";
 import PullQuoteBase from "./pull-quote.base";
-import { propTypes, defaultProps } from "./pull-quote-prop-types";
 
-const PullQuote = ({ children, ...props }) => (
-  <PullQuoteBase {...props}>{children}</PullQuoteBase>
-);
-
-PullQuote.propTypes = propTypes;
-PullQuote.defaultProps = defaultProps;
-
-export default PullQuote;
+export default PullQuoteBase;

--- a/packages/pull-quote/src/pull-quote.web.js
+++ b/packages/pull-quote/src/pull-quote.web.js
@@ -3,12 +3,12 @@ import PullQuoteBase from "./pull-quote.base";
 import makeTwitterUrl from "./utils";
 import { propTypes, defaultProps } from "./pull-quote-prop-types";
 
-const PullQuote = ({ caption, ...props }) => {
+const PullQuote = ({ children, ...props }) => {
   const { twitter } = props;
   return (
     <blockquote url={twitter ? makeTwitterUrl(twitter) : ""}>
       <PullQuoteBase {...props}>
-        <cite>{caption}</cite>
+        <cite>{children}</cite>
       </PullQuoteBase>
     </blockquote>
   );

--- a/packages/pull-quote/src/styles/index.js
+++ b/packages/pull-quote/src/styles/index.js
@@ -20,6 +20,10 @@ const styles = StyleSheet.create({
   link: {
     ...sharedStyles.link,
     paddingTop: 2
+  },
+  text: {
+    ...sharedStyles.text,
+    paddingTop: 4
   }
 });
 

--- a/packages/pull-quote/src/styles/shared.js
+++ b/packages/pull-quote/src/styles/shared.js
@@ -42,6 +42,14 @@ const sharedStyles = {
     marginBottom: spacing(-8),
     marginTop: 0
   },
+  text: {
+    ...fontFactory({
+      font: "supporting",
+      fontSize: "caption"
+    }),
+    color: colours.functional.secondary,
+    marginBottom: 0
+  },
   twitterContainer: {
     alignItems: "center",
     borderLeftColor: colours.functional.keyline,


### PR DESCRIPTION
A couple of features were missing in the pull-quotes. 

Added features:
- Support markups inside pull-quotes
- Add "text" field that's used in the ast for extra caption text
- Added section colouring to the pull-quote quotation marks and caption

Also fixed the keys inside article body to clear up the warnings

![screen shot 2018-11-16 at 16 13 11](https://user-images.githubusercontent.com/1849590/48633262-e16ce880-e9ba-11e8-8153-4c991473273f.png)
![screenshot_1542385151](https://user-images.githubusercontent.com/1849590/48633524-68ba5c00-e9bb-11e8-8e6e-13310cadb98b.png)
