### PR TITLE
refactor: bump airbnb lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "dashify": "0.2.2",
     "dextrose": "4.0.7",
     "eslint": "5.9.0",
-    "eslint-config-airbnb": "16.1.0",
+    "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "3.3.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.2",

--- a/packages/ad/src/ad.js
+++ b/packages/ad/src/ad.js
@@ -54,7 +54,7 @@ class Ad extends Component {
       slotName,
       style
     } = this.props;
-    const { hasError, isAdReady, windowWidth } = this.state;
+    const { config, hasError, isAdReady, windowWidth } = this.state;
 
     if (hasError) return null;
 
@@ -69,7 +69,7 @@ class Ad extends Component {
 
     const data = {
       adUnit: adConfig.adUnit,
-      config: this.state.config,
+      config,
       contextUrl,
       networkId: adConfig.networkId,
       pageTargeting: adConfig.pageTargeting,
@@ -81,7 +81,7 @@ class Ad extends Component {
         timeout: adConfig.biddersConfig.timeout
       }),
       section,
-      sizingMap: this.state.config.mappings,
+      sizingMap: config.mappings,
       slotName,
       slots: this.slots,
       slotTargeting: adConfig.slotTargeting
@@ -90,8 +90,8 @@ class Ad extends Component {
     const sizeProps = !isAdReady
       ? { height: 0, width: 0 }
       : {
-          height: this.state.config.maxSizes.height,
-          width: this.state.config.maxSizes.width
+          height: config.maxSizes.height,
+          width: config.maxSizes.width
         };
 
     const AdComponent = (
@@ -107,9 +107,9 @@ class Ad extends Component {
 
     const AdPlaceholderComponent = (
       <AdPlaceholder
-        height={this.state.config.maxSizes.height}
+        height={config.maxSizes.height}
         style={styles.children}
-        width={this.state.config.maxSizes.width}
+        width={config.maxSizes.width}
       />
     );
 

--- a/packages/ad/src/dom-context.js
+++ b/packages/ad/src/dom-context.js
@@ -20,6 +20,7 @@ class DOMContext extends PureComponent {
   }
 
   handleMessageEvent = e => {
+    const { onRenderComplete } = this.props;
     const json = e.nativeEvent.data;
     if (json.indexOf("isTngMessage") === -1) {
       // don't try and process postMessage events from 3rd party scripts
@@ -31,17 +32,18 @@ class DOMContext extends PureComponent {
       throw new Error(`Error inside WebView: ${detail}`);
     }
     if (type === "renderComplete") {
-      this.props.onRenderComplete();
+      onRenderComplete();
     } else if (type === "log") {
       console.log(detail); // eslint-disable-line no-console
     }
   };
 
   handleNavigationStateChange = ({ url }) => {
+    const { baseUrl } = this.props;
     const reactPostmessageBridgePrefix = "react-js-navigation://";
     if (
       url.indexOf(reactPostmessageBridgePrefix) !== 0 &&
-      DOMContext.hasDifferentOrigin(url, this.props.baseUrl)
+      DOMContext.hasDifferentOrigin(url, baseUrl)
     ) {
       this.webView.stopLoading();
       DOMContext.openURLInBrowser(url);
@@ -49,7 +51,7 @@ class DOMContext extends PureComponent {
   };
 
   render() {
-    const { data, init, width, height } = this.props;
+    const { baseUrl, data, init, width, height } = this.props;
     // NOTE: if this generated code is not working, and you don't know why
     // because React Native doesn't report errors in webview JS code, try
     // connecting a debugger to the app, console.log(html), copy and paste
@@ -106,7 +108,7 @@ class DOMContext extends PureComponent {
             this.webView = ref;
           }}
           source={{
-            baseUrl: this.props.baseUrl,
+            baseUrl,
             html
           }}
           style={{ backgroundColor: "transparent" }}

--- a/packages/article-image/src/article-image.js
+++ b/packages/article-image/src/article-image.js
@@ -5,7 +5,9 @@ import { propTypes, defaultPropTypes } from "./article-image-prop-types";
 import styles from "./styles";
 
 const ArticleImageNative = props => {
-  const { imageOptions: { display, uri } } = props
+  const {
+    imageOptions: { display, uri }
+  } = props;
 
   return (
     <View key={uri} style={styles[`${display}Container`]}>

--- a/packages/article-image/src/article-image.js
+++ b/packages/article-image/src/article-image.js
@@ -5,7 +5,8 @@ import { propTypes, defaultPropTypes } from "./article-image-prop-types";
 import styles from "./styles";
 
 const ArticleImageNative = props => {
-  const { display, uri } = props.imageOptions;
+  const { imageOptions } = props;
+  const { display, uri } = imageOptions;
 
   return (
     <View key={uri} style={styles[`${display}Container`]}>

--- a/packages/article-image/src/article-image.js
+++ b/packages/article-image/src/article-image.js
@@ -5,8 +5,7 @@ import { propTypes, defaultPropTypes } from "./article-image-prop-types";
 import styles from "./styles";
 
 const ArticleImageNative = props => {
-  const { imageOptions } = props;
-  const { display, uri } = imageOptions;
+  const { imageOptions: { display, uri } } = props
 
   return (
     <View key={uri} style={styles[`${display}Container`]}>

--- a/packages/article-list/src/article-list-item.js
+++ b/packages/article-list/src/article-list-item.js
@@ -13,7 +13,14 @@ import { getImageUri, getHeadline } from "./utils";
 import styles from "./styles";
 
 const ArticleListItem = props => {
-  const { highResSize, imageRatio, isLoading, onPress, showImage } = props;
+  const {
+    article,
+    highResSize,
+    imageRatio,
+    isLoading,
+    onPress,
+    showImage
+  } = props;
 
   const {
     byline,
@@ -27,9 +34,9 @@ const ArticleListItem = props => {
     shortSummary,
     summary,
     url
-  } = props.article || {};
+  } = article || {};
 
-  const imageUri = getImageUri(props.article);
+  const imageUri = getImageUri(article);
   const content = showImage ? summary : shortSummary;
 
   return (

--- a/packages/article-list/src/article-list-item.js
+++ b/packages/article-list/src/article-list-item.js
@@ -14,7 +14,7 @@ import styles from "./styles";
 
 const ArticleListItem = props => {
   const {
-    article = {},
+    article,
     highResSize,
     imageRatio,
     isLoading,
@@ -34,7 +34,7 @@ const ArticleListItem = props => {
     shortSummary,
     summary,
     url
-  } = article;
+  } = article || {};
 
   const imageUri = getImageUri(article);
   const content = showImage ? summary : shortSummary;

--- a/packages/article-list/src/article-list-item.js
+++ b/packages/article-list/src/article-list-item.js
@@ -14,7 +14,7 @@ import styles from "./styles";
 
 const ArticleListItem = props => {
   const {
-    article,
+    article = {},
     highResSize,
     imageRatio,
     isLoading,
@@ -34,7 +34,7 @@ const ArticleListItem = props => {
     shortSummary,
     summary,
     url
-  } = article || {};
+  } = article;
 
   const imageUri = getImageUri(article);
   const content = showImage ? summary : shortSummary;

--- a/packages/article-list/src/article-list-item.web.js
+++ b/packages/article-list/src/article-list-item.web.js
@@ -18,6 +18,7 @@ import {
 
 const ArticleListItem = props => {
   const {
+    article,
     fadeImageIn,
     highResSize,
     imageRatio,
@@ -38,9 +39,9 @@ const ArticleListItem = props => {
     shortHeadline,
     shortSummary,
     summary
-  } = props.article || {};
+  } = article || {};
 
-  const imageUri = getImageUri(props.article);
+  const imageUri = getImageUri(article);
   if (isLoading) {
     return (
       <ListItemWrapper>

--- a/packages/article-list/src/article-list-item.web.js
+++ b/packages/article-list/src/article-list-item.web.js
@@ -18,7 +18,7 @@ import {
 
 const ArticleListItem = props => {
   const {
-    article,
+    article = {},
     fadeImageIn,
     highResSize,
     imageRatio,
@@ -39,7 +39,7 @@ const ArticleListItem = props => {
     shortHeadline,
     shortSummary,
     summary
-  } = article || {};
+  } = article;
 
   const imageUri = getImageUri(article);
   if (isLoading) {

--- a/packages/article-list/src/article-list-item.web.js
+++ b/packages/article-list/src/article-list-item.web.js
@@ -18,7 +18,7 @@ import {
 
 const ArticleListItem = props => {
   const {
-    article = {},
+    article,
     fadeImageIn,
     highResSize,
     imageRatio,
@@ -39,7 +39,7 @@ const ArticleListItem = props => {
     shortHeadline,
     shortSummary,
     summary
-  } = article;
+  } = article || {};
 
   const imageUri = getImageUri(article);
   if (isLoading) {

--- a/packages/article-list/src/article-list-page-error.web.js
+++ b/packages/article-list/src/article-list-page-error.web.js
@@ -8,7 +8,7 @@ import {
   PageErrorImageContainer,
   PageErrorContentContainer
 } from "./styles/responsive";
-import { retryButtonStyles } from "./styles";
+import { retryButtonStyles } from "./styles/index.web";
 
 const ArticleListPageError = ({ refetch }) => (
   <PageErrorContainer>

--- a/packages/article-list/src/article-list-prop-types-base.js
+++ b/packages/article-list/src/article-list-prop-types-base.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { propTypesBase as articleItemPropTypes } from "./article-list-item-prop-types";
+import { propTypes as articleItemPropTypes } from "./article-list-item-prop-types";
 
 export const propTypes = {
   articleListHeader: PropTypes.element,

--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -34,31 +34,31 @@ class ArticleList extends Component {
   }
 
   onViewableItemsChanged(info) {
+    const { articles, onViewed } = this.props;
     if (!info.changed.length) return [];
 
     return info.changed
       .filter(viewableItem => viewableItem.isViewable)
-      .map(viewableItem =>
-        this.props.onViewed(viewableItem.item, this.props.articles)
-      );
+      .map(viewableItem => onViewed(viewableItem.item, articles));
   }
 
   fetchMoreOnEndReached(data) {
-    if (this.state.loadMoreError || this.state.loadingMore) {
+    const { fetchMore } = this.props;
+    const { loadingMore, loadMoreError } = this.state;
+    if (loadMoreError || loadingMore) {
       return null;
     }
 
     this.setState({ loadingMore: true });
 
     return new Promise((res, rej) =>
-      this.props
-        .fetchMore(data.length)
+      fetchMore(data.length)
         .then(() => this.setState({ loadingMore: false }, res))
-        .catch(loadMoreError =>
+        .catch(error =>
           this.setState(
             {
               loadingMore: false,
-              loadMoreError
+              loadMoreError: error
             },
             rej
           )
@@ -76,10 +76,13 @@ class ArticleList extends Component {
       error,
       imageRatio,
       onArticlePress,
+      onViewed,
       pageSize,
+      receiveChildList,
       refetch,
       showImages
     } = this.props;
+    const { loadMoreError, width } = this.state;
 
     if (error) {
       return (
@@ -106,12 +109,13 @@ class ArticleList extends Component {
           elementId: `${article.id}.${index}`
         }));
 
-    if (!articlesLoading) this.props.receiveChildList(data);
+    if (!articlesLoading) receiveChildList(data);
 
     const articleListFooter = () => {
       if (data.length >= count) {
         return null;
-      } else if (this.state.loadMoreError) {
+      }
+      if (loadMoreError) {
         return (
           <View>
             <ArticleListItemSeparator />
@@ -171,9 +175,7 @@ class ArticleList extends Component {
           data.length > 0 ? this.fetchMoreOnEndReached(data) : null
         }
         onEndReachedThreshold={2}
-        onViewableItemsChanged={
-          this.props.onViewed ? this.onViewableItemsChanged : null
-        }
+        onViewableItemsChanged={onViewed ? this.onViewableItemsChanged : null}
         pageSize={pageSize}
         renderItem={({ item, index }) => (
           <ErrorView>
@@ -181,7 +183,7 @@ class ArticleList extends Component {
               hasError ? null : (
                 <ArticleListItem
                   article={item.isLoading ? null : item}
-                  highResSize={this.state.width}
+                  highResSize={width}
                   imageRatio={imageRatio}
                   index={index}
                   isLoading={item.isLoading === true}

--- a/packages/article-list/src/article-list.web.js
+++ b/packages/article-list/src/article-list.web.js
@@ -8,14 +8,14 @@ import { spacing } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import { normaliseWidth } from "@times-components/utils";
 import LazyLoad from "@times-components/lazy-load";
-import { scrollUpToPaging } from "./utils";
+import { scrollUpToPaging } from "./utils/index.web";
 import ArticleListError from "./article-list-error";
 import ArticleListItem from "./article-list-item";
 import ArticleListItemSeparator from "./article-list-item-separator";
 import ArticleListPagination from "./article-list-pagination";
 import { propTypes, defaultProps } from "./article-list-prop-types";
 import ArticleListEmptyState from "./article-list-empty-state";
-import styles, { retryButtonStyles } from "./styles";
+import styles, { retryButtonStyles } from "./styles/index.web";
 import { ListContentContainer } from "./styles/responsive";
 
 class ArticleList extends Component {
@@ -34,7 +34,8 @@ class ArticleList extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.props.page === nextProps.page;
+    const { page } = this.props;
+    return page === nextProps.page;
   }
 
   render() {

--- a/packages/article-main-comment/showcase-helper.js
+++ b/packages/article-main-comment/showcase-helper.js
@@ -103,18 +103,20 @@ export class ArticleConfigurator extends Component {
   }
 
   componentDidMount() {
+    const { configuration, id } = this.props;
     schemaToMocks(
       makeParams({
-        makeArticle: makeArticle(this.props.configuration),
+        makeArticle: makeArticle(configuration),
         variables: () => ({
-          id: this.props.id
+          id
         })
       })
     ).then(mocks => this.setState({ mocks }));
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.configuration !== prevProps.configuration) {
+    const { configuration, id } = this.props;
+    if (configuration !== prevProps.configuration) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(
         {
@@ -123,9 +125,9 @@ export class ArticleConfigurator extends Component {
         () =>
           schemaToMocks(
             makeParams({
-              makeArticle: makeArticle(this.props.configuration),
+              makeArticle: makeArticle(configuration),
               variables: () => ({
-                id: this.props.id
+                id
               })
             })
           ).then(mocks => this.setState({ mocks, reRendering: false }))
@@ -134,14 +136,12 @@ export class ArticleConfigurator extends Component {
   }
 
   render() {
-    if (!this.state.mocks.length || this.state.reRendering) {
+    const { children } = this.props;
+    const { mocks, reRendering } = this.state;
+    if (!mocks.length || reRendering) {
       return null;
     }
 
-    return (
-      <MockedProvider mocks={this.state.mocks}>
-        {this.props.children}
-      </MockedProvider>
-    );
+    return <MockedProvider mocks={mocks}>{children}</MockedProvider>;
   }
 }

--- a/packages/article-main-comment/src/article-main-comment.js
+++ b/packages/article-main-comment/src/article-main-comment.js
@@ -6,8 +6,8 @@ import Article from "@times-components/article";
 import { getHeadline } from "@times-components/utils";
 import ArticleHeader from "./article-header/article-header";
 import {
-  articlePagePropTypes,
-  articlePageDefaultProps
+  articlePropTypes,
+  articleDefaultProps
 } from "./article-prop-types/article-prop-types";
 
 class ArticlePage extends Component {
@@ -17,6 +17,7 @@ class ArticlePage extends Component {
   }
 
   renderHeader() {
+    const { article, onAuthorPress } = this.props;
     const {
       author,
       byline,
@@ -27,8 +28,7 @@ class ArticlePage extends Component {
       publishedTime,
       shortHeadline,
       standfirst
-    } = this.props.article;
-    const { onAuthorPress } = this.props;
+    } = article;
 
     return (
       <ArticleHeader
@@ -93,7 +93,7 @@ class ArticlePage extends Component {
   }
 }
 
-ArticlePage.propTypes = articlePagePropTypes;
-ArticlePage.defaultProps = articlePageDefaultProps;
+ArticlePage.propTypes = articlePropTypes;
+ArticlePage.defaultProps = articleDefaultProps;
 
 export default ArticlePage;

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -14,6 +14,7 @@ class ArticlePage extends Component {
   }
 
   renderHeader() {
+    const { article } = this.props;
     const {
       author,
       byline,
@@ -24,7 +25,7 @@ class ArticlePage extends Component {
       publishedTime,
       shortHeadline,
       standfirst
-    } = this.props.article;
+    } = article;
 
     return (
       <ArticleHeader

--- a/packages/article-main-comment/src/article-prop-types/article-prop-types.js
+++ b/packages/article-main-comment/src/article-prop-types/article-prop-types.js
@@ -1,11 +1,11 @@
 import PropTypes from "prop-types";
 import {
-  articlePropTypesBase,
-  articleDefaultPropsBase
+  articlePagePropTypes,
+  articlePageDefaultProps
 } from "./article-prop-types.base";
 
 const articlePropTypes = {
-  ...articlePropTypesBase,
+  ...articlePagePropTypes,
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -19,7 +19,7 @@ const articlePropTypes = {
 };
 
 const articleDefaultProps = {
-  ...articleDefaultPropsBase
+  ...articlePageDefaultProps
 };
 
 export { articlePropTypes, articleDefaultProps };

--- a/packages/article-main-standard/showcase-helper.js
+++ b/packages/article-main-standard/showcase-helper.js
@@ -103,18 +103,20 @@ export class ArticleConfigurator extends Component {
   }
 
   componentDidMount() {
+    const { configuration, id } = this.props;
     schemaToMocks(
       makeParams({
-        makeArticle: makeArticle(this.props.configuration),
+        makeArticle: makeArticle(configuration),
         variables: () => ({
-          id: this.props.id
+          id
         })
       })
     ).then(mocks => this.setState({ mocks }));
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.configuration !== prevProps.configuration) {
+    const { configuration, id } = this.props;
+    if (configuration !== prevProps.configuration) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(
         {
@@ -123,9 +125,9 @@ export class ArticleConfigurator extends Component {
         () =>
           schemaToMocks(
             makeParams({
-              makeArticle: makeArticle(this.props.configuration),
+              makeArticle: makeArticle(configuration),
               variables: () => ({
-                id: this.props.id
+                id
               })
             })
           ).then(mocks => this.setState({ mocks, reRendering: false }))
@@ -134,14 +136,12 @@ export class ArticleConfigurator extends Component {
   }
 
   render() {
-    if (!this.state.mocks.length || this.state.reRendering) {
+    const { children } = this.props;
+    const { mocks, reRendering } = this.state;
+    if (!mocks.length || reRendering) {
       return null;
     }
 
-    return (
-      <MockedProvider mocks={this.state.mocks}>
-        {this.props.children}
-      </MockedProvider>
-    );
+    return <MockedProvider mocks={mocks}>{children}</MockedProvider>;
   }
 }

--- a/packages/article-main-standard/src/article-lead-asset/article-lead-asset.js
+++ b/packages/article-main-standard/src/article-lead-asset/article-lead-asset.js
@@ -1,11 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import ArticleLeadAssetImage, {
-  propTypes as imagePropTypes
-} from "./article-lead-asset-image";
-import ArticleLeadAssetVideo, {
-  propTypes as videoPropTypes
-} from "./article-lead-asset-video";
+import ArticleLeadAssetImage from "./article-lead-asset-image";
+import ArticleLeadAssetVideo from "./article-lead-asset-video";
 
 const ArticleLeadAsset = ({ data, width }) => {
   const LeadAsset = data.isVideo
@@ -17,8 +13,8 @@ const ArticleLeadAsset = ({ data, width }) => {
 
 ArticleLeadAsset.propTypes = {
   data: PropTypes.oneOfType([
-    PropTypes.shape(videoPropTypes),
-    PropTypes.shape(imagePropTypes)
+    PropTypes.shape(ArticleLeadAssetVideo.propTypes),
+    PropTypes.shape(ArticleLeadAssetImage.propTypes)
   ]).isRequired,
   width: PropTypes.number
 };

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -11,8 +11,8 @@ import ArticleLeadAsset from "./article-lead-asset/article-lead-asset";
 import ArticleMeta from "./article-meta/article-meta";
 import stylesFactory from "./styles/article-body";
 import {
-  articlePagePropTypes,
-  articlePageDefaultProps
+  articlePropTypes,
+  articleDefaultProps
 } from "./article-prop-types/article-prop-types";
 
 class ArticlePage extends Component {
@@ -22,6 +22,7 @@ class ArticlePage extends Component {
   }
 
   renderHeader(parentProps) {
+    const { article, onAuthorPress, onVideoPress } = this.props;
     const {
       byline,
       flags,
@@ -32,8 +33,7 @@ class ArticlePage extends Component {
       publishedTime,
       shortHeadline,
       standfirst
-    } = this.props.article;
-    const { article, onAuthorPress, onVideoPress } = this.props;
+    } = article;
     const { isVideo, leadAsset } = getLeadAsset(article);
     const styles = stylesFactory();
 
@@ -115,7 +115,7 @@ class ArticlePage extends Component {
 }
 
 ArticlePage.propTypes = {
-  ...articlePagePropTypes,
+  ...articlePropTypes,
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -126,7 +126,7 @@ ArticlePage.propTypes = {
   refetch: PropTypes.func.isRequired
 };
 ArticlePage.defaultProps = {
-  ...articlePageDefaultProps,
+  ...articleDefaultProps,
   referralUrl: null
 };
 

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -23,6 +23,7 @@ class ArticlePage extends Component {
   }
 
   renderHeader(parentProps) {
+    const { article } = this.props;
     const {
       byline,
       hasVideo,
@@ -34,8 +35,8 @@ class ArticlePage extends Component {
       shortHeadline,
       standfirst,
       topics
-    } = this.props.article;
-    const leadAssetProps = getLeadAsset(this.props.article);
+    } = article;
+    const leadAssetProps = getLeadAsset(article);
 
     return (
       <Fragment>

--- a/packages/article-paragraph/src/article-paragraph.web.js
+++ b/packages/article-paragraph/src/article-paragraph.web.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import { Paragraph } from "./styles/responsive";
 import styles from "./styles";
 
-const BodyParagraph = props => (
-  <Paragraph style={[styles.articleTextElement]}>{props.children}</Paragraph>
+const BodyParagraph = ({ children }) => (
+  <Paragraph style={[styles.articleTextElement]}>{children}</Paragraph>
 );
 
 BodyParagraph.propTypes = {

--- a/packages/article-paragraph/src/drop-cap.js
+++ b/packages/article-paragraph/src/drop-cap.js
@@ -23,7 +23,7 @@ class DropCapParagraph extends Component {
   componentDidUpdate(prevProps) {
     const { dropCap, scale, text } = this.props;
 
-    if (prevProps.scale !== this.props.scale) {
+    if (prevProps.scale !== scale) {
       this.measureTextBoxes(dropCap, text, scale);
     }
   }

--- a/packages/article-paragraph/src/index.js
+++ b/packages/article-paragraph/src/index.js
@@ -6,8 +6,7 @@ import ArticleParagraph from "./article-paragraph";
 import DropCapWrapper from "./drop-cap-with-context";
 import { propTypes, defaultProps } from "./drop-cap-prop-types";
 
-const ArticleParagraphWrapper = props => {
-  const { ast, children, colour } = props;
+const ArticleParagraphWrapper = ({ ast, children, colour, uid }) => {
   const { children: astChildren } = ast;
   const { name, attributes } = astChildren[0];
   if (name === "dropCap") {
@@ -17,17 +16,14 @@ const ArticleParagraphWrapper = props => {
       <DropCapWrapper
         colour={colour}
         dropCap={value}
-        key={`paragraph-${props.uid}`}
-        testID={`paragraph-${props.uid}`}
+        key={`paragraph-${uid}`}
+        testID={`paragraph-${uid}`}
         text={text}
       />
     );
   }
   return (
-    <ArticleParagraph
-      key={`paragraph-${props.uid}`}
-      testID={`paragraph-${props.uid}`}
-    >
+    <ArticleParagraph key={`paragraph-${uid}`} testID={`paragraph-${uid}`}>
       {children}
     </ArticleParagraph>
   );

--- a/packages/article-summary/fixtures/article-empty-paragraph.js
+++ b/packages/article-summary/fixtures/article-empty-paragraph.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultByline = "Camilla Long, Environment Editor";
 const defaultHeadline =

--- a/packages/article-summary/fixtures/article-multi.js
+++ b/packages/article-summary/fixtures/article-multi.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultByline = "Camilla Long, Environment Editor";
 const defaultHeadline =

--- a/packages/article-summary/fixtures/blank.js
+++ b/packages/article-summary/fixtures/blank.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline } from "../";
+import { ArticleSummaryHeadline } from "..";
 
 const defaultHeadline =
   "OK, so Putin’s not a lady, but he does have the wildest man‑PMT";

--- a/packages/article-summary/fixtures/default.js
+++ b/packages/article-summary/fixtures/default.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultHeadline =
   "Top medal for forces dog who took a bite out of the Taliban";

--- a/packages/article-summary/fixtures/no-byline.js
+++ b/packages/article-summary/fixtures/no-byline.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultHeadline =
   "Top medal for forces dog who took a bite out of the Taliban";

--- a/packages/article-summary/fixtures/no-datepublication.js
+++ b/packages/article-summary/fixtures/no-datepublication.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultByline = "Camilla Long, Environment Editor";
 const defaultHeadline =

--- a/packages/article-summary/fixtures/no-headline.js
+++ b/packages/article-summary/fixtures/no-headline.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryContent } from "../";
+import { ArticleSummaryContent } from "..";
 
 const defaultLabel = "Camilla Long";
 const defaultParagraph =

--- a/packages/article-summary/fixtures/no-label.js
+++ b/packages/article-summary/fixtures/no-label.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultByline = "Camilla Long, Environment Editor";
 const defaultHeadline =

--- a/packages/article-summary/fixtures/opinion-byline.js
+++ b/packages/article-summary/fixtures/opinion-byline.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultByline = "Camilla Long, Environment Editor";
 const defaultHeadline =

--- a/packages/article-summary/fixtures/review.js
+++ b/packages/article-summary/fixtures/review.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ArticleSummaryContent } from "../";
+import { ArticleSummaryContent } from "..";
 
 const defaultReview1Title = "Victoria";
 const defaultReview2Title = "Lucy Worsley’s Nights at the Opera";

--- a/packages/article-summary/fixtures/video-label.js
+++ b/packages/article-summary/fixtures/video-label.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultByline = "Camilla Long, Environment Editor";
 const defaultHeadline =

--- a/packages/article-summary/fixtures/with-byline-links.js
+++ b/packages/article-summary/fixtures/with-byline-links.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultHeadline =
   "Top medal for forces dog who took a bite out of the Taliban";

--- a/packages/article-summary/fixtures/with-summary-links.js
+++ b/packages/article-summary/fixtures/with-summary-links.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { colours } from "@times-components/styleguide";
-import { ArticleSummaryHeadline, ArticleSummaryContent } from "../";
+import { ArticleSummaryHeadline, ArticleSummaryContent } from "..";
 
 const defaultHeadline = "Sajid Javid to end hostile era for illegal immigrants";
 const defaultLabel = "Francis Elliott";

--- a/packages/article-topics/src/article-topic.js
+++ b/packages/article-topics/src/article-topic.js
@@ -3,7 +3,7 @@ import { Text, View } from "react-native";
 import Link from "@times-components/link";
 import { withTrackEvents } from "@times-components/tracking";
 import styles from "./styles";
-import { topicPropTypes } from "./article-topic-prop-types";
+import topicPropTypes from "./article-topic-prop-types";
 
 const ArticleTopic = ({ fontSize, lineHeight, name, onPress, slug }) => {
   const fontSizeStyle = fontSize ? { fontSize } : null;

--- a/packages/article/src/article-body/inset-caption.web.js
+++ b/packages/article/src/article-body/inset-caption.web.js
@@ -14,9 +14,9 @@ const InsetCaptionStyle = styled(View)`
   }
 `;
 
-const InsetCaptionWeb = props => (
+const InsetCaptionWeb = ({ caption, credits }) => (
   <InsetCaptionStyle>
-    <Caption credits={props.credits} text={props.caption} />
+    <Caption credits={credits} text={caption} />
   </InsetCaptionStyle>
 );
 

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -92,11 +92,12 @@ class Article extends Component {
   onViewableItemsChanged(info) {
     if (!info.changed.length) return [];
 
+    const { onViewed } = this.props;
+    const { dataSource } = this.state;
+
     return info.changed
       .filter(viewableItem => viewableItem.isViewable)
-      .map(viewableItem =>
-        this.props.onViewed(viewableItem.item, this.state.dataSource)
-      );
+      .map(viewableItem => onViewed(viewableItem.item, dataSource));
   }
 
   render() {
@@ -115,12 +116,13 @@ class Article extends Component {
       onVideoPress,
       receiveChildList
     } = this.props;
+    const { dataSource, width } = this.state;
 
-    if (!this.state.dataSource.content) {
+    if (!dataSource.content) {
       return null;
     }
 
-    const articleOrganised = listViewDataHelper(this.state.dataSource);
+    const articleOrganised = listViewDataHelper(dataSource);
     const articleData = articleOrganised.map((item, index) => ({
       ...item,
       elementId: `${item.type}.${index}`,
@@ -147,7 +149,7 @@ class Article extends Component {
           pageSize={listViewPageSize}
           renderRow={renderRow(analyticsStream)}
           scrollRenderAheadDistance={listViewScrollRenderAheadDistance}
-          width={this.state.width}
+          width={width}
         />
       </AdComposer>
     );

--- a/packages/article/src/article.web.js
+++ b/packages/article/src/article.web.js
@@ -43,6 +43,7 @@ class Article extends Component {
       Header,
       receiveChildList
     } = this.props;
+    const { articleWidth } = this.state;
 
     // eslint-disable-next-line react/prop-types
     const displayRelatedArticles = ({ isVisible }) =>
@@ -83,7 +84,7 @@ class Article extends Component {
                   />
                 </HeaderAdContainer>
                 <MainContainer>
-                  <Header width={this.state.articleWidth} />
+                  <Header width={articleWidth} />
                   <BodyContainer>
                     <ArticleBody
                       content={content}

--- a/packages/author-profile/__tests__/android/__snapshots__/author-profile.android.test.js.snap
+++ b/packages/author-profile/__tests__/android/__snapshots__/author-profile.android.test.js.snap
@@ -308,6 +308,9 @@ exports[`10. an article list header only changes on loading state change 2`] = `
       >
         title 1
       </Text>
+      <View>
+        <Text />
+      </View>
     </View>
   </View>
 </View>
@@ -327,6 +330,9 @@ exports[`10. an article list header only changes on loading state change 3`] = `
       >
         title 1
       </Text>
+      <View>
+        <Text />
+      </View>
     </View>
   </View>
 </View>

--- a/packages/author-profile/__tests__/ios/__snapshots__/author-profile.ios.test.js.snap
+++ b/packages/author-profile/__tests__/ios/__snapshots__/author-profile.ios.test.js.snap
@@ -308,6 +308,9 @@ exports[`10. an article list header only changes on loading state change 2`] = `
       >
         title 1
       </Text>
+      <View>
+        <Text />
+      </View>
     </View>
   </View>
 </View>
@@ -327,6 +330,9 @@ exports[`10. an article list header only changes on loading state change 3`] = `
       >
         title 1
       </Text>
+      <View>
+        <Text />
+      </View>
     </View>
   </View>
 </View>

--- a/packages/author-profile/__tests__/mock-provider.js
+++ b/packages/author-profile/__tests__/mock-provider.js
@@ -57,11 +57,12 @@ export class AuthorArticlesNoImagesProvider extends Component {
 
   render() {
     const { children, pageSize } = this.props;
+    const { author: stateAuthor } = this.state;
 
     return (
       <authorArticlesNoImagesProvider>
         {children({
-          author: this.state.author,
+          author: stateAuthor,
           fetchMore: this.fetchMore,
           pageSize,
           variables: {}
@@ -91,11 +92,12 @@ export class AuthorArticlesWithImagesProvider extends Component {
 
   render() {
     const { children, pageSize } = this.props;
+    const { author: stateAuthor } = this.state;
 
     return (
       <authorArticlesWithImagesProvider>
         {children({
-          author: this.state.author,
+          author: stateAuthor,
           fetchMore: this.fetchMore,
           pageSize,
           variables: {

--- a/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
+++ b/packages/author-profile/__tests__/web/__snapshots__/author-profile.web.test.js.snap
@@ -308,6 +308,9 @@ exports[`10. an article list header only changes on loading state change 2`] = `
       >
         title 1
       </h2>
+      <div>
+        <div />
+      </div>
     </div>
   </div>
 </header>
@@ -325,6 +328,9 @@ exports[`10. an article list header only changes on loading state change 3`] = `
       >
         title 1
       </h2>
+      <div>
+        <div />
+      </div>
     </div>
   </div>
 </header>

--- a/packages/author-profile/src/author-profile-head-base.js
+++ b/packages/author-profile/src/author-profile-head-base.js
@@ -10,7 +10,8 @@ import styles from "./styles";
 
 export class AuthorProfileHeadBase extends Component {
   shouldComponentUpdate(nextProps) {
-    return this.props.isLoading !== nextProps.isLoading;
+    const { isLoading } = this.props;
+    return isLoading !== nextProps.isLoading;
   }
 
   render() {

--- a/packages/author-profile/src/author-profile-head-prop-types.js
+++ b/packages/author-profile/src/author-profile-head-prop-types.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import {
   propTypes as basePropTypes,
-  defaultPropTypes as baseDefaultPropTypes
+  defaultProps as baseDefaultPropTypes
 } from "./author-profile-head-prop-types.base";
 
 export const propTypes = {

--- a/packages/author-profile/src/author-profile-head-prop-types.web.js
+++ b/packages/author-profile/src/author-profile-head-prop-types.web.js
@@ -1,6 +1,6 @@
 import {
   propTypes as basePropTypes,
-  defaultPropTypes as baseDefaultPropTypes
+  defaultProps as baseDefaultPropTypes
 } from "./author-profile-head-prop-types.base";
 
 export const propTypes = {

--- a/packages/brightcove-video/__tests__/brightcove-player-helper.test.js
+++ b/packages/brightcove-video/__tests__/brightcove-player-helper.test.js
@@ -191,6 +191,7 @@ describe("brightcove-player native component", () => {
           super(props);
           propsCache = props;
         }
+
         render() {
           return null;
         }

--- a/packages/brightcove-video/fixtures/button.js
+++ b/packages/brightcove-video/fixtures/button.js
@@ -2,19 +2,19 @@ import React from "react";
 import { TouchableOpacity, Text } from "react-native";
 import PropTypes from "prop-types";
 
-const Button = props => (
+const Button = ({ buttonText, onPress, testID }) => (
   <TouchableOpacity
-    onPress={props.onPress}
+    onPress={onPress}
     style={{
       backgroundColor: "blue",
       margin: 5,
       padding: 5,
       width: 200
     }}
-    testID={props.testID}
+    testID={testID}
   >
     <Text style={{ color: "white", textAlign: "center" }}>
-      {props.buttonText}
+      {buttonText}
     </Text>
   </TouchableOpacity>
 );

--- a/packages/brightcove-video/fixtures/button.js
+++ b/packages/brightcove-video/fixtures/button.js
@@ -13,9 +13,7 @@ const Button = ({ buttonText, onPress, testID }) => (
     }}
     testID={testID}
   >
-    <Text style={{ color: "white", textAlign: "center" }}>
-      {buttonText}
-    </Text>
+    <Text style={{ color: "white", textAlign: "center" }}>{buttonText}</Text>
   </TouchableOpacity>
 );
 

--- a/packages/brightcove-video/fixtures/player-adder.js
+++ b/packages/brightcove-video/fixtures/player-adder.js
@@ -14,17 +14,19 @@ class VideoAdder extends Component {
   }
 
   getVideos(count) {
+    const { accountId, policyKey, videoId } = this.props;
+
     const videos = [];
     let i = 0;
 
     while (i < count) {
       videos.push(
         <BrightcoveVideo
-          accountId={this.props.accountId}
+          accountId={accountId}
           height={200}
           key={i}
-          policyKey={this.props.policyKey}
-          videoId={this.props.videoId}
+          policyKey={policyKey}
+          videoId={videoId}
           width={300}
         />
       );
@@ -36,13 +38,15 @@ class VideoAdder extends Component {
   }
 
   render() {
+    const { videoCount } = this.state;
+
     return (
       <View>
-        {this.getVideos(this.state.videoCount)}
+        {this.getVideos(videoCount)}
         <Button
           buttonText="click here to add a video"
           onPress={() => {
-            this.setState({ videoCount: this.state.videoCount + 1 });
+            this.setState(state => ({ videoCount: state.videoCount + 1 }));
           }}
         />
       </View>

--- a/packages/brightcove-video/fixtures/video-with-external-controls.js
+++ b/packages/brightcove-video/fixtures/video-with-external-controls.js
@@ -7,15 +7,17 @@ import BrightcoveVideo from "../src/brightcove-video";
 
 class VideoWithExternalControls extends Component {
   render() {
+    const { accountId, policyKey, videoId } = this.props;
+
     return (
       <View>
         <BrightcoveVideo
-          accountId={this.props.accountId}
-          policyKey={this.props.policyKey}
+          accountId={accountId}
+          policyKey={policyKey}
           ref={ref => {
             this.bcVideo = ref;
           }}
-          videoId={this.props.videoId}
+          videoId={videoId}
         />
         <Button
           buttonText="play"

--- a/packages/brightcove-video/src/brightcove-player-helper.js
+++ b/packages/brightcove-video/src/brightcove-player-helper.js
@@ -61,7 +61,7 @@ class BrightcoveVideo extends Component {
   }
 
   onError(evt) {
-    const{ onError } = this.props;
+    const { onError } = this.props;
 
     onError(evt.nativeEvent);
   }
@@ -78,7 +78,14 @@ class BrightcoveVideo extends Component {
       progress: evt.nativeEvent.progress
     };
 
-    const { onChange, onDuration, onFinish, onPause, onPlay, onProgress } = this.props;
+    const {
+      onChange,
+      onDuration,
+      onFinish,
+      onPause,
+      onPlay,
+      onProgress
+    } = this.props;
     const { duration, isFinished, isPlaying, progress } = this.state;
 
     const playerStatusChanged = newState.isPlaying !== isPlaying;
@@ -133,10 +140,10 @@ class BrightcoveVideo extends Component {
 
   play() {
     const { runNativeCommand } = this.props;
-    
+
     runNativeCommand("play", []);
   }
-  
+
   pause() {
     const { runNativeCommand } = this.props;
 
@@ -144,7 +151,17 @@ class BrightcoveVideo extends Component {
   }
 
   render() {
-    const { accountId, autoplay, height, hideFullScreenButton, policyKey, position, videoId, width, zIndex } = this.props;
+    const {
+      accountId,
+      autoplay,
+      height,
+      hideFullScreenButton,
+      policyKey,
+      position,
+      videoId,
+      width,
+      zIndex
+    } = this.props;
     const NativeBrightcove = BrightcoveVideo.getNativeBrightcoveComponent();
 
     return (

--- a/packages/brightcove-video/src/brightcove-player-helper.js
+++ b/packages/brightcove-video/src/brightcove-player-helper.js
@@ -61,7 +61,9 @@ class BrightcoveVideo extends Component {
   }
 
   onError(evt) {
-    this.props.onError(evt.nativeEvent);
+    const{ onError } = this.props;
+
+    onError(evt.nativeEvent);
   }
 
   getNodeHandle() {
@@ -76,30 +78,33 @@ class BrightcoveVideo extends Component {
       progress: evt.nativeEvent.progress
     };
 
-    const playerStatusChanged = newState.isPlaying !== this.state.isPlaying;
+    const { onChange, onDuration, onFinish, onPause, onPlay, onProgress } = this.props;
+    const { duration, isFinished, isPlaying, progress } = this.state;
 
-    if (newState.duration !== this.state.duration) {
-      this.props.onDuration(newState.duration);
+    const playerStatusChanged = newState.isPlaying !== isPlaying;
+
+    if (newState.duration !== duration) {
+      onDuration(newState.duration);
     }
 
     if (playerStatusChanged && newState.isPlaying) {
-      this.props.onPlay();
+      onPlay();
     }
 
-    if (newState.progress !== this.state.progress) {
-      this.props.onProgress(newState.progress);
+    if (newState.progress !== progress) {
+      onProgress(newState.progress);
     }
 
     if (playerStatusChanged && !newState.isPlaying) {
-      this.props.onPause();
+      onPause();
     }
 
-    if (newState.isFinished !== this.state.isFinished && newState.isFinished) {
-      this.props.onFinish();
+    if (newState.isFinished !== isFinished && newState.isFinished) {
+      onFinish();
     }
 
-    if (this.props.onChange) {
-      this.props.onChange(evt.nativeEvent);
+    if (onChange) {
+      onChange(evt.nativeEvent);
     }
 
     this.setState(newState);
@@ -127,35 +132,40 @@ class BrightcoveVideo extends Component {
   }
 
   play() {
-    this.props.runNativeCommand("play", []);
+    const { runNativeCommand } = this.props;
+    
+    runNativeCommand("play", []);
   }
-
+  
   pause() {
-    this.props.runNativeCommand("pause", []);
+    const { runNativeCommand } = this.props;
+
+    runNativeCommand("pause", []);
   }
 
   render() {
+    const { accountId, autoplay, height, hideFullScreenButton, policyKey, position, videoId, width, zIndex } = this.props;
     const NativeBrightcove = BrightcoveVideo.getNativeBrightcoveComponent();
 
     return (
       <NativeBrightcove
-        accountId={this.props.accountId}
-        autoplay={this.props.autoplay}
-        hideFullScreenButton={this.props.hideFullScreenButton}
+        accountId={accountId}
+        autoplay={autoplay}
+        hideFullScreenButton={hideFullScreenButton}
         onChange={this.handleChange}
         onIOSError={this.onError}
         onLoadingError={this.onError}
-        policyKey={this.props.policyKey}
+        policyKey={policyKey}
         ref={ref => {
           this.bcPlayer = ref;
         }}
         style={{
-          height: this.props.height,
-          position: this.props.position,
-          width: this.props.width,
-          zIndex: this.props.zIndex
+          height,
+          position,
+          width,
+          zIndex
         }} // android handler seems to be reserved on iOS
-        videoId={this.props.videoId} // so we use this instead
+        videoId={videoId} // so we use this instead
       />
     );
   }

--- a/packages/brightcove-video/src/brightcove-player.android.js
+++ b/packages/brightcove-video/src/brightcove-player.android.js
@@ -44,13 +44,16 @@ function withNativeCommand(WrappedComponent) {
     }
 
     onChange(evt) {
-      if (evt.isFullscreen !== this.state.isFullscreen) {
+      const { onEnterFullscreen, onExitFullscreen } = this.props;
+      const { isFullscreen } = this.state;
+
+      if (evt.isFullscreen !== isFullscreen) {
         this.setState({ isFullscreen: evt.isFullscreen });
 
         if (evt.isFullscreen) {
-          this.props.onEnterFullscreen();
+          onEnterFullscreen();
         } else {
-          this.props.onExitFullscreen();
+          onExitFullscreen();
         }
       }
     }
@@ -64,11 +67,12 @@ function withNativeCommand(WrappedComponent) {
     }
 
     render() {
+      const { isFullscreen } = this.state;
       const androidSpecificProps = {
         onChange: this.onChange
       };
 
-      if (this.state.isFullscreen) {
+      if (isFullscreen) {
         androidSpecificProps.width = "100%";
         androidSpecificProps.height = "100%";
         androidSpecificProps.position = "absolute";

--- a/packages/brightcove-video/src/brightcove-player.web.js
+++ b/packages/brightcove-video/src/brightcove-player.web.js
@@ -79,9 +79,11 @@ class BrightcoveVideo extends Component {
   constructor(props) {
     super(props);
 
+    const { onError } = this.props;
+
     index += 1;
 
-    BrightcoveVideo.globalErrors.forEach(this.props.onError);
+    BrightcoveVideo.globalErrors.forEach(onError);
 
     this.state = {
       errors: [].concat(BrightcoveVideo.globalErrors),
@@ -93,7 +95,10 @@ class BrightcoveVideo extends Component {
   }
 
   componentDidMount() {
-    if (this.state.errors.length) {
+    const { onError } = this.props;
+    const { errors } = this.state;
+
+    if (errors.length) {
       return;
     }
 
@@ -118,7 +123,7 @@ class BrightcoveVideo extends Component {
 
         BrightcoveVideo.globalErrors.push(uriErr);
 
-        this.props.onError(uriErr);
+        onError(uriErr);
       };
 
       BrightcoveVideo.appendScript(s);
@@ -129,28 +134,27 @@ class BrightcoveVideo extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const playerStatusChanged = prevState.isPlaying !== this.state.isPlaying;
+    const { duration, isFinished, isPlaying, progress } = this.state;
 
-    if (prevState.duration !== this.state.duration) {
-      prevProps.onDuration(this.state.duration);
+    const playerStatusChanged = prevState.isPlaying !== isPlaying;
+
+    if (prevState.duration !== duration) {
+      prevProps.onDuration(duration);
     }
 
-    if (playerStatusChanged && this.state.isPlaying) {
+    if (playerStatusChanged && isPlaying) {
       prevProps.onPlay();
     }
 
-    if (prevState.progress !== this.state.progress) {
-      prevProps.onProgress(this.state.progress);
+    if (prevState.progress !== progress) {
+      prevProps.onProgress(progress);
     }
 
-    if (playerStatusChanged && !this.state.isPlaying) {
+    if (playerStatusChanged && !isPlaying) {
       prevProps.onPause();
     }
 
-    if (
-      prevState.isFinished !== this.state.isFinished &&
-      this.state.isFinished
-    ) {
+    if (prevState.isFinished !== isFinished && isFinished) {
       prevProps.onFinish();
     }
 
@@ -164,7 +168,9 @@ class BrightcoveVideo extends Component {
   }
 
   onError(player) {
-    this.props.onError(player.error());
+    const { onError } = this.props;
+
+    onError(player.error());
   }
 
   onPlay(player) {
@@ -207,11 +213,10 @@ class BrightcoveVideo extends Component {
   }
 
   createScript() {
+    const { accountId, playerId } = this.props;
+
     const s = document.createElement("script");
-    s.src = BrightcoveVideo.getScriptUrl(
-      this.props.accountId,
-      this.props.playerId
-    );
+    s.src = BrightcoveVideo.getScriptUrl(accountId, playerId);
 
     return s;
   }
@@ -225,9 +230,11 @@ class BrightcoveVideo extends Component {
   }
 
   initVideo(id) {
+    const { hideFullScreenButton } = this.props;
+
     bc(document.getElementById(id), {
       controlBar: {
-        fullscreenToggle: !this.props.hideFullScreenButton
+        fullscreenToggle: !hideFullScreenButton
       }
     });
 
@@ -235,8 +242,10 @@ class BrightcoveVideo extends Component {
   }
 
   init() {
+    const { id } = this.state;
+
     if (window.bc && window.videojs) {
-      this.initVideo(this.state.id);
+      this.initVideo(id);
     } else {
       BrightcoveVideo.players.push(this);
     }
@@ -255,32 +264,43 @@ class BrightcoveVideo extends Component {
   }
 
   render() {
+    const {
+      accountId,
+      autoplay,
+      height,
+      playerId,
+      poster,
+      videoId,
+      width
+    } = this.props;
+    const { id } = this.state;
+
     /* eslint jsx-a11y/media-has-caption: "off" */
     // Added a wrapping div as brightcove adds siblings to the video tag
     return (
       <div
         style={{
-          height: this.props.height,
-          width: this.props.width
+          height,
+          width
         }}
       >
         <video
-          id={this.state.id}
+          id={id}
           style={{
-            height: this.props.height,
-            width: this.props.width
+            height,
+            width
           }}
-          {...(this.props.poster ? { poster: this.props.poster.uri } : {})}
+          {...(poster ? { poster: poster.uri } : {})}
           // following 'autoplay' can not expected to always work on web
           // see: https://docs.brightcove.com/en/player/brightcove-player/guides/in-page-embed-player-implementation.html
-          autoPlay={this.props.autoplay}
+          autoPlay={autoplay}
           className="video-js"
           controls
-          data-account={this.props.accountId}
+          data-account={accountId}
           data-application-id
           data-embed="default"
-          data-player={this.props.playerId}
-          data-video-id={this.props.videoId}
+          data-player={playerId}
+          data-video-id={videoId}
         />
       </div>
     );
@@ -289,8 +309,7 @@ class BrightcoveVideo extends Component {
 
 BrightcoveVideo.globalErrors = [];
 
-BrightcoveVideo.defaultProps = defaults;
-
 BrightcoveVideo.propTypes = { poster: SourcePropType, ...propTypes };
+BrightcoveVideo.defaultProps = defaults;
 
 export default BrightcoveVideo;

--- a/packages/brightcove-video/src/brightcove-video.js
+++ b/packages/brightcove-video/src/brightcove-video.js
@@ -31,6 +31,7 @@ class BrightcoveVideo extends Component {
   componentDidMount() {
     BrightcoveVideo.activePlayers.push(this);
   }
+
   // specifically check if is launched has changed and block update if it has not;
   // this is so we don't keep reseting our player reference
   shouldComponentUpdate(nextProps, nextState) {

--- a/packages/brightcove-video/src/brightcove-video.js
+++ b/packages/brightcove-video/src/brightcove-video.js
@@ -35,9 +35,11 @@ class BrightcoveVideo extends Component {
   // specifically check if is launched has changed and block update if it has not;
   // this is so we don't keep reseting our player reference
   shouldComponentUpdate(nextProps, nextState) {
+    const { error, isLaunched } = this.state;
+
     return (
-      nextState.isLaunched !== this.state.isLaunched ||
-      nextState.error !== this.state.error ||
+      nextState.isLaunched !== isLaunched ||
+      nextState.error !== error ||
       nextProps !== this.props
     );
   }
@@ -49,13 +51,15 @@ class BrightcoveVideo extends Component {
   }
 
   play = () => {
+    const { accountId, directToFullscreen, policyKey, videoId } = this.props;
+
     const nativeModule = BrightcoveVideo.getBrightcoveFullscreenPlayerModule();
 
-    if (nativeModule && this.props.directToFullscreen) {
+    if (nativeModule && directToFullscreen) {
       nativeModule.playVideo({
-        accountId: this.props.accountId,
-        policyKey: this.props.policyKey,
-        videoId: this.props.videoId
+        accountId,
+        policyKey,
+        videoId
       });
     } else {
       if (this.playerRef) {
@@ -88,27 +92,34 @@ class BrightcoveVideo extends Component {
   };
 
   handleFinish = () => {
-    if (this.props.resetOnFinish) {
+    const { onFinish, resetOnFinish } = this.props;
+
+    if (resetOnFinish) {
       this.reset();
     }
 
-    this.props.onFinish();
+    onFinish();
   };
 
   handleError = error => {
+    const { onError } = this.props;
+
     this.setState({ error });
 
-    this.props.onError(error);
+    onError(error);
   };
 
   render() {
+    const { height, width } = this.props;
+    const { error, isLaunched } = this.state;
+
     this.playerRef = null;
 
-    if (this.state.error) {
+    if (error) {
       return <VideoError {...this.props} onReset={this.reset} />;
     }
 
-    if (this.state.isLaunched) {
+    if (isLaunched) {
       return (
         <Player
           ref={ref => {
@@ -127,8 +138,8 @@ class BrightcoveVideo extends Component {
       <TouchableWithoutFeedback onPress={this.play}>
         <View
           style={{
-            height: this.props.height,
-            width: this.props.width
+            height,
+            width
           }}
         >
           <Splash {...this.props} />

--- a/packages/brightcove-video/src/brightcove-video.web.js
+++ b/packages/brightcove-video/src/brightcove-video.web.js
@@ -25,9 +25,11 @@ class BrightcoveVideo extends Component {
   // specifically check if is launched has changed and block update if it has not;
   // this is so we don't keep reseting our player reference
   shouldComponentUpdate(nextProps, nextState) {
+    const { error, isLaunched } = this.state;
+
     return (
-      nextState.isLaunched !== this.state.isLaunched ||
-      nextState.error !== this.state.error ||
+      nextState.isLaunched !== isLaunched ||
+      nextState.error !== error ||
       nextProps !== this.props
     );
   }
@@ -54,21 +56,27 @@ class BrightcoveVideo extends Component {
   }
 
   handleFinish() {
-    if (this.props.resetOnFinish) {
+    const { onFinish, resetOnFinish } = this.props;
+
+    if (resetOnFinish) {
       this.reset();
     }
 
-    this.props.onFinish();
+    onFinish();
   }
 
   handleError(error) {
+    const { onError } = this.props;
+
     this.setState({ error });
 
-    this.props.onError(error);
+    onError(error);
   }
 
   render() {
-    if (this.state.error) {
+    const { error } = this.state;
+
+    if (error) {
       return <VideoError {...this.props} onReset={this.reset} />;
     }
 

--- a/packages/card/src/card.js
+++ b/packages/card/src/card.js
@@ -4,7 +4,8 @@ import { cardPropTypes, cardDefaultProps } from "./card-prop-types";
 import CardContent from "./card-content";
 
 const CardComponent = props => {
-  if (props.isLoading) {
+  const { isLoading } = props;
+  if (isLoading) {
     return (
       <Animations.FadeIn>
         <CardContent {...props} />

--- a/packages/date-publication/src/date-time.js
+++ b/packages/date-publication/src/date-time.js
@@ -8,7 +8,7 @@ class DatePublication extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      tz: ""
+      timezone: ""
     };
     this.updateTimezone = this.updateTimezone.bind(this);
   }
@@ -22,12 +22,13 @@ class DatePublication extends Component {
 
     const dateUTC = getUTCTime(date);
     if (!isLondonTimezone()) {
-      this.setState({ tz: isBST(dateUTC) ? " BST" : " GMT" });
+      this.setState({ timezone: isBST(dateUTC) ? " BST" : " GMT" });
     }
   }
 
   render() {
     const { children, date, showDay } = this.props;
+    const { timezone } = this.state;
     const datetimeUTC = getUTCTime(date);
     const isDateBST = isBST(datetimeUTC);
     const offset = isDateBST ? 60 : 0;
@@ -38,7 +39,7 @@ class DatePublication extends Component {
       : baseFormatString;
 
     return children(
-      `${format(datetimeLondonTimezone, formatString)}${this.state.tz}`
+      `${format(datetimeLondonTimezone, formatString)}${timezone}`
     );
   }
 }

--- a/packages/date-publication/src/date-time.js
+++ b/packages/date-publication/src/date-time.js
@@ -12,15 +12,18 @@ class DatePublication extends Component {
     };
     this.updateTimezone = this.updateTimezone.bind(this);
   }
+
   componentDidMount() {
     this.updateTimezone();
   }
+
   updateTimezone() {
     const dateUTC = getUTCTime(this.props.date);
     if (!isLondonTimezone()) {
       this.setState({ tz: isBST(dateUTC) ? " BST" : " GMT" });
     }
   }
+
   render() {
     const { children, date, showDay } = this.props;
     const datetimeUTC = getUTCTime(date);

--- a/packages/date-publication/src/date-time.js
+++ b/packages/date-publication/src/date-time.js
@@ -18,7 +18,9 @@ class DatePublication extends Component {
   }
 
   updateTimezone() {
-    const dateUTC = getUTCTime(this.props.date);
+    const { date } = this.props;
+
+    const dateUTC = getUTCTime(date);
     if (!isLondonTimezone()) {
       this.setState({ tz: isBST(dateUTC) ? " BST" : " GMT" });
     }

--- a/packages/error-view/__tests__/invokes-error.js
+++ b/packages/error-view/__tests__/invokes-error.js
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 
 class Erroring extends Component {
   componentDidMount() {
-    this.props.onError(new Error("some error"));
+    const { onError } = this.props;
+
+    onError(new Error("some error"));
   }
 
   render() {

--- a/packages/error-view/error-view.showcase.js
+++ b/packages/error-view/error-view.showcase.js
@@ -50,7 +50,8 @@ ErrorState.propTypes = {
 
 class FiresOnError extends Component {
   componentDidMount() {
-    setTimeout(() => this.props.onError(new Error("async error")), 500);
+    const { onError } = this.props;
+    setTimeout(() => onError(new Error("async error")), 500);
   }
 
   render() {

--- a/packages/error-view/src/error-view.js
+++ b/packages/error-view/src/error-view.js
@@ -25,9 +25,12 @@ class ErrorView extends Component {
   }
 
   render() {
-    return this.props.children({
-      error: this.state.error,
-      hasError: !!this.state.error,
+    const { children } = this.props;
+    const { error } = this.state;
+
+    return children({
+      error,
+      hasError: !!error,
       onError: this.handleError
     });
   }

--- a/packages/eslint-config-thetimes/package.json
+++ b/packages/eslint-config-thetimes/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
     "babel-eslint": "10.0.1",
-    "eslint-config-airbnb": "16.1.0",
+    "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "3.3.0",
     "eslint-plugin-flowtype": "3.2.0",
     "eslint-plugin-import": "2.14.0",

--- a/packages/gestures/src/gestures.js
+++ b/packages/gestures/src/gestures.js
@@ -116,7 +116,11 @@ class Gestures extends Component {
   }
 
   handlePinchChange({ nativeEvent: { touches } }) {
-    const { stateAngle, stateCenter, stateZoomRatio } = this.state;
+    const {
+      angle: stateAngle,
+      center: stateCenter,
+      zoomRatio: stateZoomRatio
+    } = this.state;
     if (touches.length < 2) {
       return;
     }

--- a/packages/gestures/src/gestures.js
+++ b/packages/gestures/src/gestures.js
@@ -141,14 +141,8 @@ class Gestures extends Component {
           viewLayout,
           translate(
             {
-              translateX: subtract(
-                center.pageX,
-                viewLayout.x
-              ),
-              translateY: subtract(
-                center.pageY,
-                viewLayout.y
-              )
+              translateX: subtract(center.pageX, viewLayout.x),
+              translateY: subtract(center.pageY, viewLayout.y)
             },
             [{ scale: zoomRatio }]
           )
@@ -171,9 +165,7 @@ class Gestures extends Component {
       >
         <TouchableWithoutFeedback>
           <View {...this.props}>
-            <Animated.View style={transformStyle}>
-              {children}
-            </Animated.View>
+            <Animated.View style={transformStyle}>{children}</Animated.View>
           </View>
         </TouchableWithoutFeedback>
       </View>

--- a/packages/gestures/src/gestures.js
+++ b/packages/gestures/src/gestures.js
@@ -78,11 +78,12 @@ class Gestures extends Component {
         this.handlePinchChange(evt);
       },
       onPanResponderRelease: () => {
+        const { angle, zoomRatio } = this.state;
         Animated.parallel([
-          Animated.spring(this.state.zoomRatio, {
+          Animated.spring(zoomRatio, {
             toValue: 1
           }),
-          Animated.spring(this.state.angle, {
+          Animated.spring(angle, {
             toValue: 0
           })
         ]).start();
@@ -100,12 +101,13 @@ class Gestures extends Component {
   }
 
   onViewLayout(evt) {
+    const { viewLayout } = this.state;
     const { x, y, width, height } = evt.nativeEvent.layout;
 
-    this.state.viewLayout.x.setValue(x);
-    this.state.viewLayout.y.setValue(y);
-    this.state.viewLayout.width.setValue(width);
-    this.state.viewLayout.height.setValue(height);
+    viewLayout.x.setValue(x);
+    viewLayout.y.setValue(y);
+    viewLayout.width.setValue(width);
+    viewLayout.height.setValue(height);
   }
 
   handlePinchStart({ nativeEvent: { touches } }) {
@@ -114,6 +116,7 @@ class Gestures extends Component {
   }
 
   handlePinchChange({ nativeEvent: { touches } }) {
+    const { stateAngle, stateCenter, stateZoomRatio } = this.state;
     if (touches.length < 2) {
       return;
     }
@@ -122,33 +125,36 @@ class Gestures extends Component {
     const angle = (currentAngle - this.startAngle) % 360;
     const center = pointBetweenTwoTouches(touches);
 
-    this.state.zoomRatio.setValue(zoomRatio);
-    this.state.angle.setValue(angle);
-    this.state.center.pageX.setValue(center.pageX);
-    this.state.center.pageY.setValue(center.pageY);
+    stateZoomRatio.setValue(zoomRatio);
+    stateAngle.setValue(angle);
+    stateCenter.pageX.setValue(center.pageX);
+    stateCenter.pageY.setValue(center.pageY);
   }
 
   render() {
+    const { children } = this.props;
+    const { angle, center, viewLayout, zoomRatio } = this.state;
+
     const transformStyle = {
       transform: [
         ...resetOrigin(
-          this.state.viewLayout,
+          viewLayout,
           translate(
             {
               translateX: subtract(
-                this.state.center.pageX,
-                this.state.viewLayout.x
+                center.pageX,
+                viewLayout.x
               ),
               translateY: subtract(
-                this.state.center.pageY,
-                this.state.viewLayout.y
+                center.pageY,
+                viewLayout.y
               )
             },
-            [{ scale: this.state.zoomRatio }]
+            [{ scale: zoomRatio }]
           )
         ),
         {
-          rotate: this.state.angle.interpolate({
+          rotate: angle.interpolate({
             inputRange: [0, 359],
             outputRange: ["0 deg", "359 deg"]
           })
@@ -166,7 +172,7 @@ class Gestures extends Component {
         <TouchableWithoutFeedback>
           <View {...this.props}>
             <Animated.View style={transformStyle}>
-              {this.props.children}
+              {children}
             </Animated.View>
           </View>
         </TouchableWithoutFeedback>

--- a/packages/gradient/src/gradient-prop-types.base.js
+++ b/packages/gradient/src/gradient-prop-types.base.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import {
   propTypes as sharedPropTypes,
-  defaultPropTypes as sharedDefaultPropTypes
+  defaultProps as sharedDefaultPropTypes
 } from "./gradient-prop-types";
 
 export const propTypes = {

--- a/packages/image/src/image.web.js
+++ b/packages/image/src/image.web.js
@@ -40,13 +40,12 @@ class TimesImage extends Component {
   }
 
   highResImage({ highResSize, lowResSize, url }) {
+    const { highResIsLoaded } = this.state;
     if (!lowResSize || highResSize) {
       return (
         <StyledImage
           alt=""
-          isLoaded={
-            lowResSize && highResSize ? this.state.highResIsLoaded : true
-          }
+          isLoaded={lowResSize && highResSize ? highResIsLoaded : true}
           onLoad={this.handleHighResOnLoad}
           onTransitionEnd={this.onHighResTransitionEnd}
           src={appendSize(url, "resize", highResSize)}
@@ -59,11 +58,12 @@ class TimesImage extends Component {
   }
 
   lowResImage({ lowResSize, url }) {
-    if (lowResSize && !this.state.highResIsVisible) {
+    const { highResIsVisible, lowResIsLoaded } = this.state;
+    if (lowResSize && !highResIsVisible) {
       return (
         <StyledImage
           alt=""
-          isLoaded={this.state.lowResIsLoaded}
+          isLoaded={lowResIsLoaded}
           onLoad={this.handleLowResOnLoad}
           src={appendSize(url, "resize", lowResSize)}
           zIndex={1}

--- a/packages/image/src/modal-image.js
+++ b/packages/image/src/modal-image.js
@@ -5,10 +5,7 @@ import Gestures from "@times-components/gestures";
 import Button from "@times-components/link";
 import CloseButton from "./close-button";
 import Image from "./image";
-import {
-  modalImageDefaultProps,
-  modalImagePropTypes
-} from "./modal-image-prop-types";
+import { modalPropTypes, modalDefaultProps } from "./modal-image-prop-types";
 import styles, { captionStyles } from "./styles";
 
 class ModalImage extends Component {
@@ -31,13 +28,14 @@ class ModalImage extends Component {
 
   render() {
     const { caption, credits } = this.props;
+    const { showModal } = this.state;
 
     return (
       <View>
         <Modal
           onRequestClose={this.hideModal}
           presentationStyle="fullScreen"
-          visible={this.state.showModal}
+          visible={showModal}
         >
           <View style={styles.modal}>
             <View style={styles.buttonContainer}>
@@ -57,7 +55,7 @@ class ModalImage extends Component {
   }
 }
 
-ModalImage.propTypes = modalImagePropTypes;
-ModalImage.defaultProps = modalImageDefaultProps;
+ModalImage.propTypes = modalPropTypes;
+ModalImage.defaultProps = modalDefaultProps;
 
 export default ModalImage;

--- a/packages/interactive-wrapper/src/interactive-wrapper.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.js
@@ -69,8 +69,11 @@ class InteractiveWrapper extends Component {
   }
 
   render() {
+    const { id } = this.props;
+    const { height } = this.state;
+
     return (
-      <View style={{ height: this.state.height }}>
+      <View style={{ height }}>
         <WebView
           onLoadEnd={this.onLoadEnd}
           onMessage={this.onMessage}
@@ -80,10 +83,10 @@ class InteractiveWrapper extends Component {
           }}
           source={{
             uri: `${editorialLambdaProtocol}${editorialLambdaOrigin}/${editorialLambdaSlug}/${
-              this.props.id
+              id
             }`
           }}
-          style={{ height: this.state.height }}
+          style={{ height }}
           {...InteractiveWrapper.postMessageBugWorkaround()}
         />
       </View>

--- a/packages/interactive-wrapper/src/interactive-wrapper.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.js
@@ -82,9 +82,7 @@ class InteractiveWrapper extends Component {
             this.webview = webview;
           }}
           source={{
-            uri: `${editorialLambdaProtocol}${editorialLambdaOrigin}/${editorialLambdaSlug}/${
-              id
-            }`
+            uri: `${editorialLambdaProtocol}${editorialLambdaOrigin}/${editorialLambdaSlug}/${id}`
           }}
           style={{ height }}
           {...InteractiveWrapper.postMessageBugWorkaround()}

--- a/packages/interactive-wrapper/src/interactive-wrapper.web.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.web.js
@@ -10,21 +10,22 @@ export default class InteractiveWrapper extends Component {
   }
 
   componentDidMount() {
+    const { attributes, element, source } = this.props;
     const placeholder = this.placeholder.current;
     const { parentNode } = placeholder;
 
-    const element = document.createElement(this.props.element);
+    const newElement = document.createElement(element);
     const link = document.createElement("link");
 
-    link.setAttribute("href", this.props.source);
+    link.setAttribute("href", source);
     link.setAttribute("rel", "import");
 
-    Object.keys(this.props.attributes).forEach(key =>
-      element.setAttribute(key, this.props.attributes[key])
+    Object.keys(attributes).forEach(key =>
+      newElement.setAttribute(key, attributes[key])
     );
 
-    parentNode.replaceChild(element, placeholder);
-    parentNode.insertBefore(link, element);
+    parentNode.replaceChild(newElement, placeholder);
+    parentNode.insertBefore(link, newElement);
 
     delete this.placeholder.current;
   }

--- a/packages/jest-configurator/src/react-native-mock-components.js
+++ b/packages/jest-configurator/src/react-native-mock-components.js
@@ -2,12 +2,14 @@ import React from "react";
 
 const mockReactNativeComponent = componentName => {
   const RealComponent = require.requireActual(componentName);
-  const MockComponent = props =>
-    React.createElement(
+  const MockComponent = props => {
+    const { children } = props;
+    return React.createElement(
       componentName,
       Object.assign({}, props, { style: null }),
-      props.children
+      children
     );
+  };
 
   MockComponent.propTypes = RealComponent.propTypes;
   return MockComponent;

--- a/packages/lazy-load/__tests__/web/lazy.web.test.js
+++ b/packages/lazy-load/__tests__/web/lazy.web.test.js
@@ -64,6 +64,7 @@ const tests = [
         constructor(cb, opts) {
           optsSpy(opts);
         }
+
         observe() {} // eslint-disable-line class-methods-use-this
       };
 

--- a/packages/lazy-load/lazy-load.showcase.web.js
+++ b/packages/lazy-load/lazy-load.showcase.web.js
@@ -41,9 +41,10 @@ class SeenText extends Component {
   }
 
   render() {
+    const { showVisibleText } = this.state;
     return (
       <span>
-        {this.state.showVisibleText ? "You've seen me" : "I am hiding"}
+        {showVisibleText ? "You've seen me" : "I am hiding"}
       </span>
     );
   }

--- a/packages/lazy-load/lazy-load.showcase.web.js
+++ b/packages/lazy-load/lazy-load.showcase.web.js
@@ -42,11 +42,7 @@ class SeenText extends Component {
 
   render() {
     const { showVisibleText } = this.state;
-    return (
-      <span>
-        {showVisibleText ? "You've seen me" : "I am hiding"}
-      </span>
-    );
+    return <span>{showVisibleText ? "You've seen me" : "I am hiding"}</span>;
   }
 }
 

--- a/packages/lazy-load/src/lazy-load.js
+++ b/packages/lazy-load/src/lazy-load.js
@@ -56,14 +56,17 @@ class LazyLoad extends Component {
   }
 
   handleObservation(entries) {
+    const { threshold } = this.props;
+    const { nodes } = this.state;
+
     entries.forEach(({ target, intersectionRatio }) => {
       if (
-        intersectionRatio >= this.props.threshold &&
-        !this.state.nodes.get(target.id)
+        intersectionRatio >= threshold &&
+        !nodes.get(target.id)
       ) {
         this.pending.add(target);
       } else if (
-        intersectionRatio < this.props.threshold &&
+        intersectionRatio < threshold &&
         this.pending.has(target)
       ) {
         this.pending.delete(target);
@@ -78,12 +81,12 @@ class LazyLoad extends Component {
           return;
         }
 
-        this.setState({
+        this.setState(state => ({
           nodes: new Map([
-            ...this.state.nodes,
+            ...state.nodes,
             ...[...this.pending].map(n => [n.id, n])
           ])
-        });
+        }));
 
         this.pending.clear();
       }, 100);
@@ -118,10 +121,13 @@ class LazyLoad extends Component {
   }
 
   render() {
-    return this.props.children({
-      clientHasRendered: this.state.clientHasRendered,
+    const { children } = this.props;
+    const { clientHasRendered, nodes } = this.state;
+
+    return children({
+      clientHasRendered,
       isObserving: this.isObserving,
-      observed: this.state.nodes,
+      observed: nodes,
       registerNode: this.registerNode
     });
   }

--- a/packages/lazy-load/src/lazy-load.js
+++ b/packages/lazy-load/src/lazy-load.js
@@ -60,15 +60,9 @@ class LazyLoad extends Component {
     const { nodes } = this.state;
 
     entries.forEach(({ target, intersectionRatio }) => {
-      if (
-        intersectionRatio >= threshold &&
-        !nodes.get(target.id)
-      ) {
+      if (intersectionRatio >= threshold && !nodes.get(target.id)) {
         this.pending.add(target);
-      } else if (
-        intersectionRatio < threshold &&
-        this.pending.has(target)
-      ) {
+      } else if (intersectionRatio < threshold && this.pending.has(target)) {
         this.pending.delete(target);
       }
     });

--- a/packages/pagination/src/pagination-wrapper.js
+++ b/packages/pagination/src/pagination-wrapper.js
@@ -33,6 +33,7 @@ export default PaginatedComponent => {
     }
 
     componentDidMount() {
+      const { page } = this.state;
       if (typeof window !== "undefined") {
         window.onpopstate = event => {
           if (event.state) {
@@ -43,7 +44,7 @@ export default PaginatedComponent => {
         };
       }
 
-      Helper.replaceHistory(this.state.page);
+      Helper.replaceHistory(page);
     }
 
     componentWillUnmount() {

--- a/packages/provider-test-tools/src/mock-fixture.js
+++ b/packages/provider-test-tools/src/mock-fixture.js
@@ -44,13 +44,16 @@ class MockFixture extends Component {
   }
 
   componentDidMount() {
-    schemaToMocks(this.props.params).then(mocks => this.setState({ mocks }));
+    const { params } = this.props;
+
+    schemaToMocks(params).then(mocks => this.setState({ mocks }));
   }
 
   render() {
-    return this.state.mocks.length === 0
-      ? null
-      : this.props.render(this.state.mocks);
+    const { render } = this.props;
+    const { mocks } = this.state;
+
+    return mocks.length === 0 ? null : render(mocks);
   }
 }
 

--- a/packages/provider-test-tools/src/mocked-provider.js
+++ b/packages/provider-test-tools/src/mocked-provider.js
@@ -12,7 +12,7 @@ class MockedProvider extends Component {
   constructor(props, context) {
     super(props, context);
 
-    const link = this.props.isLoading
+    const link = props.isLoading
       ? new ApolloLink(() => Observable.of())
       : new MockLink(props.mocks);
 
@@ -26,11 +26,9 @@ class MockedProvider extends Component {
   }
 
   render() {
-    return (
-      <ApolloProvider client={this.client}>
-        {this.props.children}
-      </ApolloProvider>
-    );
+    const { children } = this.props;
+
+    return <ApolloProvider client={this.client}>{children}</ApolloProvider>;
   }
 }
 

--- a/packages/provider-test-tools/src/provider-tester.js
+++ b/packages/provider-test-tools/src/provider-tester.js
@@ -39,7 +39,9 @@ export default function providerTester(
     }
 
     render() {
-      return this.props.children(this.state);
+      const { children } = this.props;
+
+      return children(this.state);
     }
   }
 

--- a/packages/provider/__tests__/inner.js
+++ b/packages/provider/__tests__/inner.js
@@ -8,7 +8,9 @@ class Inner extends Component {
   }
 
   componentDidUpdate({ debouncedProps }) {
-    if (debouncedProps !== this.props.debouncedProps) {
+    const { debouncedProps: propsDebouncedProps } = this.props;
+
+    if (debouncedProps !== propsDebouncedProps) {
       this.numberOfDebouncedPropsUpdates += 1;
     }
   }

--- a/packages/provider/__tests__/provider.test.js
+++ b/packages/provider/__tests__/provider.test.js
@@ -206,7 +206,9 @@ describe("Provider Tests", () => {
       }
 
       render() {
-        return this.props.children;
+        const { children } = this.props;
+
+        return children;
       }
     }
     ErrorSpy.propTypes = {

--- a/packages/pull-quote/src/pull-quote.web.js
+++ b/packages/pull-quote/src/pull-quote.web.js
@@ -3,13 +3,16 @@ import PullQuoteBase from "./pull-quote.base";
 import makeTwitterUrl from "./utils";
 import { propTypes, defaultProps } from "./pull-quote-prop-types";
 
-const PullQuote = ({ caption, ...props }) => (
-  <blockquote url={props.twitter ? makeTwitterUrl(props.twitter) : ""}>
-    <PullQuoteBase {...props}>
-      <cite>{caption}</cite>
-    </PullQuoteBase>
-  </blockquote>
-);
+const PullQuote = ({ caption, ...props }) => {
+  const { twitter } = props;
+  return (
+    <blockquote url={twitter ? makeTwitterUrl(twitter) : ""}>
+      <PullQuoteBase {...props}>
+        <cite>{caption}</cite>
+      </PullQuoteBase>
+    </blockquote>
+  );
+};
 
 PullQuote.propTypes = propTypes;
 PullQuote.defaultProps = defaultProps;

--- a/packages/related-articles/src/related-article-item.base.js
+++ b/packages/related-articles/src/related-article-item.base.js
@@ -38,15 +38,17 @@ class RelatedArticleItem extends Component {
   }
 
   componentDidMount() {
-    if (this.props.imageConfig.showHiRes) {
+    const { imageConfig } = this.props;
+    if (imageConfig.showHiRes) {
       this.setHighResSize();
     }
   }
 
   componentDidUpdate(prevProps) {
+    const { imageConfig } = this.props;
     if (
-      prevProps.imageConfig.showHiRes !== this.props.imageConfig.showHiRes &&
-      this.props.imageConfig.showHiRes
+      prevProps.imageConfig.showHiRes !== imageConfig.showHiRes &&
+      imageConfig.showHiRes
     ) {
       this.setHighResSize();
     }
@@ -92,16 +94,18 @@ class RelatedArticleItem extends Component {
         type: summaryType
       }
     } = this.props;
+    const { article } = this.props;
+    const { highResSize } = this.state;
 
     const imageUri = getImageUri(leadAsset, leadAssetOverride, cropSize);
 
     return children({
-      article: this.props.article,
+      article,
       card: (
         <View ref={this.node}>
           <Card
             contentContainerClass={contentContainerClass}
-            highResSize={this.state.highResSize}
+            highResSize={highResSize}
             imageContainerClass={imageContainerClass}
             imageRatio={imageRatio}
             imageStyle={imageStyle}
@@ -130,7 +134,7 @@ class RelatedArticleItem extends Component {
                         : `summary`;
                       return (
                         <ArticleSummaryContent
-                          ast={this.props.article[`summary${item}`]}
+                          ast={article[`summary${item}`]}
                           className={`summaryHidden ${summaryClass}${summaryClassSuffix}`}
                           key={item}
                         />

--- a/packages/related-articles/src/related-articles.js
+++ b/packages/related-articles/src/related-articles.js
@@ -12,7 +12,8 @@ import withTrackingContext from "./related-articles-tracking-context";
 
 class RelatedArticles extends Component {
   shouldComponentUpdate(nextProps) {
-    return nextProps.isVisible !== this.props.isVisible;
+    const { isVisible } = this.props;
+    return nextProps.isVisible !== isVisible;
   }
 
   render() {

--- a/packages/slice/src/templates/leadoneandtwo/index.js
+++ b/packages/slice/src/templates/leadoneandtwo/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { leadConfig, supportConfig } from "./config";
-import { propTypes, defaultProps } from "./proptypes";
+import propTypes from "./proptypes";
 import styles from "../styles";
 
 const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
@@ -23,6 +23,5 @@ const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
 };
 
 LeadOneAndTwoSlice.propTypes = propTypes;
-LeadOneAndTwoSlice.defaultProps = defaultProps;
 
 export default LeadOneAndTwoSlice;

--- a/packages/slice/src/templates/leadoneandtwo/index.web.js
+++ b/packages/slice/src/templates/leadoneandtwo/index.web.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { propTypes, defaultProps } from "./proptypes";
+import propTypes from "./proptypes";
 import { getSeparator, SliceContainer } from "../styles/responsive";
 import {
   getContainer,
@@ -7,7 +7,11 @@ import {
   getSupportContainer,
   SupportsContainer
 } from "./responsive";
-import { getLeadConfig, getSupportConfig, getConfigWrapper } from "./config";
+import {
+  getLeadConfig,
+  getSupportConfig,
+  getConfigWrapper
+} from "./config.web";
 
 const supportConfig = getSupportConfig();
 const Separator = getSeparator({ hasLeftRightMargin: false });
@@ -73,6 +77,5 @@ class LeadOneAndTwoSlice extends Component {
 }
 
 LeadOneAndTwoSlice.propTypes = propTypes;
-LeadOneAndTwoSlice.defaultProps = defaultProps;
 
 export default LeadOneAndTwoSlice;

--- a/packages/slice/src/templates/opiniononeandtwo/index.js
+++ b/packages/slice/src/templates/opiniononeandtwo/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { View } from "react-native";
 import styles from "../styles";
 import { opinionConfig, supportConfig } from "./config";
-import { propTypes, defaultProps } from "./proptypes";
+import propTypes from "./proptypes";
 import opinionStyles from "./styles";
 
 const OpinionOneAndTwoSlice = ({
@@ -30,6 +30,5 @@ const OpinionOneAndTwoSlice = ({
 };
 
 OpinionOneAndTwoSlice.propTypes = propTypes;
-OpinionOneAndTwoSlice.defaultProps = defaultProps;
 
 export default OpinionOneAndTwoSlice;

--- a/packages/slice/src/templates/opiniononeandtwo/index.web.js
+++ b/packages/slice/src/templates/opiniononeandtwo/index.web.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { propTypes, defaultProps } from "./proptypes";
+import propTypes from "./proptypes";
 import { SliceContainer } from "../styles/responsive";
 import {
   getSeparator,
@@ -8,7 +8,11 @@ import {
   getSupportContainer,
   getSupportsContainer
 } from "./responsive";
-import { getOpinionConfig, getSupportConfig, getConfigWrapper } from "./config";
+import {
+  getOpinionConfig,
+  getSupportConfig,
+  getConfigWrapper
+} from "./config.web";
 
 const supportConfig = getSupportConfig();
 
@@ -86,6 +90,5 @@ class OpinionOneAndTwoSlice extends Component {
 }
 
 OpinionOneAndTwoSlice.propTypes = propTypes;
-OpinionOneAndTwoSlice.defaultProps = defaultProps;
 
 export default OpinionOneAndTwoSlice;

--- a/packages/slice/src/templates/standard/index.web.js
+++ b/packages/slice/src/templates/standard/index.web.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import propTypes from "./proptypes";
 import { getSeparator, SliceContainer } from "../styles/responsive";
 import { getChildrenContainer, ChildContainer } from "./responsive";
-import { getConfig, getConfigWrapper } from "./config";
+import { getConfig, getConfigWrapper } from "./config.web";
 
 const Separator = getSeparator({ hasLeftRightMargin: true });
 

--- a/packages/ssr/src/lib/graphql-logging-link.js
+++ b/packages/ssr/src/lib/graphql-logging-link.js
@@ -6,6 +6,7 @@ class LogLink extends ApolloLink {
     this.uri = uri;
     this.logger = logger;
   }
+
   request(operation, forward) {
     let msg = `Connecting to GraphQL at ${this.uri} for ${
       operation.operationName

--- a/packages/ssr/src/lib/run-server.js
+++ b/packages/ssr/src/lib/run-server.js
@@ -8,9 +8,9 @@ const { fragmentMatcher } = require("@times-components/schema");
 const { getDataFromTree } = require("react-apollo");
 const { InMemoryCache } = require("apollo-cache-inmemory");
 const ReactDOMServer = require("react-dom/server");
-const safeStringify = require("./safe-stringify");
 const { ServerStyleSheet } = require("styled-components");
 const { ApolloLink } = require("apollo-link");
+const safeStringify = require("./safe-stringify");
 const errorLink = require("./graphql-error-link");
 const LoggingLink = require("./graphql-logging-link");
 

--- a/packages/storybook/storybook-provider.js
+++ b/packages/storybook/storybook-provider.js
@@ -7,7 +7,7 @@ import { InMemoryCache } from "apollo-cache-inmemory";
 import { fragmentMatcher } from "@times-components/schema";
 import { text } from "@storybook/addon-knobs/react";
 
-const StorybookProvider = props => {
+const StorybookProvider = ({ children }) => {
   const nbsp = "\u00A0";
   const uri = text(
     `GraphQL${nbsp}Endpoint`,
@@ -29,7 +29,7 @@ const StorybookProvider = props => {
 
   return (
     <ApolloProvider client={client} debounceTimeMs={250}>
-      {props.children}
+      {children}
     </ApolloProvider>
   );
 };

--- a/packages/styleguide/src/animations/index.js
+++ b/packages/styleguide/src/animations/index.js
@@ -8,17 +8,20 @@ class FadeIn extends Component {
   };
 
   componentDidMount() {
-    Animated.timing(this.state.fadeAnim, {
+    const { fadeAnim } = this.state;
+
+    Animated.timing(fadeAnim, {
       duration: 300,
       toValue: 1
     }).start();
   }
 
   render() {
+    const { fadeAnim } = this.state;
+    const { children } = this.props;
+
     return (
-      <Animated.View style={{ opacity: this.state.fadeAnim }}>
-        {this.props.children}
-      </Animated.View>
+      <Animated.View style={{ opacity: fadeAnim }}>{children}</Animated.View>
     );
   }
 }

--- a/packages/topic/__tests__/mock-provider.js
+++ b/packages/topic/__tests__/mock-provider.js
@@ -63,14 +63,14 @@ export class TopicArticlesProvider extends Component {
 
   render() {
     const { children, pageSize } = this.props;
-    const { topic } = this.state;
+    const { topic: stateTopic } = this.state;
 
     return (
       <topicArticlesProvider>
         {children({
           fetchMore: this.fetchMore,
           pageSize,
-          topic,
+          topic: stateTopic,
           variables: {
             imageRatio: "5:4"
           }

--- a/packages/topic/__tests__/mock-provider.js
+++ b/packages/topic/__tests__/mock-provider.js
@@ -63,13 +63,14 @@ export class TopicArticlesProvider extends Component {
 
   render() {
     const { children, pageSize } = this.props;
+    const { topic } = this.state;
 
     return (
       <topicArticlesProvider>
         {children({
           fetchMore: this.fetchMore,
           pageSize,
-          topic: this.state.topic,
+          topic,
           variables: {
             imageRatio: "5:4"
           }

--- a/packages/tracking/__tests__/list-component.js
+++ b/packages/tracking/__tests__/list-component.js
@@ -15,29 +15,36 @@ class ListComponent extends Component {
       receiveChildList: PropTypes.func
     };
   }
+
   static get defaultProps() {
     return {
       items: [{ someKey: "1", someValue: "one" }],
       receiveChildList: () => {}
     };
   }
+
   static get someStatic() {
     return { foo: "bar" };
   }
+
   constructor(props, context) {
     super(props, context);
     this.onViewableItemsChanged = this.onViewableItemsChanged.bind(this);
     props.receiveChildList(props.items);
   }
+
   onViewableItemsChanged({ info }) {
+    const { onViewed } = this.props;
     const filtered = info.changed.filter(item => item.isViewable);
-    filtered.forEach(item => this.props.onViewed(item));
+    filtered.forEach(item => onViewed(item));
   }
+
   render() {
+    const { items } = this.props;
     return (
       <FlatList
-        data={this.props.items}
-        initialNumToRender={this.props.items.length}
+        data={items}
+        initialNumToRender={items.length}
         keyExtractor={({ someKey }) => someKey}
         onViewableItemsChanged={this.onViewableItemsChanged}
         renderItem={({ item }) => <Text>Item {item.someValue}</Text>}

--- a/packages/tracking/__tests__/shared-tracking-tests.js
+++ b/packages/tracking/__tests__/shared-tracking-tests.js
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import renderer from "react-test-renderer";
 
-const TestComponent = props => <Text>{props.someProp}</Text>;
+const TestComponent = ({ someProp }) => <Text>{someProp}</Text>;
 TestComponent.propTypes = { someProp: PropTypes.string };
 TestComponent.defaultProps = { someProp: "foo" };
 TestComponent.someStatic = { foo: "bar" };

--- a/packages/tracking/__tests__/test-tracking-context.js
+++ b/packages/tracking/__tests__/test-tracking-context.js
@@ -13,6 +13,7 @@ export default WrappedComponent => {
         }
       };
     }
+
     render() {
       return <WrappedComponent {...this.props} />;
     }

--- a/packages/tracking/__tests__/track-events.test.js
+++ b/packages/tracking/__tests__/track-events.test.js
@@ -9,9 +9,10 @@ import sharedTrackingTests from "./shared-tracking-tests";
 module.exports = () => {
   describe("TrackEvents", () => {
     const TestComponent = ({ event1, event2, ...props }) => {
+      const { someProp } = props;
       event1("event1 arg");
       event2("event2 arg");
-      return <Text>{props.someProp}</Text>;
+      return <Text>{someProp}</Text>;
     };
     TestComponent.propTypes = {
       event1: PropTypes.func,

--- a/packages/tracking/__tests__/tracking-context.test.js
+++ b/packages/tracking/__tests__/tracking-context.test.js
@@ -7,14 +7,15 @@ import { withTrackingContext } from "../src/tracking";
 
 module.exports = () => {
   describe("WithTrackingContext", () => {
-    const TestComponent = props => <Text>{props.someProp}</Text>;
+    const TestComponent = ({ someProp }) => <Text>{someProp}</Text>;
     TestComponent.propTypes = { someProp: PropTypes.string };
     TestComponent.defaultProps = { someProp: "foo" };
     TestComponent.someStatic = { foo: "bar" };
 
     const withTestTracking = WrappedComponent => {
       const TestTracking = (props, context) => {
-        context.tracking.analytics({
+        const { tracking } = context;
+        tracking.analytics({
           action: "Viewed",
           attrs: {},
           component: "TestComponent"

--- a/packages/tracking/__tests__/tracking.web.test.js
+++ b/packages/tracking/__tests__/tracking.web.test.js
@@ -11,6 +11,7 @@ class FakeIntersectionObserver {
   static clearObserving() {
     FakeIntersectionObserver.observing.splice(0);
   }
+
   static dispatchObservedAll() {
     this.observationCallback(
       this.observing.map(element => ({
@@ -22,15 +23,19 @@ class FakeIntersectionObserver {
       }))
     );
   }
+
   static dispatchObservedAllAsUndefined() {
     this.observationCallback();
   }
+
   constructor(callback) {
     this.constructor.observationCallback = callback;
   }
+
   observe(element) {
     this.constructor.observing.push(element);
   }
+
   disconnect() {
     this.constructor.clearObserving();
   }
@@ -51,26 +56,33 @@ class ListComponent extends Component {
       receiveChildList: PropTypes.func
     };
   }
+
   static get defaultProps() {
     return {
       items: [{ someKey: "1", someValue: "one" }],
       receiveChildList: () => {}
     };
   }
+
   static get someStatic() {
     return { foo: "bar" };
   }
+
   constructor(props) {
     super(props);
     props.receiveChildList(props.items);
   }
+
   componentDidUpdate() {
-    this.props.receiveChildList(this.props.items);
+    const { items, receiveChildList } = this.props;
+    receiveChildList(items);
   }
+
   render() {
+    const { items } = this.props;
     return (
       <View>
-        {this.props.items.map(item => (
+        {items.map(item => (
           <Text id={item.elementId} key={item.someKey}>
             Item {item.someValue}
           </Text>

--- a/packages/tracking/src/track-events.js
+++ b/packages/tracking/src/track-events.js
@@ -38,11 +38,12 @@ export default (WrappedComponent, { analyticsEvents = [] } = {}) => {
 
   class WithTrackEvents extends Component {
     get wrappedAnalyticsEvents() {
+      const { tracking } = this.context;
       return this.wrapWithTracking(
         analyticsEvents,
         (attrs, actionName, trackingName) =>
-          this.context.tracking &&
-          this.context.tracking.analytics({
+          tracking &&
+          tracking.analytics({
             action: actionName,
             attrs,
             component: trackingName || componentName
@@ -59,7 +60,7 @@ export default (WrappedComponent, { analyticsEvents = [] } = {}) => {
           const funcWrapped = (...args) => {
             const attrs = resolveAttrs(getAttrs, this.props, args);
             tracking(attrs, actionName, trackingName);
-            return this.props[eventName] && this.props[eventName](...args);
+            return this.props[eventName] && this.props[eventName](...args); // eslint-disable-line react/destructuring-assignment
           };
 
           return {

--- a/packages/tracking/src/track-scroll-depth.js
+++ b/packages/tracking/src/track-scroll-depth.js
@@ -20,7 +20,8 @@ export default (
     }
 
     onChildView(childProps) {
-      this.context.tracking.analytics({
+      const { tracking } = this.context;
+      tracking.analytics({
         action: "Scrolled",
         attrs: {
           ...resolveAttrs(getAttrs, childProps),

--- a/packages/tracking/src/track-scroll-depth.web.js
+++ b/packages/tracking/src/track-scroll-depth.web.js
@@ -45,7 +45,8 @@ export default (
     }
 
     onObserved(observed = []) {
-      if (!this.context.tracking) {
+      const { tracking } = this.context;
+      if (!tracking) {
         return;
       }
 
@@ -59,7 +60,8 @@ export default (
     }
 
     onChildView(childProps) {
-      this.context.tracking.analytics({
+      const { tracking } = this.context;
+      tracking.analytics({
         action: "Scrolled",
         attrs: {
           ...resolveAttrs(getAttrs, childProps),

--- a/packages/tracking/storybook-components/box.js
+++ b/packages/tracking/storybook-components/box.js
@@ -12,9 +12,9 @@ export const boxStyles = StyleSheet.create({
   }
 });
 
-const Box = props => (
-  <View id={props.id} style={[boxStyles.box, { backgroundColor: props.color }]}>
-    {props.children}
+const Box = ({ children, color, id }) => (
+  <View id={id} style={[boxStyles.box, { backgroundColor: color }]}>
+    {children}
   </View>
 );
 Box.propTypes = {

--- a/packages/tracking/storybook-components/boxes.js
+++ b/packages/tracking/storybook-components/boxes.js
@@ -10,22 +10,25 @@ const viewabilityConfig = {
 export default class Boxes extends Component {
   constructor(props) {
     super(props);
+    const { boxes, receiveChildList } = this.props;
     this.onViewableItemsChanged = this.onViewableItemsChanged.bind(this);
-    this.props.receiveChildList(this.props.boxes);
+    receiveChildList(boxes);
   }
+
   onViewableItemsChanged(info) {
+    const { boxes, onViewed } = this.props;
     if (info.changed) {
       info.changed
         .filter(viewableItem => viewableItem.isViewable)
-        .map(viewableItem =>
-          this.props.onViewed(viewableItem.item, this.props.boxes)
-        );
+        .map(viewableItem => onViewed(viewableItem.item, boxes));
     }
   }
+
   render() {
+    const { boxes } = this.props;
     return (
       <FlatList
-        data={this.props.boxes}
+        data={boxes}
         keyExtractor={({ id }) => id}
         onViewableItemsChanged={this.onViewableItemsChanged}
         renderItem={({ item }) => (

--- a/packages/tracking/storybook-components/boxes.web.js
+++ b/packages/tracking/storybook-components/boxes.web.js
@@ -5,10 +5,13 @@ import Box from "./box";
 
 export default class Boxes extends Component {
   componentDidMount() {
-    this.props.receiveChildList(this.props.boxes);
+    const { boxes, receiveChildList } = this.props;
+    receiveChildList(boxes);
   }
+
   render() {
-    return this.props.boxes.map(item => (
+    const { boxes } = this.props;
+    return boxes.map(item => (
       <Box id={item.elementId} key={item.elementId} {...item}>
         <Text>{item.elementId}</Text>
       </Box>

--- a/packages/tracking/tracking.showcase.js
+++ b/packages/tracking/tracking.showcase.js
@@ -10,12 +10,12 @@ import {
 import Box, { boxStyles } from "./storybook-components/box";
 import Boxes from "./storybook-components/boxes";
 
-const BoxWithButtons = props => (
-  <View style={[boxStyles.box, { backgroundColor: props.color }]}>
-    <Button onPress={() => props.onPress("button 1")} title="Press me" />
+const BoxWithButtons = ({ color, onPress }) => (
+  <View style={[boxStyles.box, { backgroundColor: color }]}>
+    <Button onPress={() => onPress("button 1")} title="Press me" />
     <Button
       color="limegreen"
-      onPress={() => props.onPress("button 2")}
+      onPress={() => onPress("button 2")}
       title="Or me"
     />
   </View>

--- a/packages/video/__tests__/web/is-paid.web.test.js
+++ b/packages/video/__tests__/web/is-paid.web.test.js
@@ -1,4 +1,4 @@
-import { isPaidOnly } from "../../src/video";
+import { isPaidOnly } from "../../src/video.web";
 
 it("isPaidOnly true should be true", () => {
   expect(isPaidOnly(true)).toBe(true);

--- a/packages/video/src/inline-video-player.web.js
+++ b/packages/video/src/inline-video-player.web.js
@@ -40,8 +40,11 @@ const css = `
 
 class InlineVideoPlayer extends Component {
   static index = 0;
+
   static scriptLoadError = false;
+
   static activePlayers = [];
+
   static brightcoveSDKLoadedStarted = false;
 
   static brightcoveSDKHasLoaded() {
@@ -135,10 +138,9 @@ class InlineVideoPlayer extends Component {
   }
 
   createBrightcoveScript() {
+    const { accountId, playerId } = this.props;
     const s = document.createElement("script");
-    s.src = `//players.brightcove.net/${this.props.accountId}/${
-      this.props.playerId
-    }_default/index.min.js`;
+    s.src = `//players.brightcove.net/${accountId}/${playerId}_default/index.min.js`;
 
     return s;
   }
@@ -160,8 +162,9 @@ class InlineVideoPlayer extends Component {
 
   render() {
     const { width, height, poster, videoId, accountId, playerId } = this.props;
+    const { error, showSkyBanner } = this.state;
 
-    if (this.state.error) {
+    if (error) {
       throw new Error(); // caught by parent ErrorView
     }
 
@@ -170,11 +173,11 @@ class InlineVideoPlayer extends Component {
       // Added a wrapping div as brightcove adds siblings to the video tag
       <div data-testid="video-component" style={{ height, width }}>
         <div style={{ position: "relative" }}>
-          {this.state.showSkyBanner && <SkySportsBanner />}
+          {showSkyBanner && <SkySportsBanner />}
           <video
             id={this.id}
             style={{ height, width }}
-            {...(poster ? { poster: this.props.poster.uri } : {})}
+            {...(poster ? { poster: poster.uri } : {})}
             className="video-js"
             controls
             data-account={accountId}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7545,19 +7545,23 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-airbnb-base@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
-  integrity sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==
+eslint-config-airbnb-base@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz#b5a1b480b80dfad16433d6c4ad84e6605052c05c"
+  integrity sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==
   dependencies:
     eslint-restricted-globals "^0.1.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
 
-eslint-config-airbnb@16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz#2546bfb02cc9fe92284bf1723ccf2e87bc45ca46"
-  integrity sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==
+eslint-config-airbnb@17.1.0:
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz#3964ed4bc198240315ff52030bf8636f42bc4732"
+  integrity sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==
   dependencies:
-    eslint-config-airbnb-base "^12.1.0"
+    eslint-config-airbnb-base "^13.1.0"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
 
 eslint-config-prettier@3.3.0:
   version "3.3.0"


### PR DESCRIPTION
Following the bumps of the `eslint` family of packages, this PR bumps the `eslint-config-airbnb` package. Airbnb are now using the latest `eslint-plugin-react` package which causes numerous changes to our codebase - none breaking, all stylistic. We have adopted airbnb to avoid bikeshedding, so this PR follows that decision.

- destruct everything in React
- newline spaces between Class properties and methods
- no using `state` directly in `setState` because it is asynchronous, use in a function instead
- enforces some explicit pathname declarations