### PR TITLE
fix: Check for children length in paragraph

### DIFF
--- a/packages/article-paragraph/src/index.js
+++ b/packages/article-paragraph/src/index.js
@@ -8,6 +8,10 @@ import { propTypes, defaultProps } from "./drop-cap-prop-types";
 
 const ArticleParagraphWrapper = ({ ast, children, colour, uid }) => {
   const { children: astChildren } = ast;
+  if (!astChildren || astChildren.length === 0) {
+    return null;
+  }
+
   const { name, attributes } = astChildren[0];
   if (name === "dropCap") {
     const { value } = attributes;


### PR DESCRIPTION
We got articles with empty paragraphs coming through TPA, which is crashing the article view in mobile apps. This needs to resolved on the backend but a client side check is added to `patch` the crash.

Example article that's broken: https://www.thetimes.co.uk/article/f1fe5dd0-ed13-11e8-bea1-693d823de728 