### PR TITLE
feat: Add support for centred captions

### DIFF
--- a/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`caption with only container styles 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "backgroundColor": "blue",
+        "paddingTop": 5,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 13,
+          "lineHeight": 20,
+        }
+      }
+    >
+      Some caption text goes in here
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 9,
+          "fontWeight": "400",
+          "letterSpacing": 1,
+          "lineHeight": 20,
+        }
+      }
+    >
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`caption with specific styles 1`] = `
 <View>
   <View
@@ -31,48 +71,6 @@ exports[`caption with specific styles 1`] = `
           "fontWeight": "400",
           "letterSpacing": 1,
           "lineHeight": 20,
-        }
-      }
-    >
-      JUST CREDITS
-    </Text>
-  </View>
-</View>
-`;
-
-exports[`centred caption with specific styles 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "backgroundColor": "red",
-        "paddingTop": 5,
-      }
-    }
-  >
-    <Text
-      style={
-        Object {
-          "color": "green",
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 13,
-          "lineHeight": 20,
-          "textAlign": "center",
-        }
-      }
-    >
-      Some caption text goes in here
-    </Text>
-    <Text
-      style={
-        Object {
-          "color": "green",
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 9,
-          "fontWeight": "400",
-          "letterSpacing": 1,
-          "lineHeight": 20,
-          "textAlign": "center",
         }
       }
     >

--- a/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption-with-style.android.test.js.snap
@@ -39,3 +39,45 @@ exports[`caption with specific styles 1`] = `
   </View>
 </View>
 `;
+
+exports[`centred caption with specific styles 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "backgroundColor": "red",
+        "paddingTop": 5,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "green",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 13,
+          "lineHeight": 20,
+          "textAlign": "center",
+        }
+      }
+    >
+      Some caption text goes in here
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "green",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 9,
+          "fontWeight": "400",
+          "letterSpacing": 1,
+          "lineHeight": 20,
+          "textAlign": "center",
+        }
+      }
+    >
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
+++ b/packages/caption/__tests__/android/__snapshots__/caption.android.test.js.snap
@@ -48,3 +48,52 @@ exports[`4. caption with child 1`] = `
   </View>
 </View>
 `;
+
+exports[`5. centred caption without credits 1`] = `
+<View>
+  <View>
+    <Text>
+      Some caption text goes in here
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`6. centred caption caption with credits 1`] = `
+<View>
+  <View>
+    <Text>
+      Some caption text goes in here
+    </Text>
+    <Text>
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`7. centred caption caption with credits only 1`] = `
+<View>
+  <View>
+    <Text>
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`8. centred caption caption with child 1`] = `
+<View>
+  <Text>
+    Hello world!
+  </Text>
+  <View>
+    <Text>
+      Some caption text goes in here
+    </Text>
+    <Text>
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/caption/__tests__/ios/__snapshots__/caption-with-style.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption-with-style.ios.test.js.snap
@@ -39,3 +39,45 @@ exports[`caption with specific styles 1`] = `
   </View>
 </View>
 `;
+
+exports[`centred caption with specific styles 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "backgroundColor": "red",
+        "paddingTop": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "green",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 13,
+          "lineHeight": 16,
+          "textAlign": "center",
+        }
+      }
+    >
+      Some caption text goes in here
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "green",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 9,
+          "fontWeight": "400",
+          "letterSpacing": 1,
+          "lineHeight": 16,
+          "textAlign": "center",
+        }
+      }
+    >
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/caption/__tests__/ios/__snapshots__/caption-with-style.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption-with-style.ios.test.js.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`caption with only container styles 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "backgroundColor": "blue",
+        "paddingTop": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 13,
+          "lineHeight": 16,
+        }
+      }
+    >
+      Some caption text goes in here
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "GillSansMTStd-Medium",
+          "fontSize": 9,
+          "fontWeight": "400",
+          "letterSpacing": 1,
+          "lineHeight": 16,
+        }
+      }
+    >
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`caption with specific styles 1`] = `
 <View>
   <View
@@ -31,48 +71,6 @@ exports[`caption with specific styles 1`] = `
           "fontWeight": "400",
           "letterSpacing": 1,
           "lineHeight": 16,
-        }
-      }
-    >
-      JUST CREDITS
-    </Text>
-  </View>
-</View>
-`;
-
-exports[`centred caption with specific styles 1`] = `
-<View>
-  <View
-    style={
-      Object {
-        "backgroundColor": "red",
-        "paddingTop": 10,
-      }
-    }
-  >
-    <Text
-      style={
-        Object {
-          "color": "green",
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 13,
-          "lineHeight": 16,
-          "textAlign": "center",
-        }
-      }
-    >
-      Some caption text goes in here
-    </Text>
-    <Text
-      style={
-        Object {
-          "color": "green",
-          "fontFamily": "GillSansMTStd-Medium",
-          "fontSize": 9,
-          "fontWeight": "400",
-          "letterSpacing": 1,
-          "lineHeight": 16,
-          "textAlign": "center",
         }
       }
     >

--- a/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
+++ b/packages/caption/__tests__/ios/__snapshots__/caption.ios.test.js.snap
@@ -48,3 +48,52 @@ exports[`4. caption with child 1`] = `
   </View>
 </View>
 `;
+
+exports[`5. centred caption without credits 1`] = `
+<View>
+  <View>
+    <Text>
+      Some caption text goes in here
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`6. centred caption caption with credits 1`] = `
+<View>
+  <View>
+    <Text>
+      Some caption text goes in here
+    </Text>
+    <Text>
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`7. centred caption caption with credits only 1`] = `
+<View>
+  <View>
+    <Text>
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`8. centred caption caption with child 1`] = `
+<View>
+  <Text>
+    Hello world!
+  </Text>
+  <View>
+    <Text>
+      Some caption text goes in here
+    </Text>
+    <Text>
+      JUST CREDITS
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/caption/__tests__/shared-with-style.base.js
+++ b/packages/caption/__tests__/shared-with-style.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Caption from "../src/caption";
+import Caption, { CentredCaption } from "../src/caption";
 
 const captionText = "Some caption text goes in here";
 const credits = "Just credits";
@@ -17,6 +17,14 @@ export default () => {
   it("caption with specific styles", () => {
     const testInstance = TestRenderer.create(
       <Caption credits={credits} style={style} text={captionText} />
+    );
+
+    expect(testInstance.toJSON()).toMatchSnapshot();
+  });
+
+  it("centred caption with specific styles", () => {
+    const testInstance = TestRenderer.create(
+      <CentredCaption credits={credits} style={style} text={captionText} />
     );
 
     expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/caption/__tests__/shared-with-style.base.js
+++ b/packages/caption/__tests__/shared-with-style.base.js
@@ -30,7 +30,11 @@ export default () => {
 
   it("caption with only container styles", () => {
     const testInstance = TestRenderer.create(
-      <Caption credits={credits} style={containerOnlyStyle} text={captionText} />
+      <Caption
+        credits={credits}
+        style={containerOnlyStyle}
+        text={captionText}
+      />
     );
 
     expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/caption/__tests__/shared-with-style.base.js
+++ b/packages/caption/__tests__/shared-with-style.base.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
-import Caption, { CentredCaption } from "../src/caption";
+import Caption from "../src/caption";
 
 const captionText = "Some caption text goes in here";
 const credits = "Just credits";
@@ -13,6 +13,12 @@ const style = {
   }
 };
 
+const containerOnlyStyle = {
+  container: {
+    backgroundColor: "blue"
+  }
+};
+
 export default () => {
   it("caption with specific styles", () => {
     const testInstance = TestRenderer.create(
@@ -22,9 +28,9 @@ export default () => {
     expect(testInstance.toJSON()).toMatchSnapshot();
   });
 
-  it("centred caption with specific styles", () => {
+  it("caption with only container styles", () => {
     const testInstance = TestRenderer.create(
-      <CentredCaption credits={credits} style={style} text={captionText} />
+      <Caption credits={credits} style={containerOnlyStyle} text={captionText} />
     );
 
     expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/caption/__tests__/shared.base.js
+++ b/packages/caption/__tests__/shared.base.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Text } from "react-native";
 import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
-import Caption from "../src/caption";
+import Caption, { CentredCaption } from "../src/caption";
 
 const captionText = "Some caption text goes in here";
 const credits = "Just credits";
@@ -44,6 +44,48 @@ export default () => {
           <Caption credits={credits} text={captionText}>
             <Text>Hello world!</Text>
           </Caption>
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "centred caption without credits",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <CentredCaption text={captionText} />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "centred caption caption with credits",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <CentredCaption credits={credits} text={captionText} />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "centred caption caption with credits only",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <CentredCaption credits={credits} />
+        );
+
+        expect(testInstance.toJSON()).toMatchSnapshot();
+      }
+    },
+    {
+      name: "centred caption caption with child",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <CentredCaption credits={credits} text={captionText}>
+            <Text>Hello world!</Text>
+          </CentredCaption>
         );
 
         expect(testInstance.toJSON()).toMatchSnapshot();

--- a/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
@@ -59,3 +59,65 @@ exports[`caption with specific styles 1`] = `
   </div>
 </div>
 `;
+
+exports[`centred caption with specific styles 1`] = `
+<style>
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 17px;
+  padding-top: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 1px;
+  line-height: 17px;
+  padding-top: 0px;
+}
+
+.S3 {
+  padding-top: 10px;
+}
+
+.S4 {
+  padding-top: 0px;
+}
+
+.IS1 {
+  color: rgba(0,128,0,1.00);
+  text-align: center;
+}
+
+.IS2 {
+  color: rgba(0,128,0,1.00);
+  text-align: center;
+}
+
+.IS3 {
+  background-color: rgba(255,0,0,1.00);
+}
+</style>
+
+<div
+  className="S4"
+>
+  <div
+    className="IS3 S3"
+  >
+    <div
+      className="IS1 S1"
+    >
+      Some caption text goes in here
+    </div>
+    <div
+      className="IS2 S2"
+    >
+      JUST CREDITS
+    </div>
+  </div>
+</div>
+`;

--- a/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption-with-style.web.test.js.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`caption with only container styles 1`] = `
+<style>
+.S1 {
+  color: rgba(105,105,105,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 13px;
+  font-weight: inherit;
+  line-height: 17px;
+  padding-top: 0px;
+}
+
+.S2 {
+  color: rgba(51,51,51,1.00);
+  font-family: GillSansMTStd-Medium;
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 1px;
+  line-height: 17px;
+  padding-top: 0px;
+}
+
+.S3 {
+  padding-top: 10px;
+}
+
+.S4 {
+  padding-top: 0px;
+}
+
+.IS1 {
+  background-color: rgba(0,0,255,1.00);
+}
+</style>
+
+<div
+  className="S4"
+>
+  <div
+    className="IS1 S3"
+  >
+    <div
+      className="S1"
+    >
+      Some caption text goes in here
+    </div>
+    <div
+      className="S2"
+    >
+      JUST CREDITS
+    </div>
+  </div>
+</div>
+`;
+
 exports[`caption with specific styles 1`] = `
 <style>
 .S1 {
@@ -33,68 +87,6 @@ exports[`caption with specific styles 1`] = `
 
 .IS2 {
   color: rgba(0,128,0,1.00);
-}
-
-.IS3 {
-  background-color: rgba(255,0,0,1.00);
-}
-</style>
-
-<div
-  className="S4"
->
-  <div
-    className="IS3 S3"
-  >
-    <div
-      className="IS1 S1"
-    >
-      Some caption text goes in here
-    </div>
-    <div
-      className="IS2 S2"
-    >
-      JUST CREDITS
-    </div>
-  </div>
-</div>
-`;
-
-exports[`centred caption with specific styles 1`] = `
-<style>
-.S1 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 13px;
-  font-weight: inherit;
-  line-height: 17px;
-  padding-top: 0px;
-}
-
-.S2 {
-  font-family: GillSansMTStd-Medium;
-  font-size: 9px;
-  font-weight: 400;
-  letter-spacing: 1px;
-  line-height: 17px;
-  padding-top: 0px;
-}
-
-.S3 {
-  padding-top: 10px;
-}
-
-.S4 {
-  padding-top: 0px;
-}
-
-.IS1 {
-  color: rgba(0,128,0,1.00);
-  text-align: center;
-}
-
-.IS2 {
-  color: rgba(0,128,0,1.00);
-  text-align: center;
 }
 
 .IS3 {

--- a/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
@@ -48,3 +48,88 @@ exports[`4. caption with child 1`] = `
   </div>
 </div>
 `;
+
+exports[`5. centred caption without credits 1`] = `
+<div>
+  <div>
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      Some caption text goes in here
+    </div>
+  </div>
+</div>
+`;
+
+exports[`6. centred caption caption with credits 1`] = `
+<div>
+  <div>
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      Some caption text goes in here
+    </div>
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      JUST CREDITS
+    </div>
+  </div>
+</div>
+`;
+
+exports[`7. centred caption caption with credits only 1`] = `
+<div>
+  <div>
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      JUST CREDITS
+    </div>
+  </div>
+</div>
+`;
+
+exports[`8. centred caption caption with child 1`] = `
+<div>
+  <div>
+    Hello world!
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      Some caption text goes in here
+    </div>
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      JUST CREDITS
+    </div>
+  </div>
+</div>
+`;

--- a/packages/caption/caption.showcase.js
+++ b/packages/caption/caption.showcase.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { Image } from "react-native";
-import Caption from "./src/caption";
+import Caption, { CentredCaption } from "./src/caption";
 
 const captionText =
   'The prime minister said HMS Queen Elizabeth was a symbol of Britain’s status as a "great maritime nation"';
 const credits = "BEN STANSALL/PA WIRE";
 const exampleImage =
-  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7d2fd06c-a460-11e7-8955-1ad2a9a7928d.jpg?crop=1500%2C844%2C0%2C78&resize=685";
+  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2Ff10d34c8-abaf-11e8-9969-06853d7144fd.jpg?crop=1688%2C949%2C0%2C88&resize=685";
 const style = {
   container: {
     backgroundColor: "blue"
@@ -31,6 +31,11 @@ export default {
     {
       component: () => <Caption credits={credits} />,
       name: "Credits only",
+      type: "story"
+    },
+    {
+      component: () => <CentredCaption credits={credits} text={captionText} />,
+      name: "Centred caption",
       type: "story"
     },
     {

--- a/packages/caption/src/caption.js
+++ b/packages/caption/src/caption.js
@@ -36,3 +36,4 @@ Caption.propTypes = propTypes;
 Caption.defaultProps = defaultProps;
 
 export default Caption;
+export { default as CentredCaption } from "./centred-caption";

--- a/packages/caption/src/centred-caption.js
+++ b/packages/caption/src/centred-caption.js
@@ -1,0 +1,24 @@
+import React from "react";
+import Caption from "./caption";
+import { defaultProps, propTypes } from "./caption-prop-types";
+
+const CentredCaption = ({ children, credits, style, text }) => (
+  <Caption
+    credits={credits}
+    style={{
+      ...style,
+      text: {
+        ...style.text,
+        textAlign: "center"
+      }
+    }}
+    text={text}
+  >
+    {children}
+  </Caption>
+);
+
+CentredCaption.propTypes = propTypes;
+CentredCaption.defaultProps = defaultProps;
+
+export default CentredCaption;


### PR DESCRIPTION
- Create a new `<CenteredCaption />` component in the `caption` package 
- First use will be the `article-magazine-comment` template.

### Android
<img width="304" alt="screenshot 2018-11-23 at 14 48 59" src="https://user-images.githubusercontent.com/1736782/48949171-04554a80-ef2f-11e8-8b8e-785a90c4d310.png">

### Web
<img width="798" alt="screenshot 2018-11-23 at 14 51 01" src="https://user-images.githubusercontent.com/1736782/48949232-38c90680-ef2f-11e8-8b5f-a91cb825faa3.png">
