### PR TITLE
fix: Small fixes noticed in SSR

### DIFF
--- a/packages/article-main-comment/article-main-comment.showcase.js
+++ b/packages/article-main-comment/article-main-comment.showcase.js
@@ -197,5 +197,5 @@ export default {
       type: "story"
     }
   ],
-  name: "Pages/Article"
+  name: "Pages/Templates"
 };

--- a/packages/article-main-comment/src/article-main-comment.js
+++ b/packages/article-main-comment/src/article-main-comment.js
@@ -30,9 +30,11 @@ class ArticlePage extends Component {
       standfirst
     } = article;
 
+    const authorImage = author && author.image ? author.image : null;
+
     return (
       <ArticleHeader
-        authorImage={author.image}
+        authorImage={authorImage}
         byline={byline}
         flags={flags}
         headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -27,9 +27,11 @@ class ArticlePage extends Component {
       standfirst
     } = article;
 
+    const authorImage = author && author.image ? author.image : null;
+
     return (
       <ArticleHeader
-        authorImage={author.image}
+        authorImage={authorImage}
         byline={byline}
         flags={flags}
         headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-main-comment/src/styles/responsive.web.js
+++ b/packages/article-main-comment/src/styles/responsive.web.js
@@ -90,7 +90,7 @@ export const Seperator = styled(View)`
   display: none;
 
   @media (min-width: ${breakpoints.medium}px) {
-    background-color: ${colours.functional.keyline}
+    background-color: ${colours.functional.keyline};
     display: flex;
     height: ${spacing(3)};
     margin: 0 ${spacing(2)};

--- a/packages/article-skeleton/src/article-body/article-body.web.js
+++ b/packages/article-skeleton/src/article-body/article-body.web.js
@@ -125,9 +125,9 @@ const renderers = ({ observed, registerNode }) => ({
   paywall(key, attributes, children) {
     return {
       element: (
-        <div className="paywall" key={key}>
+        <span className="paywall" key={key}>
           {children}
-        </div>
+        </span>
       )
     };
   },


### PR DESCRIPTION
Some small issues I noticed when testing the article template selector in SSR but didn't want to bundle these with that breaking change. They were:

* Error that a `div` was inside a `p` tag. This was paywalled content. Changed to a span.
* Small temporary fix to account for a missing author image for the `article-main-comment` template. This is a required field and should always be populated, however, we are waiting for the implementation into TPA. 