### PR TITLE
Feat/centre aligned captions magazine

### DIFF
--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -126,42 +126,7 @@ exports[`full article with style 1`] = `
         }
       >
         <ModalImage />
-        <View>
-          <View
-            style={
-              Object {
-                "paddingTop": 5,
-              }
-            }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#696969",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 13,
-                  "lineHeight": 20,
-                }
-              }
-            >
-              Some Caption
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 9,
-                  "fontWeight": "400",
-                  "letterSpacing": 1,
-                  "lineHeight": 20,
-                }
-              }
-            >
-              SOME CREDITS
-            </Text>
-          </View>
-        </View>
+        <CenteredCaption />
       </View>
     </View>
     <View>
@@ -229,29 +194,15 @@ exports[`full article with style 1`] = `
         }
       >
         <Video />
-        <View>
-          <View
-            style={
-              Object {
+        <Caption
+          style={
+            Object {
+              "container": Object {
                 "paddingLeft": 10,
-                "paddingTop": 5,
-              }
+              },
             }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#696969",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 13,
-                  "lineHeight": 20,
-                }
-              }
-            >
-              This is video caption
-            </Text>
-          </View>
-        </View>
+          }
+        />
       </View>
     </View>
     <View>

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -62,16 +62,10 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           highResSize={1440}
           uri="https://crop169.io"
         />
-        <View>
-          <View>
-            <Text>
-              Some Caption
-            </Text>
-            <Text>
-              SOME CREDITS
-            </Text>
-          </View>
-        </View>
+        <CenteredCaption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>
@@ -211,16 +205,10 @@ exports[`4. an article with ads 1`] = `
           highResSize={1440}
           uri="https://crop169.io"
         />
-        <View>
-          <View>
-            <Text>
-              Some Caption
-            </Text>
-            <Text>
-              SOME CREDITS
-            </Text>
-          </View>
-        </View>
+        <CenteredCaption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -126,42 +126,7 @@ exports[`full article with style 1`] = `
         }
       >
         <ModalImage />
-        <View>
-          <View
-            style={
-              Object {
-                "paddingTop": 10,
-              }
-            }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#696969",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 13,
-                  "lineHeight": 16,
-                }
-              }
-            >
-              Some Caption
-            </Text>
-            <Text
-              style={
-                Object {
-                  "color": "#333333",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 9,
-                  "fontWeight": "400",
-                  "letterSpacing": 1,
-                  "lineHeight": 16,
-                }
-              }
-            >
-              SOME CREDITS
-            </Text>
-          </View>
-        </View>
+        <CenteredCaption />
       </View>
     </View>
     <View>
@@ -228,29 +193,15 @@ exports[`full article with style 1`] = `
         }
       >
         <Video />
-        <View>
-          <View
-            style={
-              Object {
+        <Caption
+          style={
+            Object {
+              "container": Object {
                 "paddingLeft": 10,
-                "paddingTop": 10,
-              }
+              },
             }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#696969",
-                  "fontFamily": "GillSansMTStd-Medium",
-                  "fontSize": 13,
-                  "lineHeight": 16,
-                }
-              }
-            >
-              This is video caption
-            </Text>
-          </View>
-        </View>
+          }
+        />
       </View>
     </View>
     <View>

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -62,16 +62,10 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           highResSize={1440}
           uri="https://crop169.io"
         />
-        <View>
-          <View>
-            <Text>
-              Some Caption
-            </Text>
-            <Text>
-              SOME CREDITS
-            </Text>
-          </View>
-        </View>
+        <CenteredCaption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>
@@ -211,16 +205,10 @@ exports[`4. an article with ads 1`] = `
           highResSize={1440}
           uri="https://crop169.io"
         />
-        <View>
-          <View>
-            <Text>
-              Some Caption
-            </Text>
-            <Text>
-              SOME CREDITS
-            </Text>
-          </View>
-        </View>
+        <CenteredCaption
+          credits="Some Credits"
+          text="Some Caption"
+        />
       </View>
     </View>
     <View>

--- a/packages/article-magazine-comment/__tests__/mocks.native.js
+++ b/packages/article-magazine-comment/__tests__/mocks.native.js
@@ -17,6 +17,11 @@ jest.mock("@times-components/article-label", () => "ArticleLabel");
 jest.mock("@times-components/article-topics", () => "ArticleTopics");
 jest.mock("@times-components/brightcove-video", () => "BrightcoveVideo");
 jest.mock("@times-components/button", () => "Button");
+jest.mock("@times-components/caption", () => ({
+  __esModule: true,
+  CentredCaption: "CenteredCaption",
+  default: "Caption"
+}));
 jest.mock("@times-components/image", () => ({
   __esModule: true,
   default: "Image",

--- a/packages/article-magazine-comment/__tests__/mocks.web.js
+++ b/packages/article-magazine-comment/__tests__/mocks.web.js
@@ -13,7 +13,8 @@ jest.mock("@times-components/article-image", () => "ArticleImage");
 jest.mock("@times-components/article-topics", () => "ArticleTopics");
 jest.mock("@times-components/caption", () => ({
   __esModule: true,
-  CentredCaption: "CenteredCaption"
+  CentredCaption: "CenteredCaption",
+  default: "Caption"
 }));
 jest.mock("@times-components/date-publication", () => "DatePublication");
 jest.mock("@times-components/image", () => "Image");

--- a/packages/article-magazine-comment/__tests__/mocks.web.js
+++ b/packages/article-magazine-comment/__tests__/mocks.web.js
@@ -11,7 +11,10 @@ jest.mock("@times-components/article-flag", () => ({
 }));
 jest.mock("@times-components/article-image", () => "ArticleImage");
 jest.mock("@times-components/article-topics", () => "ArticleTopics");
-jest.mock("@times-components/caption", () => "Caption");
+jest.mock("@times-components/caption", () => ({
+  __esModule: true,
+  CentredCaption: "CenteredCaption"
+}));
 jest.mock("@times-components/date-publication", () => "DatePublication");
 jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/link", () => "Link");

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -642,7 +642,7 @@ exports[`full article with style 1`] = `
           className="c12 S1"
         >
           <figcaption>
-            <Caption />
+            <CenteredCaption />
           </figcaption>
         </div>
       </figure>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -75,7 +75,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
         </div>
         <div>
           <figcaption>
-            <Caption
+            <CenteredCaption
               credits="Some Credits"
               text="Some Caption"
             />
@@ -241,7 +241,7 @@ exports[`4. an article with ads 1`] = `
         </div>
         <div>
           <figcaption>
-            <Caption
+            <CenteredCaption
               credits="Some Credits"
               text="Some Caption"
             />

--- a/packages/article-magazine-comment/src/article-lead-asset/article-lead-asset.js
+++ b/packages/article-magazine-comment/src/article-lead-asset/article-lead-asset.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
-import Caption from "@times-components/caption";
+import { CentredCaption } from "@times-components/caption";
 import ArticleLeadAssetImage from "./article-lead-asset-image";
 import ArticleLeadAssetVideo from "./article-lead-asset-video";
 import styles from "../styles";
@@ -14,7 +14,7 @@ const ArticleLeadAsset = ({ data, width }) => {
   return (
     <View style={styles.leadAssetContainer}>
       <LeadAsset {...data} width={width} />
-      <Caption credits={data.credits} text={data.caption} />
+      <CentredCaption credits={data.credits} text={data.caption} />
     </View>
   );
 };

--- a/packages/article-magazine-comment/src/article-lead-asset/article-lead-asset.web.js
+++ b/packages/article-magazine-comment/src/article-lead-asset/article-lead-asset.web.js
@@ -45,7 +45,10 @@ const LeadAssetComponent = ({
         </AspectRatioContainer>
         <LeadAssetCaptionContainer>
           <figcaption>
-            <CentredCaption credits={leadAsset.credits} text={leadAsset.caption} />
+            <CentredCaption
+              credits={leadAsset.credits}
+              text={leadAsset.caption}
+            />
           </figcaption>
         </LeadAssetCaptionContainer>
       </figure>

--- a/packages/article-magazine-comment/src/article-lead-asset/article-lead-asset.web.js
+++ b/packages/article-magazine-comment/src/article-lead-asset/article-lead-asset.web.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Caption from "@times-components/caption";
+import { CentredCaption } from "@times-components/caption";
 import Image from "@times-components/image";
 import { AspectRatioContainer } from "@times-components/utils";
 import Video from "@times-components/video";
@@ -45,7 +45,7 @@ const LeadAssetComponent = ({
         </AspectRatioContainer>
         <LeadAssetCaptionContainer>
           <figcaption>
-            <Caption credits={leadAsset.credits} text={leadAsset.caption} />
+            <CentredCaption credits={leadAsset.credits} text={leadAsset.caption} />
           </figcaption>
         </LeadAssetCaptionContainer>
       </figure>


### PR DESCRIPTION
This is dependent on #1519 and should be rebased off of master once it has been merged. To view the changes of this PR in isolation, check out https://github.com/newsuk/times-components/commit/b814ec077d0da54d8467a1b53834e793ed0a1727 

This centre aligns captions in the magazine comment template 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
