### PR TITLE
chore: To allow consistent results if template is queried

### DIFF
--- a/packages/provider-test-tools/fixtures/article.json
+++ b/packages/provider-test-tools/fixtures/article.json
@@ -1534,6 +1534,7 @@
   "shortIdentifier": "37b27qd2s",
   "slug": "france-defies-may-over-russia",
   "standfirst": "How did one of Britain’s top young athletes end up running elite parties for swingers? Chris Reynolds Gordon tells Rick Broadbent about his extraordinary life",
+  "template": "mainstandard",
   "topics": [
     {
       "name": "Islington",


### PR DESCRIPTION
Fixes the problem with inconsistent results in #1512 

Required to go in first and separate from the breaking change.