### PR TITLE
chore: update styled components

### DIFF
--- a/packages/article-image/__tests__/shared-with-style.web.js
+++ b/packages/article-image/__tests__/shared-with-style.web.js
@@ -25,9 +25,12 @@ export default () => {
         ArticleImage: justChildren,
         ArticleImageWeb: justChildren,
         Caption: justChildren,
+        ForwardRef: justChildren,
         InlineImage: justChildren,
         InsetCaptionWeb: justChildren,
         "responsive-styles__component": justChildren,
+        responsiveweb__InsetImageStyle: justChildren,
+        StyledComponent: justChildren,
         TimesImage: propsNoChildren,
         ...meltNative
       }),

--- a/packages/article-image/__tests__/shared.web.js
+++ b/packages/article-image/__tests__/shared.web.js
@@ -25,6 +25,7 @@ export default () => {
         ArticleImage: justChildren,
         ArticleImageWeb: justChildren,
         Caption: justChildren,
+        ForwardRef: justChildren,
         TimesImage: propsNoChildren,
         ...meltNative
       }),

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -34,22 +34,20 @@ Array [
     />
   </div>,
   <div>
-    <responsiveweb__InsetCaptionStyle>
-      <div
-        className="c1"
-      >
+    <div
+      className="c1"
+    >
+      <div>
         <div>
           <div>
-            <div>
-              Some caption
-            </div>
-            <div>
-              SOME CREDITS
-            </div>
+            Some caption
+          </div>
+          <div>
+            SOME CREDITS
           </div>
         </div>
       </div>
-    </responsiveweb__InsetCaptionStyle>
+    </div>
   </div>,
 ]
 `;
@@ -160,37 +158,33 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
 }
 
 <figure>
-  <responsiveweb__InsetImageStyle>
-    <div
-      className="c0"
-    >
-      <TimesImage
-        aspectRatio={1.5}
-        fadeImageIn={false}
-        highResSize={null}
-        lowResSize={null}
-        uri="https://img/someImage"
-      />
-    </div>
-  </responsiveweb__InsetImageStyle>
-  <responsiveweb__InsetCaptionContainerStyle>
-    <div
-      className="c2"
-    >
-      <figcaption>
+  <div
+    className="c0"
+  >
+    <TimesImage
+      aspectRatio={1.5}
+      fadeImageIn={false}
+      highResSize={null}
+      lowResSize={null}
+      uri="https://img/someImage"
+    />
+  </div>
+  <div
+    className="c2"
+  >
+    <figcaption>
+      <div>
         <div>
           <div>
-            <div>
-              Landscape caption
-            </div>
-            <div>
-              LANDSCAPE CREDITS
-            </div>
+            Landscape caption
+          </div>
+          <div>
+            LANDSCAPE CREDITS
           </div>
         </div>
-      </figcaption>
-    </div>
-  </responsiveweb__InsetCaptionContainerStyle>
+      </div>
+    </figcaption>
+  </div>
 </figure>
 `;
 
@@ -262,36 +256,32 @@ exports[`4. inline image (portrait) with caption and credits 1`] = `
 }
 
 <figure>
-  <responsiveweb__InsetImageStyle>
-    <div
-      className="c0"
-    >
-      <TimesImage
-        aspectRatio={0.6666666666666666}
-        fadeImageIn={false}
-        highResSize={null}
-        lowResSize={null}
-        uri="https://img/someImage"
-      />
-    </div>
-  </responsiveweb__InsetImageStyle>
-  <responsiveweb__InsetCaptionContainerStyle>
-    <div
-      className="c2"
-    >
-      <figcaption>
+  <div
+    className="c0"
+  >
+    <TimesImage
+      aspectRatio={0.6666666666666666}
+      fadeImageIn={false}
+      highResSize={null}
+      lowResSize={null}
+      uri="https://img/someImage"
+    />
+  </div>
+  <div
+    className="c2"
+  >
+    <figcaption>
+      <div>
         <div>
           <div>
-            <div>
-              Portrait caption
-            </div>
-            <div>
-              PORTRAIT CREDITS
-            </div>
+            Portrait caption
+          </div>
+          <div>
+            PORTRAIT CREDITS
           </div>
         </div>
-      </figcaption>
-    </div>
-  </responsiveweb__InsetCaptionContainerStyle>
+      </div>
+    </figcaption>
+  </div>
 </figure>
 `;

--- a/packages/article-image/package.json
+++ b/packages/article-image/package.json
@@ -52,7 +52,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -72,7 +72,7 @@
     "@times-components/image": "4.3.13",
     "@times-components/styleguide": "3.8.3",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-list/package.json
+++ b/packages/article-list/package.json
@@ -56,7 +56,7 @@
     "eslint": "5.9.0",
     "graphql": "0.13.2",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -88,7 +88,7 @@
     "@times-components/watermark": "2.1.53",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/article-magazine-comment/package.json
+++ b/packages/article-magazine-comment/package.json
@@ -49,7 +49,7 @@
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-dom": "16.5.2",
@@ -74,7 +74,7 @@
     "@times-components/video": "4.1.21",
     "lodash.invert": "4.3.0",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-main-comment/package.json
+++ b/packages/article-main-comment/package.json
@@ -49,7 +49,7 @@
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-dom": "16.5.2",
@@ -72,7 +72,7 @@
     "@times-components/utils": "4.0.14",
     "lodash.invert": "4.3.0",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-main-standard/package.json
+++ b/packages/article-main-standard/package.json
@@ -49,7 +49,7 @@
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "mockdate": "2.0.2",
     "prettier": "1.14.3",
     "react": "16.5.2",
@@ -77,7 +77,7 @@
     "@times-components/video-label": "2.1.56",
     "lodash.invert": "4.3.0",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article-paragraph/package.json
+++ b/packages/article-paragraph/package.json
@@ -40,7 +40,7 @@
     "@times-components/styleguide": "3.8.3",
     "lodash.invert": "4.3.0",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "devDependencies": {
     "@thetimes/jest-lint": "*",
@@ -55,7 +55,7 @@
     "babel-plugin-styled-components": "1.5.1",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-dom": "16.5.2",

--- a/packages/article-skeleton/package.json
+++ b/packages/article-skeleton/package.json
@@ -54,7 +54,7 @@
     "depcheck": "0.6.9",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -93,7 +93,7 @@
     "lodash.invert": "4.3.0",
     "mockdate": "2.0.2",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/article/package.json
+++ b/packages/article/package.json
@@ -68,7 +68,7 @@
     "@times-components/provider": "1.8.3",
     "@times-components/styleguide": "3.8.3",
     "lodash.invert": "4.3.0",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/author-profile/package.json
+++ b/packages/author-profile/package.json
@@ -54,7 +54,7 @@
     "depcheck": "0.6.9",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "mockdate": "2.0.2",
     "prettier": "1.14.3",
     "react": "16.5.2",
@@ -87,7 +87,7 @@
     "@times-components/utils": "4.0.14",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/card/__tests__/shared-with-style.native.js
+++ b/packages/card/__tests__/shared-with-style.native.js
@@ -3,8 +3,10 @@ import {
   addSerializers,
   compose,
   flattenStyleTransform,
+  justChildren,
   minimalNativeTransform,
-  print
+  print,
+  replaceTransform
 } from "@times-components/jest-serializer";
 import shared from "./shared-with-style.base";
 
@@ -17,7 +19,10 @@ export default () => {
     compose(
       print,
       flattenStyleTransform,
-      minimalNativeTransform
+      minimalNativeTransform,
+      replaceTransform({
+        ForwardRef: justChildren
+      })
     )
   );
 

--- a/packages/card/__tests__/shared.web.js
+++ b/packages/card/__tests__/shared.web.js
@@ -28,6 +28,7 @@ export default () => {
       replaceTransform({
         CardComponent: justChildren,
         CardContent: justChildren,
+        ForwardRef: justChildren,
         Gradient: propsNoChildren,
         Loading: justChildren,
         TimesImage: propsNoChildren,

--- a/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card-loading-style.test.js.snap
@@ -234,49 +234,47 @@ exports[`1. card loading state 1`] = `
 }
 </style>
 
-<indexweb__FadeIn>
+<div
+  className="c0 S1"
+>
   <div
-    className="c0 S1"
+    className="S7"
   >
     <div
-      className="S7"
+      className="S2"
     >
-      <div
-        className="S2"
-      >
-        <TimesImage
-          aspectRatio={0.6666666666666666}
-          fadeImageIn={false}
-          highResSize={800}
-          lowResSize={60}
-          uri="https://img.io/img"
+      <TimesImage
+        aspectRatio={0.6666666666666666}
+        fadeImageIn={false}
+        highResSize={800}
+        lowResSize={60}
+        uri="https://img.io/img"
+      />
+    </div>
+    <div
+      className="S6"
+    >
+      <Component>
+        <Gradient
+          className="IS8"
+          degrees={264}
         />
-      </div>
-      <div
-        className="S6"
-      >
-        <Component>
-          <Gradient
-            className="IS8"
-            degrees={264}
-          />
-          <Gradient
-            className="IS11"
-            degrees={267}
-          />
-          <Gradient
-            className="IS14"
-            degrees={267}
-          />
-          <Gradient
-            className="IS17"
-            degrees={267}
-          />
-        </Component>
-      </div>
+        <Gradient
+          className="IS11"
+          degrees={267}
+        />
+        <Gradient
+          className="IS14"
+          degrees={267}
+        />
+        <Gradient
+          className="IS17"
+          degrees={267}
+        />
+      </Component>
     </div>
   </div>
-</indexweb__FadeIn>
+</div>
 `;
 
 exports[`2. card with reversed loading state 1`] = `
@@ -514,47 +512,45 @@ exports[`2. card with reversed loading state 1`] = `
 }
 </style>
 
-<indexweb__FadeIn>
+<div
+  className="c0 S5"
+>
   <div
-    className="c0 S5"
+    className="S7"
   >
     <div
-      className="S7"
+      className="S4"
     >
-      <div
-        className="S4"
-      >
-        <Component>
-          <Gradient
-            className="IS3"
-            degrees={264}
-          />
-          <Gradient
-            className="IS6"
-            degrees={267}
-          />
-          <Gradient
-            className="IS9"
-            degrees={267}
-          />
-          <Gradient
-            className="IS12"
-            degrees={267}
-          />
-        </Component>
-      </div>
-      <div
-        className="S6"
-      >
-        <TimesImage
-          aspectRatio={0.6666666666666666}
-          fadeImageIn={false}
-          highResSize={800}
-          lowResSize={60}
-          uri="https://img.io/img"
+      <Component>
+        <Gradient
+          className="IS3"
+          degrees={264}
         />
-      </div>
+        <Gradient
+          className="IS6"
+          degrees={267}
+        />
+        <Gradient
+          className="IS9"
+          degrees={267}
+        />
+        <Gradient
+          className="IS12"
+          degrees={267}
+        />
+      </Component>
+    </div>
+    <div
+      className="S6"
+    >
+      <TimesImage
+        aspectRatio={0.6666666666666666}
+        fadeImageIn={false}
+        highResSize={800}
+        lowResSize={60}
+        uri="https://img.io/img"
+      />
     </div>
   </div>
-</indexweb__FadeIn>
+</div>
 `;

--- a/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
+++ b/packages/card/__tests__/web/__snapshots__/card.web.test.js.snap
@@ -97,7 +97,42 @@ exports[`6. card with reversed layout and no image 1`] = `
 `;
 
 exports[`7. card with a loading state 1`] = `
-<indexweb__FadeIn>
+<StyledComponent
+  forwardedClass={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "attrs": Array [],
+      "componentStyle": ComponentStyle {
+        "componentId": "indexweb__FadeIn-gNxVQn",
+        "isStatic": true,
+        "lastClassName": "cqvuVo",
+        "rules": Array [
+          "animation:",
+          Keyframes {
+            "id": "sc-keyframes-eMLfYp",
+            "inject": [Function],
+            "name": "eMLfYp",
+            "rules": Array [
+              "@-webkit-keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+              "@keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+            ],
+            "toString": [Function],
+          },
+          " 0.3s ease-in-out;",
+        ],
+      },
+      "displayName": "indexweb__FadeIn",
+      "render": [Function],
+      "styledComponentId": "indexweb__FadeIn-gNxVQn",
+      "target": [Function],
+      "toString": [Function],
+      "warnTooManyClasses": [Function],
+      "withComponent": [Function],
+      Symbol(Symbol.hasInstance): [Function],
+    }
+  }
+  forwardedRef={null}
+>
   <div>
     <div>
       <div>
@@ -127,11 +162,46 @@ exports[`7. card with a loading state 1`] = `
       </div>
     </div>
   </div>
-</indexweb__FadeIn>
+</StyledComponent>
 `;
 
 exports[`8. card with a loading state and no image 1`] = `
-<indexweb__FadeIn>
+<StyledComponent
+  forwardedClass={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "attrs": Array [],
+      "componentStyle": ComponentStyle {
+        "componentId": "indexweb__FadeIn-gNxVQn",
+        "isStatic": true,
+        "lastClassName": "cqvuVo",
+        "rules": Array [
+          "animation:",
+          Keyframes {
+            "id": "sc-keyframes-eMLfYp",
+            "inject": [Function],
+            "name": "eMLfYp",
+            "rules": Array [
+              "@-webkit-keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+              "@keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+            ],
+            "toString": [Function],
+          },
+          " 0.3s ease-in-out;",
+        ],
+      },
+      "displayName": "indexweb__FadeIn",
+      "render": [Function],
+      "styledComponentId": "indexweb__FadeIn-gNxVQn",
+      "target": [Function],
+      "toString": [Function],
+      "warnTooManyClasses": [Function],
+      "withComponent": [Function],
+      Symbol(Symbol.hasInstance): [Function],
+    }
+  }
+  forwardedRef={null}
+>
   <div>
     <div>
       <div>
@@ -152,11 +222,46 @@ exports[`8. card with a loading state and no image 1`] = `
       </div>
     </div>
   </div>
-</indexweb__FadeIn>
+</StyledComponent>
 `;
 
 exports[`9. card with reversed loading state 1`] = `
-<indexweb__FadeIn>
+<StyledComponent
+  forwardedClass={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "attrs": Array [],
+      "componentStyle": ComponentStyle {
+        "componentId": "indexweb__FadeIn-gNxVQn",
+        "isStatic": true,
+        "lastClassName": "cqvuVo",
+        "rules": Array [
+          "animation:",
+          Keyframes {
+            "id": "sc-keyframes-eMLfYp",
+            "inject": [Function],
+            "name": "eMLfYp",
+            "rules": Array [
+              "@-webkit-keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+              "@keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+            ],
+            "toString": [Function],
+          },
+          " 0.3s ease-in-out;",
+        ],
+      },
+      "displayName": "indexweb__FadeIn",
+      "render": [Function],
+      "styledComponentId": "indexweb__FadeIn-gNxVQn",
+      "target": [Function],
+      "toString": [Function],
+      "warnTooManyClasses": [Function],
+      "withComponent": [Function],
+      Symbol(Symbol.hasInstance): [Function],
+    }
+  }
+  forwardedRef={null}
+>
   <div>
     <div>
       <div>
@@ -186,11 +291,46 @@ exports[`9. card with reversed loading state 1`] = `
       </div>
     </div>
   </div>
-</indexweb__FadeIn>
+</StyledComponent>
 `;
 
 exports[`10. card with reversed loading state with no image 1`] = `
-<indexweb__FadeIn>
+<StyledComponent
+  forwardedClass={
+    Object {
+      "$$typeof": Symbol(react.forward_ref),
+      "attrs": Array [],
+      "componentStyle": ComponentStyle {
+        "componentId": "indexweb__FadeIn-gNxVQn",
+        "isStatic": true,
+        "lastClassName": "cqvuVo",
+        "rules": Array [
+          "animation:",
+          Keyframes {
+            "id": "sc-keyframes-eMLfYp",
+            "inject": [Function],
+            "name": "eMLfYp",
+            "rules": Array [
+              "@-webkit-keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+              "@keyframes eMLfYp{from{opacity:0;}to{opacity:1;}}",
+            ],
+            "toString": [Function],
+          },
+          " 0.3s ease-in-out;",
+        ],
+      },
+      "displayName": "indexweb__FadeIn",
+      "render": [Function],
+      "styledComponentId": "indexweb__FadeIn-gNxVQn",
+      "target": [Function],
+      "toString": [Function],
+      "warnTooManyClasses": [Function],
+      "withComponent": [Function],
+      Symbol(Symbol.hasInstance): [Function],
+    }
+  }
+  forwardedRef={null}
+>
   <div>
     <div>
       <div>
@@ -211,7 +351,7 @@ exports[`10. card with reversed loading state with no image 1`] = `
       </div>
     </div>
   </div>
-</indexweb__FadeIn>
+</StyledComponent>
 `;
 
 exports[`11. card should not re-render when imageratio prop is changed 1`] = `

--- a/packages/card/__tests__/web/serializers.js
+++ b/packages/card/__tests__/web/serializers.js
@@ -36,8 +36,10 @@ export default () => {
       replaceTransform({
         CardComponent: justChildren,
         CardContent: justChildren,
+        ForwardRef: justChildren,
         Gradient: propsNoChildren,
         Loading: justChildren,
+        StyledComponent: justChildren,
         TimesImage: propsNoChildren,
         ...meltNative
       }),

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -51,7 +51,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -71,7 +71,7 @@
     "@times-components/image": "4.3.13",
     "@times-components/styleguide": "3.8.3",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -51,7 +51,7 @@
     "depcheck": "0.6.9",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -72,7 +72,7 @@
     "@times-components/svgs": "2.1.21",
     "@times-components/utils": "4.0.14",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/key-facts/package.json
+++ b/packages/key-facts/package.json
@@ -48,7 +48,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -71,7 +71,7 @@
     "@times-components/styleguide": "3.8.3",
     "lodash.invert": "4.3.0",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -48,7 +48,7 @@
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "react-native": "0.55.4",
-    "styled-components": "3.4.0",
+    "styled-components": "4.1.1",
     "webpack": "4.6.0",
     "webpack-cli": "2.1.4"
   },

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -51,7 +51,7 @@
     "depcheck": "0.6.9",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -69,7 +69,7 @@
   "dependencies": {
     "@times-components/styleguide": "3.8.3",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/pagination/__tests__/shared.web.js
+++ b/packages/pagination/__tests__/shared.web.js
@@ -4,8 +4,10 @@ import {
   addSerializers,
   compose,
   enzymeRenderedSerializer,
+  justChildren,
   minimalWebTransform,
   print,
+  replaceTransform,
   rnwTransform
 } from "@times-components/jest-serializer";
 import shared from "./shared.base";
@@ -17,6 +19,9 @@ export default withPageState => {
     compose(
       print,
       minimalWebTransform,
+      replaceTransform({
+        ForwardRef: justChildren
+      }),
       rnwTransform(AppRegistry)
     )
   );

--- a/packages/pagination/__tests__/web/pagination-with-styles.web.test.js
+++ b/packages/pagination/__tests__/web/pagination-with-styles.web.test.js
@@ -5,6 +5,7 @@ import {
   addSerializers,
   compose,
   enzymeRenderedSerializer,
+  justChildren,
   hoistStyleTransform,
   minimalWebTransform,
   replaceTransform,
@@ -33,6 +34,7 @@ addSerializers(
   compose(
     stylePrinter,
     replaceTransform({
+      ForwardRef: justChildren,
       svg: null
     }),
     rnwTransform(AppRegistry, styles),

--- a/packages/pagination/__tests__/web/pagination.web.test.js
+++ b/packages/pagination/__tests__/web/pagination.web.test.js
@@ -5,10 +5,12 @@ import {
   addSerializers,
   compose,
   enzymeRenderedSerializer,
+  justChildren,
   minimaliseTransform,
   minimalWebTransform,
   rnwTransform,
   stylePrinter,
+  replaceTransform,
   replacePropTransform
 } from "@times-components/jest-serializer";
 import { hash, iterator } from "@times-components/test-utils";
@@ -25,7 +27,10 @@ addSerializers(
       (value, key) =>
         key === "style" || key === "className" || key === "data-testid"
     ),
-    replacePropTransform((value, key) => (key === "d" ? hash(value) : value))
+    replacePropTransform((value, key) => (key === "d" ? hash(value) : value)),
+    replaceTransform({
+      ForwardRef: justChildren
+    })
   )
 );
 

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -52,7 +52,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -74,7 +74,7 @@
     "@times-components/tracking": "2.2.6",
     "prop-types": "15.6.2",
     "react-display-name": "0.2.3",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/pull-quote/package.json
+++ b/packages/pull-quote/package.json
@@ -51,7 +51,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -71,7 +71,7 @@
     "@times-components/link": "3.1.12",
     "@times-components/styleguide": "3.8.3",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default styles 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18,23 +18,23 @@ exports[`default styles 1`] = `
   justify-content: center;
 }
 
-.c1 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c1 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c1 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c1 .leadSummary125Class {
+.c0 .leadSummary125Class {
   display: block;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -50,7 +50,7 @@ exports[`default styles 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -65,18 +65,18 @@ exports[`default styles 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c2 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .leadHeadlineClass {
+  .c0 .leadHeadlineClass {
     font-size: 30px;
     line-height: 30px;
   }
 
-  .c1 .leadImageContainerClass {
+  .c0 .leadImageContainerClass {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -84,7 +84,7 @@ exports[`default styles 1`] = `
     min-width: auto;
   }
 
-  .c1 .leadContentContainerClass {
+  .c0 .leadContentContainerClass {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -96,15 +96,15 @@ exports[`default styles 1`] = `
     min-width: 300px;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 
-  .c1 .leadSummary125Class {
+  .c0 .leadSummary125Class {
     display: block;
   }
 
-  .c1 .leadSummary175Class {
+  .c0 .leadSummary175Class {
     display: none;
   }
 }
@@ -122,7 +122,7 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -131,7 +131,7 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c2 {
     padding-left: 0px;
     padding-right: 0px;
     width: 80.8%;
@@ -139,13 +139,13 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c2 {
     width: 56.2%;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -156,7 +156,7 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     -webkit-box-flex: 1.5;
     -webkit-flex-grow: 1.5;
     -ms-flex-positive: 1.5;
@@ -313,16 +313,16 @@ exports[`default styles 1`] = `
     </h3>
   </div>
   <div
-    className="c0 c1 S4"
+    className="c0 S4"
   >
     <div
-      className="c2 S4"
+      className="c1 S4"
     >
       <div
-        className="c3 c4 c5 S4"
+        className="c2 S4"
       >
         <div
-          className="c6 c7 c8 S4"
+          className="c3 S4"
         >
           <Link>
             <div

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default styles 1`] = `
-.c4 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18,11 +18,11 @@ exports[`default styles 1`] = `
   justify-content: center;
 }
 
-.c3 .opinionContentContainerClass {
+.c0 .opinionContentContainerClass {
   min-height: 250px;
 }
 
-.c3 .opinionImageContainerClass {
+.c0 .opinionImageContainerClass {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -32,25 +32,25 @@ exports[`default styles 1`] = `
   right: 0;
 }
 
-.c3 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c3 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c3 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c3 .opinionSummary125Class {
+.c0 .opinionSummary125Class {
   display: block;
   padding-right: 20px;
   width: 60%;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -66,7 +66,7 @@ exports[`default styles 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -80,48 +80,48 @@ exports[`default styles 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c4 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:520px) {
-  .c3 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-height: 200px;
   }
 
-  .c3 .opinionHeadlineClass {
+  .c0 .opinionHeadlineClass {
     padding-right: 30px;
     width: 80%;
   }
 }
 
 @media (min-width:520px) {
-  .c2 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     min-width: 130px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .opinionBylineClass,
-  .c1 .opinionHeadlineClass {
+  .c0 .opinionBylineClass,
+  .c0 .opinionHeadlineClass {
     font-size: 30px;
     line-height: 30px;
     width: 100%;
   }
 
-  .c1 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-width: auto;
     padding-right: 55px;
   }
 
-  .c1 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     max-width: 167px;
     min-width: auto;
     position: relative;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 }
@@ -141,34 +141,34 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
     width: 80.8%;
   }
 
-  .c5 a {
+  .c2 a {
     display: block;
     height: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c5 {
+  .c2 {
     width: 56.2%;
   }
 }
 
 @media (min-width:768px) {
-  .c8 a > div,
-  .c8 a > div > div {
+  .c3 a > div,
+  .c3 a > div > div {
     height: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -179,7 +179,7 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     border-bottom: none;
     margin-bottom: 0;
     min-width: auto;
@@ -344,16 +344,16 @@ exports[`default styles 1`] = `
     </h3>
   </div>
   <div
-    className="c0 c1 c2 c3 S4"
+    className="c0 S4"
   >
     <div
-      className="c4 S4"
+      className="c1 S4"
     >
       <div
-        className="c5 S4"
+        className="c2 S4"
       >
         <div
-          className="c6 c7 c8 S4"
+          className="c3 S4"
         >
           <Link>
             <div

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default styles 1`] = `
-.c3 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18,7 +18,7 @@ exports[`default styles 1`] = `
   justify-content: center;
 }
 
-.c7 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -26,19 +26,19 @@ exports[`default styles 1`] = `
   padding-right: 10px;
 }
 
-.c2 .imageContainerClass {
+.c0 .imageContainerClass {
   display: block;
 }
 
-.c2 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c2 .summary125Class {
+.c0 .summary125Class {
   display: block;
 }
 
-.c6 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -54,13 +54,13 @@ exports[`default styles 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c3 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -70,18 +70,18 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:768px) {
-  .c2 .imageContainerClass {
+  .c0 .imageContainerClass {
     display: block;
   }
 
-  .c2 .headlineClass {
+  .c0 .headlineClass {
     font-size: 30px;
     line-height: 30px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .imageContainerClass {
+  .c0 .imageContainerClass {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -90,7 +90,7 @@ exports[`default styles 1`] = `
     padding-right: 10px;
   }
 
-  .c1 .contentContainerClass {
+  .c0 .contentContainerClass {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -113,7 +113,7 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -121,13 +121,13 @@ exports[`default styles 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     width: 80.8%;
   }
 }
 
 @media (min-width:1024px) {
-  .c4 {
+  .c2 {
     width: 56.2%;
   }
 }
@@ -291,16 +291,16 @@ exports[`default styles 1`] = `
     </h3>
   </div>
   <div
-    className="c0 c1 c2 S4"
+    className="c0 S4"
   >
     <div
-      className="c3 S4"
+      className="c1 S4"
     >
       <div
-        className="c4 c5 c6 S4"
+        className="c2 S4"
       >
         <div
-          className="c7 S4"
+          className="c3 S4"
         >
           <Link>
             <div

--- a/packages/related-articles/package.json
+++ b/packages/related-articles/package.json
@@ -53,7 +53,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "mockdate": "2.0.2",
     "prettier": "1.14.3",
     "react": "16.5.2",

--- a/packages/slice/__tests__/serializers-with-style.web.js
+++ b/packages/slice/__tests__/serializers-with-style.web.js
@@ -3,8 +3,10 @@ import {
   addSerializers,
   compose,
   enzymeRenderedSerializer,
+  justChildren,
   flattenStyleTransform,
   minimalWebTransform,
+  replaceTransform,
   rnwTransform,
   stylePrinter
 } from "@times-components/jest-serializer";
@@ -27,6 +29,9 @@ addSerializers(
     stylePrinter,
     minimalWebTransform,
     flattenStyleTransform,
+    replaceTransform({
+      ForwardRef: justChildren
+    }),
     rnwTransform(AppRegistry, styles)
   )
 );

--- a/packages/slice/__tests__/serializers.web.js
+++ b/packages/slice/__tests__/serializers.web.js
@@ -2,9 +2,11 @@ import {
   addSerializers,
   compose,
   enzymeRenderedSerializer,
+  justChildren,
   minimalWebTransform,
   minimaliseTransform,
-  print
+  print,
+  replaceTransform
 } from "@times-components/jest-serializer";
 
 addSerializers(
@@ -13,6 +15,9 @@ addSerializers(
   compose(
     print,
     minimalWebTransform,
-    minimaliseTransform((value, key) => key === "style" || key === "className")
+    minimaliseTransform((value, key) => key === "style" || key === "className"),
+    replaceTransform({
+      ForwardRef: justChildren
+    })
   )
 );

--- a/packages/slice/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/slice/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. a single child element 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18,23 +18,23 @@ exports[`1. a single child element 1`] = `
   justify-content: center;
 }
 
-.c1 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c1 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c1 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c1 .leadSummary125Class {
+.c0 .leadSummary125Class {
   display: block;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -50,7 +50,7 @@ exports[`1. a single child element 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -65,18 +65,18 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c2 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .leadHeadlineClass {
+  .c0 .leadHeadlineClass {
     font-size: 30px;
     line-height: 30px;
   }
 
-  .c1 .leadImageContainerClass {
+  .c0 .leadImageContainerClass {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -84,7 +84,7 @@ exports[`1. a single child element 1`] = `
     min-width: auto;
   }
 
-  .c1 .leadContentContainerClass {
+  .c0 .leadContentContainerClass {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -96,15 +96,15 @@ exports[`1. a single child element 1`] = `
     min-width: 300px;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 
-  .c1 .leadSummary125Class {
+  .c0 .leadSummary125Class {
     display: block;
   }
 
-  .c1 .leadSummary175Class {
+  .c0 .leadSummary175Class {
     display: none;
   }
 }
@@ -122,7 +122,7 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -131,7 +131,7 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c2 {
     padding-left: 0px;
     padding-right: 0px;
     width: 80.8%;
@@ -139,13 +139,13 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c2 {
     width: 56.2%;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -156,7 +156,7 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     -webkit-box-flex: 1.5;
     -webkit-flex-grow: 1.5;
     -ms-flex-positive: 1.5;
@@ -175,16 +175,16 @@ exports[`1. a single child element 1`] = `
 </style>
 
 <div
-  className="c0 c1 S1"
+  className="c0 S1"
 >
   <div
-    className="c2 S1"
+    className="c1 S1"
   >
     <div
-      className="c3 c4 c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 c7 c8 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -198,7 +198,7 @@ exports[`1. a single child element 1`] = `
 `;
 
 exports[`2. two child elements 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -215,7 +215,7 @@ exports[`2. two child elements 1`] = `
   justify-content: center;
 }
 
-.c10 {
+.c5 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -225,7 +225,7 @@ exports[`2. two child elements 1`] = `
   height: auto;
 }
 
-.c9 {
+.c4 {
   border-bottom-color: #DBDBDB;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -237,23 +237,23 @@ exports[`2. two child elements 1`] = `
   min-width: auto;
 }
 
-.c1 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c1 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c1 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c1 .leadSummary125Class {
+.c0 .leadSummary125Class {
   display: block;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -269,7 +269,7 @@ exports[`2. two child elements 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -283,19 +283,19 @@ exports[`2. two child elements 1`] = `
   width: auto;
 }
 
-.c11 {
+.c6 {
   padding-left: 10px;
   padding-right: 10px;
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c2 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c10 {
+  .c5 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -303,7 +303,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c9 {
+  .c4 {
     border-bottom: none;
     border-right-color: #DBDBDB;
     border-right-style: solid;
@@ -316,12 +316,12 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c1 .leadHeadlineClass {
+  .c0 .leadHeadlineClass {
     font-size: 30px;
     line-height: 30px;
   }
 
-  .c1 .leadImageContainerClass {
+  .c0 .leadImageContainerClass {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -329,7 +329,7 @@ exports[`2. two child elements 1`] = `
     min-width: auto;
   }
 
-  .c1 .leadContentContainerClass {
+  .c0 .leadContentContainerClass {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -341,15 +341,15 @@ exports[`2. two child elements 1`] = `
     min-width: 300px;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 
-  .c1 .leadSummary125Class {
+  .c0 .leadSummary125Class {
     display: block;
   }
 
-  .c1 .leadSummary175Class {
+  .c0 .leadSummary175Class {
     display: none;
   }
 }
@@ -367,7 +367,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -376,19 +376,19 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -402,7 +402,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     -webkit-box-flex: 2.75;
     -webkit-flex-grow: 2.75;
     -ms-flex-positive: 2.75;
@@ -411,7 +411,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c11 {
+  .c6 {
     margin-left: 10px;
     margin-right: 10px;
     padding-left: 0;
@@ -420,7 +420,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c11 {
+  .c6 {
     margin-top: 0;
   }
 }
@@ -436,16 +436,16 @@ exports[`2. two child elements 1`] = `
 </style>
 
 <div
-  className="c0 c1 S1"
+  className="c0 S1"
 >
   <div
-    className="c2 S1"
+    className="c1 S1"
   >
     <div
-      className="c3 c4 c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 c7 c8 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -454,13 +454,13 @@ exports[`2. two child elements 1`] = `
         </div>
       </div>
       <div
-        className="c9 S1"
+        className="c4 S1"
       />
       <div
-        className="c10 S1"
+        className="c5 S1"
       >
         <div
-          className="c11 S1"
+          className="c6 S1"
         >
           <div
             className="S1"
@@ -475,7 +475,7 @@ exports[`2. two child elements 1`] = `
 `;
 
 exports[`3. three child elements 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -492,7 +492,7 @@ exports[`3. three child elements 1`] = `
   justify-content: center;
 }
 
-.c10 {
+.c5 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -502,7 +502,7 @@ exports[`3. three child elements 1`] = `
   height: auto;
 }
 
-.c9 {
+.c4 {
   border-bottom-color: #DBDBDB;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -514,23 +514,23 @@ exports[`3. three child elements 1`] = `
   min-width: auto;
 }
 
-.c1 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c1 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c1 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c1 .leadSummary125Class {
+.c0 .leadSummary125Class {
   display: block;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -546,7 +546,7 @@ exports[`3. three child elements 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -560,24 +560,24 @@ exports[`3. three child elements 1`] = `
   width: auto;
 }
 
-.c11 {
+.c6 {
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c12 {
+.c7 {
   padding-left: 10px;
   padding-right: 10px;
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c2 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c10 {
+  .c5 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -585,7 +585,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c9 {
+  .c4 {
     border-bottom: none;
     border-right-color: #DBDBDB;
     border-right-style: solid;
@@ -598,12 +598,12 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c1 .leadHeadlineClass {
+  .c0 .leadHeadlineClass {
     font-size: 30px;
     line-height: 30px;
   }
 
-  .c1 .leadImageContainerClass {
+  .c0 .leadImageContainerClass {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -611,7 +611,7 @@ exports[`3. three child elements 1`] = `
     min-width: auto;
   }
 
-  .c1 .leadContentContainerClass {
+  .c0 .leadContentContainerClass {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -623,15 +623,15 @@ exports[`3. three child elements 1`] = `
     min-width: 300px;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 
-  .c1 .leadSummary125Class {
+  .c0 .leadSummary125Class {
     display: none;
   }
 
-  .c1 .leadSummary175Class {
+  .c0 .leadSummary175Class {
     display: block;
   }
 }
@@ -669,7 +669,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -678,19 +678,19 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -704,7 +704,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     -webkit-box-flex: 1.5;
     -webkit-flex-grow: 1.5;
     -ms-flex-positive: 1.5;
@@ -713,7 +713,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c11 {
+  .c6 {
     margin-left: 10px;
     margin-right: 10px;
     padding-left: 0;
@@ -722,13 +722,13 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c11 {
+  .c6 {
     margin-top: 0;
   }
 }
 
 @media (min-width:768px) {
-  .c12 {
+  .c7 {
     margin-left: 10px;
     margin-right: 10px;
     padding-left: 0;
@@ -737,7 +737,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c12 {
+  .c7 {
     margin-top: 0;
   }
 }
@@ -753,16 +753,16 @@ exports[`3. three child elements 1`] = `
 </style>
 
 <div
-  className="c0 c1 S1"
+  className="c0 S1"
 >
   <div
-    className="c2 S1"
+    className="c1 S1"
   >
     <div
-      className="c3 c4 c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 c7 c8 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -771,13 +771,13 @@ exports[`3. three child elements 1`] = `
         </div>
       </div>
       <div
-        className="c9 S1"
+        className="c4 S1"
       />
       <div
-        className="c10 S1"
+        className="c5 S1"
       >
         <div
-          className="c11 S1"
+          className="c6 S1"
         >
           <div
             className="S1"
@@ -786,7 +786,7 @@ exports[`3. three child elements 1`] = `
           </div>
         </div>
         <div
-          className="c12 S1"
+          className="c7 S1"
         >
           <div
             className="S1"

--- a/packages/slice/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/slice/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. a single child element 1`] = `
-.c4 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -18,11 +18,11 @@ exports[`1. a single child element 1`] = `
   justify-content: center;
 }
 
-.c3 .opinionContentContainerClass {
+.c0 .opinionContentContainerClass {
   min-height: 250px;
 }
 
-.c3 .opinionImageContainerClass {
+.c0 .opinionImageContainerClass {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -32,25 +32,25 @@ exports[`1. a single child element 1`] = `
   right: 0;
 }
 
-.c3 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c3 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c3 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c3 .opinionSummary125Class {
+.c0 .opinionSummary125Class {
   display: block;
   padding-right: 20px;
   width: 60%;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -66,7 +66,7 @@ exports[`1. a single child element 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -80,48 +80,48 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c4 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:520px) {
-  .c3 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-height: 200px;
   }
 
-  .c3 .opinionHeadlineClass {
+  .c0 .opinionHeadlineClass {
     padding-right: 30px;
     width: 80%;
   }
 }
 
 @media (min-width:520px) {
-  .c2 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     min-width: 130px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .opinionBylineClass,
-  .c1 .opinionHeadlineClass {
+  .c0 .opinionBylineClass,
+  .c0 .opinionHeadlineClass {
     font-size: 30px;
     line-height: 30px;
     width: 100%;
   }
 
-  .c1 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-width: auto;
     padding-right: 55px;
   }
 
-  .c1 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     max-width: 167px;
     min-width: auto;
     position: relative;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 }
@@ -141,34 +141,34 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
     width: 80.8%;
   }
 
-  .c5 a {
+  .c2 a {
     display: block;
     height: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c5 {
+  .c2 {
     width: 56.2%;
   }
 }
 
 @media (min-width:768px) {
-  .c8 a > div,
-  .c8 a > div > div {
+  .c3 a > div,
+  .c3 a > div > div {
     height: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-box-flex: 0;
     -webkit-flex-grow: 0;
     -ms-flex-positive: 0;
@@ -179,7 +179,7 @@ exports[`1. a single child element 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     border-bottom: none;
     margin-bottom: 0;
     min-width: auto;
@@ -200,16 +200,16 @@ exports[`1. a single child element 1`] = `
 </style>
 
 <div
-  className="c0 c1 c2 c3 S1"
+  className="c0 S1"
 >
   <div
-    className="c4 S1"
+    className="c1 S1"
   >
     <div
-      className="c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 c7 c8 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -223,7 +223,7 @@ exports[`1. a single child element 1`] = `
 `;
 
 exports[`2. two child elements 1`] = `
-.c5 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -240,11 +240,11 @@ exports[`2. two child elements 1`] = `
   justify-content: center;
 }
 
-.c4 .opinionContentContainerClass {
+.c0 .opinionContentContainerClass {
   min-height: 250px;
 }
 
-.c4 .opinionImageContainerClass {
+.c0 .opinionImageContainerClass {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -254,25 +254,25 @@ exports[`2. two child elements 1`] = `
   right: 0;
 }
 
-.c4 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c4 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c4 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c4 .opinionSummary125Class {
+.c0 .opinionSummary125Class {
   display: block;
   padding-right: 20px;
   width: 60%;
 }
 
-.c6 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -288,7 +288,7 @@ exports[`2. two child elements 1`] = `
   width: 100%;
 }
 
-.c9 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -301,7 +301,7 @@ exports[`2. two child elements 1`] = `
   width: auto;
 }
 
-.c10 {
+.c4 {
   border-bottom-color: #DBDBDB;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -313,7 +313,7 @@ exports[`2. two child elements 1`] = `
   min-width: auto;
 }
 
-.c12 {
+.c5 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -323,7 +323,7 @@ exports[`2. two child elements 1`] = `
   height: auto;
 }
 
-.c16 {
+.c6 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -336,62 +336,62 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c5 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:520px) {
-  .c4 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-height: 200px;
   }
 
-  .c4 .opinionHeadlineClass {
+  .c0 .opinionHeadlineClass {
     padding-right: 30px;
     width: 80%;
   }
 }
 
 @media (min-width:520px) {
-  .c3 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     min-width: 120px;
   }
 }
 
 @media (min-width:768px) {
-  .c2 .opinionBylineClass,
-  .c2 .opinionHeadlineClass {
+  .c0 .opinionBylineClass,
+  .c0 .opinionHeadlineClass {
     font-size: 30px;
     line-height: 30px;
     width: 100%;
   }
 
-  .c2 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-width: auto;
     padding-right: 55px;
   }
 
-  .c2 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     max-width: 167px;
     min-width: auto;
     position: relative;
   }
 
-  .c2 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     min-width: 165px;
   }
 
-  .c1 .opinionSummary125Class {
+  .c0 .opinionSummary125Class {
     display: none;
   }
 
-  .c1 .opinionSummary145Class {
+  .c0 .opinionSummary145Class {
     display: block;
   }
 }
@@ -408,34 +408,34 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
     width: 100%;
   }
 
-  .c6 a {
+  .c2 a {
     display: block;
     height: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c9 a > div,
-  .c9 a > div > div {
+  .c3 a > div,
+  .c3 a > div > div {
     height: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c8 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -449,7 +449,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c7 {
+  .c3 {
     border-bottom: none;
     margin-bottom: 0;
     min-width: auto;
@@ -460,7 +460,7 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c10 {
+  .c4 {
     border-bottom: none;
     border-right-color: #DBDBDB;
     border-right-style: solid;
@@ -474,13 +474,13 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c10 {
+  .c4 {
     display: block;
   }
 }
 
 @media (min-width:768px) {
-  .c12 {
+  .c5 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -491,13 +491,13 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c11 {
+  .c5 {
     min-width: 400px;
   }
 }
 
 @media (min-width:768px) {
-  .c16 {
+  .c6 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -506,19 +506,19 @@ exports[`2. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c15 {
+  .c6 {
     padding-left: 10px;
   }
 }
 
 @media (min-width:768px) {
-  .c14 {
+  .c6 {
     max-width: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c13 {
+  .c6 {
     padding-left: 10px;
   }
 }
@@ -534,16 +534,16 @@ exports[`2. two child elements 1`] = `
 </style>
 
 <div
-  className="c0 c1 c2 c3 c4 S1"
+  className="c0 S1"
 >
   <div
-    className="c5 S1"
+    className="c1 S1"
   >
     <div
-      className="c6 S1"
+      className="c2 S1"
     >
       <div
-        className="c7 c8 c9 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -552,13 +552,13 @@ exports[`2. two child elements 1`] = `
         </div>
       </div>
       <div
-        className="c10 S1"
+        className="c4 S1"
       />
       <div
-        className="c11 c12 S1"
+        className="c5 S1"
       >
         <div
-          className="c13 c14 c15 c16 S1"
+          className="c6 S1"
         >
           <div
             className="S1"
@@ -573,7 +573,7 @@ exports[`2. two child elements 1`] = `
 `;
 
 exports[`3. three child elements 1`] = `
-.c4 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -590,11 +590,11 @@ exports[`3. three child elements 1`] = `
   justify-content: center;
 }
 
-.c3 .opinionContentContainerClass {
+.c0 .opinionContentContainerClass {
   min-height: 250px;
 }
 
-.c3 .opinionImageContainerClass {
+.c0 .opinionImageContainerClass {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
@@ -604,25 +604,25 @@ exports[`3. three child elements 1`] = `
   right: 0;
 }
 
-.c3 .supportImageContainerClass {
+.c0 .supportImageContainerClass {
   display: none;
 }
 
-.c3 .supportSummaryClass {
+.c0 .supportSummaryClass {
   display: none;
 }
 
-.c3 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c3 .opinionSummary125Class {
+.c0 .opinionSummary125Class {
   display: block;
   padding-right: 20px;
   width: 60%;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -638,7 +638,7 @@ exports[`3. three child elements 1`] = `
   width: 100%;
 }
 
-.c9 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -651,7 +651,7 @@ exports[`3. three child elements 1`] = `
   width: auto;
 }
 
-.c10 {
+.c4 {
   border-bottom-color: #DBDBDB;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -663,7 +663,7 @@ exports[`3. three child elements 1`] = `
   min-width: auto;
 }
 
-.c13 {
+.c5 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -673,7 +673,7 @@ exports[`3. three child elements 1`] = `
   height: auto;
 }
 
-.c17 {
+.c6 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -685,7 +685,7 @@ exports[`3. three child elements 1`] = `
   padding-right: 10px;
 }
 
-.c21 {
+.c7 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -695,9 +695,6 @@ exports[`3. three child elements 1`] = `
   min-height: auto;
   padding-left: 10px;
   padding-right: 10px;
-}
-
-.c20 {
   border-top-color: #DBDBDB;
   border-top-style: solid;
   border-top-width: 1px;
@@ -706,48 +703,48 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c4 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:520px) {
-  .c3 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-height: 200px;
   }
 
-  .c3 .opinionHeadlineClass {
+  .c0 .opinionHeadlineClass {
     padding-right: 30px;
     width: 80%;
   }
 }
 
 @media (min-width:520px) {
-  .c2 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     min-width: 120px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .opinionBylineClass,
-  .c1 .opinionHeadlineClass {
+  .c0 .opinionBylineClass,
+  .c0 .opinionHeadlineClass {
     font-size: 30px;
     line-height: 30px;
     width: 100%;
   }
 
-  .c1 .opinionContentContainerClass {
+  .c0 .opinionContentContainerClass {
     min-width: auto;
     padding-right: 55px;
   }
 
-  .c1 .opinionImageContainerClass {
+  .c0 .opinionImageContainerClass {
     max-width: 167px;
     min-width: auto;
     position: relative;
   }
 
-  .c1 .supportImageContainerClass {
+  .c0 .supportImageContainerClass {
     display: block;
   }
 }
@@ -767,34 +764,34 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
     width: 80.8%;
   }
 
-  .c5 a {
+  .c2 a {
     display: block;
     height: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c5 {
+  .c2 {
     width: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c9 a > div,
-  .c9 a > div > div {
+  .c3 a > div,
+  .c3 a > div > div {
     height: 100%;
   }
 }
 
 @media (min-width:768px) {
-  .c8 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -808,7 +805,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     border-bottom-color: #DBDBDB;
     border-bottom-style: solid;
     border-bottom-width: 1px;
@@ -821,7 +818,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c6 {
+  .c3 {
     border-bottom: none;
     margin-bottom: 0;
     min-width: auto;
@@ -832,7 +829,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c10 {
+  .c4 {
     border-bottom: none;
     border-right-color: #DBDBDB;
     border-right-style: solid;
@@ -846,13 +843,13 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c10 {
+  .c4 {
     display: block;
   }
 }
 
 @media (min-width:768px) {
-  .c13 {
+  .c5 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -863,19 +860,19 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c12 {
+  .c5 {
     min-width: 100%;
   }
 }
 
 @media (min-width:1024px) {
-  .c11 {
+  .c5 {
     min-width: auto;
   }
 }
 
 @media (min-width:768px) {
-  .c17 {
+  .c6 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -884,25 +881,25 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c16 {
+  .c6 {
     padding-left: 0;
   }
 }
 
 @media (min-width:768px) {
-  .c15 {
+  .c6 {
     max-width: 50%;
   }
 }
 
 @media (min-width:1024px) {
-  .c14 {
+  .c6 {
     padding-left: 10px;
   }
 }
 
 @media (min-width:768px) {
-  .c21 {
+  .c7 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -911,7 +908,7 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c20 {
+  .c7 {
     border-left-color: #DBDBDB;
     border-left-style: solid;
     border-left-width: 1px;
@@ -924,13 +921,13 @@ exports[`3. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c19 {
+  .c7 {
     max-width: 50%;
   }
 }
 
 @media (min-width:1024px) {
-  .c18 {
+  .c7 {
     padding-left: 10px;
   }
 }
@@ -946,16 +943,16 @@ exports[`3. three child elements 1`] = `
 </style>
 
 <div
-  className="c0 c1 c2 c3 S1"
+  className="c0 S1"
 >
   <div
-    className="c4 S1"
+    className="c1 S1"
   >
     <div
-      className="c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 c7 c8 c9 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -964,13 +961,13 @@ exports[`3. three child elements 1`] = `
         </div>
       </div>
       <div
-        className="c10 S1"
+        className="c4 S1"
       />
       <div
-        className="c11 c12 c13 S1"
+        className="c5 S1"
       >
         <div
-          className="c14 c15 c16 c17 S1"
+          className="c6 S1"
         >
           <div
             className="S1"
@@ -979,7 +976,7 @@ exports[`3. three child elements 1`] = `
           </div>
         </div>
         <div
-          className="c18 c19 c20 c21 S1"
+          className="c7 S1"
         >
           <div
             className="S1"

--- a/packages/slice/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/slice/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -3,7 +3,7 @@
 exports[`1. no child elements 1`] = `""`;
 
 exports[`2. a single child element 1`] = `
-.c3 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -20,7 +20,7 @@ exports[`2. a single child element 1`] = `
   justify-content: center;
 }
 
-.c7 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -28,19 +28,19 @@ exports[`2. a single child element 1`] = `
   padding-right: 10px;
 }
 
-.c2 .imageContainerClass {
+.c0 .imageContainerClass {
   display: block;
 }
 
-.c2 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c2 .summary125Class {
+.c0 .summary125Class {
   display: block;
 }
 
-.c6 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -56,13 +56,13 @@ exports[`2. a single child element 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c3 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -72,18 +72,18 @@ exports[`2. a single child element 1`] = `
 }
 
 @media (min-width:768px) {
-  .c2 .imageContainerClass {
+  .c0 .imageContainerClass {
     display: block;
   }
 
-  .c2 .headlineClass {
+  .c0 .headlineClass {
     font-size: 30px;
     line-height: 30px;
   }
 }
 
 @media (min-width:768px) {
-  .c1 .imageContainerClass {
+  .c0 .imageContainerClass {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
@@ -92,7 +92,7 @@ exports[`2. a single child element 1`] = `
     padding-right: 10px;
   }
 
-  .c1 .contentContainerClass {
+  .c0 .contentContainerClass {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -115,7 +115,7 @@ exports[`2. a single child element 1`] = `
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -123,13 +123,13 @@ exports[`2. a single child element 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     width: 80.8%;
   }
 }
 
 @media (min-width:1024px) {
-  .c4 {
+  .c2 {
     width: 56.2%;
   }
 }
@@ -145,16 +145,16 @@ exports[`2. a single child element 1`] = `
 </style>
 
 <div
-  className="c0 c1 c2 S1"
+  className="c0 S1"
 >
   <div
-    className="c3 S1"
+    className="c1 S1"
   >
     <div
-      className="c4 c5 c6 S1"
+      className="c2 S1"
     >
       <div
-        className="c7 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -168,7 +168,7 @@ exports[`2. a single child element 1`] = `
 `;
 
 exports[`3. two child elements 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -185,7 +185,7 @@ exports[`3. two child elements 1`] = `
   justify-content: center;
 }
 
-.c6 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -193,7 +193,7 @@ exports[`3. two child elements 1`] = `
   padding-right: 10px;
 }
 
-.c7 {
+.c4 {
   border-bottom-color: #DBDBDB;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -205,19 +205,19 @@ exports[`3. two child elements 1`] = `
   min-width: auto;
 }
 
-.c1 .imageContainerClass {
+.c0 .imageContainerClass {
   display: block;
 }
 
-.c1 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c1 .summary125Class {
+.c0 .summary125Class {
   display: block;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -233,13 +233,13 @@ exports[`3. two child elements 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c2 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -249,7 +249,7 @@ exports[`3. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c4 {
     border-bottom: none;
     border-right-color: #DBDBDB;
     border-right-style: solid;
@@ -262,11 +262,11 @@ exports[`3. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c1 .imageContainerClass {
+  .c0 .imageContainerClass {
     display: block;
   }
 
-  .c1 .headlineClass {
+  .c0 .headlineClass {
     font-size: 30px;
     line-height: 30px;
   }
@@ -283,7 +283,7 @@ exports[`3. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -291,13 +291,13 @@ exports[`3. two child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c2 {
     width: 80.8%;
   }
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c2 {
     width: 56.2%;
   }
 }
@@ -313,16 +313,16 @@ exports[`3. two child elements 1`] = `
 </style>
 
 <div
-  className="c0 c1 S1"
+  className="c0 S1"
 >
   <div
-    className="c2 S1"
+    className="c1 S1"
   >
     <div
-      className="c3 c4 c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -331,10 +331,10 @@ exports[`3. two child elements 1`] = `
         </div>
       </div>
       <div
-        className="c7 S1"
+        className="c4 S1"
       />
       <div
-        className="c6 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -348,7 +348,7 @@ exports[`3. two child elements 1`] = `
 `;
 
 exports[`4. three child elements 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -365,7 +365,7 @@ exports[`4. three child elements 1`] = `
   justify-content: center;
 }
 
-.c6 {
+.c3 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -373,7 +373,7 @@ exports[`4. three child elements 1`] = `
   padding-right: 10px;
 }
 
-.c7 {
+.c4 {
   border-bottom-color: #DBDBDB;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -385,19 +385,19 @@ exports[`4. three child elements 1`] = `
   min-width: auto;
 }
 
-.c1 .imageContainerClass {
+.c0 .imageContainerClass {
   display: none;
 }
 
-.c1 .summaryHidden {
+.c0 .summaryHidden {
   display: none;
 }
 
-.c1 .summary125Class {
+.c0 .summary125Class {
   display: block;
 }
 
-.c5 {
+.c2 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -413,13 +413,13 @@ exports[`4. three child elements 1`] = `
 }
 
 @media (-webkit-min-device-pixel-ratio:2) {
-  .c2 {
+  .c1 {
     border-bottom-width: 0.5px;
   }
 }
 
 @media (min-width:768px) {
-  .c6 {
+  .c3 {
     -webkit-flex-basis: 0 !important;
     -ms-flex-preferred-size: 0 !important;
     flex-basis: 0 !important;
@@ -429,7 +429,7 @@ exports[`4. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c7 {
+  .c4 {
     border-bottom: none;
     border-right-color: #DBDBDB;
     border-right-style: solid;
@@ -442,11 +442,11 @@ exports[`4. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c1 .imageContainerClass {
+  .c0 .imageContainerClass {
     display: block;
   }
 
-  .c1 .headlineClass {
+  .c0 .headlineClass {
     font-size: 30px;
     line-height: 30px;
   }
@@ -463,7 +463,7 @@ exports[`4. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c5 {
+  .c2 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -471,7 +471,7 @@ exports[`4. three child elements 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
+  .c2 {
     padding-left: 20px;
     padding-right: 20px;
     width: 100%;
@@ -479,7 +479,7 @@ exports[`4. three child elements 1`] = `
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c2 {
     width: 100%;
   }
 }
@@ -495,16 +495,16 @@ exports[`4. three child elements 1`] = `
 </style>
 
 <div
-  className="c0 c1 S1"
+  className="c0 S1"
 >
   <div
-    className="c2 S1"
+    className="c1 S1"
   >
     <div
-      className="c3 c4 c5 S1"
+      className="c2 S1"
     >
       <div
-        className="c6 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -513,10 +513,10 @@ exports[`4. three child elements 1`] = `
         </div>
       </div>
       <div
-        className="c7 S1"
+        className="c4 S1"
       />
       <div
-        className="c6 S1"
+        className="c3 S1"
       >
         <div
           className="S1"
@@ -525,10 +525,10 @@ exports[`4. three child elements 1`] = `
         </div>
       </div>
       <div
-        className="c7 S1"
+        className="c4 S1"
       />
       <div
-        className="c6 S1"
+        className="c3 S1"
       >
         <div
           className="S1"

--- a/packages/slice/package.json
+++ b/packages/slice/package.json
@@ -51,7 +51,7 @@
     "enzyme": "3.6.0",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -69,7 +69,7 @@
   "dependencies": {
     "@times-components/styleguide": "3.8.3",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -73,7 +73,7 @@
     "react-native": "0.55.4",
     "react-native-web": "0.9.0",
     "shrink-ray": "0.1.3",
-    "styled-components": "3.4.0",
+    "styled-components": "4.1.1",
     "unfetch": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -49,7 +49,7 @@
     "depcheck": "0.6.9",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "prettier": "1.14.3",
     "react": "16.5.2",
     "react-art": "16.5.2",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/topic/package.json
+++ b/packages/topic/package.json
@@ -52,7 +52,7 @@
     "depcheck": "0.6.9",
     "eslint": "5.9.0",
     "jest": "23.3.0",
-    "jest-styled-components": "5.0.1",
+    "jest-styled-components": "6.3.1",
     "mockdate": "2.0.2",
     "prettier": "1.14.3",
     "react": "16.5.2",
@@ -80,7 +80,7 @@
     "@times-components/utils": "4.0.14",
     "lodash.get": "4.4.2",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -80,7 +80,7 @@
     "@times-components/styleguide": "3.8.3",
     "@times-components/svgs": "2.1.21",
     "prop-types": "15.6.2",
-    "styled-components": "3.4.0"
+    "styled-components": "4.1.1"
   },
   "peerDependencies": {
     "react": ">=16.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,6 +571,23 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@emotion/is-prop-valid@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
+  integrity sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==
+  dependencies:
+    "@emotion/memoize" "^0.6.6"
+
+"@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
+
 "@expo/vector-icons@^6.3.1":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-6.3.1.tgz#ffb97cc2343e4a330b44ce3063ee7c8571a6a50d"
@@ -3489,6 +3506,15 @@ babel-plugin-styled-components@1.5.1:
     babel-types "^6.26.0"
     stylis "^3.0.0"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.9.0.tgz#7b814bbe55900d9e0f6ec2c66741a1992c1c4a3d"
+  integrity sha512-DRurNjnndoIAiW0+vYgQyGmnCtKyCEGP9Y19Z9NrSwMEMGBWl2S7Q7F70RyGDae+KKeighhOPI1WttIb3r0xaA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+    lodash "^4.17.10"
+
 babel-plugin-syntax-async-functions@^6.13.0, babel-plugin-syntax-async-functions@^6.5.0, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -4843,7 +4869,7 @@ buffer@4.9.1, buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.0.3, buffer@^5.1.0:
+buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
@@ -6259,10 +6285,10 @@ css-selector-tokenizer@^0.7.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-to-react-native@^2.0.3:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.1.tgz#7f3f4c95de65501b8720c87bf0caf1f39073b88e"
-  integrity sha512-v++LRcf633phJiYZBDqtmGPj3+BVof0isd2jgwYLWZJ5YSuhCkrfYtDsNhM6oJthiEco0f9tDVJ1vUkDJNgGEA==
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
+  integrity sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==
   dependencies:
     css-color-keywords "^1.0.0"
     fbjs "^0.8.5"
@@ -6273,7 +6299,7 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
   integrity sha1-lGfQMsOM+u+58teVASUwYvh/ob0=
 
-css@^2.2.1:
+css@^2.2.1, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -11460,12 +11486,12 @@ jest-snapshot@^23.0.1, jest-snapshot@^23.6.0:
     pretty-format "^23.6.0"
     semver "^5.5.0"
 
-jest-styled-components@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-5.0.1.tgz#386c5a161a0f5e783444d624bfc18c6d228d1277"
-  integrity sha512-ZQgTjEZcjWNwADtv+D26MmUUVP2NrAzxCPra5NvflRgiAWaVKt+adHcWRILIyrUo3XfjK1tqiCjS/wjXjeTNGg==
+jest-styled-components@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.3.1.tgz#fa21a89bfe8c20081c7c083cbaed2200854b60e3"
+  integrity sha512-zie3ajvJbwlbHCAq8/Bv5jdbcYCz0ZMRNNX6adL7wSRpkCVPQtiJigv1140JN1ZOJIODPn8VKrjeFCN+jlPa7w==
   dependencies:
-    css "^2.2.1"
+    css "^2.2.4"
 
 jest-util@^23.4.0:
   version "23.4.0"
@@ -12681,6 +12707,11 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
+
+memoize-one@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.3.tgz#cdfdd942853f1a1b4c71c5336b8c49da0bf0273c"
+  integrity sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==
 
 memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
@@ -15739,10 +15770,15 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.3.1, react-is@^16.4.2, react-is@^16.5.2:
+react-is@^16.4.2, react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
   integrity sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==
+
+react-is@^16.6.0:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
 react-lifecycles-compat@^3, react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -18026,20 +18062,21 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-styled-components@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.0.tgz#d256fb4667e6c115a7ed61ab78f120283b43dd00"
-  integrity sha1-0lb7RmfmwRWn7WGrePEgKDtD3QA=
+styled-components@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.1.tgz#943922048fae556e286bcbfdd29da4f1399446bc"
+  integrity sha512-UzT/qyoOyKpYooeLdwKrPHZ85R8KWl8i0fbyH9I3z6B2WT9uGDCV7J4kbfKsBeSWFD9EytBriEODOkybcUFD/Q==
   dependencies:
-    buffer "^5.0.3"
-    css-to-react-native "^2.0.3"
-    fbjs "^0.8.16"
-    hoist-non-react-statics "^2.5.0"
+    "@emotion/is-prop-valid" "^0.6.8"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
     prop-types "^15.5.4"
-    react-is "^16.3.1"
+    react-is "^16.6.0"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
-    supports-color "^3.2.3"
+    supports-color "^5.5.0"
 
 stylelint-config-recommended@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Update to styled components across all packages. 

This removes a lot of strict mode warnings.

Please note that some snapshots updated to help flatten them and to conform with a slimmer structure to Styled Components.