### PR TITLE
Feat: theme article labels

### DIFF
--- a/packages/styleguide/src/theme/theme-factory.js
+++ b/packages/styleguide/src/theme/theme-factory.js
@@ -10,10 +10,12 @@ const sectionColourPicker = (
       ...secondarySectionColours
     },
     magazinecomment: {
-      ...sectionColours
+      ...sectionColours,
+      ...secondarySectionColours
     },
     magazinestandard: {
-      ...sectionColours
+      ...sectionColours,
+      ...secondarySectionColours
     },
     maincomment: {
       ...sectionColours


### PR DESCRIPTION
- Add support for secondary colour overrides for `magazine-comment` and `magazinestandard`
- Needed for https://nidigitalsolutions.jira.com/browse/REPLAT-4535