### PR TITLE
fix: Support null article data on article package

### DIFF
--- a/packages/article/__tests__/article.test.js
+++ b/packages/article/__tests__/article.test.js
@@ -23,6 +23,13 @@ const requiredProps = {
 };
 
 describe("Article", () => {
+  it("renders with ArticleMainStandard as the default template if no article is provided", () => {
+    const testRenderer = TestRenderer.create(<Article {...requiredProps} />);
+    const testInstance = testRenderer.root;
+
+    expect(testInstance.findByType(ArticleMainStandard)).toBeTruthy();
+  });
+
   it("renders with ArticleMainStandard as the default template if no template is provided", () => {
     const testRenderer = TestRenderer.create(
       <Article article={{}} {...requiredProps} />

--- a/packages/article/__tests__/article.test.js
+++ b/packages/article/__tests__/article.test.js
@@ -23,8 +23,10 @@ const requiredProps = {
 };
 
 describe("Article", () => {
-  it("renders with ArticleMainStandard as the default template if no article is provided", () => {
-    const testRenderer = TestRenderer.create(<Article {...requiredProps} />);
+  it("renders with ArticleMainStandard as the default template if article is null", () => {
+    const testRenderer = TestRenderer.create(
+      <Article {...requiredProps} article={null} />
+    );
     const testInstance = testRenderer.root;
 
     expect(testInstance.findByType(ArticleMainStandard)).toBeTruthy();

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -10,8 +10,8 @@ export const templates = {
 };
 
 const Article = props => {
-  const { article = {} } = props;
-  const { template = "mainstandard" } = article;
+  const { article } = props;
+  const { template = "mainstandard" } = article || {};
 
   const Component = templates[template];
   return <Component {...props} />;

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -11,7 +11,7 @@ export const templates = {
 
 const Article = props => {
   const {
-    article: { template = "mainstandard" }
+    article: { template = "mainstandard" } = { template: "mainstandard" }
   } = props;
 
   const Component = templates[template];

--- a/packages/article/src/article.js
+++ b/packages/article/src/article.js
@@ -10,9 +10,8 @@ export const templates = {
 };
 
 const Article = props => {
-  const {
-    article: { template = "mainstandard" } = { template: "mainstandard" }
-  } = props;
+  const { article = {} } = props;
+  const { template = "mainstandard" } = article;
 
   const Component = templates[template];
   return <Component {...props} />;


### PR DESCRIPTION
Native apps can use the article package with no data to show an error view, so the article package should work when article is undefined. Added a default value and a test