### PR TITLE
fix: Handle empty author object in article comment templates 

### DIFF
--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -29,10 +29,12 @@ class ArticlePage extends Component {
       standfirst
     } = article;
 
+    const authorImage = author && author.image ? author.image : null;
+
     return (
       <Fragment>
         <ArticleHeader
-          authorImage={author.image}
+          authorImage={authorImage}
           byline={byline}
           flags={flags}
           headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -18,7 +18,9 @@ class ArticlePage extends Component {
     const { article } = this.props;
     const leadAssetProps = getLeadAsset(article);
     const {
-      author,
+      author = {
+        image: null
+      },
       byline,
       flags,
       headline,
@@ -29,12 +31,10 @@ class ArticlePage extends Component {
       standfirst
     } = article;
 
-    const authorImage = author && author.image ? author.image : null;
-
     return (
       <Fragment>
         <ArticleHeader
-          authorImage={authorImage}
+          authorImage={author.image}
           byline={byline}
           flags={flags}
           headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -16,7 +16,9 @@ class ArticlePage extends Component {
   renderHeader() {
     const { article } = this.props;
     const {
-      author,
+      author = {
+        image: null
+      },
       byline,
       flags,
       headline,
@@ -27,11 +29,9 @@ class ArticlePage extends Component {
       standfirst
     } = article;
 
-    const authorImage = author && author.image ? author.image : null;
-
     return (
       <ArticleHeader
-        authorImage={authorImage}
+        authorImage={author.image}
         byline={byline}
         flags={flags}
         headline={getHeadline(headline, shortHeadline)}


### PR DESCRIPTION
- sets a default `author` object in article comment templates -  `main` and `magazine`
- Fixes 500 errors in render when view an article with this template as no author object is being currently returned.