### PR TITLE
fix: Update byline wrapper to a textview for better linebreaking

### DIFF
--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -64,14 +64,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View
-    style={
-      Object {
-        "flexDirection": "row",
-        "flexWrap": "wrap",
-      }
-    }
-  >
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -106,7 +99,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -27,7 +27,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -62,7 +62,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -74,7 +74,7 @@ exports[`2. article summary with opinion byline 1`] = `
       title="Test label"
     />
   </View>
-  <View>
+  <Text>
     <ArticleBylineOpinion
       ast={
         Array [
@@ -95,7 +95,7 @@ exports[`2. article summary with opinion byline 1`] = `
       }
       isOpinionByline={true}
     />
-  </View>
+  </Text>
   <Text
     accessibilityRole="heading"
     aria-level="3"
@@ -143,7 +143,7 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -163,7 +163,7 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -305,7 +305,7 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
       publication="SUNDAYTIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -325,7 +325,7 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -374,7 +374,7 @@ exports[`9. article summary component with no label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -394,7 +394,7 @@ exports[`9. article summary component with no label 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -443,7 +443,7 @@ exports[`11. article summary component with no date publication 1`] = `
       ...
     </Text>
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -463,7 +463,7 @@ exports[`11. article summary component with no date publication 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -495,7 +495,7 @@ exports[`12. article summary component with a video label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -515,6 +515,6 @@ exports[`12. article summary component with a video label 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -64,14 +64,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View
-    style={
-      Object {
-        "flexDirection": "row",
-        "flexWrap": "wrap",
-      }
-    }
-  >
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -106,7 +99,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -27,7 +27,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -62,7 +62,7 @@ exports[`1. article summary component with a single paragraph 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -74,7 +74,7 @@ exports[`2. article summary with opinion byline 1`] = `
       title="Test label"
     />
   </View>
-  <View>
+  <Text>
     <ArticleBylineOpinion
       ast={
         Array [
@@ -95,7 +95,7 @@ exports[`2. article summary with opinion byline 1`] = `
       }
       isOpinionByline={true}
     />
-  </View>
+  </Text>
   <Text
     accessibilityRole="heading"
     aria-level="3"
@@ -143,7 +143,7 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -163,7 +163,7 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -305,7 +305,7 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
       publication="SUNDAYTIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -325,7 +325,7 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -374,7 +374,7 @@ exports[`9. article summary component with no label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -394,7 +394,7 @@ exports[`9. article summary component with no label 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -443,7 +443,7 @@ exports[`11. article summary component with no date publication 1`] = `
       ...
     </Text>
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -463,7 +463,7 @@ exports[`11. article summary component with no date publication 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;
 
@@ -495,7 +495,7 @@ exports[`12. article summary component with a video label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <View>
+  <Text>
     <ArticleByline
       ast={
         Array [
@@ -515,6 +515,6 @@ exports[`12. article summary component with a video label 1`] = `
         ]
       }
     />
-  </View>
+  </Text>
 </View>
 `;

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -47,10 +47,11 @@ exports[`1. article summary component with a single paragraph 1`] = `
 }
 
 .S6 {
-  -ms-flex-wrap: wrap;
-  -webkit-box-lines: multiple;
-  -webkit-flex-wrap: wrap;
-  flex-wrap: wrap;
+  color: inherit;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
   margin-bottom: 0px;
 }
 </style>

--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -32,13 +32,13 @@ const ArticleSummary = props => {
     if (bylineProps.ast.length === 0) return null;
 
     return (
-      <View className={bylineProps.bylineClass} style={styles.bylineWrapper}>
+      <Text className={bylineProps.bylineClass}>
         {bylineProps.isOpinionByline ? (
           <ArticleBylineOpinion {...bylineProps} />
         ) : (
           <ArticleByline {...bylineProps} />
         )}
-      </View>
+      </Text>
     );
   };
 

--- a/packages/article-summary/src/styles/shared.js
+++ b/packages/article-summary/src/styles/shared.js
@@ -2,10 +2,6 @@ import styleguide from "@times-components/styleguide";
 
 const { colours, fontFactory, fonts, spacing } = styleguide();
 const sharedStyles = {
-  bylineWrapper: {
-    flexDirection: "row",
-    flexWrap: "wrap"
-  },
   headline: {
     color: colours.functional.primary,
     fontFamily: fonts.headline,

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. one lead related article 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. one lead and one support related article 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -101,11 +101,11 @@ exports[`1. one lead and one support related article 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. one lead and two support related articles 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -101,11 +101,11 @@ exports[`1. one lead and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -147,11 +147,11 @@ exports[`1. one lead and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. no short headline 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -124,14 +124,7 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "flexWrap": "wrap",
-                    }
-                  }
-                >
+                <Text>
                   <Text
                     style={
                       Object {
@@ -145,7 +138,7 @@ exports[`default styles 1`] = `
                   >
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. one opinion related article 1`] = `
                     title="test label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. one opinion and one support related article 1`] = `
                     title="first label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"
@@ -111,11 +111,11 @@ exports[`1. one opinion and one support related article 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. one opinion and two support related articles 1`] = `
                     title="first label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"
@@ -111,11 +111,11 @@ exports[`1. one opinion and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -157,11 +157,11 @@ exports[`1. one opinion and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. no short headline 1`] = `
                     title="test label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -77,14 +77,7 @@ exports[`default styles 1`] = `
                     TEST LABEL
                   </Text>
                 </View>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "flexWrap": "wrap",
-                    }
-                  }
-                >
+                <Text>
                   <Text
                     style={
                       Object {
@@ -98,7 +91,7 @@ exports[`default styles 1`] = `
                   >
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   style={
                     Object {

--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -56,14 +56,14 @@ exports[`1. has video 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long
                   </Text>
                   <Text>
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -124,14 +124,7 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "flexWrap": "wrap",
-                    }
-                  }
-                >
+                <Text>
                   <Text
                     style={
                       Object {
@@ -158,7 +151,7 @@ exports[`default styles 1`] = `
                   >
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -56,14 +56,14 @@ exports[`1. a single related article 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long
                   </Text>
                   <Text>
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. two related articles 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -110,11 +110,11 @@ exports[`1. two related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. three related articles 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -110,11 +110,11 @@ exports[`1. three related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -165,11 +165,11 @@ exports[`1. three related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -56,14 +56,14 @@ exports[`1. no short headline 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long
                   </Text>
                   <Text>
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. one lead related article 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. one lead and one support related article 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -101,11 +101,11 @@ exports[`1. one lead and one support related article 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. one lead and two support related articles 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -101,11 +101,11 @@ exports[`1. one lead and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -147,11 +147,11 @@ exports[`1. one lead and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. no short headline 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -124,14 +124,7 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "flexWrap": "wrap",
-                    }
-                  }
-                >
+                <Text>
                   <Text
                     style={
                       Object {
@@ -145,7 +138,7 @@ exports[`default styles 1`] = `
                   >
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. one opinion related article 1`] = `
                     title="test label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. one opinion and one support related article 1`] = `
                     title="first label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"
@@ -111,11 +111,11 @@ exports[`1. one opinion and one support related article 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. one opinion and two support related articles 1`] = `
                     title="first label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"
@@ -111,11 +111,11 @@ exports[`1. one opinion and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -157,11 +157,11 @@ exports[`1. one opinion and two support related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Deborah Haynes
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -47,11 +47,11 @@ exports[`1. no short headline 1`] = `
                     title="test label"
                   />
                 </View>
-                <View>
+                <Text>
                   <Text>
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   accessibilityRole="heading"
                   aria-level="3"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -77,14 +77,7 @@ exports[`default styles 1`] = `
                     TEST LABEL
                   </Text>
                 </View>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "flexWrap": "wrap",
-                    }
-                  }
-                >
+                <Text>
                   <Text
                     style={
                       Object {
@@ -98,7 +91,7 @@ exports[`default styles 1`] = `
                   >
                     Sathnam Sanghera
                   </Text>
-                </View>
+                </Text>
                 <Text
                   style={
                     Object {

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -56,14 +56,14 @@ exports[`1. a single related article 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long
                   </Text>
                   <Text>
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. two related articles 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -110,11 +110,11 @@ exports[`1. two related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -55,11 +55,11 @@ exports[`1. three related articles 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -110,11 +110,11 @@ exports[`1. three related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>
@@ -165,11 +165,11 @@ exports[`1. three related articles 1`] = `
                 <Text>
                   January 17 2018, 12:00pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long, Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -56,14 +56,14 @@ exports[`1. has video 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long
                   </Text>
                   <Text>
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -56,14 +56,14 @@ exports[`1. no short headline 1`] = `
                 <Text>
                   March 13 2015, 6:54pm
                 </Text>
-                <View>
+                <Text>
                   <Text>
                     Camilla Long
                   </Text>
                   <Text>
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -124,14 +124,7 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "row",
-                      "flexWrap": "wrap",
-                    }
-                  }
-                >
+                <Text>
                   <Text
                     style={
                       Object {
@@ -158,7 +151,7 @@ exports[`default styles 1`] = `
                   >
                     , Environment Editor
                   </Text>
-                </View>
+                </Text>
               </View>
             </Card>
           </View>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -61,9 +61,9 @@ exports[`1. one lead related article 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Deborah Haynes
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -61,9 +61,9 @@ exports[`1. one lead and one support related article 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Deborah Haynes
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -112,9 +112,9 @@ exports[`1. one lead and one support related article 1`] = `
                       </time>
                     </div>
                     <div>
-                      <div>
+                      <span>
                         Deborah Haynes
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -68,9 +68,9 @@ exports[`1. one lead and two support related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Deborah Haynes
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -119,9 +119,9 @@ exports[`1. one lead and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      <div>
+                      <span>
                         Deborah Haynes
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </Card>
@@ -168,9 +168,9 @@ exports[`1. one lead and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      <div>
+                      <span>
                         Deborah Haynes
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -61,9 +61,9 @@ exports[`1. no short headline 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Deborah Haynes
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -281,6 +281,19 @@ exports[`default styles 1`] = `
   margin-bottom: 0px;
 }
 
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
 .IS1 {
   color: rgba(29,29,27,1.00);
 }
@@ -355,13 +368,13 @@ exports[`default styles 1`] = `
                     </time>
                   </div>
                   <div
-                    className="S4"
+                    className="S10"
                   >
-                    <div
+                    <span
                       className="S9"
                     >
                       Deborah Haynes
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -39,9 +39,9 @@ exports[`1. one opinion related article 1`] = `
                     />
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Sathnam Sanghera
-                    </div>
+                    </span>
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -39,9 +39,9 @@ exports[`1. one opinion and one support related article 1`] = `
                     />
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Sathnam Sanghera
-                    </div>
+                    </span>
                   </div>
                   <h3
                     aria-level="3"
@@ -126,9 +126,9 @@ exports[`1. one opinion and one support related article 1`] = `
                       </time>
                     </div>
                     <div>
-                      <div>
+                      <span>
                         Deborah Haynes
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -39,9 +39,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                     />
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Sathnam Sanghera
-                    </div>
+                    </span>
                   </div>
                   <h3
                     aria-level="3"
@@ -119,9 +119,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      <div>
+                      <span>
                         Deborah Haynes
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </Card>
@@ -168,9 +168,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      <div>
+                      <span>
                         Deborah Haynes
-                      </div>
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -39,9 +39,9 @@ exports[`1. no short headline 1`] = `
                     />
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Sathnam Sanghera
-                    </div>
+                    </span>
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -261,6 +261,19 @@ exports[`default styles 1`] = `
 .S6 {
   border-top-width: 0px;
   border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S7 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
   color: rgba(51,51,51,1.00);
   display: inline;
   font-family: TimesModern-Bold;
@@ -271,7 +284,7 @@ exports[`default styles 1`] = `
   margin-top: 0px;
 }
 
-.S7 {
+.S8 {
   border-top-width: 0px;
   border-bottom-width: 0px;
   color: inherit;
@@ -284,7 +297,7 @@ exports[`default styles 1`] = `
   margin-bottom: 0px;
 }
 
-.S8 {
+.S9 {
   border-top-width: 0px;
   border-bottom-width: 0px;
   color: rgba(105,105,105,1.00);
@@ -297,7 +310,7 @@ exports[`default styles 1`] = `
   margin-bottom: 10px;
 }
 
-.S9 {
+.S10 {
   border-top-width: 0px;
   border-bottom-width: 0px;
   color: rgba(105,105,105,1.00);
@@ -357,16 +370,16 @@ exports[`default styles 1`] = `
                     </div>
                   </div>
                   <div
-                    className="opinionBylineClass S4"
+                    className="opinionBylineClass S6"
                   >
-                    <div
+                    <span
                       className="S5"
                     >
                       Sathnam Sanghera
-                    </div>
+                    </span>
                   </div>
                   <h3
-                    className="opinionHeadlineClass S6"
+                    className="opinionHeadlineClass S7"
                   >
                     Test Short Headline
                   </h3>
@@ -374,10 +387,10 @@ exports[`default styles 1`] = `
                     className="S4"
                   >
                     <div
-                      className="summaryHidden opinionSummary125Class S8"
+                      className="summaryHidden opinionSummary125Class S9"
                     >
                       <span
-                        className="S7"
+                        className="S8"
                       >
                         
                         Summary 125
@@ -385,10 +398,10 @@ exports[`default styles 1`] = `
                       </span>
                     </div>
                     <div
-                      className="summaryHidden opinionSummary160Class S8"
+                      className="summaryHidden opinionSummary160Class S9"
                     >
                       <span
-                        className="S7"
+                        className="S8"
                       >
                         
                         Summary 160
@@ -397,7 +410,7 @@ exports[`default styles 1`] = `
                     </div>
                   </div>
                   <div
-                    className="S9"
+                    className="S10"
                   >
                     <time>
                       March 13 2015, 6:54pm

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -62,12 +62,12 @@ exports[`1. a single related article 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long
-                    </div>
-                    <div>
+                    </span>
+                    <span>
                       , Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -61,9 +61,9 @@ exports[`1. two related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long, Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -119,9 +119,9 @@ exports[`1. two related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long, Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -68,9 +68,9 @@ exports[`1. three related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long, Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -133,9 +133,9 @@ exports[`1. three related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long, Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -198,9 +198,9 @@ exports[`1. three related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long, Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -62,12 +62,12 @@ exports[`1. has video 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long
-                    </div>
-                    <div>
+                    </span>
+                    <span>
                       , Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -62,12 +62,12 @@ exports[`1. no short headline 1`] = `
                     </time>
                   </div>
                   <div>
-                    <div>
+                    <span>
                       Camilla Long
-                    </div>
-                    <div>
+                    </span>
+                    <span>
                       , Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -253,6 +253,19 @@ exports[`default styles 1`] = `
   margin-bottom: 0px;
 }
 
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
 .IS1 {
   color: rgba(219,19,59,1.00);
 }
@@ -327,18 +340,18 @@ exports[`default styles 1`] = `
                     </time>
                   </div>
                   <div
-                    className="S4"
+                    className="S10"
                   >
-                    <div
+                    <span
                       className="S9"
                     >
                       Camilla Long
-                    </div>
-                    <div
+                    </span>
+                    <span
                       className="S9"
                     >
                       , Environment Editor
-                    </div>
+                    </span>
                   </div>
                 </div>
               </Card>


### PR DESCRIPTION
Converted byline wrapper to a text view to provide better line breaks on multiple byline scenario

Before:
![screenshot_1544179921](https://user-images.githubusercontent.com/1849590/49644118-70e04700-fa0f-11e8-9669-2f183d9cba25.png)

After:
![screenshot_1544180397](https://user-images.githubusercontent.com/1849590/49644104-66be4880-fa0f-11e8-9b3d-c1cb56711887.png)
