### PR TITLE
fix: Center alignment on native article meta

### DIFF
--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -83,7 +83,13 @@ exports[`full article with style 1`] = `
         >
           Some Standfirst
         </Text>
-        <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
           <View
             style={
               Object {

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -83,7 +83,13 @@ exports[`full article with style 1`] = `
         >
           Some Standfirst
         </Text>
-        <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
           <View
             style={
               Object {

--- a/packages/article-magazine-comment/src/styles/shared.js
+++ b/packages/article-magazine-comment/src/styles/shared.js
@@ -47,6 +47,9 @@ const sharedStyles = {
     flexDirection: "row",
     flexWrap: "wrap"
   },
+  metaContainer: {
+    alignItems: "center"
+  },
   standFirst: {
     ...fontFactory({
       font: "headlineRegular",

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -72,7 +72,13 @@ exports[`full article with style 1`] = `
         >
           Some Standfirst
         </Text>
-        <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
           <View
             style={
               Object {

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -72,7 +72,13 @@ exports[`full article with style 1`] = `
         >
           Some Standfirst
         </Text>
-        <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
           <View
             style={
               Object {

--- a/packages/article-magazine-standard/src/styles/shared.js
+++ b/packages/article-magazine-standard/src/styles/shared.js
@@ -44,6 +44,9 @@ const sharedStyles = {
     flexDirection: "row",
     flexWrap: "wrap"
   },
+  metaContainer: {
+    alignItems: "center"
+  },
   standFirst: {
     ...fontFactory({
       font: "headlineRegular",

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -86,7 +86,13 @@ exports[`full article with style 1`] = `
         >
           Some Standfirst
         </Text>
-        <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
           <View
             style={
               Object {

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -86,7 +86,13 @@ exports[`full article with style 1`] = `
         >
           Some Standfirst
         </Text>
-        <View>
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+            }
+          }
+        >
           <View
             style={
               Object {

--- a/packages/article-main-comment/src/styles/shared.js
+++ b/packages/article-main-comment/src/styles/shared.js
@@ -47,6 +47,9 @@ const sharedStyles = {
     flexDirection: "row",
     flexWrap: "wrap"
   },
+  metaContainer: {
+    alignItems: "center"
+  },
   standFirst: {
     ...fontFactory({
       font: "headlineRegular",


### PR DESCRIPTION
Article bylines were misaligned on native, added a style to metaContainer on all templates

Before:
![screenshot_1544196305](https://user-images.githubusercontent.com/1849590/49656391-28d41b00-fa35-11e8-8bfe-9a6fe7aa7365.png)

After:
![screenshot_1544196287](https://user-images.githubusercontent.com/1849590/49656386-240f6700-fa35-11e8-9739-251678fa18a6.png)
