### PR TITLE
feat: Integration tests for all article templates

### DIFF
--- a/packages/fixture-generator/src/__tests__/mock-article.test.ts
+++ b/packages/fixture-generator/src/__tests__/mock-article.test.ts
@@ -1,4 +1,5 @@
 import MockArticle from "../mock-article";
+import { TemplateType } from "../types";
 
 describe("The mock Article", () => {
   it("should return the minimum article type requirements", () => {
@@ -17,4 +18,9 @@ describe("The mock Article", () => {
     const mockArticle = new MockArticle().setRelatedArticles(5).get();
     expect(mockArticle.relatedArticleSlice!.items.length).toBe(5);
   })
+
+  it("should return a maincomment template", () => {
+    const mockArticle = new MockArticle().setTemplate('maincomment' as TemplateType).get();
+    expect(mockArticle.template).toBe("maincomment");
+  });
 });

--- a/packages/fixture-generator/src/mock-article.ts
+++ b/packages/fixture-generator/src/mock-article.ts
@@ -57,6 +57,11 @@ class MockArticle {
     return this;
   }
 
+  setTemplate(template: TemplateType) {
+    this.article.template = template;
+    return this;
+  }
+
   sundayTimes() {
     this.article.publicationName = getPublicationName(
       PublicationName.SUNDAYTIMES

--- a/packages/ssr/__tests__/integration/article.js
+++ b/packages/ssr/__tests__/integration/article.js
@@ -1,37 +1,43 @@
 import { MockArticle } from "@times-components/fixture-generator";
 
 const relatedArticleCount = 3;
+const articleTemplateTest = template =>
+  xdescribe(`Article - template=${template}`, () => {
+    it("loads hi-res images for related articles", () =>
+      cy
+        .task("startMockServerWith", {
+          Article: new MockArticle()
+            .sundayTimes()
+            .setRelatedArticles(relatedArticleCount)
+            .setTemplate(template)
+            .get()
+        })
+        .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
+        .get("#related-articles")
+        .scrollIntoView()
+        .then(() => {
+          // wait for the image to transition and be removed (unfortunately Cypress doesn't auto wait for this)
+          cy.wait(2000);
 
-describe("Article", () => {
-  it("loads hi-res images for related articles", () =>
-    cy
-      .task("startMockServerWith", {
-        Article: new MockArticle()
-          .sundayTimes()
-          .setRelatedArticles(relatedArticleCount)
-          .get()
-      })
-      .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
-      .get("#related-articles")
-      .scrollIntoView()
-      .then(() => {
-        // wait for the image to transition and be removed (unfortunately Cypress doesn't auto wait for this)
-        cy.wait(2000);
+          cy.get("#related-articles img").as("raImages");
 
-        cy.get("#related-articles img").as("raImages");
+          cy.get("@raImages")
+            .its("length")
+            .should("eq", relatedArticleCount);
 
-        cy.get("@raImages")
-          .its("length")
-          .should("eq", relatedArticleCount);
+          cy.get("@raImages").each(item => {
+            const url = new URL(item.attr("src"));
+            const initialResize = "100";
+            expect(url.searchParams.get("resize")).to.not.equal(initialResize);
+          });
+        }));
 
-        cy.get("@raImages").each(item => {
-          const url = new URL(item.attr("src"));
-          const initialResize = "100";
-          expect(url.searchParams.get("resize")).to.not.equal(initialResize);
-        });
-      }));
-
-  xit("loaded all the required article ads", () => {
-    cy.loadedArticleAds();
+    it("loaded all the required article ads", () => {
+      cy.loadedArticleAds();
+    });
   });
-});
+
+articleTemplateTest("mainstandard");
+articleTemplateTest("maincomment");
+articleTemplateTest("magazinestandard");
+articleTemplateTest("magazinecomment");


### PR DESCRIPTION
This provides identical cypress tests for all article templates that we currently have. They are identical to follow the strategy that we only care that the page loads and performs the client side actions that we require (e.g. Lazy Loading). More specific tests will be duplicated what we do further down the tree.