### PR TITLE
feat: add SpotIM comments to articles on web

### DIFF
--- a/packages/article-comments/package.json
+++ b/packages/article-comments/package.json
@@ -40,7 +40,8 @@
     "@times-components/link": "3.1.18",
     "@times-components/provider": "1.8.8",
     "@times-components/styleguide": "3.9.4",
-    "prop-types": "15.6.2"
+    "prop-types": "15.6.2",
+    "styled-components": "3.4.0"
   },
   "devDependencies": {
     "@thetimes/jest-lint": "*",
@@ -52,6 +53,7 @@
     "@times-components/test-utils": "2.0.4",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
+    "babel-plugin-styled-components": "1.5.1",
     "eslint": "5.9.0",
     "jest": "23.3.0",
     "prettier": "1.14.3",

--- a/packages/article-comments/src/article-comments.web.js
+++ b/packages/article-comments/src/article-comments.web.js
@@ -1,0 +1,90 @@
+/* eslint-env browser */
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { CommentContainer, CommentGuidelines } from "./styles/responsive";
+import executeSSOtransaction from "./comment-login";
+
+class ArticleComments extends Component {
+  constructor() {
+    super();
+    this.container = null;
+  }
+
+  componentDidMount() {
+    this.initialiseComments();
+  }
+
+  componentWillUnmount() {
+    this.disposeComments();
+  }
+
+  initialiseComments() {
+    const { articleId, isReadOnly, spotAccountId } = this.props;
+
+    if (!this.container || !articleId || !spotAccountId) {
+      return;
+    }
+
+    const launcherScript = document.createElement("script");
+    launcherScript.setAttribute("async", "async");
+    launcherScript.setAttribute(
+      "src",
+      `https://launcher.spot.im/spot/${spotAccountId}`
+    );
+    launcherScript.setAttribute("data-spotim-module", "spotim-launcher");
+    launcherScript.setAttribute("data-post-id", articleId);
+    launcherScript.setAttribute(
+      "data-post-url",
+      `https://www.thetimes.co.uk/article/${articleId}`
+    );
+    launcherScript.setAttribute("data-seo-enabled", true);
+    launcherScript.setAttribute("data-livefyre-url", articleId);
+    this.container.appendChild(launcherScript);
+
+    if (!isReadOnly) {
+      if (window.SPOTIM && window.SPOTIM.startSSO) {
+        executeSSOtransaction();
+      } else {
+        document.addEventListener("spot-im-api-ready", executeSSOtransaction);
+      }
+    }
+  }
+
+  disposeComments() {
+    if (this.container) {
+      this.container.innerHTML = "";
+    }
+  }
+
+  render() {
+    return (
+      <CommentContainer>
+        <CommentGuidelines>
+          Comments are subject to our community guidelines, which can be viewed{" "}
+          <a href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32">
+            here
+          </a>
+          .
+        </CommentGuidelines>
+        <div
+          ref={el => {
+            this.container = el;
+          }}
+        />
+      </CommentContainer>
+    );
+  }
+}
+
+ArticleComments.propTypes = {
+  articleId: PropTypes.string.isRequired,
+  isReadOnly: PropTypes.bool,
+  spotAccountId: PropTypes.string.isRequired
+};
+
+ArticleComments.defaultProps = {
+  isReadOnly: false
+};
+
+export default ArticleComments;

--- a/packages/article-comments/src/comment-login.web.js
+++ b/packages/article-comments/src/comment-login.web.js
@@ -1,0 +1,23 @@
+/* eslint-env browser */
+
+const ssoCallback = (codeA, completeSSOCallback) => {
+  const url = `/api/comments/login?codeA=${encodeURIComponent(codeA)}`;
+  const xhr = new XMLHttpRequest();
+  xhr.addEventListener("load", () => {
+    const success = xhr.status === 200;
+    const { spotimCodeB } = success ? JSON.parse(xhr.response) : {};
+    if (spotimCodeB) {
+      completeSSOCallback(spotimCodeB);
+    }
+  });
+  xhr.open("GET", url);
+  xhr.send();
+};
+
+const executeSSOtransaction = () => {
+  if (window.SPOTIM && window.SPOTIM.startSSO) {
+    window.SPOTIM.startSSO(ssoCallback);
+  }
+};
+
+export default executeSSOtransaction;

--- a/packages/article-comments/src/styles/responsive.web.js
+++ b/packages/article-comments/src/styles/responsive.web.js
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import {
+  breakpoints,
+  colours,
+  fonts,
+  fontSizes,
+  spacing
+} from "@times-components/styleguide";
+
+export const CommentContainer = styled.div`
+  margin-left: auto;
+  margin-right: auto;
+
+  @media (min-width: ${breakpoints.medium}px) {
+    width: 80.8%;
+  }
+
+  @media (min-width: ${breakpoints.wide}px) {
+    width: 56.2%;
+  }
+`;
+
+export const CommentGuidelines = styled.p`
+  color: ${colours.functional.secondary};
+  font-family: "${fonts.supporting}";
+  font-size: ${fontSizes.commentsGuidelines}px;
+  margin-bottom: ${spacing(-2)};
+  margin-left: 7px;
+  margin-top: ${spacing(5)};
+`;

--- a/packages/article-magazine-comment/.jestlint
+++ b/packages/article-magazine-comment/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 36,
+  "maxAttributeStringLength": 65,
   "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article-magazine-comment/__tests__/mocks.web.js
+++ b/packages/article-magazine-comment/__tests__/mocks.web.js
@@ -3,6 +3,7 @@ jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({
   ArticleBylineWithLinks: "ArticleBylineWithLinks"
 }));
+jest.mock("@times-components/article-comments", () => "ArticleComments");
 jest.mock("@times-components/article-flag", () => ({
   ExclusiveArticleFlag: "ExclusiveArticleFlag",
   NewArticleFlag: "NewArticleFlag",

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -743,6 +743,7 @@ exports[`full article with style 1`] = `
       <aside>
         <RelatedArticles />
       </aside>
+      <ArticleComments />
     </div>
   </div>
 </article>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -149,6 +149,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -301,6 +304,9 @@ exports[`4. an article with ads 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -468,6 +474,9 @@ exports[`8. an article with no author 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -171,5 +171,15 @@ exports[`1. a full article 1`] = `
       </time>
     </a>
   </aside>
+  <p>
+    Comments are subject to our community guidelines, which can be viewed
+     
+    <a
+      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+    >
+      here
+    </a>
+    .
+  </p>
 </article>
 `;

--- a/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-comment/__tests__/web/semantic.web.test.js
@@ -144,6 +144,7 @@ const tests = [
             onTopicPress={() => {}}
             onVideoPress={() => {}}
             receiveChildList={() => {}}
+            spotAccountId=""
           />
         </Context.Provider>
       );

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -55,7 +55,8 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
-      receiveChildList
+      receiveChildList,
+      spotAccountId
     } = this.props;
 
     if (error || isLoading) {
@@ -69,6 +70,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        spotAccountId={spotAccountId}
       />
     );
   }

--- a/packages/article-magazine-comment/src/article-prop-types/article-prop-types.web.js
+++ b/packages/article-magazine-comment/src/article-prop-types/article-prop-types.web.js
@@ -1,10 +1,12 @@
+import PropTypes from "prop-types";
 import {
   articlePagePropTypes,
   articlePageDefaultProps
 } from "./article-prop-types.base";
 
 const articlePropTypes = {
-  ...articlePagePropTypes
+  ...articlePagePropTypes,
+  spotAccountId: PropTypes.string.isRequired
 };
 
 const articleDefaultProps = {

--- a/packages/article-magazine-standard/.jestlint
+++ b/packages/article-magazine-standard/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 36,
+  "maxAttributeStringLength": 65,
   "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article-magazine-standard/__tests__/mocks.web.js
+++ b/packages/article-magazine-standard/__tests__/mocks.web.js
@@ -3,6 +3,7 @@ jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({
   ArticleBylineWithLinks: "ArticleBylineWithLinks"
 }));
+jest.mock("@times-components/article-comments", () => "ArticleComments");
 jest.mock("@times-components/article-flag", () => ({
   ExclusiveArticleFlag: "ExclusiveArticleFlag",
   NewArticleFlag: "NewArticleFlag",

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -710,6 +710,7 @@ exports[`full article with style 1`] = `
       <aside>
         <RelatedArticles />
       </aside>
+      <ArticleComments />
     </div>
   </div>
 </article>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -144,6 +144,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -291,6 +294,9 @@ exports[`4. an article with ads 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -167,5 +167,15 @@ exports[`1. a full article 1`] = `
       </time>
     </a>
   </aside>
+  <p>
+    Comments are subject to our community guidelines, which can be viewed
+     
+    <a
+      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+    >
+      here
+    </a>
+    .
+  </p>
 </article>
 `;

--- a/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-magazine-standard/__tests__/web/semantic.web.test.js
@@ -144,6 +144,7 @@ const tests = [
             onTopicPress={() => {}}
             onVideoPress={() => {}}
             receiveChildList={() => {}}
+            spotAccountId=""
           />
         </Context.Provider>
       );

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -51,7 +51,8 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
-      receiveChildList
+      receiveChildList,
+      spotAccountId
     } = this.props;
 
     if (error || isLoading) {
@@ -65,6 +66,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        spotAccountId={spotAccountId}
       />
     );
   }

--- a/packages/article-main-comment/.jestlint
+++ b/packages/article-main-comment/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 36,
+  "maxAttributeStringLength": 65,
   "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article-main-comment/__tests__/mocks.web.js
+++ b/packages/article-main-comment/__tests__/mocks.web.js
@@ -3,6 +3,7 @@ jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({
   ArticleBylineWithLinks: "ArticleBylineWithLinks"
 }));
+jest.mock("@times-components/article-comments", () => "ArticleComments");
 jest.mock("@times-components/article-flag", () => ({
   ExclusiveArticleFlag: "ExclusiveArticleFlag",
   NewArticleFlag: "NewArticleFlag",

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -667,6 +667,7 @@ exports[`full article with style 1`] = `
       <aside>
         <RelatedArticles />
       </aside>
+      <ArticleComments />
     </div>
   </div>
 </article>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -128,6 +128,9 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -259,6 +262,9 @@ exports[`4. an article with ads 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -161,5 +161,15 @@ exports[`1. a full article 1`] = `
       </time>
     </a>
   </aside>
+  <p>
+    Comments are subject to our community guidelines, which can be viewed
+     
+    <a
+      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+    >
+      here
+    </a>
+    .
+  </p>
 </article>
 `;

--- a/packages/article-main-comment/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-comment/__tests__/web/semantic.web.test.js
@@ -144,6 +144,7 @@ const tests = [
             onTopicPress={() => {}}
             onVideoPress={() => {}}
             receiveChildList={() => {}}
+            spotAccountId=""
           />
         </Context.Provider>
       );

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -50,7 +50,8 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
-      receiveChildList
+      receiveChildList,
+      spotAccountId
     } = this.props;
 
     if (error || isLoading) {
@@ -64,6 +65,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        spotAccountId={spotAccountId}
       />
     );
   }

--- a/packages/article-main-standard/.jestlint
+++ b/packages/article-main-standard/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 36,
+  "maxAttributeStringLength": 65,
   "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article-main-standard/__tests__/mocks.web.js
+++ b/packages/article-main-standard/__tests__/mocks.web.js
@@ -3,6 +3,7 @@ jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({
   ArticleBylineWithLinks: "ArticleBylineWithLinks"
 }));
+jest.mock("@times-components/article-comments", () => "ArticleComments");
 jest.mock("@times-components/article-flag", () => ({
   ExclusiveArticleFlag: "ExclusiveArticleFlag",
   NewArticleFlag: "NewArticleFlag",

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-lead-asset.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-lead-asset.web.test.js.snap
@@ -246,6 +246,9 @@ exports[`1. a full article with an image as the lead asset 1`] = `
           }
         />
       </aside>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -327,6 +330,9 @@ exports[`2. an article with a video as the lead asset 1`] = `
       <aside
         id="related-articles"
       />
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -371,6 +377,9 @@ exports[`3. an article with no lead asset 1`] = `
       </p>
       <aside
         id="related-articles"
+      />
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       />
     </div>
   </div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -756,6 +756,7 @@ exports[`full article with style 1`] = `
       <aside>
         <RelatedArticles />
       </aside>
+      <ArticleComments />
     </div>
   </div>
 </article>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -42,6 +42,9 @@ exports[`2. an article with no headline falls back to use shortheadline 1`] = `
       <aside
         id="related-articles"
       />
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+      />
     </div>
   </div>
 </article>
@@ -88,6 +91,9 @@ exports[`3. an article with ads 1`] = `
       />
       <aside
         id="related-articles"
+      />
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
       />
     </div>
   </div>

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -180,5 +180,15 @@ exports[`1. a full article with an image as the lead asset 1`] = `
       </time>
     </a>
   </aside>
+  <p>
+    Comments are subject to our community guidelines, which can be viewed
+     
+    <a
+      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+    >
+      here
+    </a>
+    .
+  </p>
 </article>
 `;

--- a/packages/article-main-standard/__tests__/web/semantic.web.test.js
+++ b/packages/article-main-standard/__tests__/web/semantic.web.test.js
@@ -143,6 +143,7 @@ const tests = [
             onRelatedArticlePress={() => {}}
             onTopicPress={() => {}}
             onVideoPress={() => {}}
+            spotAccountId=""
           />
         </Context.Provider>
       );

--- a/packages/article-main-standard/src/article-main-standard.web.js
+++ b/packages/article-main-standard/src/article-main-standard.web.js
@@ -71,7 +71,8 @@ class ArticlePage extends Component {
       analyticsStream,
       error,
       isLoading,
-      receiveChildList
+      receiveChildList,
+      spotAccountId
     } = this.props;
 
     if (error || isLoading) {
@@ -85,6 +86,7 @@ class ArticlePage extends Component {
         data={article}
         Header={this.renderHeader}
         receiveChildList={receiveChildList}
+        spotAccountId={spotAccountId}
       />
     );
   }

--- a/packages/article-skeleton/.jestlint
+++ b/packages/article-skeleton/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 36,
-  "maxFileSize": 23101,
+  "maxAttributeStringLength": 65,
+  "maxFileSize": 23725,
   "maxLines": 780
 }

--- a/packages/article-skeleton/__tests__/images.base.js
+++ b/packages/article-skeleton/__tests__/images.base.js
@@ -51,6 +51,7 @@ export default () =>
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            spotAccountId=""
           />
         );
 
@@ -90,6 +91,7 @@ export default () =>
             onTopicPress={() => {}}
             onTwitterLinkPress={() => {}}
             onVideoPress={() => {}}
+            spotAccountId=""
           />
         );
 

--- a/packages/article-skeleton/__tests__/shared-with-style.web.js
+++ b/packages/article-skeleton/__tests__/shared-with-style.web.js
@@ -307,6 +307,7 @@ export default () => {
         onTopicPress={() => {}}
         onTwitterLinkPress={() => {}}
         onVideoPress={() => {}}
+        spotAccountId=""
       />
     );
 

--- a/packages/article-skeleton/__tests__/shared.base.js
+++ b/packages/article-skeleton/__tests__/shared.base.js
@@ -28,6 +28,7 @@ const renderArticle = (data, header = null) => (
       onTopicPress={() => {}}
       onTwitterLinkPress={() => {}}
       onVideoPress={() => {}}
+      spotAccountId=""
     />
   </Context.Provider>
 );

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. a secondary image 1`] = `
+.c4 {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c5 {
+  color: #696969;
+  font-family: "GillSansMTStd-Medium";
+  font-size: 13px;
+  margin-bottom: -10px;
+  margin-left: 7px;
+  margin-top: 25px;
+}
+
 .c3 {
   width: 100%;
   -webkit-flex-direction: row;
@@ -23,6 +37,18 @@ exports[`1. a secondary image 1`] = `
   -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 80.8%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    width: 56.2%;
+  }
 }
 
 @media (min-width:768px) {
@@ -104,12 +130,41 @@ exports[`1. a secondary image 1`] = `
         </div>
       </div>
       <aside />
+      <div
+        className="c4"
+      >
+        <p
+          className="c5"
+        >
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a>
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>
 `;
 
 exports[`2. an inline image 1`] = `
+.c4 {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c5 {
+  color: #696969;
+  font-family: "GillSansMTStd-Medium";
+  font-size: 13px;
+  margin-bottom: -10px;
+  margin-left: 7px;
+  margin-top: 25px;
+}
+
 .c3 {
   width: 100%;
   -webkit-flex-direction: row;
@@ -136,6 +191,18 @@ exports[`2. an inline image 1`] = `
 }
 
 @media (min-width:768px) {
+  .c4 {
+    width: 80.8%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    width: 56.2%;
+  }
+}
+
+@media (min-width:768px) {
   .c3 {
     width: 80.8%;
     margin: 0 auto;
@@ -214,6 +281,21 @@ exports[`2. an inline image 1`] = `
         </div>
       </div>
       <aside />
+      <div
+        className="c4"
+      >
+        <p
+          className="c5"
+        >
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a>
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -37,6 +37,19 @@ exports[`1. a secondary image 1`] = `
       <aside
         id="related-articles"
       />
+      <div>
+        <p>
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a
+            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>
@@ -79,6 +92,19 @@ exports[`2. an inline image 1`] = `
       <aside
         id="related-articles"
       />
+      <div>
+        <p>
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a
+            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`full article with style 1`] = `
+.c13 {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c14 {
+  color: #696969;
+  font-family: "GillSansMTStd-Medium";
+  font-size: 13px;
+  margin-bottom: -10px;
+  margin-left: 7px;
+  margin-top: 25px;
+}
+
 .c3 {
   color: #333333;
   display: block;
@@ -91,6 +105,18 @@ exports[`full article with style 1`] = `
   -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
+}
+
+@media (min-width:768px) {
+  .c13 {
+    width: 80.8%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c13 {
+    width: 56.2%;
+  }
 }
 
 @media (min-width:768px) {
@@ -440,6 +466,21 @@ exports[`full article with style 1`] = `
       <aside>
         <RelatedArticles />
       </aside>
+      <div
+        className="c13"
+      >
+        <p
+          className="c14"
+        >
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a>
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -324,6 +324,19 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           }
         />
       </aside>
+      <div>
+        <p>
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a
+            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>
@@ -650,6 +663,19 @@ exports[`2. a full article with all content items with not a dropcap template 1`
           }
         />
       </aside>
+      <div>
+        <p>
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a
+            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>
@@ -729,6 +755,19 @@ exports[`3. an article with no content 1`] = `
           }
         />
       </aside>
+      <div>
+        <p>
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a
+            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>
@@ -758,6 +797,19 @@ exports[`4. an article with a nested markup in first paragraph displays no drop 
       <aside
         id="related-articles"
       />
+      <div>
+        <p>
+          Comments are subject to our community guidelines, which can be viewed
+           
+          <a
+            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
+            here
+          </a>
+          .
+        </p>
+        <div />
+      </div>
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/article-lazy.web.test.js
+++ b/packages/article-skeleton/__tests__/web/article-lazy.web.test.js
@@ -82,6 +82,7 @@ iterator([
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          spotAccountId=""
         />
       );
 
@@ -139,6 +140,7 @@ iterator([
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          spotAccountId=""
         />
       );
 
@@ -175,6 +177,7 @@ iterator([
           onTopicPress={() => {}}
           onTwitterLinkPress={() => {}}
           onVideoPress={() => {}}
+          spotAccountId=""
         />
       );
 

--- a/packages/article-skeleton/src/article-skeleton-prop-types.js
+++ b/packages/article-skeleton/src/article-skeleton-prop-types.js
@@ -5,7 +5,8 @@ const articleSkeletonPropTypes = {
   analyticsStream: PropTypes.func.isRequired,
   data: PropTypes.shape({}),
   Header: PropTypes.func,
-  receiveChildList: PropTypes.func
+  receiveChildList: PropTypes.func,
+  spotAccountId: PropTypes.string
 };
 
 const articleSkeletonDefaultProps = {

--- a/packages/article-skeleton/src/article-skeleton.web.js
+++ b/packages/article-skeleton/src/article-skeleton.web.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import Ad, { AdComposer } from "@times-components/ad";
+import ArticleComments from "@times-components/article-comments";
 import LazyLoad from "@times-components/lazy-load";
 import RelatedArticles from "@times-components/related-articles";
 import { spacing } from "@times-components/styleguide";
@@ -42,9 +43,19 @@ class ArticleSkeleton extends Component {
     const {
       adConfig,
       analyticsStream,
-      data: { content, section, url, topics, relatedArticleSlice, template },
+      data: {
+        commentsEnabled,
+        content,
+        id: articleId,
+        section,
+        url,
+        topics,
+        relatedArticleSlice,
+        template
+      },
       Header,
-      receiveChildList
+      receiveChildList,
+      spotAccountId
     } = this.props;
     const { articleWidth } = this.state;
     // eslint-disable-next-line react/prop-types
@@ -109,6 +120,12 @@ class ArticleSkeleton extends Component {
                         isVisible: !!observed.get("related-articles")
                       })}
                     </aside>
+                    {commentsEnabled && (
+                      <ArticleComments
+                        articleId={articleId}
+                        spotAccountId={spotAccountId}
+                      />
+                    )}
                   </BodyContainer>
                 </MainContainer>
               </Fragment>

--- a/packages/provider-queries/src/article.web.js
+++ b/packages/provider-queries/src/article.web.js
@@ -4,7 +4,6 @@ import gql from "graphql-tag";
 export default addTypenameToDocument(gql`
   query ArticleQuery($id: ID!) {
     article(id: $id) {
-      commentCount
       commentsEnabled
       content: paywalledContent
       flags

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -1,16 +1,13 @@
 # SSR
 
-An unpublished package which allows developers to easily play with
-server-side-rendering (SSR). Add any "pages" (top level components) here for
-rendering, by adding a route and the webpack config necessary to create a client
-bundle.
+The renderer used to render top level components server side and to create client
+bundles. Add any "pages" (top level components) here for rendering, by adding a
+route and the webpack config necessary to create a client bundle.
 
 ## Usage
 
-Before each command below you should set the envar `GRAPHQL_ENDPOINT` which will
-be used for data fetching. In order to create a bundle it relies on each package
-having it's own `rnw` bundle generated. Use `npx lerna run bundle` at the root
-to simulate a published package.
+In order to create a bundle, we need for all packages to have their own `rnw` bundle.
+Use `npx lerna run bundle` at the root to simulate a published package.
 
 ```bash
 yarn bundle:dev
@@ -29,7 +26,7 @@ warnings/errors. The server-side response is also compressed for testing client
 perf.
 
 ```bash
-yarn start
+GRAPHQL_ENDPOINT=<API endpoint> SPOT_ID=<SpotIM ID> yarn start
 ```
 
 Run a simple node server which serves up the various pages which currently
@@ -39,9 +36,12 @@ include:
 - `/profile/:author-slug`
 - `/topic/:topic-slug`
 
-They will use the client side bundle you generated above. You can optionally set
-`AUTH_TOKEN` as an envar (instructions should be available from your API
-provider) to get unteased articles.
+They will use the client side bundle you generated above.
+
+- `GRAPHQL_ENDPOINT` is used for data fetching.
+- `SPOT_ID` is used to render comments on article pages.
+- You can optionally set `GRAPHQL_TOKEN` (instructions should be available from your
+  API provider) to get unteased articles.
 
 ```bash
 yarn bundle:profile
@@ -53,21 +53,12 @@ visualise the webpack bundle or upload it to other tools
 [suggested by webpack](https://webpack.js.org/guides/code-splitting/#bundle-analysis)
 
 ```bash
-yarn start:tpamock
+yarn start:testserver
 ```
 
-This starts an [Apollo sever](https://www.apollographql.com/docs/apollo-server/)
-with a mock implementation using the fixture generator from `provider-test-tools`.
-This should be expanded on to provide different use cases for particular queries
-and used for testing with Cypress so that we have a closely integration
-"fixture server" for robust e2e testing.
-
-```bash
-yarn start:test
-```
-
-Simply starts the SSR server but sets the `GRAPHQL_ENDPOINT` to port 4000 which
-is where the mock TPA server should be running using `yarn start:tpamock`.
+Simply starts the SSR server but sets the `SPOT_ID` to a fixed dummy value (so
+the SpotIM script will written on the article page, but not found/run), and sets
+`GRAPHQL_ENDPOINT` to port 4000 which is where the test TPA server should be running.
 
 ## Contributing
 

--- a/packages/ssr/__tests__/cypress/support/commands.js
+++ b/packages/ssr/__tests__/cypress/support/commands.js
@@ -10,17 +10,3 @@ Cypress.Commands.add("goToPreviousArticle", () => {
     .first()
     .click();
 });
-
-Cypress.Commands.add("loadedAd", selector => {
-  //  open devtools
-  // cy.get(selector).debug().pause();
-  cy.wait(2000);
-  cy.get(selector).should(element => {
-    expect(element).to.exist;
-    expect(element).to.be.visible;
-    expect(element).to.not.be.empty;
-  });
-  cy.get(selector)
-    .get("googleQueryId")
-    .should("not.be.empty");
-});

--- a/packages/ssr/__tests__/integration/article.js
+++ b/packages/ssr/__tests__/integration/article.js
@@ -3,13 +3,23 @@ import { MockArticle } from "@times-components/fixture-generator";
 const relatedArticleCount = 3;
 
 describe("Article", () => {
+  let sundayTimesArticleWithThreeRelatedArticles;
+
+  beforeEach(() => {
+    sundayTimesArticleWithThreeRelatedArticles = new MockArticle()
+      .sundayTimes()
+      .setRelatedArticles(relatedArticleCount)
+      .get();
+  });
+
+  afterEach(() => {
+    cy.task("stopMockServer");
+  });
+
   it("loads hi-res images for related articles", () =>
     cy
       .task("startMockServerWith", {
-        Article: new MockArticle()
-          .sundayTimes()
-          .setRelatedArticles(relatedArticleCount)
-          .get()
+        Article: sundayTimesArticleWithThreeRelatedArticles
       })
       .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
       .get("#related-articles")
@@ -31,7 +41,40 @@ describe("Article", () => {
         });
       }));
 
-  it("loaded all the required article ads", () => {
-    cy.loadedAd("#header");
+  it("loads all the required article ads", () => {
+    cy.task("startMockServerWith", {
+      Article: sundayTimesArticleWithThreeRelatedArticles
+    })
+      .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
+      .wait(2000);
+
+    cy.get("#header")
+      .should("exist")
+      .should("be.visible")
+      .should("not.be.empty");
+
+    cy.get("#header")
+      .get("googleQueryId")
+      .should("not.be.empty");
+  });
+
+  it("has SpotIM comment tag", () => {
+    const articleWithCommentsEnabled = {
+      ...sundayTimesArticleWithThreeRelatedArticles,
+      commentsEnabled: true
+    };
+
+    cy.task("startMockServerWith", {
+      Article: articleWithCommentsEnabled
+    }).visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d");
+
+    cy.get("script[data-spotim-module]")
+      .should("have.attr", "src", "https://launcher.spot.im/spot/5p0t_1m_1d")
+      .should("have.attr", "data-post-id", articleWithCommentsEnabled.id)
+      .should(
+        "have.attr",
+        "data-post-url",
+        `https://www.thetimes.co.uk/article/${articleWithCommentsEnabled.id}`
+      );
   });
 });

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -13,10 +13,10 @@
     "prepublishOnly": "yarn bundle:prod",
     "prettier:diff": "prettier --list-different '**/*.*'",
     "start": "webpack --config=src/standalone-renderer/webpack.config.js && node src/standalone-renderer/app.js",
-    "start:testservers": "GRAPHQL_ENDPOINT=http://localhost:4000/graphql yarn start & wait-on tcp:3000",
-    "stop:testservers": "kill $(lsof -t -i:3000,4000)",
-    "test:integration": "yarn bundle:prod && yarn start:testservers && cypress run; exitCode=$?; yarn stop:testservers; exit $exitCode",
-    "test:integration:debug": "yarn bundle:prod && yarn start:testservers && DEBUG=cypress:* cypress open; exitCode=$?; yarn stop:testservers; exit $exitCode"
+    "start:testserver": "GRAPHQL_ENDPOINT=http://localhost:4000/graphql SPOT_ID=5p0t_1m_1d yarn start & wait-on tcp:3000",
+    "stop:testserver": "kill $(lsof -t -i:3000)",
+    "test:integration": "yarn bundle:prod && yarn start:testserver && cypress run; exitCode=$?; yarn stop:testserver; exit $exitCode",
+    "test:integration:debug": "yarn bundle:prod && yarn start:testserver && DEBUG=cypress:* cypress open; exitCode=$?; yarn stop:testserver; exit $exitCode"
   },
   "repository": {
     "type": "git",

--- a/packages/ssr/src/client/article.js
+++ b/packages/ssr/src/client/article.js
@@ -2,14 +2,20 @@ const article = require("../component/article");
 const runClient = require("../lib/run-client");
 
 if (window.nuk && window.nuk.ssr && window.nuk.article) {
-  const { rootTag, makeArticleUrl, mapArticleToAdConfig } = window.nuk.ssr;
+  const {
+    rootTag,
+    makeArticleUrl,
+    mapArticleToAdConfig,
+    spotAccountId
+  } = window.nuk.ssr;
   const { articleId, debounceTimeMs } = window.nuk.article;
 
   const data = {
     articleId,
     debounceTimeMs,
     makeArticleUrl,
-    mapArticleToAdConfig
+    mapArticleToAdConfig,
+    spotAccountId
   };
 
   const clientOptions = {

--- a/packages/ssr/src/component/article.js
+++ b/packages/ssr/src/component/article.js
@@ -14,7 +14,8 @@ module.exports = (client, analyticsStream, data) => {
     articleId,
     debounceTimeMs,
     makeArticleUrl,
-    mapArticleToAdConfig
+    mapArticleToAdConfig,
+    spotAccountId
   } = data;
 
   return React.createElement(
@@ -45,7 +46,8 @@ module.exports = (client, analyticsStream, data) => {
             onAuthorPress: () => {},
             onRelatedArticlePress: () => {},
             onTopicPress: () => {},
-            refetch
+            refetch,
+            spotAccountId
           })
         )
     )

--- a/packages/ssr/src/server/article.js
+++ b/packages/ssr/src/server/article.js
@@ -6,7 +6,7 @@ const defaultAdConfig = require("../lib/ads/make-article-ad-config")
 module.exports = (
   articleId,
   headers,
-  { graphqlApiUrl, logger, makeArticleUrl }
+  { graphqlApiUrl, logger, makeArticleUrl, spotAccountId }
 ) => {
   if (typeof articleId !== "string") {
     throw new Error(`Article ID should be a string. Received ${articleId}`);
@@ -22,6 +22,11 @@ module.exports = (
       `Make article url function is required. Received ${makeArticleUrl}`
     );
   }
+  if (typeof spotAccountId !== "string") {
+    throw new Error(
+      `SpotIM account ID should be a string. Received ${spotAccountId}`
+    );
+  }
 
   const options = {
     client: {
@@ -33,7 +38,8 @@ module.exports = (
       articleId,
       debounceTimeMs: 0,
       makeArticleUrl,
-      mapArticleToAdConfig: defaultAdConfig
+      mapArticleToAdConfig: defaultAdConfig,
+      spotAccountId
     },
     name: "article"
   };

--- a/packages/ssr/src/standalone-renderer/app.js
+++ b/packages/ssr/src/standalone-renderer/app.js
@@ -27,9 +27,11 @@ const makeHtml = (
             ${responsiveStyles}
           </head>
           <body style="margin:0">
-            <script>window.nuk = {graphqlapi: {url: "${
-              process.env.GRAPHQL_ENDPOINT
-            }"}, tracking: {enabled: false}};</script>
+            <script>window.nuk = {
+              graphqlapi: {url: "${process.env.GRAPHQL_ENDPOINT}"},
+              ssr: {spotAccountId: "${process.env.SPOT_ID}"},
+              tracking: {enabled: false}
+            };</script>
             ${initialProps}
             ${initialState}
             <div id="main-container">${markup}</div>
@@ -55,6 +57,7 @@ server.get("/article/:id", (request, response) => {
     params: { id: articleId }
   } = request;
   const graphqlApiUrl = process.env.GRAPHQL_ENDPOINT;
+  const spotAccountId = process.env.SPOT_ID;
   const headers = process.env.GRAPHQL_TOKEN
     ? {
         "nuk-tpatoken": process.env.GRAPHQL_TOKEN
@@ -62,7 +65,12 @@ server.get("/article/:id", (request, response) => {
     : null;
 
   ssr
-    .article(articleId, headers, { graphqlApiUrl, logger, makeArticleUrl })
+    .article(articleId, headers, {
+      graphqlApiUrl,
+      logger,
+      makeArticleUrl,
+      spotAccountId
+    })
     .then(({ initialProps, initialState, markup, responsiveStyles, styles }) =>
       response.send(
         makeHtml(initialState, initialProps, {

--- a/packages/ssr/src/standalone-renderer/page-init/article.js
+++ b/packages/ssr/src/standalone-renderer/page-init/article.js
@@ -6,6 +6,7 @@ const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
+  ...window.nuk.ssr,
   makeArticleUrl,
   mapArticleToAdConfig: defaultMapArticleToConfig,
   rootTag

--- a/packages/ssr/src/standalone-renderer/page-init/author-profile.js
+++ b/packages/ssr/src/standalone-renderer/page-init/author-profile.js
@@ -6,6 +6,7 @@ const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
+  ...window.nuk.ssr,
   makeArticleUrl,
   mapProfileToAdConfig: defaultMapProfileToConfig,
   rootTag

--- a/packages/ssr/src/standalone-renderer/page-init/topic.js
+++ b/packages/ssr/src/standalone-renderer/page-init/topic.js
@@ -6,6 +6,7 @@ const rootTag = "main-container";
 
 window.nuk = window.nuk || {};
 window.nuk.ssr = {
+  ...window.nuk.ssr,
   makeArticleUrl,
   mapTopicToAdConfig: defaultMapTopicToConfig,
   rootTag

--- a/packages/styleguide/src/fonts/font-sizes-base.js
+++ b/packages/styleguide/src/fonts/font-sizes-base.js
@@ -8,6 +8,7 @@ const fontSizes = {
   cardHeadline: 27,
   cardMeta: 13,
   cardMetaMobile: 12,
+  commentsGuidelines: 13,
   commentsHeadline: 27,
   credits: 9,
   dropCap: 96,


### PR DESCRIPTION
This PR adds commenting to our article pages. See [JIRA ticket](https://nidigitalsolutions.jira.com/browse/REPLAT-3000).

In the SSR package,
```
yarn bundle:dev
GRAPHQL_ENDPOINT="<TimesPublicApiUrl>" SPOT_ID="<SpotImAccountId>" yarn start
```
