### PR TITLE
fix: key facts stories

### DIFF
--- a/packages/key-facts/key-facts.showcase.js
+++ b/packages/key-facts/key-facts.showcase.js
@@ -1,27 +1,10 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-import invert from "lodash.invert";
 import { ScrollView } from "react-native";
-import Context from "@times-components/context";
 import { LateralSpacingDecorator } from "@times-components/storybook";
-import { colours, scales } from "@times-components/styleguide";
-import KeyFacts from "./src/key-facts";
 import data from "./fixtures/key-facts-showcase.json";
 import dataNoTitle from "./fixtures/key-facts-no-title-showcase.json";
-
-const selectSection = select =>
-  select("Section", invert(colours.section), colours.section.default);
-const selectScales = select => select("Scale", scales, scales.medium);
-
-const renderKeyFacts = (ast, select) => {
-  const scale = selectScales(select);
-  const sectionColour = selectSection(select);
-  return (
-    <Context.Provider value={{ theme: { scale, sectionColour } }}>
-      <KeyFacts ast={ast} onLinkPress={() => {}} />
-    </Context.Provider>
-  );
-};
+import renderKeyFacts from "./showcase-helper";
 
 export default {
   children: [
@@ -32,7 +15,7 @@ export default {
     {
       component: ({ select }) => (
         <ScrollView style={{ width: "100%" }}>
-          {renderKeyFacts(data, select)}
+          {renderKeyFacts({ ast: data, hasScaling: true, select })}
         </ScrollView>
       ),
       name: "with title",
@@ -42,7 +25,7 @@ export default {
     {
       component: ({ select }) => (
         <ScrollView style={{ width: "100%" }}>
-          {renderKeyFacts(dataNoTitle, select)}
+          {renderKeyFacts({ ast: dataNoTitle, hasScaling: true, select })}
         </ScrollView>
       ),
       name: "without title",

--- a/packages/key-facts/key-facts.showcase.web.js
+++ b/packages/key-facts/key-facts.showcase.web.js
@@ -3,20 +3,18 @@ import React from "react";
 import invert from "lodash.invert";
 import Context from "@times-components/context";
 import { LateralSpacingDecorator } from "@times-components/storybook";
-import { colours, scales } from "@times-components/styleguide";
+import { colours } from "@times-components/styleguide";
 import KeyFacts from "./src/key-facts";
 import data from "./fixtures/key-facts-showcase.json";
 import dataNoTitle from "./fixtures/key-facts-no-title-showcase.json";
 
 const selectSection = select =>
   select("Section", invert(colours.section), colours.section.default);
-const selectScales = select => select("Scale", scales, scales.medium);
 
 const renderKeyFacts = (ast, select) => {
-  const scale = selectScales(select);
   const sectionColour = selectSection(select);
   return (
-    <Context.Provider value={{ theme: { scale, sectionColour } }}>
+    <Context.Provider value={{ theme: { sectionColour } }}>
       <KeyFacts ast={ast} onLinkPress={() => {}} />
     </Context.Provider>
   );

--- a/packages/key-facts/key-facts.showcase.web.js
+++ b/packages/key-facts/key-facts.showcase.web.js
@@ -1,24 +1,7 @@
-/* eslint-disable react/prop-types */
-import React from "react";
-import invert from "lodash.invert";
-import Context from "@times-components/context";
 import { LateralSpacingDecorator } from "@times-components/storybook";
-import { colours } from "@times-components/styleguide";
-import KeyFacts from "./src/key-facts";
 import data from "./fixtures/key-facts-showcase.json";
 import dataNoTitle from "./fixtures/key-facts-no-title-showcase.json";
-
-const selectSection = select =>
-  select("Section", invert(colours.section), colours.section.default);
-
-const renderKeyFacts = (ast, select) => {
-  const sectionColour = selectSection(select);
-  return (
-    <Context.Provider value={{ theme: { sectionColour } }}>
-      <KeyFacts ast={ast} onLinkPress={() => {}} />
-    </Context.Provider>
-  );
-};
+import renderKeyFacts from "./showcase-helper";
 
 export default {
   children: [
@@ -27,13 +10,15 @@ export default {
       type: "decorator"
     },
     {
-      component: ({ select }) => renderKeyFacts(data, select),
+      component: ({ select }) =>
+        renderKeyFacts({ ast: data, hasScaling: false, select }),
       name: "with title",
       platform: "web",
       type: "story"
     },
     {
-      component: ({ select }) => renderKeyFacts(dataNoTitle, select),
+      component: ({ select }) =>
+        renderKeyFacts({ ast: dataNoTitle, hasScaling: false, select }),
       name: "without title",
       platform: "web",
       type: "story"

--- a/packages/key-facts/key-facts.showcase.web.js
+++ b/packages/key-facts/key-facts.showcase.web.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import invert from "lodash.invert";
-import { ScrollView } from "react-native";
 import Context from "@times-components/context";
 import { LateralSpacingDecorator } from "@times-components/storybook";
 import { colours, scales } from "@times-components/styleguide";
@@ -30,23 +29,15 @@ export default {
       type: "decorator"
     },
     {
-      component: ({ select }) => (
-        <ScrollView style={{ width: "100%" }}>
-          {renderKeyFacts(data, select)}
-        </ScrollView>
-      ),
+      component: ({ select }) => renderKeyFacts(data, select),
       name: "with title",
-      platform: "native",
+      platform: "web",
       type: "story"
     },
     {
-      component: ({ select }) => (
-        <ScrollView style={{ width: "100%" }}>
-          {renderKeyFacts(dataNoTitle, select)}
-        </ScrollView>
-      ),
+      component: ({ select }) => renderKeyFacts(dataNoTitle, select),
       name: "without title",
-      platform: "native",
+      platform: "web",
       type: "story"
     }
   ],

--- a/packages/key-facts/showcase-helper.js
+++ b/packages/key-facts/showcase-helper.js
@@ -1,0 +1,22 @@
+/* eslint-disable react/prop-types */
+import React from "react";
+import invert from "lodash.invert";
+import Context from "@times-components/context";
+import { colours, scales } from "@times-components/styleguide";
+import KeyFacts from "./src/key-facts";
+
+const selectScales = select => select("Scale", scales, scales.medium);
+const selectSection = select =>
+  select("Section", invert(colours.section), colours.section.default);
+
+const renderKeyFacts = ({ ast, select, hasScaling = false }) => {
+  const scale = hasScaling ? selectScales(select) : null;
+  const sectionColour = selectSection(select);
+  return (
+    <Context.Provider value={{ theme: { scale, sectionColour } }}>
+      <KeyFacts ast={ast} onLinkPress={() => {}} />
+    </Context.Provider>
+  );
+};
+
+export default renderKeyFacts;


### PR DESCRIPTION
Split out the key facts stories so that scaling context and knob not seen on web