### PR TITLE
fix: magazine comment empty author

### DIFF
--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -285,3 +285,162 @@ exports[`4. an article with ads 1`] = `
   </View>
 </RCTScrollView>
 `;
+
+exports[`8. an article with no author 1`] = `
+<RCTScrollView
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View>
+        <Image
+          aspectRatio={1}
+          uri={null}
+        />
+        <View>
+          <ArticleLabel
+            color="#1D1D1B"
+            title="Some Label"
+          />
+        </View>
+        <Text>
+          Some Headline
+        </Text>
+        <View>
+          <View>
+            <NewArticleFlag />
+          </View>
+        </View>
+        <Text
+          accessibilityRole="heading"
+          aria-level="2"
+        >
+          Some Standfirst
+        </Text>
+        <View>
+          <View>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Some byline",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </View>
+          <View>
+            <Text>
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View>
+        <ModalImage
+          aspectRatio={1.7777777777777777}
+          caption="Some Caption"
+          credits="Some Credits"
+          highResSize={1440}
+          uri="https://crop169.io"
+        />
+        <CenteredCaption
+          credits="Some Credits"
+          text="Some Caption"
+        />
+      </View>
+    </View>
+    <View>
+      <View>
+        <Text
+          selectable={true}
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleTopics
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <RelatedArticles
+        slice={
+          Object {
+            "__typename": "StandardSlice",
+            "items": Array [
+              Object {
+                "article": Object {
+                  "__typename": "Article",
+                  "byline": Array [],
+                  "hasVideo": false,
+                  "headline": "RA Headline",
+                  "id": "ra-1",
+                  "label": "RA Label",
+                  "leadAsset": Object {
+                    "__typename": "Image",
+                    "crop169": Object {
+                      "__typename": "Crop",
+                      "url": "https://racrop169.io",
+                    },
+                    "crop32": Object {
+                      "__typename": "Crop",
+                      "url": "https://racrop32.io",
+                    },
+                    "title": "RA Title",
+                  },
+                  "publicationName": "TIMES",
+                  "publishedTime": "2015-03-23T19:39:39.000Z",
+                  "shortHeadline": "Headline",
+                  "shortIdentifier": "2k629tpvh",
+                  "slug": "this-is-slug",
+                  "summary105": Array [],
+                  "summary125": Array [],
+                  "summary145": Array [],
+                  "summary160": Array [],
+                  "summary175": Array [],
+                  "summary225": Array [],
+                  "url": "https://ra.io",
+                },
+              },
+            ],
+            "sliceName": "StandardSlice",
+          }
+        }
+      />
+    </View>
+    <View>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        url="https://url.io"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -285,3 +285,162 @@ exports[`4. an article with ads 1`] = `
   </View>
 </RCTScrollView>
 `;
+
+exports[`8. an article with no author 1`] = `
+<RCTScrollView
+  initialNumToRender={10}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onEndReachedThreshold={2}
+  scrollEventThrottle={50}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View>
+      <View>
+        <Image
+          aspectRatio={1}
+          uri={null}
+        />
+        <View>
+          <ArticleLabel
+            color="#1D1D1B"
+            title="Some Label"
+          />
+        </View>
+        <Text>
+          Some Headline
+        </Text>
+        <View>
+          <View>
+            <NewArticleFlag />
+          </View>
+        </View>
+        <Text
+          accessibilityRole="heading"
+          aria-level="2"
+        >
+          Some Standfirst
+        </Text>
+        <View>
+          <View>
+            <ArticleBylineWithLinks
+              ast={
+                Array [
+                  Object {
+                    "attributes": Object {},
+                    "children": Array [
+                      Object {
+                        "attributes": Object {
+                          "value": "Some byline",
+                        },
+                        "children": Array [],
+                        "name": "text",
+                      },
+                    ],
+                    "name": "inline",
+                  },
+                ]
+              }
+            />
+          </View>
+          <View>
+            <Text>
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View>
+        <ModalImage
+          aspectRatio={1.7777777777777777}
+          caption="Some Caption"
+          credits="Some Credits"
+          highResSize={1440}
+          uri="https://crop169.io"
+        />
+        <CenteredCaption
+          credits="Some Credits"
+          text="Some Caption"
+        />
+      </View>
+    </View>
+    <View>
+      <View>
+        <Text
+          selectable={true}
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleTopics
+          topics={
+            Array [
+              Object {
+                "name": "Topic",
+                "slug": "topic",
+              },
+            ]
+          }
+        />
+      </View>
+    </View>
+    <View>
+      <RelatedArticles
+        slice={
+          Object {
+            "__typename": "StandardSlice",
+            "items": Array [
+              Object {
+                "article": Object {
+                  "__typename": "Article",
+                  "byline": Array [],
+                  "hasVideo": false,
+                  "headline": "RA Headline",
+                  "id": "ra-1",
+                  "label": "RA Label",
+                  "leadAsset": Object {
+                    "__typename": "Image",
+                    "crop169": Object {
+                      "__typename": "Crop",
+                      "url": "https://racrop169.io",
+                    },
+                    "crop32": Object {
+                      "__typename": "Crop",
+                      "url": "https://racrop32.io",
+                    },
+                    "title": "RA Title",
+                  },
+                  "publicationName": "TIMES",
+                  "publishedTime": "2015-03-23T19:39:39.000Z",
+                  "shortHeadline": "Headline",
+                  "shortIdentifier": "2k629tpvh",
+                  "slug": "this-is-slug",
+                  "summary105": Array [],
+                  "summary125": Array [],
+                  "summary145": Array [],
+                  "summary160": Array [],
+                  "summary175": Array [],
+                  "summary225": Array [],
+                  "url": "https://ra.io",
+                },
+              },
+            ],
+            "sliceName": "StandardSlice",
+          }
+        }
+      />
+    </View>
+    <View>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        url="https://url.io"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/packages/article-magazine-comment/__tests__/shared.base.js
+++ b/packages/article-magazine-comment/__tests__/shared.base.js
@@ -149,6 +149,19 @@ const negativeTests = [
 
       expect(textNodes).toEqual([]);
     }
+  },
+  {
+    name: "an article with no author",
+    test() {
+      const testRenderer = TestRenderer.create(
+        <ArticleMagazineComment
+          {...sharedProps}
+          article={articleFixture({ ...testFixture, author: null })}
+        />
+      );
+
+      expect(testRenderer).toMatchSnapshot();
+    }
   }
 ];
 

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -305,3 +305,170 @@ exports[`4. an article with ads 1`] = `
   </div>
 </article>
 `;
+
+exports[`8. an article with no author 1`] = `
+<article>
+  <div>
+    <Ad
+      contextUrl="https://url.io"
+      section="Some Section"
+      slotName="header"
+    />
+  </div>
+  <div>
+    <div>
+      <div>
+        <Image
+          aspectRatio={1}
+          uri={null}
+        />
+      </div>
+      <div>
+        <div>
+          SOME LABEL
+        </div>
+      </div>
+      <h1
+        aria-level="1"
+        role="heading"
+      >
+        Some Headline
+      </h1>
+      <div>
+        <div>
+          <div>
+            <NewArticleFlag />
+          </div>
+        </div>
+      </div>
+      <h2
+        aria-level="2"
+        role="heading"
+      >
+        Some Standfirst
+      </h2>
+      <div>
+        <div>
+          <ArticleBylineWithLinks
+            ast={
+              Array [
+                Object {
+                  "attributes": Object {},
+                  "children": Array [
+                    Object {
+                      "attributes": Object {
+                        "value": "Some byline",
+                      },
+                      "children": Array [],
+                      "name": "text",
+                    },
+                  ],
+                  "name": "inline",
+                },
+              ]
+            }
+          />
+        </div>
+        <div />
+        <div>
+          <div>
+            <DatePublication
+              date="2015-03-13T18:54:58.000Z"
+              publication="TIMES"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <figure>
+        <div>
+          <div>
+            <Image
+              highResSize={null}
+              lowResSize={100}
+              uri="https://crop169.io"
+            />
+          </div>
+        </div>
+        <div>
+          <figcaption>
+            <CenteredCaption
+              credits="Some Credits"
+              text="Some Caption"
+            />
+          </figcaption>
+        </div>
+      </figure>
+    </div>
+    <div>
+      <p>
+        Some content
+      </p>
+      <div>
+        <nav>
+          <ArticleTopics
+            topics={
+              Array [
+                Object {
+                  "name": "Topic",
+                  "slug": "topic",
+                },
+              ]
+            }
+          />
+        </nav>
+      </div>
+      <aside
+        id="related-articles"
+      >
+        <RelatedArticles
+          isVisible={false}
+          slice={
+            Object {
+              "__typename": "StandardSlice",
+              "items": Array [
+                Object {
+                  "article": Object {
+                    "__typename": "Article",
+                    "byline": Array [],
+                    "hasVideo": false,
+                    "headline": "RA Headline",
+                    "id": "ra-1",
+                    "label": "RA Label",
+                    "leadAsset": Object {
+                      "__typename": "Image",
+                      "crop169": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop169.io",
+                      },
+                      "crop32": Object {
+                        "__typename": "Crop",
+                        "url": "https://racrop32.io",
+                      },
+                      "title": "RA Title",
+                    },
+                    "publicationName": "TIMES",
+                    "publishedTime": "2015-03-23T19:39:39.000Z",
+                    "shortHeadline": "Headline",
+                    "shortIdentifier": "2k629tpvh",
+                    "slug": "this-is-slug",
+                    "summary105": Array [],
+                    "summary125": Array [],
+                    "summary145": Array [],
+                    "summary160": Array [],
+                    "summary175": Array [],
+                    "summary225": Array [],
+                    "url": "https://ra.io",
+                  },
+                },
+              ],
+              "sliceName": "StandardSlice",
+            }
+          }
+        />
+      </aside>
+    </div>
+  </div>
+</article>
+`;

--- a/packages/article-magazine-comment/src/article-magazine-comment.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.js
@@ -31,11 +31,12 @@ class ArticleMagazineComment extends Component {
       standfirst
     } = article;
     const { leadAsset } = getLeadAsset(article);
+    const authorImage = author && author.image ? author.image : null;
 
     return (
       <Fragment>
         <ArticleHeader
-          authorImage={author.image}
+          authorImage={authorImage}
           byline={byline}
           flags={flags}
           headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-magazine-comment/src/article-magazine-comment.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.js
@@ -20,7 +20,9 @@ class ArticleMagazineComment extends Component {
   renderHeader({ width }) {
     const { article, onAuthorPress, onVideoPress } = this.props;
     const {
-      author,
+      author = {
+        image: null
+      },
       byline,
       flags,
       headline,
@@ -31,12 +33,11 @@ class ArticleMagazineComment extends Component {
       standfirst
     } = article;
     const { leadAsset } = getLeadAsset(article);
-    const authorImage = author && author.image ? author.image : null;
 
     return (
       <Fragment>
         <ArticleHeader
-          authorImage={authorImage}
+          authorImage={author.image}
           byline={byline}
           flags={flags}
           headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -30,11 +30,12 @@ class ArticlePage extends Component {
       shortHeadline,
       standfirst
     } = article;
+    const authorImage = author && author.image ? author.image : null;
 
     return (
       <Fragment>
         <ArticleHeader
-          authorImage={author.image}
+          authorImage={authorImage}
           byline={byline}
           flags={flags}
           headline={getHeadline(headline, shortHeadline)}

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -30,12 +30,11 @@ class ArticlePage extends Component {
       shortHeadline,
       standfirst
     } = article;
-    const authorImage = author && author.image ? author.image : null;
 
     return (
       <Fragment>
         <ArticleHeader
-          authorImage={authorImage}
+          authorImage={author.image}
           byline={byline}
           flags={flags}
           headline={getHeadline(headline, shortHeadline)}


### PR DESCRIPTION
Magazine comment template is crashing when author image is null. This pr adds a null check for web and native