### PR TITLE
feat: Add new fonts to styleguide

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -77,6 +77,39 @@
     font-style: normal;
   }
 
+  @font-face {
+    font-family: CenturyGothic-Bold;
+    src: url(/fonts/CenturyGothic-Bold.woff2) format("woff2"),
+        url(/fonts/CenturyGothic-Bold.woff) format("woff"),
+        url(/fonts/CenturyGothic-Bold.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/CenturyGothic-Bold.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/CenturyGothic-Bold.woff) format("woff");
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: Flama-Bold;
+    src: url(/fonts/Flama-Bold.woff2) format("woff2"),
+        url(/fonts/Flama-Bold.woff) format("woff"),
+        url(/fonts/Flama-Bold.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/flama-bold-webfont.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/flama-bold-webfont.woff) format("woff");
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  @font-face {
+    font-family: Tiempos-Headline-Bold;
+    src: url(/fonts/Tiempos-Headline-Bold.woff2) format("woff2"),
+        url(/fonts/Tiempos-Headline-Bold.woff) format("woff"),
+        url(/fonts/Tiempos-Headline-Bold.ttf) format("truetype"),
+        url(https://www.thetimes.co.uk/fonts/TiemposHeadlineWebBold.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/fonts/TiemposHeadlineWebBold.woff) format("woff");
+    font-weight: 400;
+    font-style: normal;
+  }
+
   * {
     -webkit-font-smoothing: antialiased;
     font-smoothing: antialiased;

--- a/lib/fetch-fonts.js
+++ b/lib/fetch-fonts.js
@@ -88,6 +88,36 @@ const fonts = [
       `${fontCdn}/GillSans/GillSansMTStd-Medium-f147e4bbf2.woff`,
       `${fontCdn}/GillSans/GillSansMTStd-Medium-45ad758029.ttf`
     ]
+  },
+  {
+    fontName: "CenturyGothic-Bold",
+    fileName: "CenturyGothic-Bold",
+    fontFamily: "CenturyGothic-Bold",
+    sources: [
+      `${fontCdn}/CenturyGothic/CenturyGothic-Bold.woff2`,
+      `${fontCdn}/CenturyGothic/CenturyGothic-Bold.woff`,
+      `${fontCdn}/CenturyGothic/CenturyGothic-Bold.ttf`
+    ]
+  },
+  {
+    fontName: "Flama-Bold",
+    fileName: "Flama-Bold",
+    fontFamily: "Flama-Bold",
+    sources: [
+      `${fontCdn}/Flama/flama-bold-webfont.woff2`,
+      `${fontCdn}/Flama/flama-bold-webfont.woff`,
+      `${fontCdn}/Flama/flama-bold-webfont.ttf`
+    ]
+  },
+  {
+    fontName: "Tiempos-Headline-Bold",
+    fileName: "Tiempos-Headline-Bold",
+    fontFamily: "Tiempos-Headline-Bold",
+    sources: [
+      `${fontCdn}/Tiempos/TiemposHeadlineWebBold.woff2`,
+      `${fontCdn}/Tiempos/TiemposHeadlineWebBold.woff`,
+      `${fontCdn}/Tiempos/TiemposHeadlineWebBold.ttf`
+    ]
   }
 ];
 

--- a/packages/styleguide/src/fonts/fonts.js
+++ b/packages/styleguide/src/fonts/fonts.js
@@ -2,12 +2,12 @@ const fonts = {
   body: "TimesDigitalW04",
   bodyRegular: "TimesDigitalW04-Regular",
   bodyRegularSmallCaps: "TimesDigitalW04-RegularSC",
-  culturemagazine: "Flama-Bold",
+  cultureMagazine: "Flama-Bold",
   dropCap: "TimesModern-Regular",
   headline: "TimesModern-Bold",
   headlineRegular: "TimesModern-Regular",
-  stmagazine: "Tiempos-Headline-Bold",
-  stylemagazine: "CenturyGothic-Bold",
+  stMagazine: "Tiempos-Headline-Bold",
+  styleMagazine: "CenturyGothic-Bold",
   supporting: "GillSansMTStd-Medium"
 };
 

--- a/packages/styleguide/src/fonts/fonts.js
+++ b/packages/styleguide/src/fonts/fonts.js
@@ -2,9 +2,12 @@ const fonts = {
   body: "TimesDigitalW04",
   bodyRegular: "TimesDigitalW04-Regular",
   bodyRegularSmallCaps: "TimesDigitalW04-RegularSC",
+  culturemagazine: "Flama-Bold",
   dropCap: "TimesModern-Regular",
   headline: "TimesModern-Bold",
   headlineRegular: "TimesModern-Regular",
+  stmagazine: "Tiempos-Headline-Bold",
+  stylemagazine: "CenturyGothic-Bold",
   supporting: "GillSansMTStd-Medium"
 };
 

--- a/packages/styleguide/styleguide.showcase.js
+++ b/packages/styleguide/styleguide.showcase.js
@@ -93,6 +93,34 @@ const fontFixture = select => {
         </Text>
         {fontDisplayer(fonts.supporting, phrase, styleguide.fontSizes)}
       </View>
+      <View style={styles.showoffFontsContainer}>
+        <Text style={styles.headline}>
+          Style Magazine (Century Gothic Bold)
+        </Text>
+        <Text>
+          Used for theme specific headlines, drop caps and pull-quotes in style
+          magazines
+        </Text>
+        {fontDisplayer(fonts.stylemagazine, phrase, styleguide.fontSizes)}
+      </View>
+      <View style={styles.showoffFontsContainer}>
+        <Text style={styles.headline}>Culture Magazine (Flama Bold)</Text>
+        <Text>
+          Used for theme specific headlines, drop caps and pull-quotes in
+          culture magazines
+        </Text>
+        {fontDisplayer(fonts.culturemagazine, phrase, styleguide.fontSizes)}
+      </View>
+      <View style={styles.showoffFontsContainer}>
+        <Text style={styles.headline}>
+          Sunday Times Magazine (Tiempos Headline Bold)
+        </Text>
+        <Text>
+          Used for theme specific headlines, drop caps and pull-quotes in the
+          Sunday Times magazines
+        </Text>
+        {fontDisplayer(fonts.stmagazine, phrase, styleguide.fontSizes)}
+      </View>
     </ScrollView>
   );
 };

--- a/packages/styleguide/styleguide.showcase.js
+++ b/packages/styleguide/styleguide.showcase.js
@@ -98,18 +98,18 @@ const fontFixture = select => {
           Style Magazine (Century Gothic Bold)
         </Text>
         <Text>
-          Used for theme specific headlines, drop caps and pull-quotes in style
-          magazines
+          Used for theme specific headlines, drop caps and pull-quotes in the
+          Style magazine
         </Text>
-        {fontDisplayer(fonts.stylemagazine, phrase, styleguide.fontSizes)}
+        {fontDisplayer(fonts.styleMagazine, phrase, styleguide.fontSizes)}
       </View>
       <View style={styles.showoffFontsContainer}>
         <Text style={styles.headline}>Culture Magazine (Flama Bold)</Text>
         <Text>
-          Used for theme specific headlines, drop caps and pull-quotes in
-          culture magazines
+          Used for theme specific headlines, drop caps and pull-quotes in the
+          Culture magazine
         </Text>
-        {fontDisplayer(fonts.culturemagazine, phrase, styleguide.fontSizes)}
+        {fontDisplayer(fonts.cultureMagazine, phrase, styleguide.fontSizes)}
       </View>
       <View style={styles.showoffFontsContainer}>
         <Text style={styles.headline}>
@@ -117,9 +117,9 @@ const fontFixture = select => {
         </Text>
         <Text>
           Used for theme specific headlines, drop caps and pull-quotes in the
-          Sunday Times magazines
+          Sunday Times Magazine
         </Text>
-        {fontDisplayer(fonts.stmagazine, phrase, styleguide.fontSizes)}
+        {fontDisplayer(fonts.stMagazine, phrase, styleguide.fontSizes)}
       </View>
     </ScrollView>
   );


### PR DESCRIPTION
Part one of font theming story
Added new fonts to the styleguide: https://nidigitalsolutions.jira.com/browse/REPLAT-4649

I opted for naming fonts per magazine sections as they are all specific to certain magazine sections we have (culture, style and ST)

Web:
![screenshot 2018-12-13 at 11 40 52](https://user-images.githubusercontent.com/1849590/49936509-024a3000-fecc-11e8-85ff-85a307f71dfa.png)

Android:
![screenshot_1544701238](https://user-images.githubusercontent.com/1849590/49936519-05ddb700-fecc-11e8-92fe-147f1829bb71.png)
