### PR TITLE
Feat/article template integration tests

### DIFF
--- a/packages/fixture-generator/src/__tests__/mock-article.test.ts
+++ b/packages/fixture-generator/src/__tests__/mock-article.test.ts
@@ -1,4 +1,5 @@
 import MockArticle from "../mock-article";
+import { TemplateType } from "../types";
 
 describe("The mock Article", () => {
   it("should return the minimum article type requirements", () => {
@@ -17,4 +18,9 @@ describe("The mock Article", () => {
     const mockArticle = new MockArticle().setRelatedArticles(5).get();
     expect(mockArticle.relatedArticleSlice!.items.length).toBe(5);
   })
+
+  it("should return a maincomment template", () => {
+    const mockArticle = new MockArticle().setTemplate('maincomment' as TemplateType).get();
+    expect(mockArticle.template).toBe("maincomment");
+  });
 });

--- a/packages/fixture-generator/src/mock-article.ts
+++ b/packages/fixture-generator/src/mock-article.ts
@@ -57,6 +57,11 @@ class MockArticle {
     return this;
   }
 
+  setTemplate(template: TemplateType) {
+    this.article.template = template;
+    return this;
+  }
+
   sundayTimes() {
     this.article.publicationName = getPublicationName(
       PublicationName.SUNDAYTIMES

--- a/packages/ssr/__tests__/integration/article.js
+++ b/packages/ssr/__tests__/integration/article.js
@@ -1,92 +1,99 @@
 import { MockArticle } from "@times-components/fixture-generator";
-
 const relatedArticleCount = 3;
 
-describe("Article", () => {
-  let sundayTimesArticleWithThreeRelatedArticles;
+const articleTemplateTest = template =>
+  describe("Article", () => {
+    let sundayTimesArticleWithThreeRelatedArticles;
 
-  beforeEach(() => {
-    sundayTimesArticleWithThreeRelatedArticles = new MockArticle()
-      .sundayTimes()
-      .setRelatedArticles(relatedArticleCount)
-      .get();
-  });
+    beforeEach(() => {
+      sundayTimesArticleWithThreeRelatedArticles = new MockArticle()
+        .sundayTimes()
+        .setRelatedArticles(relatedArticleCount)
+        .template(template)
+        .get();
+    });
 
-  afterEach(() => {
-    cy.task("stopMockServer");
-  });
+    afterEach(() => {
+      cy.task("stopMockServer");
+    });
 
-  it("loads hi-res images for related articles", () =>
-    cy
-      .task("startMockServerWith", {
+    it("loads hi-res images for related articles", () =>
+      cy
+        .task("startMockServerWith", {
+          Article: sundayTimesArticleWithThreeRelatedArticles
+        })
+        .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
+        .get("#related-articles")
+        .scrollIntoView()
+        .then(() => {
+          // wait for the image to transition and be removed (unfortunately Cypress doesn't auto wait for this)
+          cy.wait(2000);
+
+          cy.get("#related-articles img").as("raImages");
+
+          cy.get("@raImages")
+            .its("length")
+            .should("eq", relatedArticleCount);
+
+          cy.get("@raImages").each(item => {
+            const url = new URL(item.attr("src"));
+            const initialResize = "100";
+            expect(url.searchParams.get("resize")).to.not.equal(initialResize);
+          });
+        }));
+
+    it("loads all the required article ads", () => {
+      cy.task("startMockServerWith", {
         Article: sundayTimesArticleWithThreeRelatedArticles
       })
-      .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
-      .get("#related-articles")
-      .scrollIntoView()
-      .then(() => {
-        // wait for the image to transition and be removed (unfortunately Cypress doesn't auto wait for this)
-        cy.wait(2000);
+        .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
+        .wait(2000);
 
-        cy.get("#related-articles img").as("raImages");
+      cy.get("#header")
+        .should("be.visible")
+        .should("not.be.empty");
 
-        cy.get("@raImages")
-          .its("length")
-          .should("eq", relatedArticleCount);
+      cy.get("#header")
+        .get("googleQueryId")
+        .should("not.be.empty");
+    });
 
-        cy.get("@raImages").each(item => {
-          const url = new URL(item.attr("src"));
-          const initialResize = "100";
-          expect(url.searchParams.get("resize")).to.not.equal(initialResize);
-        });
-      }));
+    it("has SpotIM comment tag when article comments are enabled", () => {
+      const articleWithCommentsEnabled = {
+        ...sundayTimesArticleWithThreeRelatedArticles,
+        commentsEnabled: true
+      };
 
-  it("loads all the required article ads", () => {
-    cy.task("startMockServerWith", {
-      Article: sundayTimesArticleWithThreeRelatedArticles
-    })
-      .visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d")
-      .wait(2000);
+      cy.task("startMockServerWith", {
+        Article: articleWithCommentsEnabled
+      }).visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d");
 
-    cy.get("#header")
-      .should("be.visible")
-      .should("not.be.empty");
+      cy.get("script[data-spotim-module]")
+        .should("have.attr", "src", "https://launcher.spot.im/spot/5p0t_1m_1d")
+        .should("have.attr", "data-post-id", articleWithCommentsEnabled.id)
+        .should(
+          "have.attr",
+          "data-post-url",
+          `https://www.thetimes.co.uk/article/${articleWithCommentsEnabled.id}`
+        );
+    });
 
-    cy.get("#header")
-      .get("googleQueryId")
-      .should("not.be.empty");
+    it("does not have SpotIM comment tag when article comments are disabled", () => {
+      const articleWithCommentsDisabled = {
+        ...sundayTimesArticleWithThreeRelatedArticles,
+        commentsEnabled: false
+      };
+
+      cy.task("startMockServerWith", {
+        Article: articleWithCommentsDisabled
+      }).visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d");
+
+      cy.get("script[data-spotim-module]").should("not.exist");
+    });
   });
 
-  it("has SpotIM comment tag when article comments are enabled", () => {
-    const articleWithCommentsEnabled = {
-      ...sundayTimesArticleWithThreeRelatedArticles,
-      commentsEnabled: true
-    };
 
-    cy.task("startMockServerWith", {
-      Article: articleWithCommentsEnabled
-    }).visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d");
-
-    cy.get("script[data-spotim-module]")
-      .should("have.attr", "src", "https://launcher.spot.im/spot/5p0t_1m_1d")
-      .should("have.attr", "data-post-id", articleWithCommentsEnabled.id)
-      .should(
-        "have.attr",
-        "data-post-url",
-        `https://www.thetimes.co.uk/article/${articleWithCommentsEnabled.id}`
-      );
-  });
-
-  it("does not have SpotIM comment tag when article comments are disabled", () => {
-    const articleWithCommentsDisabled = {
-      ...sundayTimesArticleWithThreeRelatedArticles,
-      commentsEnabled: false
-    };
-
-    cy.task("startMockServerWith", {
-      Article: articleWithCommentsDisabled
-    }).visit("/article/8763d1a0-ca57-11e8-bde6-fae32479843d");
-
-    cy.get("script[data-spotim-module]").should("not.exist");
-  });
-});
+articleTemplateTest("mainstandard");
+articleTemplateTest("maincomment");
+articleTemplateTest("magazinestandard");
+articleTemplateTest("magazinecomment");

--- a/packages/ssr/__tests__/integration/article.js
+++ b/packages/ssr/__tests__/integration/article.js
@@ -9,7 +9,7 @@ const articleTemplateTest = template =>
       sundayTimesArticleWithThreeRelatedArticles = new MockArticle()
         .sundayTimes()
         .setRelatedArticles(relatedArticleCount)
-        .template(template)
+        .setTemplate(template)
         .get();
     });
 

--- a/packages/ssr/__tests__/integration/article.js
+++ b/packages/ssr/__tests__/integration/article.js
@@ -1,4 +1,5 @@
 import { MockArticle } from "@times-components/fixture-generator";
+
 const relatedArticleCount = 3;
 
 const articleTemplateTest = template =>
@@ -91,7 +92,6 @@ const articleTemplateTest = template =>
       cy.get("script[data-spotim-module]").should("not.exist");
     });
   });
-
 
 articleTemplateTest("mainstandard");
 articleTemplateTest("maincomment");

--- a/packages/ssr/__tests__/integration/article.js
+++ b/packages/ssr/__tests__/integration/article.js
@@ -2,7 +2,7 @@ import { MockArticle } from "@times-components/fixture-generator";
 const relatedArticleCount = 3;
 
 const articleTemplateTest = template =>
-  describe("Article", () => {
+  describe(`Article - template=${template}`, () => {
     let sundayTimesArticleWithThreeRelatedArticles;
 
     beforeEach(() => {


### PR DESCRIPTION
This is a re-open of 1557.

This provides identical cypress tests for all article templates that we currently have. They are identical to follow the strategy that we only care that the page loads and performs the client side actions that we require (e.g. Lazy Loading). More specific tests will be duplicated what we do further down the tree.

Please Note: Tests were commented out by @L0wry and merged when they shouldn't have been meaning we have lost coverage. This PR at least gives us some coverage on the Article templates.
