### PR TITLE
fix: Correct storybook fonts urls

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -82,8 +82,8 @@
     src: url(/fonts/CenturyGothic-Bold.woff2) format("woff2"),
         url(/fonts/CenturyGothic-Bold.woff) format("woff"),
         url(/fonts/CenturyGothic-Bold.ttf) format("truetype"),
-        url(https://www.thetimes.co.uk/fonts/CenturyGothic-Bold.woff2) format("woff2"),
-        url(https://www.thetimes.co.uk/fonts/CenturyGothic-Bold.woff) format("woff");
+        url(https://www.thetimes.co.uk/d/fonts/CenturyGothic/CenturyGothic-Bold.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/d/fonts/CenturyGothic/CenturyGothic-Bold.woff) format("woff");
     font-weight: 400;
     font-style: normal;
   }
@@ -93,8 +93,8 @@
     src: url(/fonts/Flama-Bold.woff2) format("woff2"),
         url(/fonts/Flama-Bold.woff) format("woff"),
         url(/fonts/Flama-Bold.ttf) format("truetype"),
-        url(https://www.thetimes.co.uk/fonts/flama-bold-webfont.woff2) format("woff2"),
-        url(https://www.thetimes.co.uk/fonts/flama-bold-webfont.woff) format("woff");
+        url(https://www.thetimes.co.uk/d/fonts/Flama/flama-bold-webfont.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/d/fonts/Flama/flama-bold-webfont.woff) format("woff");
     font-weight: 400;
     font-style: normal;
   }
@@ -104,8 +104,8 @@
     src: url(/fonts/Tiempos-Headline-Bold.woff2) format("woff2"),
         url(/fonts/Tiempos-Headline-Bold.woff) format("woff"),
         url(/fonts/Tiempos-Headline-Bold.ttf) format("truetype"),
-        url(https://www.thetimes.co.uk/fonts/TiemposHeadlineWebBold.woff2) format("woff2"),
-        url(https://www.thetimes.co.uk/fonts/TiemposHeadlineWebBold.woff) format("woff");
+        url(https://www.thetimes.co.uk/d/fonts/Tiempos/TiemposHeadlineWebBold.woff2) format("woff2"),
+        url(https://www.thetimes.co.uk/d/fonts/Tiempos/TiemposHeadlineWebBold.woff) format("woff");
     font-weight: 400;
     font-style: normal;
   }


### PR DESCRIPTION
Quick fix for fonts in storybooks for componentes.thetimes.co.uk