### PR TITLE
chore: use link component in article-comment

### DIFF
--- a/packages/article-comments/.jestlint
+++ b/packages/article-comments/.jestlint
@@ -1,3 +1,3 @@
 {
-  "maxAttributeStringLength": 65
+  "maxAttributeStringLength": 71
 }

--- a/packages/article-comments/__tests__/web/__snapshots__/shared-with-style.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared-with-style.web.test.js.snap
@@ -36,7 +36,8 @@ exports[`comments error 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>
@@ -98,7 +99,8 @@ exports[`disabled comments 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>
@@ -143,7 +145,8 @@ exports[`enabled comments 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>

--- a/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
+++ b/packages/article-comments/__tests__/web/__snapshots__/shared.web.test.js.snap
@@ -5,7 +5,11 @@ exports[`comments error 1`] = `
   <p>
     Comments are subject to our community guidelines, which can be viewed
      
-    <a>
+    <a
+      data-focusable={true}
+      dir="auto"
+      role="link"
+    >
       here
     </a>
     .
@@ -22,7 +26,11 @@ exports[`disabled comments 1`] = `
   <p>
     Comments are subject to our community guidelines, which can be viewed
      
-    <a>
+    <a
+      data-focusable={true}
+      dir="auto"
+      role="link"
+    >
       here
     </a>
     .
@@ -35,7 +43,11 @@ exports[`enabled comments 1`] = `
   <p>
     Comments are subject to our community guidelines, which can be viewed
      
-    <a>
+    <a
+      data-focusable={true}
+      dir="auto"
+      role="link"
+    >
       here
     </a>
     .
@@ -49,7 +61,11 @@ exports[`single comment 1`] = `
   <p>
     Comments are subject to our community guidelines, which can be viewed
      
-    <a>
+    <a
+      data-focusable={true}
+      dir="auto"
+      role="link"
+    >
       here
     </a>
     .
@@ -63,7 +79,11 @@ exports[`zero comments 1`] = `
   <p>
     Comments are subject to our community guidelines, which can be viewed
      
-    <a>
+    <a
+      data-focusable={true}
+      dir="auto"
+      role="link"
+    >
       here
     </a>
     .

--- a/packages/article-comments/src/comments.web.js
+++ b/packages/article-comments/src/comments.web.js
@@ -2,11 +2,13 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { TextLink } from "@times-components/link";
 import {
   CommentContainer,
   CommentEnabledGuidelines
 } from "./styles/responsive";
 import executeSSOtransaction from "./comment-login";
+import styles from "./styles";
 
 class Comments extends Component {
   constructor() {
@@ -65,9 +67,12 @@ class Comments extends Component {
       <CommentContainer>
         <CommentEnabledGuidelines>
           Comments are subject to our community guidelines, which can be viewed{" "}
-          <a href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32">
+          <TextLink
+            style={styles.link}
+            url="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+          >
             here
-          </a>
+          </TextLink>
           .
         </CommentEnabledGuidelines>
         <div

--- a/packages/article-comments/src/disabled-comments.web.js
+++ b/packages/article-comments/src/disabled-comments.web.js
@@ -1,9 +1,11 @@
 import React from "react";
+import { TextLink } from "@times-components/link";
 import {
   CommentContainer,
   CommentDisabledHeadline,
   CommentDisabledGuidelines
 } from "./styles/responsive";
+import styles from "./styles";
 
 const DisabledComments = () => (
   <CommentContainer>
@@ -12,9 +14,12 @@ const DisabledComments = () => (
     </CommentDisabledHeadline>
     <CommentDisabledGuidelines>
       Comments are subject to our community guidelines, which can be viewed{" "}
-      <a href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32">
+      <TextLink
+        style={styles.link}
+        url="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      >
         here
-      </a>
+      </TextLink>
       .
     </CommentDisabledGuidelines>
   </CommentContainer>

--- a/packages/article-comments/src/styles/index.web.js
+++ b/packages/article-comments/src/styles/index.web.js
@@ -1,0 +1,14 @@
+import { StyleSheet } from "react-native";
+import { fonts, fontSizes } from "@times-components/styleguide";
+import sharedStyles from "./shared";
+
+const styles = StyleSheet.create({
+  ...sharedStyles,
+  link: {
+    ...sharedStyles.link,
+    fontFamily: fonts.supporting,
+    fontSize: fontSizes.commentsGuidelines
+  }
+});
+
+export default styles;

--- a/packages/article-in-depth/.jestlint
+++ b/packages/article-in-depth/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 65,
+  "maxAttributeStringLength": 71,
   "maxFileSize": 47414,
   "maxLines": 780
 }

--- a/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-in-depth/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -171,7 +171,8 @@ exports[`1. a full article 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>

--- a/packages/article-magazine-comment/.jestlint
+++ b/packages/article-magazine-comment/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 65,
+  "maxAttributeStringLength": 71,
   "maxFileSize": 46746,
   "maxLines": 780
 }

--- a/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -175,7 +175,8 @@ exports[`1. a full article 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>

--- a/packages/article-magazine-standard/.jestlint
+++ b/packages/article-magazine-standard/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 65,
+  "maxAttributeStringLength": 71,
   "maxFileSize": 44614,
   "maxLines": 780
 }

--- a/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -171,7 +171,8 @@ exports[`1. a full article 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>

--- a/packages/article-main-comment/.jestlint
+++ b/packages/article-main-comment/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 65,
+  "maxAttributeStringLength": 71,
   "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-comment/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -165,7 +165,8 @@ exports[`1. a full article 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>

--- a/packages/article-main-standard/.jestlint
+++ b/packages/article-main-standard/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 65,
+  "maxAttributeStringLength": 71,
   "maxFileSize": 20685,
   "maxLines": 780
 }

--- a/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
+++ b/packages/article-main-standard/__tests__/web/__snapshots__/semantic.web.test.js.snap
@@ -184,7 +184,8 @@ exports[`1. a full article with an image as the lead asset 1`] = `
     Comments are subject to our community guidelines, which can be viewed
      
     <a
-      href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      href="https://www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
+      role="link"
     >
       here
     </a>

--- a/packages/article-skeleton/.jestlint
+++ b/packages/article-skeleton/.jestlint
@@ -1,6 +1,6 @@
 {
   "maxAttributes": 8,
-  "maxAttributeStringLength": 65,
+  "maxAttributeStringLength": 36,
   "maxFileSize": 23725,
   "maxLines": 780
 }

--- a/packages/article-skeleton/__tests__/mocks.web.js
+++ b/packages/article-skeleton/__tests__/mocks.web.js
@@ -3,6 +3,7 @@ jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({
   ArticleBylineWithLinks: "ArticleBylineWithLinks"
 }));
+jest.mock("@times-components/article-comments", () => "ArticleComments");
 jest.mock("@times-components/article-flag", () => ({
   ExclusiveArticleFlag: "ExclusiveArticleFlag",
   NewArticleFlag: "NewArticleFlag",

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images-with-style.web.test.js.snap
@@ -1,20 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`1. a secondary image 1`] = `
-.c4 {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c5 {
-  color: #696969;
-  font-family: "GillSansMTStd-Medium";
-  font-size: 13px;
-  margin: 0 0 -10px 0;
-  padding-left: 7px;
-  padding-top: 30px;
-}
-
 .c3 {
   width: 100%;
   -webkit-flex-direction: row;
@@ -37,18 +23,6 @@ exports[`1. a secondary image 1`] = `
   -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
-}
-
-@media (min-width:768px) {
-  .c4 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    width: 56.2%;
-  }
 }
 
 @media (min-width:768px) {
@@ -130,41 +104,13 @@ exports[`1. a secondary image 1`] = `
         </div>
       </div>
       <aside />
-      <div
-        className="c4"
-      >
-        <p
-          className="c5"
-        >
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a>
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments />
     </div>
   </div>
 </article>
 `;
 
 exports[`2. an inline image 1`] = `
-.c4 {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c5 {
-  color: #696969;
-  font-family: "GillSansMTStd-Medium";
-  font-size: 13px;
-  margin: 0 0 -10px 0;
-  padding-left: 7px;
-  padding-top: 30px;
-}
-
 .c3 {
   width: 100%;
   -webkit-flex-direction: row;
@@ -191,18 +137,6 @@ exports[`2. an inline image 1`] = `
 }
 
 @media (min-width:768px) {
-  .c4 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c4 {
-    width: 56.2%;
-  }
-}
-
-@media (min-width:768px) {
   .c3 {
     width: 80.8%;
     margin: 0 auto;
@@ -281,21 +215,7 @@ exports[`2. an inline image 1`] = `
         </div>
       </div>
       <aside />
-      <div
-        className="c4"
-      >
-        <p
-          className="c5"
-        >
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a>
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments />
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-images.web.test.js.snap
@@ -37,19 +37,11 @@ exports[`1. a secondary image 1`] = `
       <aside
         id="related-articles"
       />
-      <div>
-        <p>
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a
-            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
-          >
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        isEnabled={true}
+        spotAccountId=""
+      />
     </div>
   </div>
 </article>
@@ -92,19 +84,11 @@ exports[`2. an inline image 1`] = `
       <aside
         id="related-articles"
       />
-      <div>
-        <p>
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a
-            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
-          >
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        isEnabled={true}
+        spotAccountId=""
+      />
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article-with-style.web.test.js.snap
@@ -1,20 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`full article with style 1`] = `
-.c13 {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.c14 {
-  color: #696969;
-  font-family: "GillSansMTStd-Medium";
-  font-size: 13px;
-  margin: 0 0 -10px 0;
-  padding-left: 7px;
-  padding-top: 30px;
-}
-
 .c3 {
   color: #333333;
   display: block;
@@ -105,18 +91,6 @@ exports[`full article with style 1`] = `
   font-size: 110px;
   font-family: "TimesModern-Regular";
   color: #333333;
-}
-
-@media (min-width:768px) {
-  .c13 {
-    width: 80.8%;
-  }
-}
-
-@media (min-width:1024px) {
-  .c13 {
-    width: 56.2%;
-  }
 }
 
 @media (min-width:768px) {
@@ -466,21 +440,7 @@ exports[`full article with style 1`] = `
       <aside>
         <RelatedArticles />
       </aside>
-      <div
-        className="c13"
-      >
-        <p
-          className="c14"
-        >
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a>
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments />
     </div>
   </div>
 </article>

--- a/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
+++ b/packages/article-skeleton/__tests__/web/__snapshots__/article.web.test.js.snap
@@ -324,19 +324,11 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
           }
         />
       </aside>
-      <div>
-        <p>
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a
-            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
-          >
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        isEnabled={true}
+        spotAccountId=""
+      />
     </div>
   </div>
 </article>
@@ -663,19 +655,11 @@ exports[`2. a full article with all content items with not a dropcap template 1`
           }
         />
       </aside>
-      <div>
-        <p>
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a
-            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
-          >
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        isEnabled={true}
+        spotAccountId=""
+      />
     </div>
   </div>
 </article>
@@ -755,19 +739,11 @@ exports[`3. an article with no content 1`] = `
           }
         />
       </aside>
-      <div>
-        <p>
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a
-            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
-          >
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        isEnabled={true}
+        spotAccountId=""
+      />
     </div>
   </div>
 </article>
@@ -797,19 +773,11 @@ exports[`4. an article with a nested markup in first paragraph displays no drop 
       <aside
         id="related-articles"
       />
-      <div>
-        <p>
-          Comments are subject to our community guidelines, which can be viewed
-           
-          <a
-            href="//www.thetimes.co.uk/article/f4024fbe-d989-11e6-9063-500e6740fc32"
-          >
-            here
-          </a>
-          .
-        </p>
-        <div />
-      </div>
+      <ArticleComments
+        articleId="198c4b2f-ecec-4f34-be53-c89f83bc1b44"
+        isEnabled={true}
+        spotAccountId=""
+      />
     </div>
   </div>
 </article>


### PR DESCRIPTION
Use `link` component in `article-comment` package instead of a "raw" `a` tag.