### PR TITLE
fix: don't show images on author pages with no lead assets turned on

### DIFF
--- a/packages/author-profile/__tests__/shared.base.js
+++ b/packages/author-profile/__tests__/shared.base.js
@@ -55,7 +55,6 @@ export default (props, platformTests = []) => {
           <AuthorProfile
             {...props}
             author={{ ...props.author, hasLeadAssets: false, image: "" }}
-            hasLeadAssets={false}
             isLoading={false}
             pageSize={12}
           />
@@ -87,7 +86,6 @@ export default (props, platformTests = []) => {
           <AuthorProfile
             {...props}
             author={{ ...props.author, hasLeadAssets: false }}
-            hasLeadAssets={false}
             isLoading={false}
             page={2}
           />

--- a/packages/author-profile/author-profile.showcase.js
+++ b/packages/author-profile/author-profile.showcase.js
@@ -46,11 +46,7 @@ const articleImageRatio = "3:2";
 const pageSize = 20;
 const slug = "deborah-haynes";
 
-const makeAuthorProfile = (
-  decorateAction,
-  params,
-  { hasLeadAssets = true } = {}
-) => (
+const makeAuthorProfile = (decorateAction, params) => (
   <MockFixture
     params={params}
     render={mocks => (
@@ -74,7 +70,6 @@ const makeAuthorProfile = (
               <AuthorProfile
                 author={author}
                 error={error}
-                hasLeadAssets={hasLeadAssets}
                 isLoading={isLoading}
                 page={page}
                 pageSize={authorPageSize}
@@ -151,10 +146,7 @@ export default {
             },
             pageSize,
             slug
-          }),
-          {
-            hasLeadAssets: false
-          }
+          })
         ),
       name: "Default without images",
       type: "story"

--- a/packages/author-profile/src/author-profile.js
+++ b/packages/author-profile/src/author-profile.js
@@ -17,7 +17,6 @@ const AuthorProfile = ({
   adConfig,
   author,
   error,
-  hasLeadAssets = true,
   isLoading: isHeaderLoading,
   onArticlePress,
   onNext,
@@ -38,6 +37,7 @@ const AuthorProfile = ({
   const {
     articles,
     biography,
+    hasLeadAssets = true,
     image: uri,
     jobTitle,
     name,


### PR DESCRIPTION
If authors have `noLeadAssets` enabled, we shouldn't be showing lead assets on their author page. This is a regression that needs fixing. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
