### PR TITLE
Feat: Video labels for remaining templates

### DIFF
--- a/packages/article-in-depth/package.json
+++ b/packages/article-in-depth/package.json
@@ -71,6 +71,7 @@
     "@times-components/date-publication": "0.19.54",
     "@times-components/styleguide": "3.12.2",
     "@times-components/utils": "4.0.17",
+    "@times-components/video-label": "2.1.67",
     "prop-types": "15.6.2",
     "styled-components": "3.4.0"
   },

--- a/packages/article-in-depth/src/article-header/article-header-prop-types.js
+++ b/packages/article-in-depth/src/article-header/article-header-prop-types.js
@@ -6,6 +6,7 @@ const { colours } = styleguide();
 const articleHeaderPropTypes = {
   backgroundColour: PropTypes.string,
   flags: PropTypes.arrayOf(PropTypes.string),
+  hasVideo: PropTypes.bool,
   headline: PropTypes.string.isRequired,
   label: PropTypes.string,
   standfirst: PropTypes.string,
@@ -15,6 +16,7 @@ const articleHeaderPropTypes = {
 const articleHeaderDefaultProps = {
   backgroundColour: colours.functional.brandColour,
   flags: null,
+  hasVideo: false,
   label: null,
   standfirst: null,
   textColour: colours.functional.white

--- a/packages/article-in-depth/src/article-header/article-header.js
+++ b/packages/article-in-depth/src/article-header/article-header.js
@@ -15,6 +15,7 @@ import styles from "../styles";
 const ArticleHeader = ({
   backgroundColour,
   flags,
+  hasVideo,
   headline,
   label,
   standfirst,
@@ -28,7 +29,7 @@ const ArticleHeader = ({
           { backgroundColor: backgroundColour, width: "100%" }
         ]}
       >
-        <Label color={textColour} label={label} />
+        <Label color={textColour} isVideo={hasVideo} label={label} />
         <Text
           style={[
             styles.articleHeadline,

--- a/packages/article-in-depth/src/article-header/article-header.web.js
+++ b/packages/article-in-depth/src/article-header/article-header.web.js
@@ -21,6 +21,7 @@ import {
 const ArticleHeader = ({
   backgroundColour,
   flags,
+  hasVideo,
   headline,
   label,
   standfirst,
@@ -32,7 +33,7 @@ const ArticleHeader = ({
         style={{ backgroundColor: backgroundColour, order: 2, width: "100%" }}
       >
         <HeaderContainer style={styles.container}>
-          <Label color={textColour} label={label} />
+          <Label color={textColour} isVideo={hasVideo} label={label} />
           <HeadlineContainer
             accessibilityRole="heading"
             aria-level="1"

--- a/packages/article-in-depth/src/article-in-depth.js
+++ b/packages/article-in-depth/src/article-in-depth.js
@@ -31,6 +31,7 @@ class ArticleInDepth extends Component {
       backgroundColour,
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -44,6 +45,7 @@ class ArticleInDepth extends Component {
         <ArticleHeader
           backgroundColour={backgroundColour}
           flags={flags}
+          hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
           standfirst={standfirst}

--- a/packages/article-in-depth/src/article-in-depth.web.js
+++ b/packages/article-in-depth/src/article-in-depth.web.js
@@ -23,6 +23,7 @@ class ArticlePage extends Component {
       backgroundColour,
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -37,6 +38,7 @@ class ArticlePage extends Component {
         <ArticleHeader
           backgroundColour={backgroundColour}
           flags={flags}
+          hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
           standfirst={standfirst}

--- a/packages/article-in-depth/src/article-label/article-label-prop-types.js
+++ b/packages/article-in-depth/src/article-label/article-label-prop-types.js
@@ -1,0 +1,16 @@
+import PropTypes from "prop-types";
+import { colours } from "@times-components/styleguide";
+
+const articleLabelPropTypes = {
+  color: PropTypes.string,
+  isVideo: PropTypes.bool,
+  label: PropTypes.string
+};
+
+const articleLabelDefaultProps = {
+  color: colours.functional.white,
+  isVideo: false,
+  label: null
+};
+
+export { articleLabelPropTypes, articleLabelDefaultProps };

--- a/packages/article-in-depth/src/article-label/article-label.js
+++ b/packages/article-in-depth/src/article-label/article-label.js
@@ -1,25 +1,28 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { View } from "react-native";
 import ArticleLabel from "@times-components/article-label";
+import VideoLabel from "@times-components/video-label";
 import { colours } from "@times-components/styleguide";
+
+import {
+  articleLabelPropTypes,
+  articleLabelDefaultProps
+} from "./article-label-prop-types";
 import styles from "../styles";
 
-const Label = ({ label, color }) =>
-  label ? (
+const HeaderLabel = ({ color, isVideo, label }) => {
+  if (!isVideo && !label) return null;
+
+  const Label = isVideo ? VideoLabel : ArticleLabel;
+
+  return (
     <View style={styles.label}>
-      <ArticleLabel color={color || colours.section.default} title={label} />
+      <Label color={color || colours.section.default} title={label} />
     </View>
-  ) : null;
-
-Label.propTypes = {
-  color: PropTypes.string,
-  label: PropTypes.string
+  );
 };
 
-Label.defaultProps = {
-  color: colours.functional.white,
-  label: null
-};
+HeaderLabel.propTypes = articleLabelPropTypes;
+HeaderLabel.defaultProps = articleLabelDefaultProps;
 
-export default Label;
+export default HeaderLabel;

--- a/packages/article-magazine-comment/package.json
+++ b/packages/article-magazine-comment/package.json
@@ -72,6 +72,7 @@
     "@times-components/image": "4.4.1",
     "@times-components/styleguide": "3.12.2",
     "@times-components/utils": "4.0.17",
+    "@times-components/video-label": "2.1.67",
     "prop-types": "15.6.2",
     "styled-components": "3.4.0"
   },

--- a/packages/article-magazine-comment/src/article-header/article-header-prop-types.js
+++ b/packages/article-magazine-comment/src/article-header/article-header-prop-types.js
@@ -4,6 +4,7 @@ const articleHeaderPropTypes = {
   authorImage: PropTypes.string.isRequired,
   byline: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   flags: PropTypes.arrayOf(PropTypes.string),
+  hasVideo: PropTypes.bool,
   headline: PropTypes.string.isRequired,
   label: PropTypes.string,
   publicationName: PropTypes.string.isRequired,
@@ -13,6 +14,7 @@ const articleHeaderPropTypes = {
 
 const articleHeaderDefaultProps = {
   flags: null,
+  hasVideo: false,
   label: null,
   standfirst: null
 };

--- a/packages/article-magazine-comment/src/article-header/article-header.js
+++ b/packages/article-magazine-comment/src/article-header/article-header.js
@@ -19,6 +19,7 @@ const ArticleHeader = ({
   authorImage,
   byline,
   flags,
+  hasVideo,
   headline,
   label,
   onAuthorPress,
@@ -30,7 +31,7 @@ const ArticleHeader = ({
     {({ theme: { headlineFont } }) => (
       <View style={styles.container}>
         <Image aspectRatio={1} style={styles.authorImage} uri={authorImage} />
-        <Label label={label} />
+        <Label isVideo={hasVideo} label={label} />
         <Text
           style={[
             styles.articleHeadline,

--- a/packages/article-magazine-comment/src/article-header/article-header.web.js
+++ b/packages/article-magazine-comment/src/article-header/article-header.web.js
@@ -24,6 +24,7 @@ const ArticleHeader = ({
   authorImage,
   byline,
   flags,
+  hasVideo,
   headline,
   label,
   publicationName,
@@ -36,7 +37,7 @@ const ArticleHeader = ({
         <AuthorImageContainer style={styles.authorImage}>
           <Image aspectRatio={1} uri={authorImage} />
         </AuthorImageContainer>
-        <Label label={label} />
+        <Label isVideo={hasVideo} label={label} />
         <HeadlineContainer
           accessibilityRole="heading"
           aria-level="1"

--- a/packages/article-magazine-comment/src/article-label/article-label-prop-types.js
+++ b/packages/article-magazine-comment/src/article-label/article-label-prop-types.js
@@ -1,0 +1,13 @@
+import PropTypes from "prop-types";
+
+const articleLabelPropTypes = {
+  isVideo: PropTypes.bool,
+  label: PropTypes.string
+};
+
+const articleLabelDefaultProps = {
+  isVideo: false,
+  label: null
+};
+
+export { articleLabelPropTypes, articleLabelDefaultProps };

--- a/packages/article-magazine-comment/src/article-label/article-label.js
+++ b/packages/article-magazine-comment/src/article-label/article-label.js
@@ -1,31 +1,36 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { View } from "react-native";
 import ArticleLabel from "@times-components/article-label";
+import VideoLabel from "@times-components/video-label";
 import Context from "@times-components/context";
 import { colours } from "@times-components/styleguide";
+
+import {
+  articleLabelPropTypes,
+  articleLabelDefaultProps
+} from "./article-label-prop-types";
 import styles from "../styles";
 
-const Label = ({ label }) =>
-  label ? (
+const HeaderLabel = ({ isVideo, label }) => {
+  if (!isVideo && !label) return null;
+
+  const Label = isVideo ? VideoLabel : ArticleLabel;
+
+  return (
     <Context.Consumer>
       {({ theme: { sectionColour } }) => (
         <View style={styles.label}>
-          <ArticleLabel
+          <Label
             color={sectionColour || colours.section.default}
             title={label}
           />
         </View>
       )}
     </Context.Consumer>
-  ) : null;
-
-Label.propTypes = {
-  label: PropTypes.string
+  );
 };
 
-Label.defaultProps = {
-  label: null
-};
+HeaderLabel.propTypes = articleLabelPropTypes;
+HeaderLabel.defaultProps = articleLabelDefaultProps;
 
-export default Label;
+export default HeaderLabel;

--- a/packages/article-magazine-comment/src/article-magazine-comment.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.js
@@ -31,6 +31,7 @@ class ArticleMagazineComment extends Component {
       },
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -45,6 +46,7 @@ class ArticleMagazineComment extends Component {
           authorImage={author.image}
           byline={byline}
           flags={flags}
+          hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
           onAuthorPress={onAuthorPress}

--- a/packages/article-magazine-comment/src/article-magazine-comment.web.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.web.js
@@ -28,6 +28,7 @@ class ArticlePage extends Component {
       },
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -42,6 +43,7 @@ class ArticlePage extends Component {
           authorImage={author.image}
           byline={byline}
           flags={flags}
+          hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
           publicationName={publicationName}

--- a/packages/article-magazine-standard/package.json
+++ b/packages/article-magazine-standard/package.json
@@ -71,6 +71,7 @@
     "@times-components/date-publication": "0.19.54",
     "@times-components/styleguide": "3.12.2",
     "@times-components/utils": "4.0.17",
+    "@times-components/video-label": "2.1.67",
     "prop-types": "15.6.2",
     "styled-components": "3.4.0"
   },

--- a/packages/article-magazine-standard/src/article-header/article-header-prop-types.js
+++ b/packages/article-magazine-standard/src/article-header/article-header-prop-types.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 const articleHeaderPropTypes = {
   byline: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   flags: PropTypes.arrayOf(PropTypes.string),
+  hasVideo: PropTypes.bool,
   headline: PropTypes.string.isRequired,
   label: PropTypes.string,
   publicationName: PropTypes.string.isRequired,
@@ -12,6 +13,7 @@ const articleHeaderPropTypes = {
 
 const articleHeaderDefaultProps = {
   flags: null,
+  hasVideo: false,
   label: null,
   standfirst: null
 };

--- a/packages/article-magazine-standard/src/article-header/article-header.js
+++ b/packages/article-magazine-standard/src/article-header/article-header.js
@@ -17,6 +17,7 @@ import styles from "../styles";
 const ArticleHeader = ({
   byline,
   flags,
+  hasVideo,
   headline,
   label,
   onAuthorPress,
@@ -27,7 +28,7 @@ const ArticleHeader = ({
   <Context.Consumer>
     {({ theme: { headlineFont } }) => (
       <View style={styles.container}>
-        <Label label={label} />
+        <Label isVideo={hasVideo} label={label} />
         <Text
           style={[
             styles.articleHeadline,

--- a/packages/article-magazine-standard/src/article-header/article-header.web.js
+++ b/packages/article-magazine-standard/src/article-header/article-header.web.js
@@ -21,6 +21,7 @@ import {
 const ArticleHeader = ({
   byline,
   flags,
+  hasVideo,
   headline,
   label,
   publicationName,
@@ -30,7 +31,7 @@ const ArticleHeader = ({
   <Context.Consumer>
     {({ theme: { headlineFont } }) => (
       <HeaderContainer style={styles.container}>
-        <Label label={label} />
+        <Label isVideo={hasVideo} label={label} />
         <HeadlineContainer
           accessibilityRole="heading"
           aria-level="1"

--- a/packages/article-magazine-standard/src/article-label/article-label-prop-types.js
+++ b/packages/article-magazine-standard/src/article-label/article-label-prop-types.js
@@ -1,0 +1,13 @@
+import PropTypes from "prop-types";
+
+const articleLabelPropTypes = {
+  isVideo: PropTypes.bool,
+  label: PropTypes.string
+};
+
+const articleLabelDefaultProps = {
+  isVideo: false,
+  label: null
+};
+
+export { articleLabelPropTypes, articleLabelDefaultProps };

--- a/packages/article-magazine-standard/src/article-label/article-label.js
+++ b/packages/article-magazine-standard/src/article-label/article-label.js
@@ -1,31 +1,36 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { View } from "react-native";
 import ArticleLabel from "@times-components/article-label";
+import VideoLabel from "@times-components/video-label";
 import Context from "@times-components/context";
 import { colours } from "@times-components/styleguide";
+
+import {
+  articleLabelPropTypes,
+  articleLabelDefaultProps
+} from "./article-label-prop-types";
 import styles from "../styles";
 
-const Label = ({ label }) =>
-  label ? (
+const HeaderLabel = ({ isVideo, label }) => {
+  if (!isVideo && !label) return null;
+
+  const Label = isVideo ? VideoLabel : ArticleLabel;
+
+  return (
     <Context.Consumer>
       {({ theme: { sectionColour } }) => (
         <View style={styles.label}>
-          <ArticleLabel
+          <Label
             color={sectionColour || colours.section.default}
             title={label}
           />
         </View>
       )}
     </Context.Consumer>
-  ) : null;
-
-Label.propTypes = {
-  label: PropTypes.string
+  );
 };
 
-Label.defaultProps = {
-  label: null
-};
+HeaderLabel.propTypes = articleLabelPropTypes;
+HeaderLabel.defaultProps = articleLabelDefaultProps;
 
-export default Label;
+export default HeaderLabel;

--- a/packages/article-magazine-standard/src/article-magazine-standard.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.js
@@ -28,6 +28,7 @@ class ArticleMagazineStandard extends Component {
     const {
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -41,6 +42,7 @@ class ArticleMagazineStandard extends Component {
         <ArticleHeader
           byline={byline}
           flags={flags}
+          hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
           onAuthorPress={onAuthorPress}

--- a/packages/article-magazine-standard/src/article-magazine-standard.web.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.web.js
@@ -25,6 +25,7 @@ class ArticlePage extends Component {
     const {
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -38,6 +39,7 @@ class ArticlePage extends Component {
         <ArticleHeader
           byline={byline}
           flags={flags}
+          hasVideo={hasVideo}
           headline={getHeadline(headline, shortHeadline)}
           label={label}
           publicationName={publicationName}

--- a/packages/article-main-comment/package.json
+++ b/packages/article-main-comment/package.json
@@ -70,6 +70,7 @@
     "@times-components/image": "4.4.1",
     "@times-components/styleguide": "3.12.2",
     "@times-components/utils": "4.0.17",
+    "@times-components/video-label": "2.1.67",
     "prop-types": "15.6.2",
     "styled-components": "3.4.0"
   },

--- a/packages/article-main-comment/src/article-header/article-header-prop-types.js
+++ b/packages/article-main-comment/src/article-header/article-header-prop-types.js
@@ -4,6 +4,7 @@ const articleHeaderPropTypes = {
   authorImage: PropTypes.string.isRequired,
   byline: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   flags: PropTypes.arrayOf(PropTypes.string),
+  hasVideo: PropTypes.bool,
   headline: PropTypes.string.isRequired,
   label: PropTypes.string,
   publicationName: PropTypes.string.isRequired,
@@ -13,6 +14,7 @@ const articleHeaderPropTypes = {
 
 const articleHeaderDefaultProps = {
   flags: null,
+  hasVideo: false,
   label: null,
   standfirst: null
 };

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Text, View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
-
 import Label from "../article-label/article-label";
 import Flags from "../article-flags/article-flags";
 import Meta from "../article-meta/article-meta";
@@ -17,6 +16,7 @@ const ArticleHeader = ({
   authorImage,
   byline,
   flags,
+  hasVideo,
   headline,
   label,
   onAuthorPress,
@@ -26,7 +26,7 @@ const ArticleHeader = ({
 }) => (
   <View style={styles.container}>
     <Image aspectRatio={1} style={styles.authorImage} uri={authorImage} />
-    <Label label={label} />
+    <Label isVideo={hasVideo} label={label} />
     <Text style={styles.articleHeadline}>{headline}</Text>
     <Flags flags={flags} />
     <Standfirst standfirst={standfirst} />

--- a/packages/article-main-comment/src/article-header/article-header.web.js
+++ b/packages/article-main-comment/src/article-header/article-header.web.js
@@ -22,6 +22,7 @@ const ArticleHeader = ({
   authorImage,
   byline,
   flags,
+  hasVideo,
   headline,
   label,
   publicationName,
@@ -32,7 +33,7 @@ const ArticleHeader = ({
     <AuthorImageContainer style={styles.authorImage}>
       <Image aspectRatio={1} uri={authorImage} />
     </AuthorImageContainer>
-    <Label label={label} />
+    <Label isVideo={hasVideo} label={label} />
     <HeadlineContainer
       accessibilityRole="heading"
       aria-level="1"

--- a/packages/article-main-comment/src/article-label/article-label-prop-types.js
+++ b/packages/article-main-comment/src/article-label/article-label-prop-types.js
@@ -1,0 +1,13 @@
+import PropTypes from "prop-types";
+
+const articleLabelPropTypes = {
+  isVideo: PropTypes.bool,
+  label: PropTypes.string
+};
+
+const articleLabelDefaultProps = {
+  isVideo: false,
+  label: null
+};
+
+export { articleLabelPropTypes, articleLabelDefaultProps };

--- a/packages/article-main-comment/src/article-label/article-label.js
+++ b/packages/article-main-comment/src/article-label/article-label.js
@@ -1,31 +1,36 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { View } from "react-native";
 import ArticleLabel from "@times-components/article-label";
+import VideoLabel from "@times-components/video-label";
 import Context from "@times-components/context";
 import { colours } from "@times-components/styleguide";
+
+import {
+  articleLabelPropTypes,
+  articleLabelDefaultProps
+} from "./article-label-prop-types";
 import styles from "../styles";
 
-const Label = ({ label }) =>
-  label ? (
+const HeaderLabel = ({ isVideo, label }) => {
+  if (!isVideo && !label) return null;
+
+  const Label = isVideo ? VideoLabel : ArticleLabel;
+
+  return (
     <Context.Consumer>
       {({ theme: { sectionColour } }) => (
         <View style={styles.label}>
-          <ArticleLabel
+          <Label
             color={sectionColour || colours.section.default}
             title={label}
           />
         </View>
       )}
     </Context.Consumer>
-  ) : null;
-
-Label.propTypes = {
-  label: PropTypes.string
+  );
 };
 
-Label.defaultProps = {
-  label: null
-};
+HeaderLabel.propTypes = articleLabelPropTypes;
+HeaderLabel.defaultProps = articleLabelDefaultProps;
 
-export default Label;
+export default HeaderLabel;

--- a/packages/article-main-comment/src/article-main-comment.js
+++ b/packages/article-main-comment/src/article-main-comment.js
@@ -22,6 +22,7 @@ class ArticlePage extends Component {
       author,
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -37,6 +38,7 @@ class ArticlePage extends Component {
         authorImage={authorImage}
         byline={byline}
         flags={flags}
+        hasVideo={hasVideo}
         headline={getHeadline(headline, shortHeadline)}
         label={label}
         onAuthorPress={onAuthorPress}

--- a/packages/article-main-comment/src/article-main-comment.web.js
+++ b/packages/article-main-comment/src/article-main-comment.web.js
@@ -21,6 +21,7 @@ class ArticlePage extends Component {
       },
       byline,
       flags,
+      hasVideo,
       headline,
       label,
       publicationName,
@@ -34,6 +35,7 @@ class ArticlePage extends Component {
         authorImage={author.image}
         byline={byline}
         flags={flags}
+        hasVideo={hasVideo}
         headline={getHeadline(headline, shortHeadline)}
         label={label}
         publicationName={publicationName}


### PR DESCRIPTION
- Adds support for video label on `article-main-comment`, `article-magazine-standard`, `article-magazine-comment` and `article-in-depth` templates

- https://nidigitalsolutions.jira.com/browse/REPLAT-4659