### PR TITLE
fix: multiple article bylines should appear on a single line

### DIFF
--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -64,40 +64,42 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
           },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -27,40 +27,42 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
           },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -72,26 +74,28 @@ exports[`2. article summary with opinion byline 1`] = `
       title="Test label"
     />
   </View>
-  <ArticleBylineOpinion
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleBylineOpinion
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-    isOpinionByline={true}
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+      isOpinionByline={true}
+    />
+  </Text>
   <Text
     accessibilityRole="heading"
     aria-level="3"
@@ -139,25 +143,27 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -299,25 +305,27 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
       publication="SUNDAYTIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -366,25 +374,27 @@ exports[`9. article summary component with no label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -433,25 +443,27 @@ exports[`11. article summary component with no date publication 1`] = `
       ...
     </Text>
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -483,24 +495,26 @@ exports[`12. article summary component with a video label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -64,40 +64,42 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
           },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -27,40 +27,42 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
           },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -72,26 +74,28 @@ exports[`2. article summary with opinion byline 1`] = `
       title="Test label"
     />
   </View>
-  <ArticleBylineOpinion
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleBylineOpinion
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-    isOpinionByline={true}
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+      isOpinionByline={true}
+    />
+  </Text>
   <Text
     accessibilityRole="heading"
     aria-level="3"
@@ -139,25 +143,27 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -299,25 +305,27 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
       publication="SUNDAYTIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -366,25 +374,27 @@ exports[`9. article summary component with no label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -433,25 +443,27 @@ exports[`11. article summary component with no date publication 1`] = `
       ...
     </Text>
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;
 
@@ -483,24 +495,26 @@ exports[`12. article summary component with a video label 1`] = `
       publication="TIMES"
     />
   </Text>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <Text>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </Text>
 </View>
 `;

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -45,6 +45,15 @@ exports[`1. article summary component with a single paragraph 1`] = `
   line-height: 15px;
   margin-bottom: 5px;
 }
+
+.S6 {
+  color: inherit;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
 </style>
 
 <div
@@ -85,40 +94,44 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
+  <div
+    className="S6"
+  >
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
           },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -27,40 +27,42 @@ exports[`1. article summary component with a single paragraph 1`] = `
       publication="TIMES"
     />
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {
-            "slug": "camilla-long",
+  <div>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {
+              "slug": "camilla-long",
+            },
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "Camilla Long",
+                },
+                "children": Array [],
+                "name": "text",
+              },
+            ],
+            "name": "author",
           },
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "Camilla Long",
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": ", Environment Editor",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "author",
-        },
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": ", Environment Editor",
-              },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -72,26 +74,28 @@ exports[`2. article summary with opinion byline 1`] = `
       title="Test label"
     />
   </div>
-  <ArticleBylineOpinion
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <div>
+    <ArticleBylineOpinion
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-    isOpinionByline={true}
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+      isOpinionByline={true}
+    />
+  </div>
   <h3
     aria-level="3"
     role="heading"
@@ -139,25 +143,27 @@ exports[`3. article summary component with multiple paragraphs 1`] = `
       publication="TIMES"
     />
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <div>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -287,25 +293,27 @@ exports[`7. article summary component with empty content at the end trimmed 1`] 
       publication="SUNDAYTIMES"
     />
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <div>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -354,25 +362,27 @@ exports[`9. article summary component with no label 1`] = `
       publication="TIMES"
     />
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <div>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -421,25 +431,27 @@ exports[`11. article summary component with no date publication 1`] = `
       ...
     </span>
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <div>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;
 
@@ -471,24 +483,26 @@ exports[`12. article summary component with a video label 1`] = `
       publication="TIMES"
     />
   </div>
-  <ArticleByline
-    ast={
-      Array [
-        Object {
-          "attributes": Object {},
-          "children": Array [
-            Object {
-              "attributes": Object {
-                "value": "A byline",
+  <div>
+    <ArticleByline
+      ast={
+        Array [
+          Object {
+            "attributes": Object {},
+            "children": Array [
+              Object {
+                "attributes": Object {
+                  "value": "A byline",
+                },
+                "children": Array [],
+                "name": "text",
               },
-              "children": Array [],
-              "name": "text",
-            },
-          ],
-          "name": "inline",
-        },
-      ]
-    }
-  />
+            ],
+            "name": "inline",
+          },
+        ]
+      }
+    />
+  </div>
 </div>
 `;

--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -35,7 +35,11 @@ const ArticleSummary = props => {
       ? ArticleBylineOpinion
       : ArticleByline;
 
-    return <Byline {...bylineProps} className={bylineProps.bylineClass} />;
+    return (
+      <Text>
+        <Byline {...bylineProps} className={bylineProps.bylineClass} />
+      </Text>
+    );
   };
 
   const renderLabel = () => {

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-1article.android.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. one lead related article 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-2articles.android.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. one lead and one support related article 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -100,7 +102,9 @@ exports[`1. one lead and one support related article 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-3articles.android.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. one lead and two support related articles 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -100,7 +102,9 @@ exports[`1. one lead and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -144,7 +148,9 @@ exports[`1. one lead and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-no-short-headline.android.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. no short headline 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/la2-with-style.android.test.js.snap
@@ -124,18 +124,20 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#333333",
-                      "flexDirection": "row",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 19,
+                <Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexDirection": "row",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 19,
+                      }
                     }
-                  }
-                >
-                  Deborah Haynes
+                  >
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-1article.android.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. one opinion related article 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-2articles.android.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. one opinion and one support related article 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"
@@ -110,7 +112,9 @@ exports[`1. one opinion and one support related article 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-3articles.android.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"
@@ -110,7 +112,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -154,7 +158,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-no-short-headline.android.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. no short headline 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/oa2-with-style.android.test.js.snap
@@ -77,18 +77,20 @@ exports[`default styles 1`] = `
                     TEST LABEL
                   </Text>
                 </View>
-                <Text
-                  style={
-                    Object {
-                      "color": "#850029",
-                      "fontFamily": "TimesModern-Bold",
-                      "fontSize": 22,
-                      "fontWeight": "400",
-                      "lineHeight": 19,
+                <Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#850029",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "400",
+                        "lineHeight": 19,
+                      }
                     }
-                  }
-                >
-                  Sathnam Sanghera
+                  >
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   style={

--- a/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-has-video.android.test.js.snap
@@ -57,10 +57,12 @@ exports[`1. has video 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long
-                </Text>
-                <Text>
-                  , Environment Editor
+                  <Text>
+                    Camilla Long
+                  </Text>
+                  <Text>
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std-with-style.android.test.js.snap
@@ -124,31 +124,33 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#333333",
-                      "flexDirection": "row",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 19,
+                <Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexDirection": "row",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 19,
+                      }
                     }
-                  }
-                >
-                  Camilla Long
-                </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#333333",
-                      "flexDirection": "row",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 19,
+                  >
+                    Camilla Long
+                  </Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexDirection": "row",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 19,
+                      }
                     }
-                  }
-                >
-                  , Environment Editor
+                  >
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-1article.test.js.snap
@@ -57,10 +57,12 @@ exports[`1. a single related article 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long
-                </Text>
-                <Text>
-                  , Environment Editor
+                  <Text>
+                    Camilla Long
+                  </Text>
+                  <Text>
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-2articles.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. two related articles 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -109,7 +111,9 @@ exports[`1. two related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-3articles.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. three related articles 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -109,7 +111,9 @@ exports[`1. three related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -162,7 +166,9 @@ exports[`1. three related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
+++ b/packages/related-articles/__tests__/android/__snapshots__/std.android-no-short-headline.test.js.snap
@@ -57,10 +57,12 @@ exports[`1. no short headline 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long
-                </Text>
-                <Text>
-                  , Environment Editor
+                  <Text>
+                    Camilla Long
+                  </Text>
+                  <Text>
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-1article.ios.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. one lead related article 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-2articles.ios.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. one lead and one support related article 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -100,7 +102,9 @@ exports[`1. one lead and one support related article 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-3articles.ios.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. one lead and two support related articles 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -100,7 +102,9 @@ exports[`1. one lead and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -144,7 +148,9 @@ exports[`1. one lead and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-no-short-headline.ios.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. no short headline 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/la2-with-style.ios.test.js.snap
@@ -124,18 +124,20 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#333333",
-                      "flexDirection": "row",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
+                <Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexDirection": "row",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      }
                     }
-                  }
-                >
-                  Deborah Haynes
+                  >
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-1article.ios.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. one opinion related article 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-2articles.ios.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. one opinion and one support related article 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"
@@ -110,7 +112,9 @@ exports[`1. one opinion and one support related article 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-3articles.ios.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"
@@ -110,7 +112,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -154,7 +158,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Deborah Haynes
+                  <Text>
+                    Deborah Haynes
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-no-short-headline.ios.test.js.snap
@@ -48,7 +48,9 @@ exports[`1. no short headline 1`] = `
                   />
                 </View>
                 <Text>
-                  Sathnam Sanghera
+                  <Text>
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   accessibilityRole="heading"

--- a/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/oa2-with-style.ios.test.js.snap
@@ -77,18 +77,20 @@ exports[`default styles 1`] = `
                     TEST LABEL
                   </Text>
                 </View>
-                <Text
-                  style={
-                    Object {
-                      "color": "#850029",
-                      "fontFamily": "TimesModern-Bold",
-                      "fontSize": 22,
-                      "fontWeight": "400",
-                      "lineHeight": 27,
+                <Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#850029",
+                        "fontFamily": "TimesModern-Bold",
+                        "fontSize": 22,
+                        "fontWeight": "400",
+                        "lineHeight": 27,
+                      }
                     }
-                  }
-                >
-                  Sathnam Sanghera
+                  >
+                    Sathnam Sanghera
+                  </Text>
                 </Text>
                 <Text
                   style={

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-1article.ios.test.js.snap
@@ -57,10 +57,12 @@ exports[`1. a single related article 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long
-                </Text>
-                <Text>
-                  , Environment Editor
+                  <Text>
+                    Camilla Long
+                  </Text>
+                  <Text>
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-2articles.ios.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. two related articles 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -109,7 +111,9 @@ exports[`1. two related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-3articles.ios.test.js.snap
@@ -56,7 +56,9 @@ exports[`1. three related articles 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -109,7 +111,9 @@ exports[`1. three related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>
@@ -162,7 +166,9 @@ exports[`1. three related articles 1`] = `
                   January 17 2018, 12:00pm
                 </Text>
                 <Text>
-                  Camilla Long, Environment Editor
+                  <Text>
+                    Camilla Long, Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-has-video.ios.test.js.snap
@@ -57,10 +57,12 @@ exports[`1. has video 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long
-                </Text>
-                <Text>
-                  , Environment Editor
+                  <Text>
+                    Camilla Long
+                  </Text>
+                  <Text>
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-no-short-headline.ios.test.js.snap
@@ -57,10 +57,12 @@ exports[`1. no short headline 1`] = `
                   March 13 2015, 6:54pm
                 </Text>
                 <Text>
-                  Camilla Long
-                </Text>
-                <Text>
-                  , Environment Editor
+                  <Text>
+                    Camilla Long
+                  </Text>
+                  <Text>
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
+++ b/packages/related-articles/__tests__/ios/__snapshots__/std-with-style.ios.test.js.snap
@@ -124,31 +124,33 @@ exports[`default styles 1`] = `
                 >
                   March 13 2015, 6:54pm
                 </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#333333",
-                      "flexDirection": "row",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
+                <Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexDirection": "row",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      }
                     }
-                  }
-                >
-                  Camilla Long
-                </Text>
-                <Text
-                  style={
-                    Object {
-                      "color": "#333333",
-                      "flexDirection": "row",
-                      "fontFamily": "GillSansMTStd-Medium",
-                      "fontSize": 13,
-                      "lineHeight": 15,
+                  >
+                    Camilla Long
+                  </Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexDirection": "row",
+                        "fontFamily": "GillSansMTStd-Medium",
+                        "fontSize": 13,
+                        "lineHeight": 15,
+                      }
                     }
-                  }
-                >
-                  , Environment Editor
+                  >
+                    , Environment Editor
+                  </Text>
                 </Text>
               </View>
             </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-1article.web.test.js.snap
@@ -61,7 +61,9 @@ exports[`1. one lead related article 1`] = `
                     </time>
                   </div>
                   <div>
-                    Deborah Haynes
+                    <span>
+                      Deborah Haynes
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-2articles.web.test.js.snap
@@ -61,7 +61,9 @@ exports[`1. one lead and one support related article 1`] = `
                     </time>
                   </div>
                   <div>
-                    Deborah Haynes
+                    <span>
+                      Deborah Haynes
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -110,7 +112,9 @@ exports[`1. one lead and one support related article 1`] = `
                       </time>
                     </div>
                     <div>
-                      Deborah Haynes
+                      <span>
+                        Deborah Haynes
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-3articles.web.test.js.snap
@@ -68,7 +68,9 @@ exports[`1. one lead and two support related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    Deborah Haynes
+                    <span>
+                      Deborah Haynes
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -117,7 +119,9 @@ exports[`1. one lead and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      Deborah Haynes
+                      <span>
+                        Deborah Haynes
+                      </span>
                     </div>
                   </div>
                 </Card>
@@ -164,7 +168,9 @@ exports[`1. one lead and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      Deborah Haynes
+                      <span>
+                        Deborah Haynes
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-no-short-headline.web.test.js.snap
@@ -61,7 +61,9 @@ exports[`1. no short headline 1`] = `
                     </time>
                   </div>
                   <div>
-                    Deborah Haynes
+                    <span>
+                      Deborah Haynes
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/la2-with-style.web.test.js.snap
@@ -281,6 +281,19 @@ exports[`default styles 1`] = `
   margin-bottom: 0px;
 }
 
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
 .IS1 {
   color: rgba(29,29,27,1.00);
 }
@@ -355,9 +368,13 @@ exports[`default styles 1`] = `
                     </time>
                   </div>
                   <div
-                    className="S9"
+                    className="S10"
                   >
-                    Deborah Haynes
+                    <span
+                      className="S9"
+                    >
+                      Deborah Haynes
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-1article.web.test.js.snap
@@ -39,7 +39,9 @@ exports[`1. one opinion related article 1`] = `
                     />
                   </div>
                   <div>
-                    Sathnam Sanghera
+                    <span>
+                      Sathnam Sanghera
+                    </span>
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-2articles.web.test.js.snap
@@ -39,7 +39,9 @@ exports[`1. one opinion and one support related article 1`] = `
                     />
                   </div>
                   <div>
-                    Sathnam Sanghera
+                    <span>
+                      Sathnam Sanghera
+                    </span>
                   </div>
                   <h3
                     aria-level="3"
@@ -124,7 +126,9 @@ exports[`1. one opinion and one support related article 1`] = `
                       </time>
                     </div>
                     <div>
-                      Deborah Haynes
+                      <span>
+                        Deborah Haynes
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-3articles.web.test.js.snap
@@ -39,7 +39,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                     />
                   </div>
                   <div>
-                    Sathnam Sanghera
+                    <span>
+                      Sathnam Sanghera
+                    </span>
                   </div>
                   <h3
                     aria-level="3"
@@ -117,7 +119,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      Deborah Haynes
+                      <span>
+                        Deborah Haynes
+                      </span>
                     </div>
                   </div>
                 </Card>
@@ -164,7 +168,9 @@ exports[`1. one opinion and two support related articles 1`] = `
                       </time>
                     </div>
                     <div>
-                      Deborah Haynes
+                      <span>
+                        Deborah Haynes
+                      </span>
                     </div>
                   </div>
                 </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-no-short-headline.web.test.js.snap
@@ -39,7 +39,9 @@ exports[`1. no short headline 1`] = `
                     />
                   </div>
                   <div>
-                    Sathnam Sanghera
+                    <span>
+                      Sathnam Sanghera
+                    </span>
                   </div>
                   <h3
                     aria-level="3"

--- a/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/oa2-with-style.web.test.js.snap
@@ -261,6 +261,19 @@ exports[`default styles 1`] = `
 .S6 {
   border-top-width: 0px;
   border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.S7 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
   color: rgba(51,51,51,1.00);
   display: inline;
   font-family: TimesModern-Bold;
@@ -271,7 +284,7 @@ exports[`default styles 1`] = `
   margin-top: 0px;
 }
 
-.S7 {
+.S8 {
   border-top-width: 0px;
   border-bottom-width: 0px;
   color: inherit;
@@ -284,7 +297,7 @@ exports[`default styles 1`] = `
   margin-bottom: 0px;
 }
 
-.S8 {
+.S9 {
   border-top-width: 0px;
   border-bottom-width: 0px;
   color: rgba(105,105,105,1.00);
@@ -297,7 +310,7 @@ exports[`default styles 1`] = `
   margin-bottom: 10px;
 }
 
-.S9 {
+.S10 {
   border-top-width: 0px;
   border-bottom-width: 0px;
   color: rgba(105,105,105,1.00);
@@ -357,12 +370,16 @@ exports[`default styles 1`] = `
                     </div>
                   </div>
                   <div
-                    className="opinionBylineClass S5"
+                    className="S6"
                   >
-                    Sathnam Sanghera
+                    <span
+                      className="opinionBylineClass S5"
+                    >
+                      Sathnam Sanghera
+                    </span>
                   </div>
                   <h3
-                    className="opinionHeadlineClass S6"
+                    className="opinionHeadlineClass S7"
                   >
                     Test Short Headline
                   </h3>
@@ -370,10 +387,10 @@ exports[`default styles 1`] = `
                     className="S4"
                   >
                     <div
-                      className="summaryHidden opinionSummary125Class S8"
+                      className="summaryHidden opinionSummary125Class S9"
                     >
                       <span
-                        className="S7"
+                        className="S8"
                       >
                         
                         Summary 125
@@ -381,10 +398,10 @@ exports[`default styles 1`] = `
                       </span>
                     </div>
                     <div
-                      className="summaryHidden opinionSummary160Class S8"
+                      className="summaryHidden opinionSummary160Class S9"
                     >
                       <span
-                        className="S7"
+                        className="S8"
                       >
                         
                         Summary 160
@@ -393,7 +410,7 @@ exports[`default styles 1`] = `
                     </div>
                   </div>
                   <div
-                    className="S9"
+                    className="S10"
                   >
                     <time>
                       March 13 2015, 6:54pm

--- a/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-1article.web.test.js.snap
@@ -62,10 +62,12 @@ exports[`1. a single related article 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long
-                  </div>
-                  <div>
-                    , Environment Editor
+                    <span>
+                      Camilla Long
+                    </span>
+                    <span>
+                      , Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-2articles.web.test.js.snap
@@ -61,7 +61,9 @@ exports[`1. two related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long, Environment Editor
+                    <span>
+                      Camilla Long, Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -117,7 +119,9 @@ exports[`1. two related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long, Environment Editor
+                    <span>
+                      Camilla Long, Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-3articles.web.test.js.snap
@@ -68,7 +68,9 @@ exports[`1. three related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long, Environment Editor
+                    <span>
+                      Camilla Long, Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -131,7 +133,9 @@ exports[`1. three related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long, Environment Editor
+                    <span>
+                      Camilla Long, Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>
@@ -194,7 +198,9 @@ exports[`1. three related articles 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long, Environment Editor
+                    <span>
+                      Camilla Long, Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-has-video.web.test.js.snap
@@ -62,10 +62,12 @@ exports[`1. has video 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long
-                  </div>
-                  <div>
-                    , Environment Editor
+                    <span>
+                      Camilla Long
+                    </span>
+                    <span>
+                      , Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-no-short-headline.web.test.js.snap
@@ -62,10 +62,12 @@ exports[`1. no short headline 1`] = `
                     </time>
                   </div>
                   <div>
-                    Camilla Long
-                  </div>
-                  <div>
-                    , Environment Editor
+                    <span>
+                      Camilla Long
+                    </span>
+                    <span>
+                      , Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>

--- a/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
+++ b/packages/related-articles/__tests__/web/__snapshots__/std-with-style.web.test.js.snap
@@ -254,6 +254,19 @@ exports[`default styles 1`] = `
   margin-bottom: 0px;
 }
 
+.S10 {
+  border-top-width: 0px;
+  border-bottom-width: 0px;
+  color: inherit;
+  display: inline;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
 .IS1 {
   color: rgba(219,19,59,1.00);
 }
@@ -328,14 +341,18 @@ exports[`default styles 1`] = `
                     </time>
                   </div>
                   <div
-                    className="S9"
+                    className="S10"
                   >
-                    Camilla Long
-                  </div>
-                  <div
-                    className="S9"
-                  >
-                    , Environment Editor
+                    <span
+                      className="S9"
+                    >
+                      Camilla Long
+                    </span>
+                    <span
+                      className="S9"
+                    >
+                      , Environment Editor
+                    </span>
                   </div>
                 </div>
               </Card>


### PR DESCRIPTION
I introduced a regression with a previous PR that led to multiple article bylines appearing across multiple lines on native instead of the single line they should appear on. This fixes that regression. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->

Before

![screenshot_1546965291](https://user-images.githubusercontent.com/719814/50848366-fdae5580-136b-11e9-8e67-a3c817c6a437.png)

After

![screen shot 2019-01-08 at 17 36 30](https://user-images.githubusercontent.com/719814/50848376-03a43680-136c-11e9-80a7-6969b8cdc30a.png)
