### PR TITLE
fix: pull quotes and drop caps should be aligned correctly at differe…

### DIFF
--- a/packages/article-paragraph/src/styles/drop-cap-sizes.js
+++ b/packages/article-paragraph/src/styles/drop-cap-sizes.js
@@ -1,9 +1,9 @@
 const fontSize = (font, scale) => {
   const config = {
     cultureMagazine: {
-      large: 115,
+      large: 110,
       medium: 90,
-      xlarge: 124
+      xlarge: 122
     },
     dropCap: {
       large: 115,
@@ -11,14 +11,14 @@ const fontSize = (font, scale) => {
       xlarge: 124
     },
     stMagazine: {
-      large: 115,
+      large: 113,
       medium: 90,
-      xlarge: 124
+      xlarge: 120
     },
     styleMagazine: {
-      large: 115,
+      large: 112,
       medium: 90,
-      xlarge: 124
+      xlarge: 119
     }
   };
 
@@ -28,9 +28,9 @@ const fontSize = (font, scale) => {
 const margins = (font, scale) => {
   const config = {
     cultureMagazine: {
-      large: { bottom: -26, top: -14 },
+      large: { bottom: -20, top: -23 },
       medium: { bottom: -30, top: -17 },
-      xlarge: { bottom: -22, top: -16 }
+      xlarge: { bottom: -22, top: -26 }
     },
     dropCap: {
       large: { bottom: -26, top: -14 },
@@ -38,14 +38,14 @@ const margins = (font, scale) => {
       xlarge: { bottom: -22, top: -16 }
     },
     stMagazine: {
-      large: { bottom: -26, top: -14 },
+      large: { bottom: -26, top: -22 },
       medium: { bottom: -30, top: -17 },
-      xlarge: { bottom: -22, top: -16 }
+      xlarge: { bottom: -22, top: -24 }
     },
     styleMagazine: {
-      large: { bottom: -26, top: -14 },
+      large: { bottom: -26, top: -25 },
       medium: { bottom: -30, top: -17 },
-      xlarge: { bottom: -22, top: -16 }
+      xlarge: { bottom: -22, top: -26 }
     }
   };
 

--- a/packages/pull-quote/__tests__/android/__snapshots__/themes-with-style.android.test.js.snap
+++ b/packages/pull-quote/__tests__/android/__snapshots__/themes-with-style.android.test.js.snap
@@ -18,6 +18,7 @@ exports[`1. pull quote in culture magazine 1`] = `
         "fontFamily": "Flama-Bold",
         "fontSize": 75,
         "marginBottom": -40,
+        "marginLeft": -3,
         "marginTop": 0,
       }
     }
@@ -95,6 +96,7 @@ exports[`2. pull quote in style magazine 1`] = `
         "fontFamily": "CenturyGothic-Bold",
         "fontSize": 75,
         "marginBottom": -40,
+        "marginLeft": -5,
         "marginTop": 0,
       }
     }
@@ -172,6 +174,7 @@ exports[`3. pull quote in the sunday times magazine 1`] = `
         "fontFamily": "Tiempos-Headline-Bold",
         "fontSize": 75,
         "marginBottom": -40,
+        "marginLeft": -2,
         "marginTop": 0,
       }
     }

--- a/packages/pull-quote/__tests__/ios/__snapshots__/themes-with-style.ios.test.js.snap
+++ b/packages/pull-quote/__tests__/ios/__snapshots__/themes-with-style.ios.test.js.snap
@@ -20,6 +20,7 @@ exports[`1. pull quote in culture magazine 1`] = `
         "fontFamily": "Flama-Bold",
         "fontSize": 75,
         "marginBottom": -40,
+        "marginLeft": -3,
         "marginTop": 0,
       }
     }
@@ -101,6 +102,7 @@ exports[`2. pull quote in style magazine 1`] = `
         "fontFamily": "CenturyGothic-Bold",
         "fontSize": 75,
         "marginBottom": -40,
+        "marginLeft": -5,
         "marginTop": 0,
       }
     }
@@ -182,6 +184,7 @@ exports[`3. pull quote in the sunday times magazine 1`] = `
         "fontFamily": "Tiempos-Headline-Bold",
         "fontSize": 75,
         "marginBottom": -40,
+        "marginLeft": -2,
         "marginTop": 0,
       }
     }

--- a/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/pull-quotes-with-style.test.js.snap
@@ -19,11 +19,8 @@ exports[`different colours 1`] = `
 .S1 {
   border-left-width: 0px;
   display: inline;
-  font-family: TimesModern-Regular;
-  font-size: 75px;
   line-height: inherit;
   margin-left: 0px;
-  margin-bottom: -40px;
   margin-top: 0px;
   padding-left: 0px;
 }
@@ -125,6 +122,9 @@ exports[`different colours 1`] = `
 
 .IS1 {
   color: rgba(133,0,41,1.00);
+  font-family: TimesModern-Regular;
+  font-size: 75px;
+  margin-bottom: -40px;
 }
 
 .IS2 {

--- a/packages/pull-quote/__tests__/web/__snapshots__/themes-with-style.web.test.js.snap
+++ b/packages/pull-quote/__tests__/web/__snapshots__/themes-with-style.web.test.js.snap
@@ -19,10 +19,7 @@ exports[`1. pull quote in culture magazine 1`] = `
 .S1 {
   border-left-width: 0px;
   display: inline;
-  font-size: 75px;
   line-height: inherit;
-  margin-left: 0px;
-  margin-bottom: -40px;
   margin-top: 0px;
   padding-left: 0px;
 }
@@ -105,6 +102,9 @@ exports[`1. pull quote in culture magazine 1`] = `
 .IS1 {
   color: rgba(105,105,105,1.00);
   font-family: Flama-Bold;
+  font-size: 75px;
+  margin-bottom: -40px;
+  margin-left: -3px;
 }
 
 .IS2 {
@@ -168,10 +168,7 @@ exports[`2. pull quote in style magazine 1`] = `
   border-left-width: 0px;
   color: rgba(105,105,105,1.00);
   display: inline;
-  font-size: 75px;
   line-height: inherit;
-  margin-left: 0px;
-  margin-bottom: -40px;
   margin-top: 0px;
   padding-left: 0px;
 }
@@ -241,6 +238,9 @@ exports[`2. pull quote in style magazine 1`] = `
 
 .IS1 {
   font-family: CenturyGothic-Bold;
+  font-size: 75px;
+  margin-bottom: -40px;
+  margin-left: -5px;
 }
 </style>
 
@@ -300,10 +300,7 @@ exports[`3. pull quote in the sunday times magazine 1`] = `
   border-left-width: 0px;
   color: rgba(105,105,105,1.00);
   display: inline;
-  font-size: 75px;
   line-height: inherit;
-  margin-left: 0px;
-  margin-bottom: -40px;
   margin-top: 0px;
   padding-left: 0px;
 }
@@ -373,6 +370,9 @@ exports[`3. pull quote in the sunday times magazine 1`] = `
 
 .IS1 {
   font-family: Tiempos-Headline-Bold;
+  font-size: 75px;
+  margin-bottom: -40px;
+  margin-left: -2px;
 }
 </style>
 

--- a/packages/pull-quote/src/pull-quote.base.js
+++ b/packages/pull-quote/src/pull-quote.base.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { Text, View } from "react-native";
-import { fonts } from "@times-components/styleguide";
 import PullQuoteContent from "./pull-quote-content";
 import PullQuoteTwitterLink from "./pull-quote-twitter-link";
 import { propTypes, defaultProps } from "./pull-quote-prop-types";
 import styles from "./styles";
+import quoteStyleFactory from "./styles/quotes";
 
 const PullQuotes = ({
   caption,
@@ -17,13 +17,7 @@ const PullQuotes = ({
   twitter
 }) => (
   <View style={styles.container}>
-    <Text
-      style={[
-        styles.quotes,
-        { color: quoteColour },
-        font ? { fontFamily: fonts[font] } : null
-      ]}
-    >
+    <Text style={[quoteStyleFactory(font), { color: quoteColour }]}>
       &ldquo;
     </Text>
     <PullQuoteContent>{children}</PullQuoteContent>

--- a/packages/pull-quote/src/styles/quotes.js
+++ b/packages/pull-quote/src/styles/quotes.js
@@ -1,0 +1,25 @@
+import styleguideFactory from "@times-components/styleguide";
+
+const { fonts, spacing } = styleguideFactory();
+
+const quoteMargins = {
+  cultureMagazine: {
+    marginLeft: -3
+  },
+  stMagazine: {
+    marginLeft: -2
+  },
+  styleMagazine: {
+    marginLeft: -5
+  }
+};
+
+const quoteStyleFactory = fontName => ({
+  ...(quoteMargins[fontName] || {}),
+  fontFamily: fonts[fontName] || fonts.headlineRegular,
+  fontSize: 75,
+  marginBottom: spacing(-8),
+  marginTop: 0
+});
+
+export default quoteStyleFactory;

--- a/packages/pull-quote/src/styles/shared.js
+++ b/packages/pull-quote/src/styles/shared.js
@@ -1,6 +1,6 @@
 import styleguideFactory from "@times-components/styleguide";
 
-const { colours, fonts, fontFactory, spacing } = styleguideFactory();
+const { colours, fontFactory, spacing } = styleguideFactory();
 const sharedStyles = {
   caption: {
     ...fontFactory({
@@ -35,12 +35,6 @@ const sharedStyles = {
     color: colours.functional.action,
     marginLeft: 3,
     textDecorationLine: "none"
-  },
-  quotes: {
-    fontFamily: fonts.headlineRegular,
-    fontSize: 75,
-    marginBottom: spacing(-8),
-    marginTop: 0
   },
   text: {
     ...fontFactory({


### PR DESCRIPTION
…nt scales and fonts

This corrects the position of drop caps and quotes at different scales and with different fonts.

## Drop Caps

**Large Culture Dropcap**

<img width="445" alt="large-culture-dropcap" src="https://user-images.githubusercontent.com/719814/50990421-e7d69700-1509-11e9-833a-8aee4edb89ef.png">

**Xlarge Culture Dropcap**

<img width="445" alt="xlarge-culture-dropcap" src="https://user-images.githubusercontent.com/719814/50990433-eefda500-1509-11e9-9151-705f2d32a0ae.png">

**Large Style Dropcap**

<img width="445" alt="large-style-dropcap" src="https://user-images.githubusercontent.com/719814/50990455-f4f38600-1509-11e9-9b8a-089f1564cc37.png">

**Xlarge Style Dropcap**

<img width="445" alt="xlarge-style-dropcap" src="https://user-images.githubusercontent.com/719814/50990465-fb81fd80-1509-11e9-9c28-5b86d4c6cb6d.png">

**Large Sunday Times Magazine**

<img width="445" alt="large-sundaytimesmag-dropcap" src="https://user-images.githubusercontent.com/719814/50990476-050b6580-150a-11e9-9598-c33ffbbfa969.png">

**Xlarge Sunday Times Magazine**

<img width="445" alt="xlarge-sundaytimesmag-dropcap" src="https://user-images.githubusercontent.com/719814/50990482-0b99dd00-150a-11e9-837e-b451bb926335.png">

## Pull Quotes

**Culture**

<img width="445" alt="culture-pullquotes" src="https://user-images.githubusercontent.com/719814/50990503-1bb1bc80-150a-11e9-96a0-a3228b9483a9.png">

**Style**

<img width="445" alt="style-pullquotes" src="https://user-images.githubusercontent.com/719814/50990511-20767080-150a-11e9-8669-cf7d03b5180e.png">

**Sunday Times Magazine**

<img width="445" alt="sundaytimesmag-pullquotes" src="https://user-images.githubusercontent.com/719814/50990516-25d3bb00-150a-11e9-8ea1-e57db978eecd.png">