### PR TITLE
fix: Tablet layout of loading spinner keyline

### DIFF
--- a/packages/article-list/__tests__/android/__snapshots__/article-list-error-with-styles.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-error-with-styles.android.test.js.snap
@@ -83,24 +83,40 @@ exports[`2. article list 1`] = `
     </View>
     <View />
     <View>
-      <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "backgroundColor": "#DBDBDB",
               "flex": 1,
-              "height": 1,
               "maxWidth": 660,
             }
           }
-        />
-        <ActivityIndicator
-          style={
-            Object {
-              "paddingVertical": 25,
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#DBDBDB",
+                "flex": 1,
+                "height": 1,
+                "maxWidth": 660,
+              }
             }
-          }
-        />
+          />
+          <ActivityIndicator
+            style={
+              Object {
+                "paddingVertical": 25,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list-error.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-error.android.test.js.snap
@@ -33,13 +33,15 @@ exports[`2. article list 1`] = `
     <View />
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
@@ -119,13 +119,15 @@ exports[`4. loading state 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list-with-styles.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-with-styles.android.test.js.snap
@@ -92,24 +92,40 @@ exports[`1. article list 1`] = `
       </View>
     </View>
     <View>
-      <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "backgroundColor": "#DBDBDB",
               "flex": 1,
-              "height": 1,
               "maxWidth": 660,
             }
           }
-        />
-        <ActivityIndicator
-          style={
-            Object {
-              "paddingVertical": 25,
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#DBDBDB",
+                "flex": 1,
+                "height": 1,
+                "maxWidth": 660,
+              }
             }
-          }
-        />
+          />
+          <ActivityIndicator
+            style={
+              Object {
+                "paddingVertical": 25,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -154,24 +170,40 @@ exports[`2. article list with no images 1`] = `
       </View>
     </View>
     <View>
-      <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "backgroundColor": "#DBDBDB",
               "flex": 1,
-              "height": 1,
               "maxWidth": 660,
             }
           }
-        />
-        <ActivityIndicator
-          style={
-            Object {
-              "paddingVertical": 25,
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#DBDBDB",
+                "flex": 1,
+                "height": 1,
+                "maxWidth": 660,
+              }
             }
-          }
-        />
+          />
+          <ActivityIndicator
+            style={
+              Object {
+                "paddingVertical": 25,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -99,13 +99,15 @@ exports[`1. article list 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -153,13 +155,15 @@ exports[`2. article list with no images 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -434,13 +438,15 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-error-with-styles.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-error-with-styles.ios.test.js.snap
@@ -83,24 +83,40 @@ exports[`2. article list 1`] = `
     </View>
     <View />
     <View>
-      <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "backgroundColor": "#DBDBDB",
               "flex": 1,
-              "height": 1,
               "maxWidth": 660,
             }
           }
-        />
-        <ActivityIndicator
-          style={
-            Object {
-              "paddingVertical": 25,
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#DBDBDB",
+                "flex": 1,
+                "height": 1,
+                "maxWidth": 660,
+              }
             }
-          }
-        />
+          />
+          <ActivityIndicator
+            style={
+              Object {
+                "paddingVertical": 25,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-error.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-error.ios.test.js.snap
@@ -33,13 +33,15 @@ exports[`2. article list 1`] = `
     <View />
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
@@ -119,13 +119,15 @@ exports[`4. loading state 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-with-styles.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-with-styles.ios.test.js.snap
@@ -92,24 +92,40 @@ exports[`1. article list 1`] = `
       </View>
     </View>
     <View>
-      <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "backgroundColor": "#DBDBDB",
               "flex": 1,
-              "height": 1,
               "maxWidth": 660,
             }
           }
-        />
-        <ActivityIndicator
-          style={
-            Object {
-              "paddingVertical": 25,
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#DBDBDB",
+                "flex": 1,
+                "height": 1,
+                "maxWidth": 660,
+              }
             }
-          }
-        />
+          />
+          <ActivityIndicator
+            style={
+              Object {
+                "paddingVertical": 25,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -154,24 +170,40 @@ exports[`2. article list with no images 1`] = `
       </View>
     </View>
     <View>
-      <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "justifyContent": "center",
+          }
+        }
+      >
         <View
           style={
             Object {
-              "backgroundColor": "#DBDBDB",
               "flex": 1,
-              "height": 1,
               "maxWidth": 660,
             }
           }
-        />
-        <ActivityIndicator
-          style={
-            Object {
-              "paddingVertical": 25,
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "#DBDBDB",
+                "flex": 1,
+                "height": 1,
+                "maxWidth": 660,
+              }
             }
-          }
-        />
+          />
+          <ActivityIndicator
+            style={
+              Object {
+                "paddingVertical": 25,
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -99,13 +99,15 @@ exports[`1. article list 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -153,13 +155,15 @@ exports[`2. article list with no images 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -434,13 +438,15 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
     </View>
     <View>
       <View>
-        <View />
-        <ActivityIndicator
-          animating={true}
-          color="#DBDBDB"
-          hidesWhenStopped={true}
-          size="large"
-        />
+        <View>
+          <View />
+          <ActivityIndicator
+            animating={true}
+            color="#DBDBDB"
+            hidesWhenStopped={true}
+            size="large"
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -1,9 +1,10 @@
 import React, { Component } from "react";
 import { ActivityIndicator, FlatList, View } from "react-native";
 import Button from "@times-components/button";
-import { colours } from "@times-components/styleguide";
+import { colours, tabletWidth } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import { normaliseWidth, screenWidthInPixels } from "@times-components/utils";
+import { ResponsiveContext } from "@times-components/responsive";
 import ArticleListError from "./article-list-error";
 import ArticleListItemWithError from "./article-list-item-with-error";
 import ArticleListItemSeparator from "./article-list-item-separator";
@@ -173,14 +174,20 @@ class ArticleList extends Component {
       }
 
       return (
-        <View>
-          <ArticleListItemSeparator />
-          <ActivityIndicator
-            color={colours.functional.keyline}
-            size="large"
-            style={styles.loadingContainer}
-          />
-        </View>
+        <ResponsiveContext.Consumer>
+          {() => (
+            <View style={{ flexDirection: "row", justifyContent: "center" }}>
+              <View style={{ flex: 1, maxWidth: tabletWidth }}>
+                <ArticleListItemSeparator />
+                <ActivityIndicator
+                  color={colours.functional.keyline}
+                  size="large"
+                  style={styles.loadingContainer}
+                />
+              </View>
+            </View>
+          )}
+        </ResponsiveContext.Consumer>
       );
     };
 

--- a/packages/article-list/src/article-list.js
+++ b/packages/article-list/src/article-list.js
@@ -4,7 +4,6 @@ import Button from "@times-components/button";
 import { colours, tabletWidth } from "@times-components/styleguide";
 import { withTrackScrollDepth } from "@times-components/tracking";
 import { normaliseWidth, screenWidthInPixels } from "@times-components/utils";
-import { ResponsiveContext } from "@times-components/responsive";
 import ArticleListError from "./article-list-error";
 import ArticleListItemWithError from "./article-list-item-with-error";
 import ArticleListItemSeparator from "./article-list-item-separator";
@@ -174,20 +173,16 @@ class ArticleList extends Component {
       }
 
       return (
-        <ResponsiveContext.Consumer>
-          {() => (
-            <View style={{ flexDirection: "row", justifyContent: "center" }}>
-              <View style={{ flex: 1, maxWidth: tabletWidth }}>
-                <ArticleListItemSeparator />
-                <ActivityIndicator
-                  color={colours.functional.keyline}
-                  size="large"
-                  style={styles.loadingContainer}
-                />
-              </View>
-            </View>
-          )}
-        </ResponsiveContext.Consumer>
+        <View style={{ flexDirection: "row", justifyContent: "center" }}>
+          <View style={{ flex: 1, maxWidth: tabletWidth }}>
+            <ArticleListItemSeparator />
+            <ActivityIndicator
+              color={colours.functional.keyline}
+              size="large"
+              style={styles.loadingContainer}
+            />
+          </View>
+        </View>
       );
     };
 


### PR DESCRIPTION
- Keyline above loading spinner (shown when paginating on apps) was being displayed to the left on landscape tablets. This PR fixes this issue.
- Found as part of design review https://nidigitalsolutions.jira.com/browse/REPLAT-4865
