### PR TITLE
feat: interactive debug params android

### DIFF
--- a/packages/article-in-depth/src/article-in-depth.js
+++ b/packages/article-in-depth/src/article-in-depth.js
@@ -88,6 +88,7 @@ class ArticleInDepth extends Component {
       adConfig,
       analyticsStream,
       article,
+      interactiveConfig,
       onAuthorPress,
       onCommentGuidelinesPress,
       onCommentsPress,
@@ -106,6 +107,7 @@ class ArticleInDepth extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        interactiveConfig={interactiveConfig}
         onAuthorPress={onAuthorPress}
         onCommentGuidelinesPress={onCommentGuidelinesPress}
         onCommentsPress={onCommentsPress}

--- a/packages/article-in-depth/src/article-prop-types/article-prop-types.js
+++ b/packages/article-in-depth/src/article-prop-types/article-prop-types.js
@@ -6,6 +6,7 @@ import {
 
 const articlePropTypes = {
   ...articlePagePropTypes,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -19,7 +20,8 @@ const articlePropTypes = {
 };
 
 const articleDefaultProps = {
-  ...articlePageDefaultProps
+  ...articlePageDefaultProps,
+  interactiveConfig: {}
 };
 
 export { articlePropTypes, articleDefaultProps };

--- a/packages/article-magazine-comment/src/article-magazine-comment.js
+++ b/packages/article-magazine-comment/src/article-magazine-comment.js
@@ -82,6 +82,7 @@ class ArticleMagazineComment extends Component {
       adConfig,
       analyticsStream,
       article,
+      interactiveConfig,
       onAuthorPress,
       onCommentGuidelinesPress,
       onCommentsPress,
@@ -100,6 +101,7 @@ class ArticleMagazineComment extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        interactiveConfig={interactiveConfig}
         onAuthorPress={onAuthorPress}
         onCommentGuidelinesPress={onCommentGuidelinesPress}
         onCommentsPress={onCommentsPress}

--- a/packages/article-magazine-comment/src/article-prop-types/article-prop-types.js
+++ b/packages/article-magazine-comment/src/article-prop-types/article-prop-types.js
@@ -6,6 +6,7 @@ import {
 
 const articlePropTypes = {
   ...articlePagePropTypes,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -19,7 +20,8 @@ const articlePropTypes = {
 };
 
 const articleDefaultProps = {
-  ...articlePageDefaultProps
+  ...articlePageDefaultProps,
+  interactiveConfig: {}
 };
 
 export { articlePropTypes, articleDefaultProps };

--- a/packages/article-magazine-standard/src/article-magazine-standard.js
+++ b/packages/article-magazine-standard/src/article-magazine-standard.js
@@ -78,6 +78,7 @@ class ArticleMagazineStandard extends Component {
       adConfig,
       analyticsStream,
       article,
+      interactiveConfig,
       onAuthorPress,
       onCommentGuidelinesPress,
       onCommentsPress,
@@ -96,6 +97,7 @@ class ArticleMagazineStandard extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        interactiveConfig={interactiveConfig}
         onAuthorPress={onAuthorPress}
         onCommentGuidelinesPress={onCommentGuidelinesPress}
         onCommentsPress={onCommentsPress}

--- a/packages/article-magazine-standard/src/article-prop-types/article-prop-types.js
+++ b/packages/article-magazine-standard/src/article-prop-types/article-prop-types.js
@@ -6,6 +6,7 @@ import {
 
 const articlePropTypes = {
   ...articlePagePropTypes,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -19,7 +20,8 @@ const articlePropTypes = {
 };
 
 const articleDefaultProps = {
-  ...articlePageDefaultProps
+  ...articlePageDefaultProps,
+  interactiveConfig: {}
 };
 
 export { articlePropTypes, articleDefaultProps };

--- a/packages/article-main-comment/src/article-main-comment.js
+++ b/packages/article-main-comment/src/article-main-comment.js
@@ -64,6 +64,7 @@ class ArticlePage extends Component {
       adConfig,
       analyticsStream,
       article,
+      interactiveConfig,
       onAuthorPress,
       onCommentGuidelinesPress,
       onCommentsPress,
@@ -82,6 +83,7 @@ class ArticlePage extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        interactiveConfig={interactiveConfig}
         onAuthorPress={onAuthorPress}
         onCommentGuidelinesPress={onCommentGuidelinesPress}
         onCommentsPress={onCommentsPress}

--- a/packages/article-main-comment/src/article-prop-types/article-prop-types.js
+++ b/packages/article-main-comment/src/article-prop-types/article-prop-types.js
@@ -6,6 +6,7 @@ import {
 
 const articlePropTypes = {
   ...articlePagePropTypes,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -19,7 +20,8 @@ const articlePropTypes = {
 };
 
 const articleDefaultProps = {
-  ...articlePageDefaultProps
+  ...articlePageDefaultProps,
+  interactiveConfig: {}
 };
 
 export { articlePropTypes, articleDefaultProps };

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -98,6 +98,7 @@ class ArticlePage extends Component {
       adConfig,
       analyticsStream,
       article,
+      interactiveConfig,
       onAuthorPress,
       onCommentGuidelinesPress,
       onCommentsPress,
@@ -117,6 +118,7 @@ class ArticlePage extends Component {
         analyticsStream={analyticsStream}
         data={article}
         Header={this.renderHeader}
+        interactiveConfig={interactiveConfig}
         onAuthorPress={onAuthorPress}
         onCommentGuidelinesPress={onCommentGuidelinesPress}
         onCommentsPress={onCommentsPress}
@@ -135,6 +137,7 @@ class ArticlePage extends Component {
 
 ArticlePage.propTypes = {
   ...articlePropTypes,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -146,6 +149,7 @@ ArticlePage.propTypes = {
 };
 ArticlePage.defaultProps = {
   ...articleDefaultProps,
+  interactiveConfig: {},
   referralUrl: null
 };
 

--- a/packages/article-skeleton/src/article-body/article-body-row.js
+++ b/packages/article-skeleton/src/article-body/article-body-row.js
@@ -20,6 +20,7 @@ const styles = styleFactory();
 
 const ArticleRow = ({
   content: { data, index },
+  interactiveConfig,
   onLinkPress,
   onTwitterLinkPress,
   onVideoPress
@@ -61,7 +62,7 @@ const ArticleRow = ({
       return {
         element: (
           <View key={key} style={styles.interactiveContainer}>
-            <InteractiveWrapper id={id} />
+            <InteractiveWrapper config={interactiveConfig} id={id} />
           </View>
         )
       };
@@ -185,6 +186,7 @@ ArticleRow.propTypes = {
     }),
     index: PropTypes.number
   }).isRequired,
+  interactiveConfig: PropTypes.shape({}).isRequired,
   onLinkPress: PropTypes.func.isRequired,
   onTwitterLinkPress: PropTypes.func.isRequired,
   onVideoPress: PropTypes.func.isRequired

--- a/packages/article-skeleton/src/article-content.js
+++ b/packages/article-skeleton/src/article-content.js
@@ -10,6 +10,7 @@ const viewabilityConfig = {
 const ArticleContent = ({
   data,
   Header,
+  interactiveConfig,
   onAuthorPress,
   onCommentsPress,
   onCommentGuidelinesPress,
@@ -39,7 +40,8 @@ const ArticleContent = ({
         onRelatedArticlePress,
         onTopicPress,
         onTwitterLinkPress,
-        onVideoPress
+        onVideoPress,
+        interactiveConfig
       )
     }
     testID="flat-list-article"
@@ -56,6 +58,7 @@ ArticleContent.propTypes = {
     })
   ).isRequired,
   Header: PropTypes.func,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -71,6 +74,7 @@ ArticleContent.propTypes = {
 
 ArticleContent.defaultProps = {
   Header: () => null,
+  interactiveConfig: {},
   onViewableItemsChanged: () => {},
   width: null
 };

--- a/packages/article-skeleton/src/article-skeleton.js
+++ b/packages/article-skeleton/src/article-skeleton.js
@@ -31,7 +31,8 @@ const renderRow = analyticsStream => (
   onRelatedArticlePress,
   onTopicPress,
   onTwitterLinkPress,
-  onVideoPress
+  onVideoPress,
+  interactiveConfig
 ) => {
   // eslint-disable-next-line default-case
   switch (rowData.type) {
@@ -39,6 +40,7 @@ const renderRow = analyticsStream => (
       return (
         <ArticleRow
           content={rowData}
+          interactiveConfig={interactiveConfig}
           onLinkPress={onLinkPress}
           onTwitterLinkPress={onTwitterLinkPress}
           onVideoPress={onVideoPress}
@@ -109,6 +111,7 @@ class ArticleSkeleton extends Component {
       adConfig,
       analyticsStream,
       Header,
+      interactiveConfig,
       onAuthorPress,
       onCommentGuidelinesPress,
       onCommentsPress,
@@ -153,6 +156,7 @@ class ArticleSkeleton extends Component {
           data={articleData}
           Header={Header}
           initialListSize={listViewSize}
+          interactiveConfig={interactiveConfig}
           onAuthorPress={onAuthorPress}
           onCommentGuidelinesPress={onCommentGuidelinesPress}
           onCommentsPress={onCommentsPress}
@@ -174,6 +178,7 @@ class ArticleSkeleton extends Component {
 
 ArticleSkeleton.propTypes = {
   ...articleSkeletonPropTypes,
+  interactiveConfig: PropTypes.shape({}),
   onAuthorPress: PropTypes.func.isRequired,
   onCommentGuidelinesPress: PropTypes.func.isRequired,
   onCommentsPress: PropTypes.func.isRequired,
@@ -182,6 +187,9 @@ ArticleSkeleton.propTypes = {
   onTwitterLinkPress: PropTypes.func.isRequired,
   onVideoPress: PropTypes.func.isRequired
 };
-ArticleSkeleton.defaultProps = articleSkeletonDefaultProps;
+ArticleSkeleton.defaultProps = {
+  ...articleSkeletonDefaultProps,
+  interactiveConfig: {}
+};
 
 export default articleTrackingContext(withTrackScrollDepth(ArticleSkeleton));

--- a/packages/interactive-wrapper/__tests__/android/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/android/__snapshots__/interactive-wrapper.test.js.snap
@@ -18,7 +18,7 @@ exports[`renders correctly 1`] = `
     <RCTWebView
       source={
         Object {
-          "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79",
+          "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79?dev=false&env=jest&platform=android&version=0.0.0",
         }
       }
       style={

--- a/packages/interactive-wrapper/__tests__/interactive-wrapper.native.js
+++ b/packages/interactive-wrapper/__tests__/interactive-wrapper.native.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Linking } from "react-native";
+import { Linking, Platform } from "react-native";
 import { shallow } from "enzyme";
 import TestRenderer from "react-test-renderer";
 import {
@@ -30,6 +30,13 @@ addSerializers(
     minimaliseTransform((value, key) => omitProps.has(key))
   )
 );
+
+const config = {
+  dev: false,
+  environment: "jest",
+  platform: Platform.OS,
+  version: "0.0.0"
+};
 
 export default () => {
   afterEach(() => {
@@ -68,6 +75,7 @@ export default () => {
         heading: "A heading",
         standfirst: "A standfirst"
       },
+      config,
       element: "chapter-header",
       id: "a0534eee-682e-4955-8e1e-84b428ef1e79",
       source:
@@ -79,7 +87,9 @@ export default () => {
   });
 
   it("When receiving a message from the webview, the height is set in state", () => {
-    const component = shallow(<InteractiveWrapper id="123456789" />);
+    const component = shallow(
+      <InteractiveWrapper config={config} id="123456789" />
+    );
     component.instance().onMessage(makeMessageEvent(400));
     expect(component.state().height).toEqual(400);
   });

--- a/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
@@ -19,7 +19,7 @@ exports[`renders correctly 1`] = `
       injectedJavaScript="window.reactBridgePostMessage = window.postMessage; window.postMessage = String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage');"
       source={
         Object {
-          "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79",
+          "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79?dev=false&env=jest&platform=ios&version=0.0.0",
         }
       }
       style={

--- a/packages/interactive-wrapper/src/interactive-wrapper.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.js
@@ -69,8 +69,13 @@ class InteractiveWrapper extends Component {
   }
 
   render() {
-    const { id } = this.props;
+    const {
+      config: { dev, environment, platform, version },
+      id
+    } = this.props;
     const { height } = this.state;
+
+    const uri = `${editorialLambdaProtocol}${editorialLambdaOrigin}/${editorialLambdaSlug}/${id}?dev=${dev}&env=${environment}&platform=${platform}&version=${version}`;
 
     return (
       <View style={{ height }}>
@@ -81,9 +86,7 @@ class InteractiveWrapper extends Component {
           ref={webview => {
             this.webview = webview;
           }}
-          source={{
-            uri: `${editorialLambdaProtocol}${editorialLambdaOrigin}/${editorialLambdaSlug}/${id}`
-          }}
+          source={{ uri }}
           style={{ height }}
           {...InteractiveWrapper.postMessageBugWorkaround()}
         />
@@ -93,7 +96,12 @@ class InteractiveWrapper extends Component {
 }
 
 InteractiveWrapper.propTypes = {
+  config: PropTypes.shape({}),
   id: PropTypes.string.isRequired
+};
+
+InteractiveWrapper.defaultProps = {
+  config: {}
 };
 
 export default InteractiveWrapper;

--- a/packages/pages/.jestlint
+++ b/packages/pages/.jestlint
@@ -1,0 +1,3 @@
+{
+  "maxAttributes": 6
+}

--- a/packages/pages/__tests__/android/__snapshots__/pages.test.js.snap
+++ b/packages/pages/__tests__/android/__snapshots__/pages.test.js.snap
@@ -41,6 +41,14 @@ exports[`article page 1`] = `
 <Article
   article={null}
   error={null}
+  interactiveConfig={
+    Object {
+      "dev": false,
+      "environment": "prod",
+      "platform": "android",
+      "version": "",
+    }
+  }
   isLoading={true}
   pageSection="News"
   referralUrl={null}

--- a/packages/pages/__tests__/ios/__snapshots__/pages.test.js.snap
+++ b/packages/pages/__tests__/ios/__snapshots__/pages.test.js.snap
@@ -41,6 +41,14 @@ exports[`article page 1`] = `
 <Article
   article={null}
   error={null}
+  interactiveConfig={
+    Object {
+      "dev": false,
+      "environment": "prod",
+      "platform": "ios",
+      "version": "",
+    }
+  }
   isLoading={true}
   pageSection="News"
   referralUrl={null}

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -40,10 +40,10 @@ const ArticleBase = ({
     isLoading || error
       ? {}
       : adTargetConfig({
-        adTestMode,
-        article,
-        sectionName: section
-      });
+          adTestMode,
+          article,
+          sectionName: section
+        });
   const theme = {
     ...themeFactory(section, template),
     scale: scale || defaults.theme.scale

--- a/packages/pages/src/article/article-base.js
+++ b/packages/pages/src/article/article-base.js
@@ -1,11 +1,13 @@
 import React from "react";
-import { NativeModules } from "react-native";
+import { NativeModules, Platform } from "react-native";
 import Article from "@times-components/article";
 import Context, { defaults } from "@times-components/context";
 import { themeFactory } from "@times-components/styleguide";
 import adTargetConfig from "./ad-targeting-config";
 import { propTypes, defaultProps } from "./article-prop-types";
 import filterInteractives from "./filter-interactives";
+
+const { appVersion = "", environment = "prod" } = NativeModules.ReactConfig;
 
 const { track } = NativeModules.ReactAnalytics;
 const {
@@ -22,6 +24,7 @@ const {
 const ArticleBase = ({
   adTestMode,
   article,
+  devInteractives,
   error,
   isLoading,
   referralUrl,
@@ -37,13 +40,20 @@ const ArticleBase = ({
     isLoading || error
       ? {}
       : adTargetConfig({
-          adTestMode,
-          article,
-          sectionName: section
-        });
+        adTestMode,
+        article,
+        sectionName: section
+      });
   const theme = {
     ...themeFactory(section, template),
     scale: scale || defaults.theme.scale
+  };
+
+  const interactiveConfig = {
+    dev: devInteractives,
+    environment,
+    platform: Platform.OS,
+    version: appVersion
   };
 
   return (
@@ -59,6 +69,7 @@ const ArticleBase = ({
         }}
         article={showInteractives ? article : filterInteractives(article)}
         error={omitErrors ? null : error}
+        interactiveConfig={interactiveConfig}
         isLoading={isLoading || (omitErrors && error)}
         onAuthorPress={(event, { slug }) => onAuthorPress(slug)}
         onCommentGuidelinesPress={() => onCommentGuidelinesPress()}

--- a/packages/pages/src/article/article-prop-types.js
+++ b/packages/pages/src/article/article-prop-types.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 
 export const propTypes = {
   article: PropTypes.shape({}),
+  devInteractives: PropTypes.bool,
   error: PropTypes.shape({}),
   isLoading: PropTypes.bool,
   omitErrors: PropTypes.bool,
@@ -14,6 +15,7 @@ export const propTypes = {
 
 export const defaultProps = {
   article: null,
+  devInteractives: false,
   error: null,
   isLoading: false,
   omitErrors: false,


### PR DESCRIPTION
Introduced a couple of query params for interactive wrappers

dev: true / false   - Dictated by the native apps, and changed via the settings screen. This way, editorial can enable all the interactives and try new ones
environment: prod/qa  (more can be added as required) - This allows different whitelists for each environment
version     - Allows whitelisting depending on versions, ie we can enable puffs for versions above "4.7.1"
platform: ios/android  - Allows whitelisting per platform