### PR TITLE
feat: tablet layout for main standard article headers

### DIFF
--- a/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -5,142 +5,144 @@ exports[`full article with style on mobile 1`] = `
   <View>
     <View>
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 5,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 5,
+              }
             }
-          }
-        >
-          <ModalImage />
+          >
+            <ModalImage />
+          </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "marginBottom": -13.75,
-              "marginTop": 10,
-            }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 33,
-              "marginBottom": 15,
-              "marginTop": 15,
-            }
-          }
-        >
-          Some Headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 28,
-              "marginTop": -7,
-              "paddingBottom": 12,
-            }
-          }
-        >
-          Some Standfirst
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 10,
-              "paddingTop": 5,
+              "paddingLeft": 10,
+              "paddingRight": 10,
             }
           }
         >
           <View
             style={
               Object {
-                "marginRight": 15,
+                "marginBottom": -13.75,
+                "marginTop": 10,
               }
             }
           >
-            <NewArticleFlag />
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "400",
+                "lineHeight": 33,
+                "marginBottom": 15,
+                "marginTop": 15,
+              }
+            }
+          >
+            Some Headline
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 28,
+                "marginTop": -7,
+                "paddingBottom": 12,
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "marginBottom": 10,
+                "paddingTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 1,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 6,
-              "paddingTop": 7,
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "marginBottom": 20,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 9,
             }
           }
         >
-          <Text
+          <View
             style={
               Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 6,
+                "paddingTop": 7,
               }
             }
           >
-            <ArticleBylineWithLinks />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 21,
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </Text>
+          </View>
+          <View
             style={
               Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 6,
+                "paddingTop": 7,
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
-          </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 21,
+                }
+              }
+            >
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -280,141 +282,155 @@ exports[`full article with style on tablet 1`] = `
       <View
         style={
           Object {
+            "alignSelf": "center",
             "paddingLeft": 10,
             "paddingRight": 10,
+            "width": 660,
           }
         }
       >
         <View
           style={
             Object {
-              "marginBottom": -13.75,
-              "marginTop": 10,
-            }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "400",
-              "lineHeight": 33,
-              "marginBottom": 15,
-              "marginTop": 15,
-            }
-          }
-        >
-          Some Headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 28,
-              "marginTop": -7,
-              "paddingBottom": 12,
-            }
-          }
-        >
-          Some Standfirst
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 10,
-              "paddingTop": 5,
+              "alignSelf": "center",
+              "marginTop": 30,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "width": 660,
             }
           }
         >
           <View
             style={
               Object {
-                "marginRight": 15,
+                "marginBottom": -13.75,
+                "marginTop": 10,
               }
             }
           >
-            <NewArticleFlag />
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 45,
+                "fontWeight": "400",
+                "lineHeight": 45,
+                "marginBottom": 15,
+                "marginTop": 15,
+              }
+            }
+          >
+            Some Headline
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 28,
+                "marginTop": -7,
+                "paddingBottom": 12,
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "marginBottom": 10,
+                "paddingTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 1,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            <ArticleBylineWithLinks />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 6,
-              "paddingTop": 7,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 21,
-              }
-            }
-          >
-            Friday March 13 2015, 6:54pm, The Times
-          </Text>
-        </View>
-      </View>
-      <View>
-        <View
-          style={
-            Object {
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
               "marginBottom": 20,
-              "paddingBottom": 20,
+              "marginLeft": 0,
+              "marginRight": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 9,
             }
           }
         >
-          <ModalImage />
+          <View
+            style={
+              Object {
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 6,
+                "paddingTop": 7,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 21,
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 6,
+                "paddingTop": 7,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 21,
+                }
+              }
+            >
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
+        </View>
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingBottom": 20,
+              }
+            }
+          >
+            <ModalImage />
+          </View>
         </View>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -14,19 +14,21 @@ exports[`2. an article with no headline falls back to use shortheadline 1`] = `
 >
   <View>
     <View>
-      <View />
       <View>
-        <Text
-          selectable={true}
-        >
-          Some Short Headline
-        </Text>
-      </View>
-      <View>
+        <View />
         <View>
-          <Text>
-            Friday March 13 2015, 6:54pm, The Times
+          <Text
+            selectable={true}
+          >
+            Some Short Headline
           </Text>
+        </View>
+        <View>
+          <View>
+            <Text>
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -62,19 +64,21 @@ exports[`3. an article with ads 1`] = `
 >
   <View>
     <View>
-      <View />
       <View>
-        <Text
-          selectable={true}
-        >
-          Some Headline
-        </Text>
-      </View>
-      <View>
+        <View />
         <View>
-          <Text>
-            Friday March 13 2015, 6:54pm, The Times
+          <Text
+            selectable={true}
+          >
+            Some Headline
           </Text>
+        </View>
+        <View>
+          <View>
+            <Text>
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -5,141 +5,143 @@ exports[`full article with style on mobile 1`] = `
   <View>
     <View>
       <View>
-        <View
-          style={
-            Object {
-              "marginBottom": 10,
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 10,
+              }
             }
-          }
-        >
-          <ModalImage />
+          >
+            <ModalImage />
+          </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "paddingLeft": 10,
-            "paddingRight": 10,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "marginBottom": -13.75,
-              "marginTop": 10,
-            }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 35,
-              "marginBottom": 7,
-              "marginTop": 15,
-            }
-          }
-        >
-          Some Headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "paddingBottom": 10,
-            }
-          }
-        >
-          Some Standfirst
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 10,
-              "paddingTop": 5,
+              "paddingLeft": 10,
+              "paddingRight": 10,
             }
           }
         >
           <View
             style={
               Object {
-                "marginRight": 15,
+                "marginBottom": -13.75,
+                "marginTop": 10,
               }
             }
           >
-            <NewArticleFlag />
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "fontWeight": "700",
+                "lineHeight": 35,
+                "marginBottom": 7,
+                "marginTop": 15,
+              }
+            }
+          >
+            Some Headline
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "paddingBottom": 10,
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "marginBottom": 10,
+                "paddingTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 1,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 4,
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
+              "marginBottom": 20,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "paddingLeft": 0,
+              "paddingRight": 0,
               "paddingTop": 9,
             }
           }
         >
-          <Text
+          <View
             style={
               Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 4,
+                "paddingTop": 9,
               }
             }
           >
-            <ArticleBylineWithLinks />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </Text>
+          </View>
+          <View
             style={
               Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 4,
+                "paddingTop": 9,
               }
             }
           >
-            Friday March 13 2015, 6:54pm, The Times
-          </Text>
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -278,140 +280,154 @@ exports[`full article with style on tablet 1`] = `
       <View
         style={
           Object {
+            "alignSelf": "center",
             "paddingLeft": 10,
             "paddingRight": 10,
+            "width": 660,
           }
         }
       >
         <View
           style={
             Object {
-              "marginBottom": -13.75,
-              "marginTop": 10,
-            }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "fontWeight": "700",
-              "lineHeight": 35,
-              "marginBottom": 7,
-              "marginTop": 15,
-            }
-          }
-        >
-          Some Headline
-        </Text>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "paddingBottom": 10,
-            }
-          }
-        >
-          Some Standfirst
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 10,
-              "paddingTop": 5,
+              "alignSelf": "center",
+              "marginTop": 30,
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "width": 660,
             }
           }
         >
           <View
             style={
               Object {
-                "marginRight": 15,
+                "marginBottom": -13.75,
+                "marginTop": 10,
               }
             }
           >
-            <NewArticleFlag />
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 45,
+                "fontWeight": "700",
+                "lineHeight": 45,
+                "marginBottom": 7,
+                "marginTop": 15,
+              }
+            }
+          >
+            Some Headline
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "paddingBottom": 10,
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "marginBottom": 10,
+                "paddingTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
           </View>
         </View>
-      </View>
-      <View
-        style={
-          Object {
-            "borderBottomColor": "#DBDBDB",
-            "borderBottomWidth": 1,
-            "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 9,
-          }
-        }
-      >
         <View
           style={
             Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            <ArticleBylineWithLinks />
-          </Text>
-        </View>
-        <View
-          style={
-            Object {
-              "borderTopColor": "#DBDBDB",
-              "borderTopWidth": 1,
-              "paddingBottom": 4,
-              "paddingTop": 9,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 15,
-              }
-            }
-          >
-            Friday March 13 2015, 6:54pm, The Times
-          </Text>
-        </View>
-      </View>
-      <View>
-        <View
-          style={
-            Object {
+              "borderBottomColor": "#DBDBDB",
+              "borderBottomWidth": 1,
               "marginBottom": 20,
-              "paddingBottom": 20,
+              "marginLeft": 0,
+              "marginRight": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 9,
             }
           }
         >
-          <ModalImage />
+          <View
+            style={
+              Object {
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 4,
+                "paddingTop": 9,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "borderTopColor": "#DBDBDB",
+                "borderTopWidth": 1,
+                "paddingBottom": 4,
+                "paddingTop": 9,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#696969",
+                  "fontFamily": "GillSansMTStd-Medium",
+                  "fontSize": 13,
+                  "lineHeight": 15,
+                }
+              }
+            >
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
+        </View>
+        <View>
+          <View
+            style={
+              Object {
+                "marginBottom": 20,
+                "paddingBottom": 20,
+              }
+            }
+          >
+            <ModalImage />
+          </View>
         </View>
       </View>
     </View>

--- a/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -14,19 +14,21 @@ exports[`2. an article with no headline falls back to use shortheadline 1`] = `
 >
   <View>
     <View>
-      <View />
       <View>
-        <Text
-          selectable={true}
-        >
-          Some Short Headline
-        </Text>
-      </View>
-      <View>
+        <View />
         <View>
-          <Text>
-            Friday March 13 2015, 6:54pm, The Times
+          <Text
+            selectable={true}
+          >
+            Some Short Headline
           </Text>
+        </View>
+        <View>
+          <View>
+            <Text>
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
         </View>
       </View>
     </View>
@@ -62,19 +64,21 @@ exports[`3. an article with ads 1`] = `
 >
   <View>
     <View>
-      <View />
       <View>
-        <Text
-          selectable={true}
-        >
-          Some Headline
-        </Text>
-      </View>
-      <View>
+        <View />
         <View>
-          <Text>
-            Friday March 13 2015, 6:54pm, The Times
+          <Text
+            selectable={true}
+          >
+            Some Headline
           </Text>
+        </View>
+        <View>
+          <View>
+            <Text>
+              Friday March 13 2015, 6:54pm, The Times
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/packages/article-main-standard/src/article-header/article-header.js
+++ b/packages/article-main-standard/src/article-header/article-header.js
@@ -7,10 +7,29 @@ import HeaderFlags from "./article-header-flags";
 import HeaderStandfirst from "./article-header-standfirst";
 import styles from "../styles/article-header";
 
-const ArticleHeader = ({ flags, hasVideo, headline, label, standfirst }) => (
-  <View style={styles.articleMainContentRow}>
+const ArticleHeader = ({
+  flags,
+  hasVideo,
+  headline,
+  isTablet,
+  label,
+  standfirst
+}) => (
+  <View
+    style={[
+      styles.articleMainContentRow,
+      isTablet && styles.articleMainContentRowTablet,
+      isTablet && styles.headerTablet
+    ]}
+  >
     <HeaderLabel isVideo={hasVideo} label={label} />
-    <Text selectable style={styles.articleHeadLineText}>
+    <Text
+      selectable
+      style={[
+        styles.articleHeadLineText,
+        isTablet && styles.articleHeadLineTextTablet
+      ]}
+    >
       {headline}
     </Text>
     <HeaderStandfirst standfirst={standfirst} />
@@ -22,6 +41,7 @@ ArticleHeader.propTypes = {
   flags: PropTypes.arrayOf(PropTypes.string),
   hasVideo: PropTypes.bool,
   headline: PropTypes.string.isRequired,
+  isTablet: PropTypes.bool,
   label: PropTypes.string,
   standfirst: PropTypes.string
 };
@@ -29,6 +49,7 @@ ArticleHeader.propTypes = {
 ArticleHeader.defaultProps = {
   flags: [],
   hasVideo: false,
+  isTablet: false,
   label: null,
   standfirst: null
 };

--- a/packages/article-main-standard/src/article-main-standard.js
+++ b/packages/article-main-standard/src/article-main-standard.js
@@ -63,19 +63,31 @@ class ArticlePage extends Component {
                 flags={flags}
                 hasVideo={hasVideo}
                 headline={getHeadline(headline, shortHeadline)}
+                isTablet={isTablet}
                 label={label}
                 standfirst={standfirst}
-                style={[styles.articleMainContentRow]}
               />
               <ArticleMeta
                 byline={byline}
+                isTablet={isTablet}
                 onAuthorPress={onAuthorPress}
                 publicationName={publicationName}
                 publishedTime={publishedTime}
               />
             </Fragment>
           );
-          return isTablet ? [header, leadAsset] : [leadAsset, header];
+          return (
+            <View
+              style={
+                isTablet && [
+                  styles.articleMainContentRow,
+                  styles.articleMainContentRowTablet
+                ]
+              }
+            >
+              {isTablet ? [header, leadAsset] : [leadAsset, header]}
+            </View>
+          );
         }}
       </ResponsiveContext.Consumer>
     );

--- a/packages/article-main-standard/src/article-meta/article-meta.js
+++ b/packages/article-main-standard/src/article-meta/article-meta.js
@@ -3,8 +3,14 @@ import { View } from "react-native";
 import styles from "../styles/article-meta";
 import ArticleMetaBase from "./article-meta-base";
 
-const ArticleMeta = props => (
-  <View style={[styles.articleMiddleContainer, styles.articleMeta]}>
+const ArticleMeta = ({ isTablet, ...props }) => (
+  <View
+    style={[
+      styles.articleMiddleContainer,
+      styles.articleMeta,
+      isTablet && styles.articleMetaTablet
+    ]}
+  >
     <ArticleMetaBase {...props} RowWrapper={View} />
   </View>
 );

--- a/packages/article-main-standard/src/styles/article-header/shared.js
+++ b/packages/article-main-standard/src/styles/article-header/shared.js
@@ -17,9 +17,18 @@ const sharedStyles = {
     color: colours.functional.brandColour,
     marginBottom: 7
   },
+  articleHeadLineTextTablet: {
+    ...fontFactory({
+      font: "headline",
+      fontSize: "articleHeadline"
+    })
+  },
   articleLabel: {
     paddingBottom: spacing(1),
     paddingTop: spacing(1)
+  },
+  headerTablet: {
+    marginTop: spacing(6)
   },
   standFirst: {
     ...fontFactory({

--- a/packages/article-main-standard/src/styles/article-meta/shared.js
+++ b/packages/article-main-standard/src/styles/article-meta/shared.js
@@ -15,6 +15,10 @@ const sharedStyles = {
     borderTopColor: colours.functional.keyline,
     borderTopWidth: 1
   },
+  articleMetaTablet: {
+    marginLeft: 0,
+    marginRight: 0
+  },
   articleMiddleContainer: {
     paddingTop: 9
   },

--- a/packages/article-main-standard/src/styles/shared.js
+++ b/packages/article-main-standard/src/styles/shared.js
@@ -1,9 +1,13 @@
-import { spacing } from "@times-components/styleguide";
+import { spacing, tabletWidth } from "@times-components/styleguide";
 
 const globalStyle = {
   articleMainContentRow: {
     paddingLeft: spacing(2),
     paddingRight: spacing(2)
+  },
+  articleMainContentRowTablet: {
+    alignSelf: "center",
+    width: tabletWidth
   }
 };
 

--- a/packages/styleguide/src/line-heights/mapping-base.js
+++ b/packages/styleguide/src/line-heights/mapping-base.js
@@ -15,6 +15,7 @@ const mapping = {
     meta: 14
   },
   headline: {
+    articleHeadline: 45,
     commentsHeadline: 29,
     headline: 35,
     leadHeadline: 26,


### PR DESCRIPTION
This adds a max width for the article header on tablet, as well as increases the headline font size. 

![screen shot 2019-01-23 at 14 55 40](https://user-images.githubusercontent.com/719814/51615116-fae06280-1f1e-11e9-9f44-3711f70253bc.png)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
