### PR TITLE
chore: Fix versions due to multiple master merges

### DIFF
--- a/packages/article-in-depth/package.json
+++ b/packages/article-in-depth/package.json
@@ -45,7 +45,7 @@
     "@times-components/storybook": "3.3.0",
     "@times-components/tealium-utils": "0.7.12",
     "@times-components/test-utils": "2.1.1",
-    "@times-components/utils": "4.0.19",
+    "@times-components/utils": "4.1.0",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/edition-slices/package.json
+++ b/packages/edition-slices/package.json
@@ -36,10 +36,10 @@
   },
   "homepage": "https://github.com/newsuk/times-components#readme",
   "dependencies": {
-    "@times-components/article-summary": "3.4.0",
-    "@times-components/image": "4.5.0",
-    "@times-components/slice-layout": "0.1.0",
-    "@times-components/styleguide": "3.14.0",
+    "@times-components/article-summary": "3.4.1",
+    "@times-components/image": "4.5.1",
+    "@times-components/slice-layout": "0.1.1",
+    "@times-components/styleguide": "3.15.0",
     "prop-types": "15.6.2"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "@times-components/jest-configurator": "2.1.21",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.3.0",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/jest-configurator/package.json
+++ b/packages/jest-configurator/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "babel-core": "6.26.0",
     "babel-jest": "23.4.2",
     "babel-plugin-istanbul": "4.1.6",

--- a/packages/lazy-load/package.json
+++ b/packages/lazy-load/package.json
@@ -38,7 +38,7 @@
     "@times-components/jest-configurator": "2.1.21",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.3.0",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "enzyme": "3.6.0",

--- a/packages/markup-forest/package.json
+++ b/packages/markup-forest/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.1.21",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/provider-test-tools/package.json
+++ b/packages/provider-test-tools/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -39,7 +39,7 @@
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/provider-test-tools": "1.11.0",
     "@times-components/storybook": "3.3.0",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/newsuk/times-components#readme",
   "devDependencies": {
     "@times-components/eslint-config-thetimes": "0.8.9",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "eslint": "5.9.0",
     "prettier": "1.14.3",
     "rimraf": "2.6.1"

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -42,7 +42,7 @@
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.1.21",
     "@times-components/jest-serializer": "3.2.0",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",

--- a/packages/tealium/package.json
+++ b/packages/tealium/package.json
@@ -28,7 +28,7 @@
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.1.21",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",

--- a/packages/watermark/package.json
+++ b/packages/watermark/package.json
@@ -41,7 +41,7 @@
     "@times-components/jest-configurator": "2.1.21",
     "@times-components/jest-serializer": "3.2.0",
     "@times-components/storybook": "3.3.0",
-    "@times-components/test-utils": "2.1.0",
+    "@times-components/test-utils": "2.1.1",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.4",
     "babel-plugin-add-react-displayname": "0.0.5",
@@ -59,7 +59,7 @@
     "webpack-cli": "2.1.4"
   },
   "dependencies": {
-    "@times-components/styleguide": "3.14.0",
+    "@times-components/styleguide": "3.15.0",
     "@times-components/svgs": "2.2.0",
     "prop-types": "15.6.2"
   },


### PR DESCRIPTION
Looks like we merged multiple PRs using the same dependencies, which caused a conflict with the version bump script. I did a quick `deps:fix` to tidy it up, this should fix master.