### PR TITLE
fix: Change ts build folder to build from dist

### DIFF
--- a/packages/fixture-generator/.prettierignore
+++ b/packages/fixture-generator/.prettierignore
@@ -1,5 +1,5 @@
 **/node_modules/*
-dist
+build
 __snapshots__
 android/*
 ios/*

--- a/packages/fixture-generator/README.md
+++ b/packages/fixture-generator/README.md
@@ -4,6 +4,8 @@ This package is meant to create a single testable location for our fixtures. Ena
 
 The aim for this package is to give us a single location for integration tests, showcase and UI tests all to use.
 
+Note: Since Jest depends on javascript, this package needs to be transpiled before running any Jest tests. Make sure to re-transpile after making any changes on this package.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before contributing to this

--- a/packages/fixture-generator/package.json
+++ b/packages/fixture-generator/package.json
@@ -2,8 +2,8 @@
   "name": "@times-components/fixture-generator",
   "version": "0.0.11",
   "description": "Creates fixture data for testing",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "transpile": "yarn getSchema && yarn gentypes && tsc",
     "gentypes": "gql-gen --schema ./schema.json --template graphql-codegen-typescript-template --out ./src/types.ts",

--- a/packages/fixture-generator/tsconfig.json
+++ b/packages/fixture-generator/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": [
       "es6"
     ] ,
-    "outDir": "./dist",
+    "outDir": "./build",
     "rootDir": "./src", 
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Currently, fixture generator package can not be used inside Jest tests. This is due to the configuration of our jest, done by `jest-configurator` package. Jest configurator picks replaces source paths from "dist/.." to "src/.." in order to run the test code on non-transpiled code. 

The problem is, fixture generator is written in typescript, so it can't be run with the current jest-configurator. To avoid this and bypass jest-configurator logic, I've moved `dist` folder into a `build` folder for fixture generator.