### PR TITLE
feat: main comment tablet header design

### DIFF
--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -1,113 +1,211 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`full article with style 1`] = `
+exports[`phone full article with style 1`] = `
 <RCTScrollView>
   <View>
     <View>
       <View
         style={
           Object {
-            "alignItems": "center",
             "borderBottomColor": "#DBDBDB",
             "borderBottomWidth": 1,
             "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
             "paddingBottom": 25,
             "paddingTop": 35,
           }
         }
       >
-        <Image
-          style={
-            Object {
-              "borderRadius": 50,
-              "height": 100,
-              "marginBottom": 25,
-              "overflow": "hidden",
-              "width": 100,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "marginBottom": 10,
-            }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
-              "marginBottom": 10,
-              "textAlign": "center",
-            }
-          }
-        >
-          Some Headline
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 15,
-              "marginTop": 5,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "marginRight": 15,
-              }
-            }
-          >
-            <NewArticleFlag />
-          </View>
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "marginBottom": 15,
-              "paddingHorizontal": 10,
-              "textAlign": "center",
-            }
-          }
-        >
-          Some Standfirst
-        </Text>
         <View
           style={
             Object {
               "alignItems": "center",
+              "paddingLeft": 10,
+              "paddingRight": 10,
             }
           }
         >
+          <Image
+            style={
+              Object {
+                "borderRadius": 50,
+                "height": 100,
+                "marginBottom": 25,
+                "overflow": "hidden",
+                "width": 100,
+              }
+            }
+          />
           <View
             style={
               Object {
-                "flexDirection": "row",
-                "flexWrap": "wrap",
+                "marginBottom": 10,
               }
             }
           >
-            <ArticleBylineWithLinks />
+            <ArticleLabel />
           </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "lineHeight": 35,
+                "marginBottom": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Headline
+          </Text>
           <View
             style={
               Object {
                 "flexDirection": "row",
-                "flexWrap": "wrap",
+                "marginBottom": 15,
+                "marginTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "marginBottom": 15,
+                "paddingHorizontal": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </View>
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleImage />
+      </View>
+    </View>
+    <View>
+      <Text
+        style={
+          Object {
+            "color": "#006699",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 17,
+            "lineHeight": 26,
+            "marginBottom": 25,
+            "marginTop": 0,
+            "textDecorationLine": "underline",
+          }
+        }
+      >
+        Some Link
+      </Text>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "fontStyle": "normal",
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View>
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "column",
+            "paddingBottom": 25,
+            "width": "100%",
+          }
+        }
+      >
+        <Video />
+        <View>
+          <View
+            style={
+              Object {
+                "paddingLeft": 10,
+                "paddingTop": 5,
               }
             }
           >
@@ -117,13 +215,202 @@ exports[`full article with style 1`] = `
                   "color": "#696969",
                   "fontFamily": "GillSansMTStd-Medium",
                   "fontSize": 13,
-                  "lineHeight": 15,
-                  "marginTop": 15,
+                  "lineHeight": 20,
                 }
               }
             >
-              Friday March 13 2015, 6:54pm, The Times
+              This is video caption
             </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <Ad
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#DBDBDB",
+            "borderTopWidth": 1,
+            "marginBottom": 20,
+            "paddingHorizontal": 10,
+            "paddingVertical": 10,
+          }
+        }
+      />
+    </View>
+    <View>
+      <View>
+        <ArticleImage />
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleImage />
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderTopColor": "#DBDBDB",
+            "borderTopWidth": 1,
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        <ArticleTopics />
+      </View>
+    </View>
+    <View>
+      <RelatedArticles />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`tablet full article with style 1`] = `
+<RCTScrollView>
+  <View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "marginBottom": 20,
+            "paddingBottom": 25,
+            "paddingTop": 35,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "width": 660,
+            }
+          }
+        >
+          <Image
+            style={
+              Object {
+                "borderRadius": 50,
+                "height": 100,
+                "marginBottom": 25,
+                "overflow": "hidden",
+                "width": 100,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "marginBottom": 10,
+              }
+            }
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "lineHeight": 35,
+                "marginBottom": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Headline
+          </Text>
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "marginBottom": 15,
+                "marginTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "marginBottom": 15,
+                "paddingHorizontal": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </View>
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -17,39 +17,41 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
   <View>
     <View>
       <View>
-        <Image
-          aspectRatio={1}
-          uri="https://image.io"
-        />
-        <Text>
-          Some Short Headline
-        </Text>
         <View>
+          <Image
+            aspectRatio={1}
+            uri="https://image.io"
+          />
+          <Text>
+            Some Short Headline
+          </Text>
           <View>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Some byline",
+            <View>
+              <ArticleBylineWithLinks
+                ast={
+                  Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
                         },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View>
-            <Text>
-              Friday March 13 2015, 6:54pm, The Times
-            </Text>
+                      ],
+                      "name": "inline",
+                    },
+                  ]
+                }
+              />
+            </View>
+            <View>
+              <Text>
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -146,39 +148,41 @@ exports[`4. an article with ads 1`] = `
   <View>
     <View>
       <View>
-        <Image
-          aspectRatio={1}
-          uri="https://image.io"
-        />
-        <Text>
-          Some Headline
-        </Text>
         <View>
+          <Image
+            aspectRatio={1}
+            uri="https://image.io"
+          />
+          <Text>
+            Some Headline
+          </Text>
           <View>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Some byline",
+            <View>
+              <ArticleBylineWithLinks
+                ast={
+                  Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
                         },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View>
-            <Text>
-              Friday March 13 2015, 6:54pm, The Times
-            </Text>
+                      ],
+                      "name": "inline",
+                    },
+                  ]
+                }
+              />
+            </View>
+            <View>
+              <Text>
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -1,113 +1,210 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`full article with style 1`] = `
+exports[`phone full article with style 1`] = `
 <RCTScrollView>
   <View>
     <View>
       <View
         style={
           Object {
-            "alignItems": "center",
             "borderBottomColor": "#DBDBDB",
             "borderBottomWidth": 1,
             "marginBottom": 20,
-            "marginLeft": 10,
-            "marginRight": 10,
             "paddingBottom": 25,
             "paddingTop": 35,
           }
         }
       >
-        <Image
-          style={
-            Object {
-              "borderRadius": 50,
-              "height": 100,
-              "marginBottom": 25,
-              "overflow": "hidden",
-              "width": 100,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "marginBottom": 10,
-            }
-          }
-        >
-          <ArticleLabel />
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#1D1D1B",
-              "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
-              "marginBottom": 10,
-              "textAlign": "center",
-            }
-          }
-        >
-          Some Headline
-        </Text>
-        <View
-          style={
-            Object {
-              "flexDirection": "row",
-              "marginBottom": 15,
-              "marginTop": 5,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "marginRight": 15,
-              }
-            }
-          >
-            <NewArticleFlag />
-          </View>
-        </View>
-        <Text
-          style={
-            Object {
-              "color": "#333333",
-              "fontFamily": "TimesModern-Regular",
-              "fontSize": 20,
-              "lineHeight": 25,
-              "marginBottom": 15,
-              "paddingHorizontal": 10,
-              "textAlign": "center",
-            }
-          }
-        >
-          Some Standfirst
-        </Text>
         <View
           style={
             Object {
               "alignItems": "center",
+              "paddingLeft": 10,
+              "paddingRight": 10,
             }
           }
         >
+          <Image
+            style={
+              Object {
+                "borderRadius": 50,
+                "height": 100,
+                "marginBottom": 25,
+                "overflow": "hidden",
+                "width": 100,
+              }
+            }
+          />
           <View
             style={
               Object {
-                "flexDirection": "row",
-                "flexWrap": "wrap",
+                "marginBottom": 10,
               }
             }
           >
-            <ArticleBylineWithLinks />
+            <ArticleLabel />
           </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "lineHeight": 35,
+                "marginBottom": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Headline
+          </Text>
           <View
             style={
               Object {
                 "flexDirection": "row",
-                "flexWrap": "wrap",
+                "marginBottom": 15,
+                "marginTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "marginBottom": 15,
+                "paddingHorizontal": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </View>
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleImage />
+      </View>
+    </View>
+    <View>
+      <Text
+        style={
+          Object {
+            "color": "#006699",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 17,
+            "lineHeight": 26,
+            "marginBottom": 25,
+            "marginTop": 0,
+            "textDecorationLine": "underline",
+          }
+        }
+      >
+        Some Link
+      </Text>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "paddingLeft": 10,
+            "paddingRight": 10,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "fontFamily": "TimesDigitalW04",
+              "fontSize": 17,
+              "lineHeight": 26,
+              "marginBottom": 20,
+            }
+          }
+        >
+          Some content
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View>
+        <PullQuote>
+          The pull quote content
+        </PullQuote>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "flexDirection": "column",
+            "paddingBottom": 25,
+            "width": "100%",
+          }
+        }
+      >
+        <Video />
+        <View>
+          <View
+            style={
+              Object {
+                "paddingLeft": 10,
+                "paddingTop": 10,
               }
             }
           >
@@ -117,13 +214,202 @@ exports[`full article with style 1`] = `
                   "color": "#696969",
                   "fontFamily": "GillSansMTStd-Medium",
                   "fontSize": 13,
-                  "lineHeight": 15,
-                  "marginTop": 15,
+                  "lineHeight": 16,
                 }
               }
             >
-              Friday March 13 2015, 6:54pm, The Times
+              This is video caption
             </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View>
+      <Ad
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "borderTopColor": "#DBDBDB",
+            "borderTopWidth": 1,
+            "marginBottom": 20,
+            "paddingHorizontal": 10,
+            "paddingVertical": 10,
+          }
+        }
+      />
+    </View>
+    <View>
+      <View>
+        <ArticleImage />
+      </View>
+    </View>
+    <View>
+      <View>
+        <ArticleImage />
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderTopColor": "#DBDBDB",
+            "borderTopWidth": 1,
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        <ArticleTopics />
+      </View>
+    </View>
+    <View>
+      <RelatedArticles />
+    </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
+  </View>
+</RCTScrollView>
+`;
+
+exports[`tablet full article with style 1`] = `
+<RCTScrollView>
+  <View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#DBDBDB",
+            "borderBottomWidth": 1,
+            "marginBottom": 20,
+            "paddingBottom": 25,
+            "paddingTop": 35,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "paddingLeft": 10,
+              "paddingRight": 10,
+              "width": 660,
+            }
+          }
+        >
+          <Image
+            style={
+              Object {
+                "borderRadius": 50,
+                "height": 100,
+                "marginBottom": 25,
+                "overflow": "hidden",
+                "width": 100,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "marginBottom": 10,
+              }
+            }
+          >
+            <ArticleLabel />
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#1D1D1B",
+                "fontFamily": "TimesModern-Bold",
+                "fontSize": 30,
+                "lineHeight": 35,
+                "marginBottom": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Headline
+          </Text>
+          <View
+            style={
+              Object {
+                "flexDirection": "row",
+                "marginBottom": 15,
+                "marginTop": 5,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "marginRight": 15,
+                }
+              }
+            >
+              <NewArticleFlag />
+            </View>
+          </View>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "TimesModern-Regular",
+                "fontSize": 20,
+                "lineHeight": 25,
+                "marginBottom": 15,
+                "paddingHorizontal": 10,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some Standfirst
+          </Text>
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <ArticleBylineWithLinks />
+            </View>
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#696969",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 13,
+                    "lineHeight": 15,
+                    "marginTop": 15,
+                  }
+                }
+              >
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -17,39 +17,41 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
   <View>
     <View>
       <View>
-        <Image
-          aspectRatio={1}
-          uri="https://image.io"
-        />
-        <Text>
-          Some Short Headline
-        </Text>
         <View>
+          <Image
+            aspectRatio={1}
+            uri="https://image.io"
+          />
+          <Text>
+            Some Short Headline
+          </Text>
           <View>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Some byline",
+            <View>
+              <ArticleBylineWithLinks
+                ast={
+                  Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
                         },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View>
-            <Text>
-              Friday March 13 2015, 6:54pm, The Times
-            </Text>
+                      ],
+                      "name": "inline",
+                    },
+                  ]
+                }
+              />
+            </View>
+            <View>
+              <Text>
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>
@@ -146,39 +148,41 @@ exports[`4. an article with ads 1`] = `
   <View>
     <View>
       <View>
-        <Image
-          aspectRatio={1}
-          uri="https://image.io"
-        />
-        <Text>
-          Some Headline
-        </Text>
         <View>
+          <Image
+            aspectRatio={1}
+            uri="https://image.io"
+          />
+          <Text>
+            Some Headline
+          </Text>
           <View>
-            <ArticleBylineWithLinks
-              ast={
-                Array [
-                  Object {
-                    "attributes": Object {},
-                    "children": Array [
-                      Object {
-                        "attributes": Object {
-                          "value": "Some byline",
+            <View>
+              <ArticleBylineWithLinks
+                ast={
+                  Array [
+                    Object {
+                      "attributes": Object {},
+                      "children": Array [
+                        Object {
+                          "attributes": Object {
+                            "value": "Some byline",
+                          },
+                          "children": Array [],
+                          "name": "text",
                         },
-                        "children": Array [],
-                        "name": "text",
-                      },
-                    ],
-                    "name": "inline",
-                  },
-                ]
-              }
-            />
-          </View>
-          <View>
-            <Text>
-              Friday March 13 2015, 6:54pm, The Times
-            </Text>
+                      ],
+                      "name": "inline",
+                    },
+                  ]
+                }
+              />
+            </View>
+            <View>
+              <Text>
+                Friday March 13 2015, 6:54pm, The Times
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/article-main-comment/__tests__/mocks.native.js
+++ b/packages/article-main-comment/__tests__/mocks.native.js
@@ -1,4 +1,8 @@
 import { mockNativeModules } from "@times-components/test-utils";
+
+// eslint-disable-next-line import/prefer-default-export
+export { setIsTablet } from "@times-components/test-utils/dimensions";
+
 // eslint-disable-next-line global-require
 jest.mock("@times-components/ad", () => require("./ad-mock"));
 jest.mock("@times-components/article-byline", () => ({

--- a/packages/article-main-comment/__tests__/shared-with-style.native.js
+++ b/packages/article-main-comment/__tests__/shared-with-style.native.js
@@ -8,7 +8,7 @@ import {
   minimalNativeTransform,
   print
 } from "@times-components/jest-serializer";
-import "./mocks.native";
+import { setIsTablet } from "./mocks.native";
 import ArticleMainComment from "../src/article-main-comment";
 import articleFixture, { testFixture } from "../fixtures/full-article";
 import sharedProps from "./shared-props";
@@ -24,7 +24,126 @@ export default () => {
     )
   );
 
-  it("full article with style", () => {
+  it("phone full article with style", () => {
+    const article = articleFixture({
+      ...testFixture,
+      author: {
+        image: "https://image.io"
+      },
+      content: [
+        {
+          attributes: {
+            caption: "An image caption",
+            credits: "The image credits",
+            display: "primary",
+            ratio: "1500:1000",
+            url: "https://image.io"
+          },
+          children: [],
+          name: "image"
+        },
+        {
+          attributes: {
+            href: "https://link.io",
+            target: "_blank"
+          },
+          children: [
+            {
+              attributes: {
+                value: "Some Link"
+              },
+              children: [],
+              name: "text"
+            }
+          ],
+          name: "link"
+        },
+        {
+          attributes: {},
+          children: [
+            {
+              attributes: {
+                value: "Some content"
+              },
+              children: [],
+              name: "text"
+            }
+          ],
+          name: "paragraph"
+        },
+        {
+          attributes: {
+            caption: {
+              name: "AName",
+              text: "a text",
+              twitter: "@AName"
+            }
+          },
+          children: [
+            {
+              attributes: {
+                value: "The pull quote content"
+              },
+              children: [],
+              name: "text"
+            }
+          ],
+          name: "pullQuote"
+        },
+        {
+          attributes: {
+            brightcoveAccountId: "57838016001",
+            brightcovePolicyKey: "1.2.3.4",
+            brightcoveVideoId: "4084164751001",
+            caption: "This is video caption",
+            display: "primary",
+            paidOnly: "false",
+            posterImageId: "0c0309d4-1aeb-11e8-9010-1eef6ba5d3de",
+            posterImageUrl: "https://image.io",
+            skySports: false
+          },
+          children: [],
+          name: "video"
+        },
+        {
+          attributes: {},
+          children: [],
+          name: "ad"
+        },
+        {
+          attributes: {
+            caption: "A Caption",
+            credits: "Some Credits",
+            display: "secondary",
+            ratio: "3:2",
+            url: "https://image-2.io"
+          },
+          children: [],
+          name: "image"
+        },
+        {
+          attributes: {
+            caption: "A Caption",
+            credits: "Some Credits",
+            display: "inline",
+            ratio: "9:4",
+            url: "https://image-inline.io"
+          },
+          children: [],
+          name: "image"
+        }
+      ]
+    });
+
+    const testRenderer = TestRenderer.create(
+      <ArticleMainComment {...sharedProps} article={article} />
+    );
+
+    expect(testRenderer).toMatchSnapshot();
+  });
+
+  it("tablet full article with style", () => {
+    setIsTablet(true);
     const article = articleFixture({
       ...testFixture,
       author: {

--- a/packages/article-main-comment/article-main-comment.showcase.js
+++ b/packages/article-main-comment/article-main-comment.showcase.js
@@ -3,6 +3,7 @@ import React from "react";
 import articleAdConfig from "@times-components/ad/fixtures/article-ad-config.json";
 import Context, { defaults } from "@times-components/context";
 import { ArticleProvider } from "@times-components/provider";
+import Responsive from "@times-components/responsive";
 import {
   article as makeParams,
   MockFixture,
@@ -36,62 +37,66 @@ const renderArticle = ({
   scale,
   section
 }) => (
-  <ArticleProvider debounceTimeMs={0} id={id}>
-    {({ article, isLoading, error, refetch }) => {
-      // When work is completed in TPA, the schema should do this for us
-      const data = {
-        author: {
-          image:
-            "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg?crop=854,854,214,0&resize=400"
-        },
-        ...article,
-        template: "maincomment"
-      };
+  <Responsive>
+    <ArticleProvider debounceTimeMs={0} id={id}>
+      {({ article, isLoading, error, refetch }) => {
+        // When work is completed in TPA, the schema should do this for us
+        const data = {
+          author: {
+            image:
+              "https://feeds.thetimes.co.uk/web/imageserver/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F0694e84e-04ff-11e7-976a-0b4b9a1a67a3.jpg?crop=854,854,214,0&resize=400"
+          },
+          ...article,
+          template: "maincomment"
+        };
 
-      return (
-        <Context.Provider
-          value={{
-            makeArticleUrl,
-            theme: {
-              ...themeFactory(section, templateName),
-              scale: scale || defaults.theme.scale
-            }
-          }}
-        >
-          <ArticleMainCommment
-            adConfig={adConfig}
-            analyticsStream={analyticsStream}
-            article={data}
-            error={error}
-            isLoading={isLoading}
-            onAuthorPress={preventDefaultedAction(decorateAction)(
-              "onAuthorPress"
-            )}
-            onCommentGuidelinesPress={preventDefaultedAction(decorateAction)(
-              "onCommentGuidelinesPress"
-            )}
-            onCommentsPress={preventDefaultedAction(decorateAction)(
-              "onCommentsPress"
-            )}
-            onLinkPress={preventDefaultedAction(decorateAction)("onLinkPress")}
-            onRelatedArticlePress={preventDefaultedAction(decorateAction)(
-              "onRelatedArticlePress"
-            )}
-            onTopicPress={preventDefaultedAction(decorateAction)(
-              "onTopicPress"
-            )}
-            onTwitterLinkPress={preventDefaultedAction(decorateAction)(
-              "onTwitterLinkPress"
-            )}
-            onVideoPress={preventDefaultedAction(decorateAction)(
-              "onVideoPress"
-            )}
-            refetch={refetch}
-          />
-        </Context.Provider>
-      );
-    }}
-  </ArticleProvider>
+        return (
+          <Context.Provider
+            value={{
+              makeArticleUrl,
+              theme: {
+                ...themeFactory(section, templateName),
+                scale: scale || defaults.theme.scale
+              }
+            }}
+          >
+            <ArticleMainCommment
+              adConfig={adConfig}
+              analyticsStream={analyticsStream}
+              article={data}
+              error={error}
+              isLoading={isLoading}
+              onAuthorPress={preventDefaultedAction(decorateAction)(
+                "onAuthorPress"
+              )}
+              onCommentGuidelinesPress={preventDefaultedAction(decorateAction)(
+                "onCommentGuidelinesPress"
+              )}
+              onCommentsPress={preventDefaultedAction(decorateAction)(
+                "onCommentsPress"
+              )}
+              onLinkPress={preventDefaultedAction(decorateAction)(
+                "onLinkPress"
+              )}
+              onRelatedArticlePress={preventDefaultedAction(decorateAction)(
+                "onRelatedArticlePress"
+              )}
+              onTopicPress={preventDefaultedAction(decorateAction)(
+                "onTopicPress"
+              )}
+              onTwitterLinkPress={preventDefaultedAction(decorateAction)(
+                "onTwitterLinkPress"
+              )}
+              onVideoPress={preventDefaultedAction(decorateAction)(
+                "onVideoPress"
+              )}
+              refetch={refetch}
+            />
+          </Context.Provider>
+        );
+      }}
+    </ArticleProvider>
+  </Responsive>
 );
 
 const mockArticle = ({

--- a/packages/article-main-comment/package.json
+++ b/packages/article-main-comment/package.json
@@ -69,6 +69,7 @@
     "@times-components/date-publication": "0.20.1",
     "@times-components/image": "4.5.1",
     "@times-components/styleguide": "3.15.0",
+    "@times-components/responsive": "0.2.1",
     "@times-components/utils": "4.1.0",
     "@times-components/video-label": "2.2.1",
     "prop-types": "15.6.2",

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Text, View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
+import { ResponsiveContext } from "@times-components/responsive";
 import Label from "../article-label/article-label";
 import Flags from "../article-flags/article-flags";
 import Meta from "../article-meta/article-meta";
@@ -24,19 +25,25 @@ const ArticleHeader = ({
   publishedTime,
   standfirst
 }) => (
-  <View style={styles.container}>
-    <Image aspectRatio={1} style={styles.authorImage} uri={authorImage} />
-    <Label isVideo={hasVideo} label={label} />
-    <Text style={styles.articleHeadline}>{headline}</Text>
-    <Flags flags={flags} />
-    <Standfirst standfirst={standfirst} />
-    <Meta
-      byline={byline}
-      onAuthorPress={onAuthorPress}
-      publicationName={publicationName}
-      publishedTime={publishedTime}
-    />
-  </View>
+  <ResponsiveContext.Consumer>
+    {({ isTablet }) => (
+      <View style={styles.header}>
+        <View style={[styles.container, isTablet && styles.containerTablet]}>
+          <Image aspectRatio={1} style={styles.authorImage} uri={authorImage} />
+          <Label isVideo={hasVideo} label={label} />
+          <Text style={styles.articleHeadline}>{headline}</Text>
+          <Flags flags={flags} />
+          <Standfirst standfirst={standfirst} />
+          <Meta
+            byline={byline}
+            onAuthorPress={onAuthorPress}
+            publicationName={publicationName}
+            publishedTime={publishedTime}
+          />
+        </View>
+      </View>
+    )}
+  </ResponsiveContext.Consumer>
 );
 
 ArticleHeader.propTypes = {

--- a/packages/article-main-comment/src/article-header/article-header.web.js
+++ b/packages/article-main-comment/src/article-header/article-header.web.js
@@ -29,7 +29,7 @@ const ArticleHeader = ({
   publishedTime,
   standfirst
 }) => (
-  <HeaderContainer style={styles.container}>
+  <HeaderContainer style={[styles.header, styles.container]}>
     <AuthorImageContainer style={styles.authorImage}>
       <Image aspectRatio={1} uri={authorImage} />
     </AuthorImageContainer>

--- a/packages/article-main-comment/src/styles/shared.js
+++ b/packages/article-main-comment/src/styles/shared.js
@@ -1,4 +1,4 @@
-import styleguide from "@times-components/styleguide";
+import styleguide, { tabletWidth } from "@times-components/styleguide";
 
 const { colours, fontFactory, spacing } = styleguide();
 const sharedStyles = {
@@ -16,13 +16,12 @@ const sharedStyles = {
   },
   container: {
     alignItems: "center",
-    borderBottomColor: colours.functional.keyline,
-    borderBottomWidth: 1,
-    marginBottom: spacing(4),
-    marginLeft: spacing(2),
-    marginRight: spacing(2),
-    paddingBottom: spacing(5),
-    paddingTop: spacing(7)
+    paddingLeft: spacing(2),
+    paddingRight: spacing(2)
+  },
+  containerTablet: {
+    alignSelf: "center",
+    width: tabletWidth
   },
   datePublication: {
     ...fontFactory({
@@ -39,6 +38,13 @@ const sharedStyles = {
   },
   flagContainer: {
     marginRight: spacing(3)
+  },
+  header: {
+    borderBottomColor: colours.functional.keyline,
+    borderBottomWidth: 1,
+    marginBottom: spacing(4),
+    paddingBottom: spacing(5),
+    paddingTop: spacing(7)
   },
   label: {
     marginBottom: spacing(2)


### PR DESCRIPTION
Reduces the width of the header on tablets for main comment articles 


<img width="798" alt="screen shot 2019-01-24 at 15 32 34" src="https://user-images.githubusercontent.com/719814/51688835-4eb97d00-1fed-11e9-8aa4-c21ad5e35d25.png">
<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
