### PR TITLE
feat: use image layout to decide which res image to request

### DIFF
--- a/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -36,7 +36,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
       </View>
       <View>
@@ -182,7 +182,7 @@ exports[`4. an article with ads 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
       </View>
       <View>

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -36,7 +36,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
       </View>
       <View>
@@ -182,7 +182,7 @@ exports[`4. an article with ads 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
       </View>
       <View>

--- a/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list-states.android.test.js.snap
@@ -60,7 +60,7 @@ exports[`4. loading state 1`] = `
           <Link>
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri={null}
                 isLoading={true}
@@ -82,7 +82,7 @@ exports[`4. loading state 1`] = `
           <Link>
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri={null}
                 isLoading={true}
@@ -104,7 +104,7 @@ exports[`4. loading state 1`] = `
           <Link>
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri={null}
                 isLoading={true}

--- a/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
+++ b/packages/article-list/__tests__/android/__snapshots__/article-list.android.test.js.snap
@@ -11,7 +11,7 @@ exports[`1. article list 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -50,7 +50,7 @@ exports[`1. article list 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead2.io"
                 isLoading={false}
@@ -125,7 +125,7 @@ exports[`2. article list with no images 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -181,7 +181,7 @@ exports[`3. a retry button when load more fails 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -234,7 +234,7 @@ exports[`4. no footer with data equalling the count 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -408,7 +408,7 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list-states.ios.test.js.snap
@@ -60,7 +60,7 @@ exports[`4. loading state 1`] = `
           <Link>
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri={null}
                 isLoading={true}
@@ -82,7 +82,7 @@ exports[`4. loading state 1`] = `
           <Link>
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri={null}
                 isLoading={true}
@@ -104,7 +104,7 @@ exports[`4. loading state 1`] = `
           <Link>
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri={null}
                 isLoading={true}

--- a/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
+++ b/packages/article-list/__tests__/ios/__snapshots__/article-list.ios.test.js.snap
@@ -11,7 +11,7 @@ exports[`1. article list 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -50,7 +50,7 @@ exports[`1. article list 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead2.io"
                 isLoading={false}
@@ -125,7 +125,7 @@ exports[`2. article list with no images 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -181,7 +181,7 @@ exports[`3. a retry button when load more fails 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -234,7 +234,7 @@ exports[`4. no footer with data equalling the count 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}
@@ -408,7 +408,7 @@ exports[`6. removes the retry button when successfully pressed 1`] = `
           >
             <View>
               <Card
-                highResSize={1440}
+                highResSize={1670}
                 imageRatio={1}
                 imageUri="https://lead1.io"
                 isLoading={false}

--- a/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -66,7 +66,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
         <CenteredCaption
           credits="Some Credits"
@@ -215,7 +215,7 @@ exports[`4. an article with ads 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
         <CenteredCaption
           credits="Some Credits"
@@ -380,7 +380,7 @@ exports[`7. an article with no author 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
         <CenteredCaption
           credits="Some Credits"

--- a/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-comment/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -66,7 +66,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
         <CenteredCaption
           credits="Some Credits"
@@ -215,7 +215,7 @@ exports[`4. an article with ads 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
         <CenteredCaption
           credits="Some Credits"
@@ -380,7 +380,7 @@ exports[`7. an article with no author 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={1670}
         />
         <CenteredCaption
           credits="Some Credits"

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -63,7 +63,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={2736}
         />
         <CenteredCaption
           credits="Some Credits"
@@ -209,7 +209,7 @@ exports[`4. an article with ads 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={2736}
         />
         <CenteredCaption
           credits="Some Credits"

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -63,7 +63,7 @@ exports[`3. an article with no headline falls back to use shortheadline 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={2736}
         />
         <CenteredCaption
           credits="Some Credits"
@@ -209,7 +209,7 @@ exports[`4. an article with ads 1`] = `
             />
           }
           uri="https://crop169.io"
-          width={1440}
+          width={2736}
         />
         <CenteredCaption
           credits="Some Credits"

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-header-with-style.android.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. article with header 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article-images.android.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. a secondary image 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}
@@ -51,7 +51,7 @@ exports[`2. an inline image 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}

--- a/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
+++ b/packages/article-skeleton/__tests__/android/__snapshots__/article.android.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}
@@ -193,7 +193,7 @@ exports[`2. an article with no content 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}
@@ -280,7 +280,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-header-with-style.ios.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. article with header 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article-images.ios.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. a secondary image 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}
@@ -51,7 +51,7 @@ exports[`2. an inline image 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}

--- a/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
+++ b/packages/article-skeleton/__tests__/ios/__snapshots__/article.ios.test.js.snap
@@ -4,7 +4,7 @@ exports[`1. a full article with all content items with dropcap template 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}
@@ -186,7 +186,7 @@ exports[`2. an article with no content 1`] = `
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}
@@ -273,7 +273,7 @@ exports[`3. an article with a nested markup in first paragraph displays no drop 
 <RCTScrollView
   ListHeaderComponent={
     <Header
-      width={1440}
+      width={1670}
     />
   }
   initialNumToRender={10}

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. default layout 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -67,7 +67,7 @@ exports[`3. handle layout change 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -86,7 +86,7 @@ exports[`4. prepend https schema 1`] = `
   <Image
     source={
       Object {
-        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -105,7 +105,7 @@ exports[`5. handle onload event 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -119,7 +119,7 @@ exports[`5. handle onload event 2`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -138,7 +138,7 @@ exports[`7. uses highressize if it is smaller than layout width 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=640",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=320",
       }
     }
   />

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. default layout 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1000",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -67,7 +67,7 @@ exports[`3. handle layout change 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -86,7 +86,7 @@ exports[`4. prepend https schema 1`] = `
   <Image
     source={
       Object {
-        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=900",
+        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -105,7 +105,7 @@ exports[`5. handle onload event 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=900",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -119,14 +119,14 @@ exports[`5. handle onload event 2`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=900",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
 </View>
 `;
 
-exports[`7. use screen width if highressize is not provided 1`] = `
+exports[`7. uses highressize if it is smaller than layout width 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -138,7 +138,7 @@ exports[`7. use screen width if highressize is not provided 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=640",
       }
     }
   />

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -36,7 +36,7 @@ exports[`1. modal image 1`] = `
               <Image
                 source={
                   Object {
-                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
                   }
                 }
               />
@@ -65,7 +65,7 @@ exports[`1. modal image 1`] = `
       <Image
         source={
           Object {
-            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
           }
         }
       />

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -36,7 +36,7 @@ exports[`1. modal image 1`] = `
               <Image
                 source={
                   Object {
-                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
                   }
                 }
               />
@@ -65,7 +65,7 @@ exports[`1. modal image 1`] = `
       <Image
         source={
           Object {
-            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
           }
         }
       />

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. default layout 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -67,7 +67,7 @@ exports[`3. handle layout change 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -86,7 +86,7 @@ exports[`4. prepend https schema 1`] = `
   <Image
     source={
       Object {
-        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -105,7 +105,7 @@ exports[`5. handle onload event 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -119,7 +119,7 @@ exports[`5. handle onload event 2`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
   />
@@ -138,7 +138,7 @@ exports[`7. uses highressize if it is smaller than layout width 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=640",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=320",
       }
     }
   />

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -12,7 +12,7 @@ exports[`1. default layout 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1000",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -67,7 +67,7 @@ exports[`3. handle layout change 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=800",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -86,7 +86,7 @@ exports[`4. prepend https schema 1`] = `
   <Image
     source={
       Object {
-        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=900",
+        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -105,7 +105,7 @@ exports[`5. handle onload event 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=900",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
@@ -119,14 +119,14 @@ exports[`5. handle onload event 2`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=900",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
       }
     }
   />
 </View>
 `;
 
-exports[`7. use screen width if highressize is not provided 1`] = `
+exports[`7. uses highressize if it is smaller than layout width 1`] = `
 <View
   aspectRatio={1.5}
 >
@@ -138,7 +138,7 @@ exports[`7. use screen width if highressize is not provided 1`] = `
   <Image
     source={
       Object {
-        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=640",
       }
     }
   />

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. modal image 1`] = `
               <Image
                 source={
                   Object {
-                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
                   }
                 }
               />
@@ -61,7 +61,7 @@ exports[`1. modal image 1`] = `
       <Image
         source={
           Object {
-            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
           }
         }
       />

--- a/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/modal-image.ios.test.js.snap
@@ -34,7 +34,7 @@ exports[`1. modal image 1`] = `
               <Image
                 source={
                   Object {
-                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
                   }
                 }
               />
@@ -61,7 +61,7 @@ exports[`1. modal image 1`] = `
       <Image
         source={
           Object {
-            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1600",
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
           }
         }
       />

--- a/packages/image/__tests__/modal-shared.native.js
+++ b/packages/image/__tests__/modal-shared.native.js
@@ -12,7 +12,7 @@ import {
 } from "@times-components/jest-serializer";
 import { hash, iterator } from "@times-components/test-utils";
 import "./mocks";
-import { ModalImage } from "../src";
+import Image, { ModalImage } from "../src";
 
 // eslint-disable-next-line react/prop-types
 const MockCaption = ({ style: { text, container } }) => (
@@ -46,6 +46,12 @@ export default () => {
       name: "modal image",
       test() {
         const testInstance = TestRenderer.create(<ModalImage {...props} />);
+
+        testInstance.root.findAllByType(Image).forEach(img =>
+          img.children[0].props.onLayout({
+            nativeEvent: { layout: { width: 700 } }
+          })
+        );
 
         expect(testInstance).toMatchSnapshot();
       }

--- a/packages/image/__tests__/shared.base.js
+++ b/packages/image/__tests__/shared.base.js
@@ -1,5 +1,4 @@
 import React from "react";
-import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
 import Image from "../src";
 import Placeholder from "../src/placeholder";
@@ -36,7 +35,7 @@ export default (renderComponent, platformTests = []) => {
     {
       name: "handle layout change",
       test() {
-        const testInstance = TestRenderer.create(<Image {...props} />);
+        const testInstance = renderComponent(<Image {...props} />);
 
         const placeholder = testInstance.root.find(
           node => node.type === Placeholder

--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -14,6 +14,10 @@ import "./mocks";
 import Image from "../src";
 import shared from "./shared.base";
 
+const getLayoutEventForWidth = width => ({
+  nativeEvent: { layout: { width } }
+});
+
 export default () => {
   addSerializers(
     expect,
@@ -44,6 +48,10 @@ export default () => {
           />
         );
 
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
+        );
+
         expect(testInstance).toMatchSnapshot();
       }
     },
@@ -51,6 +59,10 @@ export default () => {
       name: "handle onload event",
       test: () => {
         const testInstance = TestRenderer.create(<Image {...props} />);
+
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
+        );
 
         expect(testInstance).toMatchSnapshot();
 
@@ -70,6 +82,10 @@ export default () => {
           <Image {...props} uri={dataUri} />
         );
 
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
+        );
+
         expect(
           testInstance.root.find(node => node.type === ReactNativeImage).props
             .source.uri
@@ -77,10 +93,14 @@ export default () => {
       }
     },
     {
-      name: "use screen width if highResSize is not provided",
+      name: "uses highResSize if it is smaller than layout width",
       test: () => {
         const testInstance = TestRenderer.create(
-          <Image {...props} highResSize={undefined} />
+          <Image {...props} highResSize={10} />
+        );
+
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
         );
 
         expect(testInstance).toMatchSnapshot();
@@ -95,6 +115,10 @@ export default () => {
           <Image aspectRatio={3 / 2} highResSize={999} uri={uri} />
         );
 
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
+        );
+
         expect(
           testInstance.root.find(node => node.type === ReactNativeImage).props
             .source.uri
@@ -103,5 +127,11 @@ export default () => {
     }
   ];
 
-  shared(TestRenderer.create, tests);
+  shared(component => {
+    const testInstance = TestRenderer.create(component);
+
+    testInstance.root.children[0].props.onLayout(getLayoutEventForWidth(700));
+
+    return testInstance;
+  }, tests);
 };

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -3,7 +3,7 @@ import { Image, View } from "react-native";
 import {
   addMissingProtocol,
   normaliseWidth,
-  screenWidthInPixels
+  convertToPixels
 } from "@times-components/utils";
 import appendSize from "./utils";
 import { defaultProps, propTypes } from "./image-prop-types";
@@ -15,10 +15,24 @@ class TimesImage extends Component {
     super(props);
 
     this.state = {
-      isLoaded: false,
-      width: normaliseWidth(screenWidthInPixels())
+      imageRes: null,
+      isLoaded: false
     };
     this.handleLoad = this.handleLoad.bind(this);
+    this.onImageLayout = this.onImageLayout.bind(this);
+  }
+
+  onImageLayout({
+    nativeEvent: {
+      layout: { width }
+    }
+  }) {
+    const { highResSize } = this.props;
+    const imageRes = convertToPixels(
+      normaliseWidth(highResSize ? Math.min(width, highResSize) : width)
+    );
+
+    this.setState({ imageRes });
   }
 
   handleLoad() {
@@ -26,27 +40,32 @@ class TimesImage extends Component {
   }
 
   render() {
-    const { aspectRatio, highResSize, style, uri } = this.props;
-    const { isLoaded, width } = this.state;
+    const { aspectRatio, style, uri } = this.props;
+    const { isLoaded, imageRes } = this.state;
 
     const isDataImageUri = uri && uri.indexOf("data:") > -1;
 
     const srcUri = isDataImageUri
       ? uri
-      : addMissingProtocol(appendSize(uri, "resize", highResSize || width));
+      : addMissingProtocol(appendSize(uri, "resize", imageRes));
 
     const props = {
       onLoad: this.handleLoad,
-      source: srcUri
-        ? {
-            uri: srcUri
-          }
-        : null,
+      source:
+        srcUri && imageRes
+          ? {
+              uri: srcUri
+            }
+          : null,
       style: styles.imageBackground
     };
 
     return (
-      <View aspectRatio={aspectRatio} style={style}>
+      <View
+        aspectRatio={aspectRatio}
+        onLayout={this.onImageLayout}
+        style={style}
+      >
         {isLoaded ? null : <Placeholder />}
         <Image {...props} />
       </View>

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -28,8 +28,8 @@ class TimesImage extends Component {
     }
   }) {
     const { highResSize } = this.props;
-    const imageRes = convertToPixels(
-      normaliseWidth(highResSize ? Math.min(width, highResSize) : width)
+    const imageRes = normaliseWidth(
+      convertToPixels(highResSize ? Math.min(width, highResSize) : width)
     );
 
     this.setState({ imageRes });

--- a/packages/utils/__tests__/__snapshots__/screen.test.js.snap
+++ b/packages/utils/__tests__/__snapshots__/screen.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`screen utilities convertToPixels should convert a number to pixels using pixel density 1`] = `100`;
+
 exports[`screen utilities screenWidth should return the device screen width 1`] = `750`;
 
 exports[`screen utilities screenWidth should return the tablet width as screen width minus the needed padding 1`] = `640`;

--- a/packages/utils/__tests__/screen.test.js
+++ b/packages/utils/__tests__/screen.test.js
@@ -41,6 +41,6 @@ describe("screen utilities", () => {
   context("convertToPixels", () => {
     it("should convert a number to pixels using pixel density", () => {
       expect(convertToPixels(50)).toMatchSnapshot();
-    })
-  })
+    });
+  });
 });

--- a/packages/utils/__tests__/screen.test.js
+++ b/packages/utils/__tests__/screen.test.js
@@ -1,6 +1,7 @@
 /* global context */
 import {
   acceptedWidths,
+  convertToPixels,
   normaliseWidth,
   screenWidth,
   screenWidthInPixels
@@ -36,4 +37,10 @@ describe("screen utilities", () => {
       expect(screenWidthInPixels()).toMatchSnapshot();
     });
   });
+
+  context("convertToPixels", () => {
+    it("should convert a number to pixels using pixel density", () => {
+      expect(convertToPixels(50)).toMatchSnapshot();
+    })
+  })
 });

--- a/packages/utils/src/screen.base.js
+++ b/packages/utils/src/screen.base.js
@@ -1,7 +1,19 @@
 import { Dimensions } from "react-native";
 import { tabletRowPadding, tabletWidth } from "@times-components/styleguide";
 
-export const acceptedWidths = [320, 440, 660, 800, 1080, 1440];
+export const acceptedWidths = [
+  320,
+  440,
+  660,
+  800,
+  1080,
+  1280,
+  1440,
+  1670,
+  1920,
+  2308,
+  2736
+];
 
 export const normaliseWidth = width => {
   const nWidth = acceptedWidths.find(w => width <= w);

--- a/packages/utils/src/screen.js
+++ b/packages/utils/src/screen.js
@@ -4,7 +4,8 @@ import { acceptedWidths, normaliseWidth, screenWidth } from "./screen.base.js";
 
 export { acceptedWidths, normaliseWidth, screenWidth };
 
-export const convertToPixels = px => PixelRatio.getPixelSizeForLayoutSize(px);
+export const convertToPixels = points =>
+  PixelRatio.getPixelSizeForLayoutSize(points);
 
 export const screenWidthInPixels = () =>
   convertToPixels(screenWidth());

--- a/packages/utils/src/screen.js
+++ b/packages/utils/src/screen.js
@@ -3,5 +3,8 @@ import { PixelRatio } from "react-native";
 import { acceptedWidths, normaliseWidth, screenWidth } from "./screen.base.js";
 
 export { acceptedWidths, normaliseWidth, screenWidth };
+
+export const convertToPixels = px => PixelRatio.getPixelSizeForLayoutSize(px);
+
 export const screenWidthInPixels = () =>
-  PixelRatio.getPixelSizeForLayoutSize(screenWidth());
+  convertToPixels(screenWidth());

--- a/packages/utils/src/screen.js
+++ b/packages/utils/src/screen.js
@@ -7,5 +7,4 @@ export { acceptedWidths, normaliseWidth, screenWidth };
 export const convertToPixels = points =>
   PixelRatio.getPixelSizeForLayoutSize(points);
 
-export const screenWidthInPixels = () =>
-  convertToPixels(screenWidth());
+export const screenWidthInPixels = () => convertToPixels(screenWidth());


### PR DESCRIPTION
This PR uses `onLayout` on the image placeholder to decide which res image to request, meaning that we won't be requesting huge images in slices on tablet. 

<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
