### PR TITLE
fix: ios storybook app

### DIFF
--- a/lib/fix-ios-storybook.sh
+++ b/lib/fix-ios-storybook.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Fix for the missing 'config.h' file in the iOS Storybook app
+# The libfishhook.a library is not properly linked either
 # This is needed on the version 0.55.4 of React Native and can be removed once upgraded
 
 ./node_modules/react-native/scripts/ios-install-third-party.sh

--- a/lib/fix-ios-storybook.sh
+++ b/lib/fix-ios-storybook.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Fix for the missing 'config.h' file in the iOS Storybook app
+# This is needed on the version 0.55.4 of React Native and can be removed once upgraded
+
+cd node_modules/react-native/third-party/glog-0.3.4
+./configure

--- a/lib/fix-ios-storybook.sh
+++ b/lib/fix-ios-storybook.sh
@@ -4,8 +4,10 @@
 # The libfishhook.a library is not properly linked either
 # This is needed on the version 0.55.4 of React Native and can be removed once upgraded
 
-./node_modules/react-native/scripts/ios-install-third-party.sh
+pushd node_modules/react-native/
+./scripts/ios-install-third-party.sh
+popd
 pushd node_modules/react-native/third-party/glog-*
 ../../scripts/ios-configure-glog.sh
 popd
-cp ios/build/Build/Products/Debug-iphonesimulator/libfishhook.a node_modules/react-native/Libraries/WebSocket/;
+cp ios/build/Build/Products/Debug-iphonesimulator/libfishhook.a node_modules/react-native/Libraries/WebSocket/ | true

--- a/lib/fix-ios-storybook.sh
+++ b/lib/fix-ios-storybook.sh
@@ -3,5 +3,8 @@
 # Fix for the missing 'config.h' file in the iOS Storybook app
 # This is needed on the version 0.55.4 of React Native and can be removed once upgraded
 
-cd node_modules/react-native/third-party/glog-0.3.4
-./configure
+./node_modules/react-native/scripts/ios-install-third-party.sh
+pushd node_modules/react-native/third-party/glog-*
+../../scripts/ios-configure-glog.sh
+popd
+cp ios/build/Build/Products/Debug-iphonesimulator/libfishhook.a node_modules/react-native/Libraries/WebSocket/;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "storybook:publish": "./lib/publish_storybook.sh",
     "prestorybook-native": "rnstl && node ./lib/fetch-fonts",
     "storybook-native": "storybook -c .storybook.native start -p 7007 --haul ./.storybook.native/webpack.haul.storybook.js --platform all",
-    "preios": "yarn fetch-fonts",
+    "preios": "yarn fetch-fonts && ./lib/fix-ios-storybook.sh",
     "ios": "react-native run-ios --no-packager",
     "ios:logs" : "yarn ios && react-native log-ios",
     "ios:build-lib": "lerna run --scope @times-components/ios-app build:all --stream",


### PR DESCRIPTION
The iOS Storybook app won't compile when running `yarn ios`. One of the reasons is that, if you open the project and try to compile, it is missing a config.h file.

This file gets properly created once running the configure script from the glog third party dependency. Created a script for going to the right directory and executing the configure script and added a call to that script in the `preios` step in the project's `package.json` file.
