### PR TITLE
feat: Lead One and One & Lead One Full Width tiles

### DIFF
--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary-with-style.android.test.js.snap
@@ -14,14 +14,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
       title="Test label"
     />
   </View>
-  <ArticleFlags
-    flags={
-      Array [
-        "UPDATED",
-        "EXCLUSIVE",
-      ]
-    }
-  />
   <Text
     accessibilityRole="heading"
     aria-level="3"
@@ -38,6 +30,14 @@ exports[`1. article summary component with a single paragraph 1`] = `
   >
     Test Headline
   </Text>
+  <ArticleFlags
+    flags={
+      Array [
+        "UPDATED",
+        "EXCLUSIVE",
+      ]
+    }
+  />
   <Text
     style={
       Object {

--- a/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
+++ b/packages/article-summary/__tests__/android/__snapshots__/article-summary.android.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. article summary component with a single paragraph 1`] = `
       title="Test label"
     />
   </View>
+  <Text
+    accessibilityRole="heading"
+    aria-level="3"
+  >
+    Test Headline
+  </Text>
   <ArticleFlags
     flags={
       Array [
@@ -16,12 +22,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
       ]
     }
   />
-  <Text
-    accessibilityRole="heading"
-    aria-level="3"
-  >
-    Test Headline
-  </Text>
   <Text>
     <Text>
       

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary-with-style.ios.test.js.snap
@@ -14,14 +14,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
       title="Test label"
     />
   </View>
-  <ArticleFlags
-    flags={
-      Array [
-        "UPDATED",
-        "EXCLUSIVE",
-      ]
-    }
-  />
   <Text
     accessibilityRole="heading"
     aria-level="3"
@@ -38,6 +30,14 @@ exports[`1. article summary component with a single paragraph 1`] = `
   >
     Test Headline
   </Text>
+  <ArticleFlags
+    flags={
+      Array [
+        "UPDATED",
+        "EXCLUSIVE",
+      ]
+    }
+  />
   <Text
     style={
       Object {

--- a/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
+++ b/packages/article-summary/__tests__/ios/__snapshots__/article-summary.ios.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. article summary component with a single paragraph 1`] = `
       title="Test label"
     />
   </View>
+  <Text
+    accessibilityRole="heading"
+    aria-level="3"
+  >
+    Test Headline
+  </Text>
   <ArticleFlags
     flags={
       Array [
@@ -16,12 +22,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
       ]
     }
   />
-  <Text
-    accessibilityRole="heading"
-    aria-level="3"
-  >
-    Test Headline
-  </Text>
   <Text>
     <Text>
       

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary-with-style.web.test.js.snap
@@ -67,6 +67,13 @@ exports[`1. article summary component with a single paragraph 1`] = `
       title="Test label"
     />
   </div>
+  <h3
+    aria-level="3"
+    className="S2"
+    role="heading"
+  >
+    Test Headline
+  </h3>
   <ArticleFlags
     flags={
       Array [
@@ -75,13 +82,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
       ]
     }
   />
-  <h3
-    aria-level="3"
-    className="S2"
-    role="heading"
-  >
-    Test Headline
-  </h3>
   <div
     className="S4"
   >

--- a/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
+++ b/packages/article-summary/__tests__/web/__snapshots__/article-summary.web.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. article summary component with a single paragraph 1`] = `
       title="Test label"
     />
   </div>
+  <h3
+    aria-level="3"
+    role="heading"
+  >
+    Test Headline
+  </h3>
   <ArticleFlags
     flags={
       Array [
@@ -16,12 +22,6 @@ exports[`1. article summary component with a single paragraph 1`] = `
       ]
     }
   />
-  <h3
-    aria-level="3"
-    role="heading"
-  >
-    Test Headline
-  </h3>
   <div>
     <span>
       

--- a/packages/article-summary/src/article-summary-content.js
+++ b/packages/article-summary/src/article-summary-content.js
@@ -5,21 +5,23 @@ import { propTypes as treePropType } from "@times-components/markup-forest";
 import { renderAst } from "./article-summary";
 import styles from "./styles";
 
-const ArticleSummaryContent = ({ ast, className }) =>
+const ArticleSummaryContent = ({ ast, className, style }) =>
   ast.length > 0 ? (
-    <Text className={className} style={styles.text}>
+    <Text className={className} style={[styles.text, style]}>
       {renderAst(ast)}
     </Text>
   ) : null;
 
 ArticleSummaryContent.propTypes = {
   ast: PropTypes.arrayOf(treePropType),
-  className: PropTypes.string
+  className: PropTypes.string,
+  style: PropTypes.shape({})
 };
 
 ArticleSummaryContent.defaultProps = {
   ast: [],
-  className: ""
+  className: "",
+  style: null
 };
 
 export default ArticleSummaryContent;

--- a/packages/article-summary/src/article-summary.js
+++ b/packages/article-summary/src/article-summary.js
@@ -26,7 +26,8 @@ const ArticleSummary = props => {
     datePublicationProps,
     flags,
     headline,
-    labelProps
+    labelProps,
+    style
   } = props;
 
   const renderByline = () => {
@@ -59,11 +60,11 @@ const ArticleSummary = props => {
   };
 
   return (
-    <View>
+    <View style={style}>
       {renderLabel()}
-      {flags()}
       {bylineProps && bylineProps.isOpinionByline ? renderByline() : null}
       {headline()}
+      {flags()}
       {content()}
       {datePublicationProps ? (
         <Text style={styles.metaText} testID="datePublication">
@@ -92,7 +93,8 @@ ArticleSummary.propTypes = {
     color: PropTypes.string,
     isVideo: PropTypes.bool,
     title: PropTypes.string
-  })
+  }),
+  style: PropTypes.shape({})
 };
 
 ArticleSummary.defaultProps = {
@@ -101,7 +103,8 @@ ArticleSummary.defaultProps = {
   datePublicationProps: null,
   flags: () => null,
   headline: () => null,
-  labelProps: null
+  labelProps: null,
+  style: null
 };
 
 export {

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. lead one full width slice 1`] = `
     style={
       Object {
         "marginHorizontal": 10,
+        "marginVertical": 5,
       }
     }
   >
@@ -67,9 +68,6 @@ exports[`2. lead one and one slice 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -86,6 +84,7 @@ exports[`2. lead one and one slice 1`] = `
           style={
             Object {
               "marginHorizontal": 10,
+              "marginVertical": 5,
             }
           }
         >
@@ -145,9 +144,6 @@ exports[`2. lead one and one slice 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -164,6 +160,7 @@ exports[`2. lead one and one slice 1`] = `
           style={
             Object {
               "marginHorizontal": 10,
+              "marginVertical": 5,
             }
           }
         >
@@ -216,6 +213,7 @@ exports[`2. lead one and one slice 1`] = `
               "lineHeight": 20,
               "marginBottom": 10,
               "marginHorizontal": 10,
+              "marginVertical": 5,
             }
           }
         >

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -2,7 +2,13 @@
 
 exports[`1. lead one full width slice 1`] = `
 <View>
-  <View>
+  <View
+    style={
+      Object {
+        "marginHorizontal": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -26,21 +32,21 @@ exports[`1. lead one full width slice 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
+          "fontSize": 32,
           "fontWeight": "400",
-          "lineHeight": 27,
+          "lineHeight": 32,
           "marginBottom": 5,
         }
       }
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
   </View>
   <View
     style={
@@ -76,7 +82,13 @@ exports[`2. lead one and one slice 1`] = `
       }
     >
       <View>
-        <View>
+        <View
+          style={
+            Object {
+              "marginHorizontal": 10,
+            }
+          }
+        >
           <View
             style={
               Object {
@@ -100,21 +112,21 @@ exports[`2. lead one and one slice 1`] = `
               ROYALS
             </Text>
           </View>
-          <ArticleFlags />
           <Text
             style={
               Object {
                 "color": "#333333",
                 "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
+                "fontSize": 32,
                 "fontWeight": "400",
-                "lineHeight": 27,
+                "lineHeight": 32,
                 "marginBottom": 5,
               }
             }
           >
             Prince Philip ‘could be prosecuted’ over car crash
           </Text>
+          <ArticleFlags />
         </View>
         <View
           style={
@@ -148,7 +160,13 @@ exports[`2. lead one and one slice 1`] = `
       }
     >
       <View>
-        <View>
+        <View
+          style={
+            Object {
+              "marginHorizontal": 10,
+            }
+          }
+        >
           <View
             style={
               Object {
@@ -172,21 +190,21 @@ exports[`2. lead one and one slice 1`] = `
               CYBER CRIME
             </Text>
           </View>
-          <ArticleFlags />
           <Text
             style={
               Object {
                 "color": "#333333",
                 "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
+                "fontSize": 32,
                 "fontWeight": "400",
-                "lineHeight": 27,
+                "lineHeight": 32,
                 "marginBottom": 5,
               }
             }
           >
             GCHQ gives girls free cyber-classes to tackle gender gap
           </Text>
+          <ArticleFlags />
         </View>
         <Text
           style={
@@ -197,6 +215,7 @@ exports[`2. lead one and one slice 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 10,
+              "marginHorizontal": 10,
             }
           }
         >

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. lead one full width slice 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -15,12 +21,6 @@ exports[`1. lead one full width slice 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
   </View>
   <View>
     <Image
@@ -42,6 +42,12 @@ exports[`2. lead one and one slice 1`] = `
               ROYALS
             </Text>
           </View>
+          <Text
+            accessibilityRole="heading"
+            aria-level="3"
+          >
+            Prince Philip ‘could be prosecuted’ over car crash
+          </Text>
           <ArticleFlags
             flags={
               Array [
@@ -49,12 +55,6 @@ exports[`2. lead one and one slice 1`] = `
               ]
             }
           />
-          <Text
-            accessibilityRole="heading"
-            aria-level="3"
-          >
-            Prince Philip ‘could be prosecuted’ over car crash
-          </Text>
         </View>
         <View>
           <Image
@@ -74,6 +74,12 @@ exports[`2. lead one and one slice 1`] = `
               CYBER CRIME
             </Text>
           </View>
+          <Text
+            accessibilityRole="heading"
+            aria-level="3"
+          >
+            GCHQ gives girls free cyber-classes to tackle gender gap
+          </Text>
           <ArticleFlags
             flags={
               Array [
@@ -81,12 +87,6 @@ exports[`2. lead one and one slice 1`] = `
               ]
             }
           />
-          <Text
-            accessibilityRole="heading"
-            aria-level="3"
-          >
-            GCHQ gives girls free cyber-classes to tackle gender gap
-          </Text>
         </View>
         <Text>
           <Text>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -26,21 +26,21 @@ exports[`1. primary tile 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
+          "fontSize": 32,
           "fontWeight": "400",
-          "lineHeight": 27,
+          "lineHeight": 32,
           "marginBottom": 5,
         }
       }
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
   </View>
   <View
     style={
@@ -82,21 +82,21 @@ exports[`2. primary tiles without image 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
+          "fontSize": 32,
           "fontWeight": "400",
-          "lineHeight": 27,
+          "lineHeight": 32,
           "marginBottom": 5,
         }
       }
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
   </View>
   <Text
     style={

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. primary tile 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -15,12 +21,6 @@ exports[`1. primary tile 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
   </View>
   <View>
     <Image
@@ -39,6 +39,12 @@ exports[`2. primary tiles without image 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -46,12 +52,6 @@ exports[`2. primary tiles without image 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
   </View>
   <Text>
     <Text>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -2,7 +2,13 @@
 
 exports[`1. lead one full width slice 1`] = `
 <View>
-  <View>
+  <View
+    style={
+      Object {
+        "marginHorizontal": 10,
+      }
+    }
+  >
     <View
       style={
         Object {
@@ -26,21 +32,21 @@ exports[`1. lead one full width slice 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
+          "fontSize": 32,
           "fontWeight": "900",
-          "lineHeight": 25,
+          "lineHeight": 32,
           "marginBottom": 5,
         }
       }
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
   </View>
   <View
     style={
@@ -76,7 +82,13 @@ exports[`2. lead one and one slice 1`] = `
       }
     >
       <View>
-        <View>
+        <View
+          style={
+            Object {
+              "marginHorizontal": 10,
+            }
+          }
+        >
           <View
             style={
               Object {
@@ -100,21 +112,21 @@ exports[`2. lead one and one slice 1`] = `
               ROYALS
             </Text>
           </View>
-          <ArticleFlags />
           <Text
             style={
               Object {
                 "color": "#333333",
                 "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
+                "fontSize": 32,
                 "fontWeight": "900",
-                "lineHeight": 25,
+                "lineHeight": 32,
                 "marginBottom": 5,
               }
             }
           >
             Prince Philip ‘could be prosecuted’ over car crash
           </Text>
+          <ArticleFlags />
         </View>
         <View
           style={
@@ -148,7 +160,13 @@ exports[`2. lead one and one slice 1`] = `
       }
     >
       <View>
-        <View>
+        <View
+          style={
+            Object {
+              "marginHorizontal": 10,
+            }
+          }
+        >
           <View
             style={
               Object {
@@ -172,21 +190,21 @@ exports[`2. lead one and one slice 1`] = `
               CYBER CRIME
             </Text>
           </View>
-          <ArticleFlags />
           <Text
             style={
               Object {
                 "color": "#333333",
                 "fontFamily": "TimesModern-Bold",
-                "fontSize": 22,
+                "fontSize": 32,
                 "fontWeight": "900",
-                "lineHeight": 25,
+                "lineHeight": 32,
                 "marginBottom": 5,
               }
             }
           >
             GCHQ gives girls free cyber-classes to tackle gender gap
           </Text>
+          <ArticleFlags />
         </View>
         <Text
           style={
@@ -197,6 +215,7 @@ exports[`2. lead one and one slice 1`] = `
               "fontSize": 14,
               "lineHeight": 20,
               "marginBottom": 10,
+              "marginHorizontal": 10,
             }
           }
         >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -6,6 +6,7 @@ exports[`1. lead one full width slice 1`] = `
     style={
       Object {
         "marginHorizontal": 10,
+        "marginVertical": 5,
       }
     }
   >
@@ -67,9 +68,6 @@ exports[`2. lead one and one slice 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -86,6 +84,7 @@ exports[`2. lead one and one slice 1`] = `
           style={
             Object {
               "marginHorizontal": 10,
+              "marginVertical": 5,
             }
           }
         >
@@ -145,9 +144,6 @@ exports[`2. lead one and one slice 1`] = `
   <View
     style={
       Object {
-        "borderBottomColor": "#DBDBDB",
-        "borderBottomWidth": 1,
-        "borderStyle": "solid",
         "width": "100%",
       }
     }
@@ -164,6 +160,7 @@ exports[`2. lead one and one slice 1`] = `
           style={
             Object {
               "marginHorizontal": 10,
+              "marginVertical": 5,
             }
           }
         >
@@ -216,6 +213,7 @@ exports[`2. lead one and one slice 1`] = `
               "lineHeight": 20,
               "marginBottom": 10,
               "marginHorizontal": 10,
+              "marginVertical": 5,
             }
           }
         >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. lead one full width slice 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -15,12 +21,6 @@ exports[`1. lead one full width slice 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
   </View>
   <View>
     <Image
@@ -42,6 +42,12 @@ exports[`2. lead one and one slice 1`] = `
               ROYALS
             </Text>
           </View>
+          <Text
+            accessibilityRole="heading"
+            aria-level="3"
+          >
+            Prince Philip ‘could be prosecuted’ over car crash
+          </Text>
           <ArticleFlags
             flags={
               Array [
@@ -49,12 +55,6 @@ exports[`2. lead one and one slice 1`] = `
               ]
             }
           />
-          <Text
-            accessibilityRole="heading"
-            aria-level="3"
-          >
-            Prince Philip ‘could be prosecuted’ over car crash
-          </Text>
         </View>
         <View>
           <Image
@@ -74,6 +74,12 @@ exports[`2. lead one and one slice 1`] = `
               CYBER CRIME
             </Text>
           </View>
+          <Text
+            accessibilityRole="heading"
+            aria-level="3"
+          >
+            GCHQ gives girls free cyber-classes to tackle gender gap
+          </Text>
           <ArticleFlags
             flags={
               Array [
@@ -81,12 +87,6 @@ exports[`2. lead one and one slice 1`] = `
               ]
             }
           />
-          <Text
-            accessibilityRole="heading"
-            aria-level="3"
-          >
-            GCHQ gives girls free cyber-classes to tackle gender gap
-          </Text>
         </View>
         <Text>
           <Text>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -26,21 +26,21 @@ exports[`1. primary tile 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
+          "fontSize": 32,
           "fontWeight": "900",
-          "lineHeight": 25,
+          "lineHeight": 32,
           "marginBottom": 5,
         }
       }
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
   </View>
   <View
     style={
@@ -82,21 +82,21 @@ exports[`2. primary tiles without image 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
           "color": "#333333",
           "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
+          "fontSize": 32,
           "fontWeight": "900",
-          "lineHeight": 25,
+          "lineHeight": 32,
           "marginBottom": 5,
         }
       }
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
   </View>
   <Text
     style={

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. primary tile 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -15,12 +21,6 @@ exports[`1. primary tile 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
   </View>
   <View>
     <Image
@@ -39,6 +39,12 @@ exports[`2. primary tiles without image 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -46,12 +52,6 @@ exports[`2. primary tiles without image 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
   </View>
   <Text>
     <Text>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -24,6 +24,10 @@ exports[`1. lead one full width slice 1`] = `
 }
 
 .S4 {
+  margin-bottom: 5px;
+}
+
+.S5 {
   margin-bottom: 10px;
 }
 
@@ -36,7 +40,7 @@ exports[`1. lead one full width slice 1`] = `
   className="S2"
 >
   <div
-    className="S2"
+    className="S4"
   >
     <div
       className="S2"
@@ -63,7 +67,7 @@ exports[`1. lead one full width slice 1`] = `
     />
   </div>
   <div
-    className="S4"
+    className="S5"
   >
     <Image
       aspectRatio={1.7777777777777777}
@@ -97,10 +101,14 @@ exports[`2. lead one and one slice 1`] = `
 }
 
 .S4 {
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 }
 
 .S5 {
+  margin-bottom: 10px;
+}
+
+.S6 {
   color: inherit;
   font-family: inherit;
   font-size: inherit;
@@ -109,7 +117,7 @@ exports[`2. lead one and one slice 1`] = `
   margin-bottom: 0px;
 }
 
-.S6 {
+.S7 {
   color: rgba(105,105,105,1.00);
   -ms-flex-wrap: wrap;
   -webkit-box-lines: multiple;
@@ -147,7 +155,7 @@ exports[`2. lead one and one slice 1`] = `
           className="S2"
         >
           <div
-            className="S2"
+            className="S4"
           >
             <div
               className="S2"
@@ -174,7 +182,7 @@ exports[`2. lead one and one slice 1`] = `
             />
           </div>
           <div
-            className="S4"
+            className="S5"
           >
             <Image
               aspectRatio={1.7777777777777777}
@@ -196,7 +204,7 @@ exports[`2. lead one and one slice 1`] = `
             className="S2"
           >
             <div
-              className="S2"
+              className="S4"
             >
               <div
                 className="S2"
@@ -223,16 +231,16 @@ exports[`2. lead one and one slice 1`] = `
               />
             </div>
             <div
-              className="S6"
+              className="S7"
             >
               <span
-                className="S5"
+                className="S6"
               >
                 
                 GCHQ will give free cyber-classes to hundreds of girls in an attempt to boost diversity in the tech industry.
               </span>
               <span
-                className="S5"
+                className="S6"
               >
                  
                 The intelligence

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -17,9 +17,9 @@ exports[`1. lead one full width slice 1`] = `
 .S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
-  font-size: 22px;
+  font-size: 32px;
   font-weight: 400;
-  line-height: 27px;
+  line-height: 32px;
   margin-bottom: 5px;
 }
 
@@ -47,13 +47,6 @@ exports[`1. lead one full width slice 1`] = `
         ROYALS
       </div>
     </div>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
     <h3
       aria-level="3"
       className="S3"
@@ -61,6 +54,13 @@ exports[`1. lead one full width slice 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
   </div>
   <div
     className="S4"
@@ -90,9 +90,9 @@ exports[`2. lead one and one slice 1`] = `
 .S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
-  font-size: 22px;
+  font-size: 32px;
   font-weight: 400;
-  line-height: 27px;
+  line-height: 32px;
   margin-bottom: 5px;
 }
 
@@ -158,13 +158,6 @@ exports[`2. lead one and one slice 1`] = `
                 ROYALS
               </div>
             </div>
-            <ArticleFlags
-              flags={
-                Array [
-                  "NEW",
-                ]
-              }
-            />
             <h3
               aria-level="3"
               className="S3"
@@ -172,6 +165,13 @@ exports[`2. lead one and one slice 1`] = `
             >
               Prince Philip ‘could be prosecuted’ over car crash
             </h3>
+            <ArticleFlags
+              flags={
+                Array [
+                  "NEW",
+                ]
+              }
+            />
           </div>
           <div
             className="S4"
@@ -207,13 +207,6 @@ exports[`2. lead one and one slice 1`] = `
                   CYBER CRIME
                 </div>
               </div>
-              <ArticleFlags
-                flags={
-                  Array [
-                    "UPDATED",
-                  ]
-                }
-              />
               <h3
                 aria-level="3"
                 className="S3"
@@ -221,6 +214,13 @@ exports[`2. lead one and one slice 1`] = `
               >
                 GCHQ gives girls free cyber-classes to tackle gender gap
               </h3>
+              <ArticleFlags
+                flags={
+                  Array [
+                    "UPDATED",
+                  ]
+                }
+              />
             </div>
             <div
               className="S6"

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. lead one full width slice 1`] = `
         ROYALS
       </div>
     </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
     <ArticleFlags
       flags={
         Array [
@@ -15,12 +21,6 @@ exports[`1. lead one full width slice 1`] = `
         ]
       }
     />
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
   </div>
   <div>
     <Image
@@ -43,6 +43,12 @@ exports[`2. lead one and one slice 1`] = `
                 ROYALS
               </div>
             </div>
+            <h3
+              aria-level="3"
+              role="heading"
+            >
+              Prince Philip ‘could be prosecuted’ over car crash
+            </h3>
             <ArticleFlags
               flags={
                 Array [
@@ -50,12 +56,6 @@ exports[`2. lead one and one slice 1`] = `
                 ]
               }
             />
-            <h3
-              aria-level="3"
-              role="heading"
-            >
-              Prince Philip ‘could be prosecuted’ over car crash
-            </h3>
           </div>
           <div>
             <Image
@@ -75,6 +75,12 @@ exports[`2. lead one and one slice 1`] = `
                   CYBER CRIME
                 </div>
               </div>
+              <h3
+                aria-level="3"
+                role="heading"
+              >
+                GCHQ gives girls free cyber-classes to tackle gender gap
+              </h3>
               <ArticleFlags
                 flags={
                   Array [
@@ -82,12 +88,6 @@ exports[`2. lead one and one slice 1`] = `
                   ]
                 }
               />
-              <h3
-                aria-level="3"
-                role="heading"
-              >
-                GCHQ gives girls free cyber-classes to tackle gender gap
-              </h3>
             </div>
             <div>
               <span>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -17,9 +17,9 @@ exports[`1. primary tile 1`] = `
 .S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
-  font-size: 22px;
+  font-size: 32px;
   font-weight: 400;
-  line-height: 27px;
+  line-height: 32px;
   margin-bottom: 5px;
 }
 
@@ -47,13 +47,6 @@ exports[`1. primary tile 1`] = `
         ROYALS
       </div>
     </div>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
     <h3
       aria-level="3"
       className="S3"
@@ -61,6 +54,13 @@ exports[`1. primary tile 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
   </div>
   <div
     className="S4"
@@ -90,9 +90,9 @@ exports[`2. primary tiles without image 1`] = `
 .S3 {
   color: rgba(51,51,51,1.00);
   font-family: TimesModern-Bold;
-  font-size: 22px;
+  font-size: 32px;
   font-weight: 400;
-  line-height: 27px;
+  line-height: 32px;
   margin-bottom: 5px;
 }
 
@@ -138,13 +138,6 @@ exports[`2. primary tiles without image 1`] = `
         ROYALS
       </div>
     </div>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
     <h3
       aria-level="3"
       className="S3"
@@ -152,6 +145,13 @@ exports[`2. primary tiles without image 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
   </div>
   <div
     className="S5"

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -8,6 +8,12 @@ exports[`1. primary tile 1`] = `
         ROYALS
       </div>
     </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
     <ArticleFlags
       flags={
         Array [
@@ -15,12 +21,6 @@ exports[`1. primary tile 1`] = `
         ]
       }
     />
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
   </div>
   <div>
     <Image
@@ -39,6 +39,12 @@ exports[`2. primary tiles without image 1`] = `
         ROYALS
       </div>
     </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
     <ArticleFlags
       flags={
         Array [
@@ -46,12 +52,6 @@ exports[`2. primary tiles without image 1`] = `
         ]
       }
     />
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
   </div>
   <div>
     <span>

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -7,17 +7,17 @@ export default {
     {
       component: () => {
         const slice = mockLeadOneFullWidthSlice();
-        return <PrimaryTile tile={slice.lead} withImage />;
+        return <PrimaryTile tile={slice.lead} withImage withSummaryMargins />;
       },
-      name: "Primary (with image)",
+      name: "Primary (with image, with summary margins)",
       type: "story"
     },
     {
       component: () => {
         const slice = mockLeadOneFullWidthSlice();
-        return <PrimaryTile tile={slice.lead} />;
+        return <PrimaryTile tile={slice.lead} withSummaryMargins />;
       },
-      name: "Primary (without image)",
+      name: "Primary (without image, with summary margins)",
       type: "story"
     }
   ],

--- a/packages/edition-slices/src/slices/leadoneandone/index.js
+++ b/packages/edition-slices/src/slices/leadoneandone/index.js
@@ -5,8 +5,8 @@ import { PrimaryTile } from "../../tiles";
 
 const LeadOneAndOneSlice = ({ lead, support }) => (
   <LeadOneAndTwoSlice
-    renderLead={() => <PrimaryTile tile={lead} withImage />}
-    renderSupport1={() => <PrimaryTile tile={support} />}
+    renderLead={() => <PrimaryTile tile={lead} withImage withSummaryMargins />}
+    renderSupport1={() => <PrimaryTile tile={support} withSummaryMargins />}
     renderSupport2={() => null}
   />
 );

--- a/packages/edition-slices/src/slices/leadonefullwidth/index.js
+++ b/packages/edition-slices/src/slices/leadonefullwidth/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { PrimaryTile } from "../../tiles";
 
 const LeadOneFullWidthSlice = ({ lead }) => (
-  <PrimaryTile tile={lead} withImage />
+  <PrimaryTile tile={lead} withImage withSummaryMargins />
 );
 
 LeadOneFullWidthSlice.propTypes = {

--- a/packages/edition-slices/src/tiles/primary/index.js
+++ b/packages/edition-slices/src/tiles/primary/index.js
@@ -43,7 +43,10 @@ const PrimaryTile = ({
     <ArticleSummary
       flags={() => <ArticleFlags flags={flags} />}
       headline={() => (
-        <ArticleSummaryHeadline headline={headline || shortHeadline} />
+        <ArticleSummaryHeadline
+          headline={headline || shortHeadline}
+          style={styles.headline}
+        />
       )}
       label={label}
       labelProps={{

--- a/packages/edition-slices/src/tiles/primary/index.js
+++ b/packages/edition-slices/src/tiles/primary/index.js
@@ -16,7 +16,12 @@ const renderImage = imageUri => (
   </View>
 );
 
-const renderSummaryContent = summary => <ArticleSummaryContent ast={summary} />;
+const renderSummaryContent = (summary, withMargins) => (
+  <ArticleSummaryContent
+    ast={summary}
+    style={withMargins && styles.summaryContainer}
+  />
+);
 
 const PrimaryTile = ({
   tile: {
@@ -31,7 +36,8 @@ const PrimaryTile = ({
       summary125
     }
   },
-  withImage
+  withImage,
+  withSummaryMargins
 }) => (
   <View>
     <ArticleSummary
@@ -45,20 +51,23 @@ const PrimaryTile = ({
         isVideo: hasVideo,
         title: label
       }}
+      style={withSummaryMargins && styles.summaryContainer}
     />
     {withImage
       ? renderImage(leadAsset.crop169.url)
-      : renderSummaryContent(summary125)}
+      : renderSummaryContent(summary125, withSummaryMargins)}
   </View>
 );
 
 PrimaryTile.propTypes = {
   tile: PropTypes.shape({}).isRequired,
-  withImage: PropTypes.bool
+  withImage: PropTypes.bool,
+  withSummaryMargins: PropTypes.bool
 };
 
 PrimaryTile.defaultProps = {
-  withImage: false
+  withImage: false,
+  withSummaryMargins: false
 };
 
 export default PrimaryTile;

--- a/packages/edition-slices/src/tiles/primary/styles/index.js
+++ b/packages/edition-slices/src/tiles/primary/styles/index.js
@@ -1,7 +1,16 @@
 import { StyleSheet } from "react-native";
-import { spacing } from "@times-components/styleguide";
+import styleguideFactory from "@times-components/styleguide";
+
+const { fontFactory, spacing } = styleguideFactory();
 
 const styles = StyleSheet.create({
+  headline: {
+    ...fontFactory({
+      font: "headline",
+      fontSize: "sliceHeadline"
+    }),
+    lineHeight: 32
+  },
   imageContainer: {
     backgroundColor: "blue",
     marginBottom: spacing(2),

--- a/packages/edition-slices/src/tiles/primary/styles/index.js
+++ b/packages/edition-slices/src/tiles/primary/styles/index.js
@@ -6,6 +6,9 @@ const styles = StyleSheet.create({
     backgroundColor: "blue",
     marginBottom: spacing(2),
     width: "100%"
+  },
+  summaryContainer: {
+    marginHorizontal: spacing(2)
   }
 });
 

--- a/packages/edition-slices/src/tiles/primary/styles/index.js
+++ b/packages/edition-slices/src/tiles/primary/styles/index.js
@@ -17,7 +17,8 @@ const styles = StyleSheet.create({
     width: "100%"
   },
   summaryContainer: {
-    marginHorizontal: spacing(2)
+    marginHorizontal: spacing(2),
+    marginVertical: spacing(1)
   }
 });
 

--- a/packages/related-articles/src/related-articles.js
+++ b/packages/related-articles/src/related-articles.js
@@ -95,6 +95,7 @@ class RelatedArticles extends Component {
                   support2.leadAsset
                 );
               }}
+              withSeparators
             />
           );
         case "OpinionOneAndTwoSlice":

--- a/packages/slice-layout/__tests__/la2.base.js
+++ b/packages/slice-layout/__tests__/la2.base.js
@@ -13,6 +13,7 @@ export default renderComponent => {
             renderLead={() => createItem("lead")}
             renderSupport1={() => null}
             renderSupport2={() => null}
+            withSeparators
           />
         );
 
@@ -27,6 +28,7 @@ export default renderComponent => {
             renderLead={() => createItem("lead")}
             renderSupport1={() => createItem("support-1")}
             renderSupport2={() => null}
+            withSeparators
           />
         );
 
@@ -41,6 +43,7 @@ export default renderComponent => {
             renderLead={() => createItem("lead")}
             renderSupport1={() => createItem("support-1")}
             renderSupport2={() => createItem("support-2")}
+            withSeparators
           />
         );
 

--- a/packages/slice-layout/slice-layout.showcase.js
+++ b/packages/slice-layout/slice-layout.showcase.js
@@ -52,6 +52,7 @@ export default {
             )}
             renderSupport1={() => null}
             renderSupport2={() => null}
+            withSeparators
           />
         </ScrollView>
       ),
@@ -73,6 +74,7 @@ export default {
             )}
             renderSupport1={() => <Support1 id="support1" />}
             renderSupport2={() => null}
+            withSeparators
           />
         </ScrollView>
       ),
@@ -94,6 +96,7 @@ export default {
             )}
             renderSupport1={() => <Support1 id="support1" />}
             renderSupport2={() => <Support2 id="support2" />}
+            withSeparators
           />
         </ScrollView>
       ),

--- a/packages/slice-layout/src/templates/leadoneandtwo/index.js
+++ b/packages/slice-layout/src/templates/leadoneandtwo/index.js
@@ -1,20 +1,38 @@
 import React from "react";
 import { View } from "react-native";
 import { leadConfig, supportConfig } from "./config";
-import propTypes from "./proptypes";
+import { defaultProps, propTypes } from "./proptypes";
 import styles from "../styles";
 
-const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
+const LeadOneAndTwoSlice = ({
+  renderLead,
+  renderSupport1,
+  renderSupport2,
+  withSeparators
+}) => {
   const support1 = renderSupport1(supportConfig);
   const support2 = renderSupport2(supportConfig);
   const supports = [support1, support2];
   return (
     <View style={styles.container}>
-      <View style={styles.itemContainer}>
+      <View
+        style={
+          withSeparators
+            ? styles.itemContainer
+            : styles.itemContainerWithoutBorders
+        }
+      >
         <View style={styles.item}>{renderLead(leadConfig)}</View>
       </View>
       {supports.filter(support => support).map(support => (
-        <View key={support.props.id} style={styles.itemContainer}>
+        <View
+          key={support.props.id}
+          style={
+            withSeparators
+              ? styles.itemContainer
+              : styles.itemContainerWithoutBorders
+          }
+        >
           <View style={styles.item}>{support}</View>
         </View>
       ))}
@@ -23,5 +41,6 @@ const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
 };
 
 LeadOneAndTwoSlice.propTypes = propTypes;
+LeadOneAndTwoSlice.defaultProps = defaultProps;
 
 export default LeadOneAndTwoSlice;

--- a/packages/slice-layout/src/templates/leadoneandtwo/index.web.js
+++ b/packages/slice-layout/src/templates/leadoneandtwo/index.web.js
@@ -1,5 +1,5 @@
 import React from "react";
-import propTypes from "./proptypes";
+import { defaultProps, propTypes } from "./proptypes";
 import { getSeparator, SliceContainer } from "../styles/responsive";
 import {
   getContainer,
@@ -58,5 +58,6 @@ const LeadOneAndTwoSlice = ({ renderLead, renderSupport1, renderSupport2 }) => {
 };
 
 LeadOneAndTwoSlice.propTypes = propTypes;
+LeadOneAndTwoSlice.defaultProps = defaultProps;
 
 export default LeadOneAndTwoSlice;

--- a/packages/slice-layout/src/templates/leadoneandtwo/proptypes.js
+++ b/packages/slice-layout/src/templates/leadoneandtwo/proptypes.js
@@ -3,7 +3,12 @@ import PropTypes from "prop-types";
 const propTypes = {
   renderLead: PropTypes.func.isRequired,
   renderSupport1: PropTypes.func.isRequired,
-  renderSupport2: PropTypes.func.isRequired
+  renderSupport2: PropTypes.func.isRequired,
+  withSeparators: PropTypes.bool
 };
 
-export default propTypes;
+const defaultProps = {
+  withSeparators: false
+};
+
+export { propTypes, defaultProps };

--- a/packages/slice-layout/src/templates/styles/index.js
+++ b/packages/slice-layout/src/templates/styles/index.js
@@ -9,6 +9,9 @@ const styles = {
     borderBottomWidth: 1,
     borderStyle: "solid",
     width: "100%"
+  },
+  itemContainerWithoutBorders: {
+    width: "100%"
   }
 };
 


### PR DESCRIPTION
Updating layouts and styles based on the designs (there will be a second update once we get zeplin designs)

- Added summary125 to fixture generator (More summaries will be added with the actual character counts)
- Moved article flag below headline
- Added style prop to article summary so it uses the style that's passed
- Added an ability to hide separators in LeadOneAndTwoSlice in slice-layout
- Increased headline size on primary tile
- Played around the margins a bit (these will be finalised once we get zeplin designs)

![screenshot_1548689259](https://user-images.githubusercontent.com/1849590/51846318-445ef200-2311-11e9-8cab-8ac76a77e58f.png)
