### PR TITLE
feat: secondary one slice

### DIFF
--- a/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-in-depth/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -240,7 +240,9 @@ exports[`full article with style 1`] = `
       </View>
     </View>
     <View>
-      <RelatedArticles />
+      <View>
+        <RelatedArticles />
+      </View>
     </View>
     <View
       style={
@@ -493,7 +495,9 @@ exports[`full article with style in the culture magazine 1`] = `
       </View>
     </View>
     <View>
-      <RelatedArticles />
+      <View>
+        <RelatedArticles />
+      </View>
     </View>
     <View
       style={
@@ -746,7 +750,9 @@ exports[`full article with style in the style magazine 1`] = `
       </View>
     </View>
     <View>
-      <RelatedArticles />
+      <View>
+        <RelatedArticles />
+      </View>
     </View>
     <View
       style={
@@ -999,15 +1005,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
       </View>
     </View>
     <View>
-      <View
-        style={
-          Object {
-            "alignSelf": "center",
-            "maxWidth": 660,
-            "width": "100%",
-          }
-        }
-      >
+      <View>
         <RelatedArticles />
       </View>
     </View>

--- a/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-in-depth/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -239,7 +239,9 @@ exports[`full article with style 1`] = `
       </View>
     </View>
     <View>
-      <RelatedArticles />
+      <View>
+        <RelatedArticles />
+      </View>
     </View>
     <View
       style={
@@ -491,7 +493,9 @@ exports[`full article with style in the culture magazine 1`] = `
       </View>
     </View>
     <View>
-      <RelatedArticles />
+      <View>
+        <RelatedArticles />
+      </View>
     </View>
     <View
       style={
@@ -743,7 +747,9 @@ exports[`full article with style in the style magazine 1`] = `
       </View>
     </View>
     <View>
-      <RelatedArticles />
+      <View>
+        <RelatedArticles />
+      </View>
     </View>
     <View
       style={
@@ -995,15 +1001,7 @@ exports[`full article with style in the sunday times magazine 1`] = `
       </View>
     </View>
     <View>
-      <View
-        style={
-          Object {
-            "alignSelf": "center",
-            "maxWidth": 660,
-            "width": "100%",
-          }
-        }
-      >
+      <View>
         <RelatedArticles />
       </View>
     </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -232,3 +232,80 @@ exports[`2. lead one and one slice 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. secondary one slice 1`] = `
+<View>
+  <View>
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags />
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "400",
+          "lineHeight": 27,
+          "marginBottom": 5,
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -259,7 +259,6 @@ exports[`3. secondary one slice 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
@@ -274,6 +273,7 @@ exports[`3. secondary one slice 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
     <Text
       style={
         Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -113,6 +113,12 @@ exports[`3. secondary one slice 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -120,12 +126,6 @@ exports[`3. secondary one slice 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
     <Text>
       <Text>
         

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -104,3 +104,45 @@ exports[`2. lead one and one slice 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. secondary one slice 1`] = `
+<View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text>
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -149,7 +149,6 @@ exports[`3. secondary tile 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
@@ -164,6 +163,7 @@ exports[`3. secondary tile 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
     <Text
       style={
         Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -56,7 +56,7 @@ exports[`1. primary tile 1`] = `
 </View>
 `;
 
-exports[`2. primary tiles without image 1`] = `
+exports[`2. primary tile without image 1`] = `
 <View>
   <View>
     <View
@@ -120,5 +120,82 @@ exports[`2. primary tiles without image 1`] = `
       ...
     </Text>
   </Text>
+</View>
+`;
+
+exports[`3. secondary tile 1`] = `
+<View>
+  <View>
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags />
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "400",
+          "lineHeight": 27,
+          "marginBottom": 5,
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -75,6 +75,12 @@ exports[`3. secondary tile 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -82,12 +88,6 @@ exports[`3. secondary tile 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
     <Text>
       <Text>
         

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -31,7 +31,7 @@ exports[`1. primary tile 1`] = `
 </View>
 `;
 
-exports[`2. primary tiles without image 1`] = `
+exports[`2. primary tile without image 1`] = `
 <View>
   <View>
     <View>
@@ -64,5 +64,47 @@ exports[`2. primary tiles without image 1`] = `
       ...
     </Text>
   </Text>
+</View>
+`;
+
+exports[`3. secondary tile 1`] = `
+<View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text>
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -232,3 +232,80 @@ exports[`2. lead one and one slice 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. secondary one slice 1`] = `
+<View>
+  <View>
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags />
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "900",
+          "lineHeight": 25,
+          "marginBottom": 5,
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -259,7 +259,6 @@ exports[`3. secondary one slice 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
@@ -274,6 +273,7 @@ exports[`3. secondary one slice 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
     <Text
       style={
         Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -113,6 +113,12 @@ exports[`3. secondary one slice 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -120,12 +126,6 @@ exports[`3. secondary one slice 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
     <Text>
       <Text>
         

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -104,3 +104,45 @@ exports[`2. lead one and one slice 1`] = `
   </View>
 </View>
 `;
+
+exports[`3. secondary one slice 1`] = `
+<View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text>
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -149,7 +149,6 @@ exports[`3. secondary tile 1`] = `
         ROYALS
       </Text>
     </View>
-    <ArticleFlags />
     <Text
       style={
         Object {
@@ -164,6 +163,7 @@ exports[`3. secondary tile 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
+    <ArticleFlags />
     <Text
       style={
         Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -56,7 +56,7 @@ exports[`1. primary tile 1`] = `
 </View>
 `;
 
-exports[`2. primary tiles without image 1`] = `
+exports[`2. primary tile without image 1`] = `
 <View>
   <View>
     <View
@@ -120,5 +120,82 @@ exports[`2. primary tiles without image 1`] = `
       ...
     </Text>
   </Text>
+</View>
+`;
+
+exports[`3. secondary tile 1`] = `
+<View>
+  <View>
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags />
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "900",
+          "lineHeight": 25,
+          "marginBottom": 5,
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "#696969",
+          "flexWrap": "wrap",
+          "fontFamily": "TimesDigitalW04",
+          "fontSize": 14,
+          "lineHeight": 20,
+          "marginBottom": 10,
+        }
+      }
+    >
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "marginBottom": 10,
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -75,6 +75,12 @@ exports[`3. secondary tile 1`] = `
         ROYALS
       </Text>
     </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
     <ArticleFlags
       flags={
         Array [
@@ -82,12 +88,6 @@ exports[`3. secondary tile 1`] = `
         ]
       }
     />
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
     <Text>
       <Text>
         

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -31,7 +31,7 @@ exports[`1. primary tile 1`] = `
 </View>
 `;
 
-exports[`2. primary tiles without image 1`] = `
+exports[`2. primary tile without image 1`] = `
 <View>
   <View>
     <View>
@@ -64,5 +64,47 @@ exports[`2. primary tiles without image 1`] = `
       ...
     </Text>
   </Text>
+</View>
+`;
+
+exports[`3. secondary tile 1`] = `
+<View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <Text>
+      <Text>
+        
+        The 
+        <Text>
+          Duke of Edinburgh
+        </Text>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </Text>
+    </Text>
+  </View>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </View>
 </View>
 `;

--- a/packages/edition-slices/__tests__/shared-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-slices.base.js
@@ -2,7 +2,11 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
 import leadOneAndOneDataGenerator from "../fixtures/leadoneandone";
-import { LeadOneFullWidthSlice, LeadOneAndOneSlice } from "../src/slices";
+import {
+  LeadOneFullWidthSlice,
+  LeadOneAndOneSlice,
+  SecondaryOneSlice
+} from "../src/slices";
 
 jest.mock("@times-components/article-flag", () => ({
   ArticleFlags: "ArticleFlags"
@@ -34,6 +38,16 @@ export default () => {
             lead={leadOneAndOneData.lead}
             support={leadOneAndOneData.support}
           />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "secondary one slice",
+      test: () => {
+        const output = TestRenderer.create(
+          <SecondaryOneSlice secondary={leadOneAndOneData.lead} />
         );
 
         expect(output).toMatchSnapshot();

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -2,7 +2,7 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
 import leadOneAndOneDataGenerator from "../fixtures/leadoneandone";
-import { PrimaryTile } from "../src/tiles";
+import { PrimaryTile, SecondaryTile } from "../src/tiles";
 
 jest.mock("@times-components/article-flag", () => ({
   ArticleFlags: "ArticleFlags"
@@ -27,10 +27,20 @@ export default () => {
       }
     },
     {
-      name: "primary tiles without image",
+      name: "primary tile without image",
       test: () => {
         const output = TestRenderer.create(
           <PrimaryTile tile={leadOneAndOneData.lead} />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "secondary tile",
+      test: () => {
+        const output = TestRenderer.create(
+          <SecondaryTile tile={leadOneAndOneData.lead} />
         );
 
         expect(output).toMatchSnapshot();

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -324,13 +324,6 @@ exports[`3. secondary one slice 1`] = `
         ROYALS
       </div>
     </div>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
     <h3
       aria-level="3"
       className="S3"
@@ -338,6 +331,13 @@ exports[`3. secondary one slice 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
     <div
       className="S5"
     >

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -254,3 +254,115 @@ exports[`2. lead one and one slice 1`] = `
   </div>
 </div>
 `;
+
+exports[`3. secondary one slice 1`] = `
+<style>
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 5px;
+}
+
+.S4 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.S6 {
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  color: rgba(29,29,27,1.00);
+}
+</style>
+
+<div
+  className="S2"
+>
+  <div
+    className="S2"
+  >
+    <div
+      className="S2"
+    >
+      <div
+        className="IS1 S1"
+      >
+        ROYALS
+      </div>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <h3
+      aria-level="3"
+      className="S3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <div
+      className="S5"
+    >
+      <span
+        className="S4"
+      >
+        
+        The 
+        <span
+          className="S4"
+        >
+          Duke of Edinburgh
+        </span>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </span>
+    </div>
+  </div>
+  <div
+    className="S6"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </div>
+</div>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -116,6 +116,12 @@ exports[`3. secondary one slice 1`] = `
         ROYALS
       </div>
     </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
     <ArticleFlags
       flags={
         Array [
@@ -123,12 +129,6 @@ exports[`3. secondary one slice 1`] = `
         ]
       }
     />
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
     <div>
       <span>
         

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -107,3 +107,45 @@ exports[`2. lead one and one slice 1`] = `
   </div>
 </div>
 `;
+
+exports[`3. secondary one slice 1`] = `
+<div>
+  <div>
+    <div>
+      <div>
+        ROYALS
+      </div>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <div>
+      <span>
+        
+        The 
+        <span>
+          Duke of Edinburgh
+        </span>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </span>
+    </div>
+  </div>
+  <div>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </div>
+</div>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -242,13 +242,6 @@ exports[`3. secondary tile 1`] = `
         ROYALS
       </div>
     </div>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
     <h3
       aria-level="3"
       className="S3"
@@ -256,6 +249,13 @@ exports[`3. secondary tile 1`] = `
     >
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
     <div
       className="S5"
     >

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -73,7 +73,7 @@ exports[`1. primary tile 1`] = `
 </div>
 `;
 
-exports[`2. primary tiles without image 1`] = `
+exports[`2. primary tile without image 1`] = `
 <style>
 .S1 {
   font-family: GillSansMTStd-Medium;
@@ -169,6 +169,118 @@ exports[`2. primary tiles without image 1`] = `
        could be charged with driving without due care and attention after his car accident yesterday
       ...
     </span>
+  </div>
+</div>
+`;
+
+exports[`3. secondary tile 1`] = `
+<style>
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 27px;
+  margin-bottom: 5px;
+}
+
+.S4 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  color: rgba(105,105,105,1.00);
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.S6 {
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  color: rgba(29,29,27,1.00);
+}
+</style>
+
+<div
+  className="S2"
+>
+  <div
+    className="S2"
+  >
+    <div
+      className="S2"
+    >
+      <div
+        className="IS1 S1"
+      >
+        ROYALS
+      </div>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <h3
+      aria-level="3"
+      className="S3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <div
+      className="S5"
+    >
+      <span
+        className="S4"
+      >
+        
+        The 
+        <span
+          className="S4"
+        >
+          Duke of Edinburgh
+        </span>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </span>
+    </div>
+  </div>
+  <div
+    className="S6"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
   </div>
 </div>
 `;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -75,6 +75,12 @@ exports[`3. secondary tile 1`] = `
         ROYALS
       </div>
     </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
     <ArticleFlags
       flags={
         Array [
@@ -82,12 +88,6 @@ exports[`3. secondary tile 1`] = `
         ]
       }
     />
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
     <div>
       <span>
         

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -31,7 +31,7 @@ exports[`1. primary tile 1`] = `
 </div>
 `;
 
-exports[`2. primary tiles without image 1`] = `
+exports[`2. primary tile without image 1`] = `
 <div>
   <div>
     <div>
@@ -63,6 +63,48 @@ exports[`2. primary tiles without image 1`] = `
        could be charged with driving without due care and attention after his car accident yesterday
       ...
     </span>
+  </div>
+</div>
+`;
+
+exports[`3. secondary tile 1`] = `
+<div>
+  <div>
+    <div>
+      <div>
+        ROYALS
+      </div>
+    </div>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <div>
+      <span>
+        
+        The 
+        <span>
+          Duke of Edinburgh
+        </span>
+         could be charged with driving without due care and attention after his car accident yesterday
+        ...
+      </span>
+    </div>
+  </div>
+  <div>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
   </div>
 </div>
 `;

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -1,9 +1,14 @@
 import React from "react";
 import {
   mockLeadOneFullWidthSlice,
-  mockLeadOneAndOneSlice
+  mockLeadOneAndOneSlice,
+  mockSecondaryOneSlice
 } from "@times-components/fixture-generator";
-import { LeadOneFullWidthSlice, LeadOneAndOneSlice } from "./src/slices";
+import {
+  LeadOneFullWidthSlice,
+  LeadOneAndOneSlice,
+  SecondaryOneSlice
+} from "./src/slices";
 
 export default {
   children: [
@@ -21,6 +26,14 @@ export default {
         return <LeadOneAndOneSlice lead={slice.lead} support={slice.support} />;
       },
       name: "Lead One And One",
+      type: "story"
+    },
+    {
+      component: () => {
+        const slice = mockSecondaryOneSlice();
+        return <SecondaryOneSlice secondary={slice.secondary} />;
+      },
+      name: "Secondary One",
       type: "story"
     }
   ],

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -1,6 +1,9 @@
 import React from "react";
-import { mockLeadOneFullWidthSlice } from "@times-components/fixture-generator";
-import { PrimaryTile } from "./src/tiles";
+import {
+  mockLeadOneFullWidthSlice,
+  mockSecondaryOneSlice
+} from "@times-components/fixture-generator";
+import { PrimaryTile, SecondaryTile } from "./src/tiles";
 
 export default {
   children: [
@@ -18,6 +21,14 @@ export default {
         return <PrimaryTile tile={slice.lead} withSummaryMargins />;
       },
       name: "Primary (without image, with summary margins)",
+      type: "story"
+    },
+    {
+      component: () => {
+        const slice = mockSecondaryOneSlice();
+        return <SecondaryTile tile={slice.secondary} />;
+      },
+      name: "Secondary",
       type: "story"
     }
   ],

--- a/packages/edition-slices/src/edition-slices.js
+++ b/packages/edition-slices/src/edition-slices.js
@@ -1,4 +1,14 @@
-import { LeadOneFullWidthSlice, LeadOneAndOneSlice } from "./slices";
-import { PrimaryTile } from "./tiles";
+import {
+  LeadOneFullWidthSlice,
+  LeadOneAndOneSlice,
+  SecondaryOneSlice
+} from "./slices";
+import { PrimaryTile, SecondaryTile } from "./tiles";
 
-export { LeadOneFullWidthSlice, LeadOneAndOneSlice, PrimaryTile };
+export {
+  LeadOneFullWidthSlice,
+  LeadOneAndOneSlice,
+  SecondaryOneSlice,
+  PrimaryTile,
+  SecondaryTile
+};

--- a/packages/edition-slices/src/slices/index.js
+++ b/packages/edition-slices/src/slices/index.js
@@ -1,5 +1,3 @@
-import LeadOneFullWidthSlice from "./leadonefullwidth";
-import LeadOneAndOneSlice from "./leadoneandone";
-import SecondaryOneSlice from "./secondaryone";
-
-export { LeadOneFullWidthSlice, LeadOneAndOneSlice, SecondaryOneSlice };
+export { default as LeadOneFullWidthSlice } from "./leadonefullwidth";
+export { default as LeadOneAndOneSlice } from "./leadoneandone";
+export { default as SecondaryOneSlice } from "./secondaryone";

--- a/packages/edition-slices/src/slices/index.js
+++ b/packages/edition-slices/src/slices/index.js
@@ -1,4 +1,5 @@
 import LeadOneFullWidthSlice from "./leadonefullwidth";
 import LeadOneAndOneSlice from "./leadoneandone";
+import SecondaryOneSlice from "./secondaryone";
 
-export { LeadOneFullWidthSlice, LeadOneAndOneSlice };
+export { LeadOneFullWidthSlice, LeadOneAndOneSlice, SecondaryOneSlice };

--- a/packages/edition-slices/src/slices/secondaryone/index.js
+++ b/packages/edition-slices/src/slices/secondaryone/index.js
@@ -1,0 +1,11 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { SecondaryTile } from "../../tiles";
+
+const SecondaryOneSlice = ({ secondary }) => <SecondaryTile tile={secondary} />;
+
+SecondaryOneSlice.propTypes = {
+  secondary: PropTypes.shape({}).isRequired
+};
+
+export default SecondaryOneSlice;

--- a/packages/edition-slices/src/tiles/index.js
+++ b/packages/edition-slices/src/tiles/index.js
@@ -1,5 +1,2 @@
-import PrimaryTile from "./primary";
-import SecondaryTile from "./secondary";
-
-// eslint-disable-next-line import/prefer-default-export
-export { PrimaryTile, SecondaryTile };
+export { default as PrimaryTile } from "./primary";
+export { default as SecondaryTile } from "./secondary";

--- a/packages/edition-slices/src/tiles/index.js
+++ b/packages/edition-slices/src/tiles/index.js
@@ -1,4 +1,5 @@
 import PrimaryTile from "./primary";
+import SecondaryTile from "./secondary";
 
 // eslint-disable-next-line import/prefer-default-export
-export { PrimaryTile };
+export { PrimaryTile, SecondaryTile };

--- a/packages/edition-slices/src/tiles/secondary/index.js
+++ b/packages/edition-slices/src/tiles/secondary/index.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import { ArticleFlags } from "@times-components/article-flag";
+import ArticleSummary, {
+  ArticleSummaryContent,
+  ArticleSummaryHeadline
+} from "@times-components/article-summary";
+import Image from "@times-components/image";
+import { colours } from "@times-components/styleguide";
+import styles from "./styles";
+
+const renderImage = imageUri => (
+  <View style={styles.imageContainer}>
+    <Image aspectRatio={16 / 9} uri={imageUri} />
+  </View>
+);
+
+const SecondaryTile = ({
+  tile: {
+    article: {
+      flags,
+      hasVideo,
+      headline,
+      label,
+      leadAsset,
+      section,
+      shortHeadline,
+      summary125
+    }
+  }
+}) => (
+  <View>
+    <ArticleSummary
+      content={() => <ArticleSummaryContent ast={summary125} />}
+      flags={() => <ArticleFlags flags={flags} />}
+      headline={() => (
+        <ArticleSummaryHeadline headline={headline || shortHeadline} />
+      )}
+      label={label}
+      labelProps={{
+        color: colours.section[section] || colours.section.default,
+        isVideo: hasVideo,
+        title: label
+      }}
+    />
+    {renderImage(leadAsset.crop169.url)}
+  </View>
+);
+
+SecondaryTile.propTypes = {
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default SecondaryTile;

--- a/packages/edition-slices/src/tiles/secondary/styles/index.js
+++ b/packages/edition-slices/src/tiles/secondary/styles/index.js
@@ -1,0 +1,11 @@
+import { StyleSheet } from "react-native";
+import { spacing } from "@times-components/styleguide";
+
+const styles = StyleSheet.create({
+  imageContainer: {
+    marginBottom: spacing(2),
+    width: "100%"
+  }
+});
+
+export default styles;

--- a/packages/fixture-generator/src/__tests__/mock-slice.test.ts
+++ b/packages/fixture-generator/src/__tests__/mock-slice.test.ts
@@ -1,4 +1,4 @@
-import mockArticleSlice, { mockLeadOneAndTwoSlice, mockLeadOneFullWidthSlice, mockLeadOneAndOneSlice } from "../mock-slice";
+import mockArticleSlice, { mockLeadOneAndTwoSlice, mockLeadOneFullWidthSlice, mockLeadOneAndOneSlice, mockSecondaryOneSlice } from "../mock-slice";
 
 describe("The Mock EditionSlice", () => {
   it("returns the minimum articleSlice requirements", () => {
@@ -27,5 +27,11 @@ describe("The Mock EditionSlice", () => {
     expect(articleSlice.lead).toBeDefined();
     expect(articleSlice.support1).toBeDefined();
     expect(articleSlice.support2).toBeDefined();
+  });
+
+  it("returns SecondaryOneSlice", () => {
+    const articleSlice = mockSecondaryOneSlice();
+    expect(articleSlice.items.length).toBe(1);
+    expect(articleSlice.secondary).toBeDefined();
   });
 });

--- a/packages/fixture-generator/src/index.ts
+++ b/packages/fixture-generator/src/index.ts
@@ -4,7 +4,8 @@ import MockAuthor from "./mock-author";
 import mockEditionSlice, {
   mockLeadOneFullWidthSlice,
   mockLeadOneAndOneSlice,
-  mockLeadOneAndTwoSlice
+  mockLeadOneAndTwoSlice,
+  mockSecondaryOneSlice
 } from "./mock-slice";
 import MockTopic from "./mock-topic";
 
@@ -12,6 +13,7 @@ export {
   mockLeadOneFullWidthSlice,
   mockLeadOneAndOneSlice,
   mockLeadOneAndTwoSlice,
+  mockSecondaryOneSlice,
   MockArticle,
   mockEditionSlice,
   MockImage,

--- a/packages/fixture-generator/src/mock-slice.ts
+++ b/packages/fixture-generator/src/mock-slice.ts
@@ -3,6 +3,7 @@ import {
   LeadOneFullWidthSlice,
   LeadOneAndOneSlice,
   LeadOneAndTwoSlice,
+  SecondaryOneSlice,
   Tile
 } from "./types";
 import MockArticle from "./mock-article";
@@ -47,6 +48,14 @@ function mockLeadOneAndTwoSlice(): LeadOneAndTwoSlice {
   };
 }
 
+function mockSecondaryOneSlice(): SecondaryOneSlice {
+  const tiles = getTiles(1);
+  return <SecondaryOneSlice>{
+    secondary: tiles[0],
+    items: tiles
+  };
+}
+
 function mockArticleSlice(count: number): ArticleSlice {
   return { items: getTiles(count) };
 }
@@ -55,5 +64,6 @@ export default mockArticleSlice;
 export {
   mockLeadOneFullWidthSlice,
   mockLeadOneAndOneSlice,
-  mockLeadOneAndTwoSlice
+  mockLeadOneAndTwoSlice,
+  mockSecondaryOneSlice
 };


### PR DESCRIPTION
- Secondary One Slice | wireframe only | mobile only
- https://nidigitalsolutions.jira.com/browse/REPLAT-5139
- note summary is using `summary125` which should be `summary250` according to https://docs.google.com/spreadsheets/d/1NBC-dOAGcF1sgfrkfFH7uslKG7eEU4o3n3Og5T1WNC8/edit#gid=1321391883. All the summary text lengths will come in a forthcoming PR.