### PR TITLE
feat: Add all summaries to article fixtures

### DIFF
--- a/packages/fixture-generator/src/__tests__/mock-markup.test.ts
+++ b/packages/fixture-generator/src/__tests__/mock-markup.test.ts
@@ -35,4 +35,10 @@ describe("get markup", () => {
       { name: "ad" }
     ])
   });
+
+  it("should be able to generate summaries", () => {
+    const mockMarkup = new MockMarkup().addSummary("summary125").get();
+    expect(mockMarkup).toMatchObject([ { name: "paragraph" } ]); 
+    expect(mockMarkup[0].children[0].attributes.value.length).toBe(125);
+  });
 });

--- a/packages/fixture-generator/src/__tests__/mock-markup.test.ts
+++ b/packages/fixture-generator/src/__tests__/mock-markup.test.ts
@@ -7,17 +7,17 @@ describe("get markup", () => {
 
   it("should be able to generate paragraph of markup", () => {
     const mockMarkup = new MockMarkup().addParagraphs().get();
-    expect(mockMarkup).toMatchObject([ { name: "paragraph" } ]); 
+    expect(mockMarkup).toMatchObject([{ name: "paragraph" }]);
   });
 
   it("should be able to generate markup with ads", () => {
     const mockMarkup = new MockMarkup().addAds().get();
-    expect(mockMarkup).toMatchObject([ { name: "ad" } ]); 
+    expect(mockMarkup).toMatchObject([{ name: "ad" }]);
   });
 
   it("should be able to generate inline of markup", () => {
     const mockMarkup = new MockMarkup().addInlines().get();
-    expect(mockMarkup).toMatchObject([ { name: "inline" } ]); 
+    expect(mockMarkup).toMatchObject([{ name: "inline" }]);
   });
 
   it("should generate large markup shapes", () => {
@@ -38,7 +38,7 @@ describe("get markup", () => {
 
   it("should be able to generate summaries", () => {
     const mockMarkup = new MockMarkup().addSummary("summary125").get();
-    expect(mockMarkup).toMatchObject([ { name: "paragraph" } ]); 
-    expect(mockMarkup[0].children[0].attributes.value.length).toBe(125);
+    expect(mockMarkup).toMatchObject([{ name: "paragraph" }]);
+    expect(mockMarkup[0].children[0].attributes.value.length).toBeLessThanOrEqual(125);
   });
 });

--- a/packages/fixture-generator/src/mock-article.ts
+++ b/packages/fixture-generator/src/mock-article.ts
@@ -3,6 +3,7 @@ import {
   PublicationName,
   Url,
   Flag,
+  Markup,
   SectionName,
   TemplateType
 } from "./types";
@@ -13,8 +14,17 @@ import MockImage from "./mock-image";
 import getArticleSlice from "./mock-slice";
 import MockMarkup from "./mock-markup";
 
+interface TimesArticle extends Article {
+  summary105: Markup | null;
+  summary125: Markup | null;
+  summary145: Markup | null;
+  summary160: Markup | null;
+  summary175: Markup | null;
+  summary225: Markup | null;
+}
+
 class MockArticle {
-  article: Article;
+  article: TimesArticle;
 
   constructor() {
     this.article = {
@@ -48,7 +58,13 @@ class MockArticle {
       shortIdentifier: "37b27qd2s",
       standfirst: "standfirst",
       title: "title",
-      summary: new MockMarkup().addParagraphs().get()
+      summary: new MockMarkup().addParagraphs().get(),
+      summary105: new MockMarkup().addSummary("summary105").get(),
+      summary125: new MockMarkup().addSummary("summary125").get(),
+      summary145: new MockMarkup().addSummary("summary145").get(),
+      summary160: new MockMarkup().addSummary("summary160").get(),
+      summary175: new MockMarkup().addSummary("summary175").get(),
+      summary225: new MockMarkup().addSummary("summary225").get()
     };
   }
 

--- a/packages/fixture-generator/src/mock-markup.ts
+++ b/packages/fixture-generator/src/mock-markup.ts
@@ -1,5 +1,7 @@
 import { Markup } from "./types";
 
+const paragraphText =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";
 const markupTypes: Markup = {
   paragraph: {
     name: "paragraph",
@@ -8,8 +10,7 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value:
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum"
+          value: paragraphText
         },
         children: []
       }
@@ -28,6 +29,84 @@ const markupTypes: Markup = {
         name: "text",
         attributes: {
           value: "inline markup"
+        },
+        children: []
+      }
+    ]
+  },
+  summary105: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value: paragraphText.substring(0, 125)
+        },
+        children: []
+      }
+    ]
+  },
+  summary125: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value: paragraphText.substring(0, 125)
+        },
+        children: []
+      }
+    ]
+  },
+  summary145: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value: paragraphText.substring(0, 145)
+        },
+        children: []
+      }
+    ]
+  },
+  summary160: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value: paragraphText.substring(0, 160)
+        },
+        children: []
+      }
+    ]
+  },
+  summary175: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value: paragraphText.substring(0, 175)
+        },
+        children: []
+      }
+    ]
+  },
+  summary225: {
+    name: "paragraph",
+    attributes: {},
+    children: [
+      {
+        name: "text",
+        attributes: {
+          value: paragraphText.substring(0, 225)
         },
         children: []
       }
@@ -73,6 +152,11 @@ class MockMarkup {
 
   addInlines(length: number = 1) {
     this.markup = generateMarkup(this.markup, markupTypes.inline.name, length);
+    return this;
+  }
+
+  addSummary(summaryName: string) {
+    this.markup = generateMarkup(this.markup, summaryName, 1);
     return this;
   }
 

--- a/packages/fixture-generator/src/mock-markup.ts
+++ b/packages/fixture-generator/src/mock-markup.ts
@@ -1,7 +1,5 @@
 import { Markup } from "./types";
 
-const paragraphText =
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";
 const markupTypes: Markup = {
   paragraph: {
     name: "paragraph",
@@ -10,7 +8,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText
+          value:
+            "Critically, he said this would not necessarily require the withdrawal agreement to be reopened but could instead be done by a legally binding codicil. He added that should his amendment be passed in a Commons vote tomorrow it would give “enormous firepower” to the prime minister when she returned to Brussels."
         },
         children: []
       }
@@ -41,7 +40,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText.substring(0, 125)
+          value:
+            "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught"
         },
         children: []
       }
@@ -54,7 +54,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText.substring(0, 125)
+          value:
+            "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty."
         },
         children: []
       }
@@ -67,7 +68,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText.substring(0, 145)
+          value:
+            "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty."
         },
         children: []
       }
@@ -80,7 +82,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText.substring(0, 160)
+          value:
+            "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting"
         },
         children: []
       }
@@ -93,7 +96,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText.substring(0, 175)
+          value:
+            "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take"
         },
         children: []
       }
@@ -106,7 +110,8 @@ const markupTypes: Markup = {
       {
         name: "text",
         attributes: {
-          value: paragraphText.substring(0, 225)
+          value:
+            "Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty. The first is to try and stop MPs voting to take control of the Brexit process themselves. To do this a"
         },
         children: []
       }


### PR DESCRIPTION
Added all the summaries (6 of them) to fixture generators.

Paired with: @nehasri89 