### PR TITLE
feat: Increase text size for tablet widths

### DIFF
--- a/packages/article-in-depth/package.json
+++ b/packages/article-in-depth/package.json
@@ -45,7 +45,7 @@
     "@times-components/storybook": "3.3.2",
     "@times-components/tealium-utils": "0.7.14",
     "@times-components/test-utils": "2.1.4",
-    "@times-components/utils": "4.1.3",
+    "@times-components/utils": "4.2.0",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-cli": "6.26.0",
     "eslint": "5.9.0",

--- a/packages/article-magazine-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -31,8 +31,8 @@ exports[`full article with style in the culture magazine 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "Flama-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 42,
               "marginBottom": 10,
               "textAlign": "center",
             }
@@ -301,8 +301,8 @@ exports[`full article with style in the style magazine 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "CenturyGothic-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 42,
               "marginBottom": 10,
               "textAlign": "center",
             }
@@ -571,8 +571,8 @@ exports[`full article with style in the sunday times magazine 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "Tiempos-Headline-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 42,
               "marginBottom": 10,
               "textAlign": "center",
             }
@@ -1087,8 +1087,8 @@ exports[`tablet full article with style 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 40,
               "marginBottom": 10,
               "textAlign": "center",
             }

--- a/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-magazine-standard/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -31,8 +31,8 @@ exports[`full article with style in the culture magazine 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "Flama-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 42,
               "marginBottom": 10,
               "textAlign": "center",
             }
@@ -300,8 +300,8 @@ exports[`full article with style in the style magazine 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "CenturyGothic-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 42,
               "marginBottom": 10,
               "textAlign": "center",
             }
@@ -569,8 +569,8 @@ exports[`full article with style in the sunday times magazine 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "Tiempos-Headline-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 42,
               "marginBottom": 10,
               "textAlign": "center",
             }
@@ -1083,8 +1083,8 @@ exports[`tablet full article with style 1`] = `
             Object {
               "color": "#1D1D1B",
               "fontFamily": "TimesModern-Bold",
-              "fontSize": 30,
-              "lineHeight": 35,
+              "fontSize": 40,
+              "lineHeight": 40,
               "marginBottom": 10,
               "textAlign": "center",
             }

--- a/packages/article-magazine-standard/src/article-header/article-header.js
+++ b/packages/article-magazine-standard/src/article-header/article-header.js
@@ -3,7 +3,7 @@ import { Text, View } from "react-native";
 import PropTypes from "prop-types";
 import Context from "@times-components/context";
 import { ArticleFlags } from "@times-components/article-flag";
-import { fonts } from "@times-components/styleguide";
+import { fontFactory } from "@times-components/styleguide";
 
 import Label from "../article-label/article-label";
 import Meta from "../article-meta/article-meta";
@@ -33,7 +33,12 @@ const ArticleHeader = ({
         <Text
           style={[
             styles.articleHeadline,
-            headlineFont ? { fontFamily: fonts[headlineFont] } : null
+            {
+              ...fontFactory({
+                font: headlineFont || "headline",
+                fontSize: isTablet ? "pageHeadline" : "headline"
+              })
+            }
           ]}
         >
           {headline}

--- a/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
+++ b/packages/article-main-comment/__tests__/android/__snapshots__/article-with-style.android.test.js.snap
@@ -322,8 +322,8 @@ exports[`tablet full article with style 1`] = `
               Object {
                 "color": "#1D1D1B",
                 "fontFamily": "TimesModern-Bold",
-                "fontSize": 30,
-                "lineHeight": 35,
+                "fontSize": 45,
+                "lineHeight": 45,
                 "marginBottom": 10,
                 "textAlign": "center",
               }

--- a/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
+++ b/packages/article-main-comment/__tests__/ios/__snapshots__/article-with-style.ios.test.js.snap
@@ -321,8 +321,8 @@ exports[`tablet full article with style 1`] = `
               Object {
                 "color": "#1D1D1B",
                 "fontFamily": "TimesModern-Bold",
-                "fontSize": 30,
-                "lineHeight": 35,
+                "fontSize": 45,
+                "lineHeight": 45,
                 "marginBottom": 10,
                 "textAlign": "center",
               }

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -31,7 +31,7 @@ const ArticleHeader = ({
         <View style={[styles.container, isTablet && styles.containerTablet]}>
           <Image aspectRatio={1} style={styles.authorImage} uri={authorImage} />
           <Label isVideo={hasVideo} label={label} />
-          <Text style={styles.articleHeadline}>{headline}</Text>
+          <Text style={[styles.articleHeadline, isTablet && styles.articleHeadlineTablet]}>{headline}</Text>
           <View style={styles.flags}>
             <ArticleFlags flags={flags} />
           </View>

--- a/packages/article-main-comment/src/article-header/article-header.js
+++ b/packages/article-main-comment/src/article-header/article-header.js
@@ -31,7 +31,14 @@ const ArticleHeader = ({
         <View style={[styles.container, isTablet && styles.containerTablet]}>
           <Image aspectRatio={1} style={styles.authorImage} uri={authorImage} />
           <Label isVideo={hasVideo} label={label} />
-          <Text style={[styles.articleHeadline, isTablet && styles.articleHeadlineTablet]}>{headline}</Text>
+          <Text
+            style={[
+              styles.articleHeadline,
+              isTablet && styles.articleHeadlineTablet
+            ]}
+          >
+            {headline}
+          </Text>
           <View style={styles.flags}>
             <ArticleFlags flags={flags} />
           </View>

--- a/packages/article-main-comment/src/styles/shared.js
+++ b/packages/article-main-comment/src/styles/shared.js
@@ -15,7 +15,7 @@ const sharedStyles = {
     ...fontFactory({
       font: "headline",
       fontSize: "articleHeadline"
-    }),
+    })
   },
   authorImage: {
     marginBottom: spacing(5)

--- a/packages/article-main-comment/src/styles/shared.js
+++ b/packages/article-main-comment/src/styles/shared.js
@@ -11,6 +11,12 @@ const sharedStyles = {
     marginBottom: spacing(2),
     textAlign: "center"
   },
+  articleHeadlineTablet: {
+    ...fontFactory({
+      font: "headline",
+      fontSize: "articleHeadline"
+    }),
+  },
   authorImage: {
     marginBottom: spacing(5)
   },


### PR DESCRIPTION
In the internal sprint review, it showed that going to tablet width on `Article-Main-Comment` and `Article-Magazine-Standard` did not increase the headline font size.

This PR changes that.