### PR TITLE
feat: fullwidth image display type

### DIFF
--- a/packages/article-image/.jestlint
+++ b/packages/article-image/.jestlint
@@ -1,3 +1,4 @@
 {
-  "maxAttributes": 7
+  "maxAttributes": 7,
+  "maxFileSize": 12000
 }

--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. primary image with caption and credits 1`] = `
+exports[`1. mobile primary image with caption and credits 1`] = `
 <View>
   <View
     style={
@@ -66,8 +66,232 @@ exports[`1. primary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`2. secondary image with caption and credits 1`] = `
+exports[`2. tablet primary image with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "column",
+        "paddingBottom": 15,
+        "width": "100%",
+      }
+    }
+  >
+    <View>
+      <ModalImage
+        aspectRatio={1.25}
+        caption={
+          <Caption
+            credits="Some credits"
+            text="Some caption"
+          />
+        }
+        uri="https://img/someImage"
+      />
+    </View>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "paddingTop": 5,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 20,
+              }
+            }
+          >
+            Some caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 9,
+                "fontWeight": "400",
+                "letterSpacing": 1,
+                "lineHeight": 20,
+              }
+            }
+          >
+            SOME CREDITS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`3. mobile fullwidth image with caption and credits 1`] = `
 <View>
+  <View
+    style={
+      Object {
+        "maxWidth": 1180,
+      }
+    }
+  >
+    <View>
+      <ModalImage
+        aspectRatio={1.25}
+        caption={
+          <Caption
+            credits="Some credits"
+            text="Some caption"
+          />
+        }
+        uri="https://img/someImage"
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "alignSelf": "center",
+          "maxWidth": 640,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "paddingTop": 5,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 20,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 9,
+                "fontWeight": "400",
+                "letterSpacing": 1,
+                "lineHeight": 20,
+                "textAlign": "center",
+              }
+            }
+          >
+            SOME CREDITS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`4. tablet fullwidth image with caption and credits 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "maxWidth": 1180,
+      }
+    }
+  >
+    <View>
+      <ModalImage
+        aspectRatio={1.25}
+        caption={
+          <Caption
+            credits="Some credits"
+            text="Some caption"
+          />
+        }
+        uri="https://img/someImage"
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "alignSelf": "center",
+          "maxWidth": 640,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "paddingTop": 5,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 20,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 9,
+                "fontWeight": "400",
+                "letterSpacing": 1,
+                "lineHeight": 20,
+                "textAlign": "center",
+              }
+            }
+          >
+            SOME CREDITS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`5. secondary image with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
   <View
     style={
       Object {
@@ -148,8 +372,15 @@ exports[`2. secondary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`3. inline image (landscape) with caption and credits 1`] = `
-<View>
+exports[`6. inline image (landscape) with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
   <View
     style={
       Object {
@@ -230,8 +461,15 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
 </View>
 `;
 
-exports[`4. inline image (portrait) with caption and credits 1`] = `
-<View>
+exports[`7. inline image (portrait) with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
   <View
     style={
       Object {
@@ -304,79 +542,6 @@ exports[`4. inline image (portrait) with caption and credits 1`] = `
             }
           >
             PORTRAIT CREDITS
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`should render an ArticleImage with Responsive Tablet styling 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "width": 640,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "flexDirection": "column",
-        "paddingBottom": 15,
-        "width": "100%",
-      }
-    }
-  >
-    <View>
-      <ModalImage
-        aspectRatio={1.25}
-        caption={
-          <Caption
-            credits="Some credits"
-            text="Some caption"
-          />
-        }
-        uri="https://img/someImage"
-      />
-    </View>
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "paddingHorizontal": 10,
-              "paddingTop": 5,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 20,
-              }
-            }
-          >
-            Some caption
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 9,
-                "fontWeight": "400",
-                "letterSpacing": 1,
-                "lineHeight": 20,
-              }
-            }
-          >
-            SOME CREDITS
           </Text>
         </View>
       </View>

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. primary image with caption and credits 1`] = `
+exports[`1. mobile primary image with caption and credits 1`] = `
 <View>
   <View
     style={
@@ -66,8 +66,232 @@ exports[`1. primary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`2. secondary image with caption and credits 1`] = `
+exports[`2. tablet primary image with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "column",
+        "paddingBottom": 15,
+        "width": "100%",
+      }
+    }
+  >
+    <View>
+      <ModalImage
+        aspectRatio={1.25}
+        caption={
+          <Caption
+            credits="Some credits"
+            text="Some caption"
+          />
+        }
+        uri="https://img/someImage"
+      />
+    </View>
+    <View>
+      <View>
+        <View
+          style={
+            Object {
+              "paddingHorizontal": 10,
+              "paddingTop": 10,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 16,
+              }
+            }
+          >
+            Some caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 9,
+                "fontWeight": "400",
+                "letterSpacing": 1,
+                "lineHeight": 16,
+              }
+            }
+          >
+            SOME CREDITS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`3. mobile fullwidth image with caption and credits 1`] = `
 <View>
+  <View
+    style={
+      Object {
+        "maxWidth": 1180,
+      }
+    }
+  >
+    <View>
+      <ModalImage
+        aspectRatio={1.25}
+        caption={
+          <Caption
+            credits="Some credits"
+            text="Some caption"
+          />
+        }
+        uri="https://img/someImage"
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "alignSelf": "center",
+          "maxWidth": 640,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "paddingTop": 10,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 16,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 9,
+                "fontWeight": "400",
+                "letterSpacing": 1,
+                "lineHeight": 16,
+                "textAlign": "center",
+              }
+            }
+          >
+            SOME CREDITS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`4. tablet fullwidth image with caption and credits 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "maxWidth": 1180,
+      }
+    }
+  >
+    <View>
+      <ModalImage
+        aspectRatio={1.25}
+        caption={
+          <Caption
+            credits="Some credits"
+            text="Some caption"
+          />
+        }
+        uri="https://img/someImage"
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "alignSelf": "center",
+          "maxWidth": 640,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            Object {
+              "paddingTop": 10,
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "color": "#696969",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 13,
+                "lineHeight": 16,
+                "textAlign": "center",
+              }
+            }
+          >
+            Some caption
+          </Text>
+          <Text
+            style={
+              Object {
+                "color": "#333333",
+                "fontFamily": "GillSansMTStd-Medium",
+                "fontSize": 9,
+                "fontWeight": "400",
+                "letterSpacing": 1,
+                "lineHeight": 16,
+                "textAlign": "center",
+              }
+            }
+          >
+            SOME CREDITS
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`5. secondary image with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
   <View
     style={
       Object {
@@ -148,8 +372,15 @@ exports[`2. secondary image with caption and credits 1`] = `
 </View>
 `;
 
-exports[`3. inline image (landscape) with caption and credits 1`] = `
-<View>
+exports[`6. inline image (landscape) with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
   <View
     style={
       Object {
@@ -230,8 +461,15 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
 </View>
 `;
 
-exports[`4. inline image (portrait) with caption and credits 1`] = `
-<View>
+exports[`7. inline image (portrait) with caption and credits 1`] = `
+<View
+  style={
+    Object {
+      "alignSelf": "center",
+      "width": 640,
+    }
+  }
+>
   <View
     style={
       Object {
@@ -304,79 +542,6 @@ exports[`4. inline image (portrait) with caption and credits 1`] = `
             }
           >
             PORTRAIT CREDITS
-          </Text>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`should render an ArticleImage with Responsive Tablet styling 1`] = `
-<View
-  style={
-    Object {
-      "alignSelf": "center",
-      "width": 640,
-    }
-  }
->
-  <View
-    style={
-      Object {
-        "flexDirection": "column",
-        "paddingBottom": 15,
-        "width": "100%",
-      }
-    }
-  >
-    <View>
-      <ModalImage
-        aspectRatio={1.25}
-        caption={
-          <Caption
-            credits="Some credits"
-            text="Some caption"
-          />
-        }
-        uri="https://img/someImage"
-      />
-    </View>
-    <View>
-      <View>
-        <View
-          style={
-            Object {
-              "paddingHorizontal": 10,
-              "paddingTop": 10,
-            }
-          }
-        >
-          <Text
-            style={
-              Object {
-                "color": "#696969",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 13,
-                "lineHeight": 16,
-              }
-            }
-          >
-            Some caption
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#333333",
-                "fontFamily": "GillSansMTStd-Medium",
-                "fontSize": 9,
-                "fontWeight": "400",
-                "letterSpacing": 1,
-                "lineHeight": 16,
-              }
-            }
-          >
-            SOME CREDITS
           </Text>
         </View>
       </View>

--- a/packages/article-image/__tests__/shared-with-style.base.js
+++ b/packages/article-image/__tests__/shared-with-style.base.js
@@ -1,13 +1,20 @@
 import React from "react";
+import { setIsTablet } from "@times-components/test-utils/dimensions";
 import { iterator } from "@times-components/test-utils";
 import ArticleImage from "../src/article-image";
 import primaryImageFixture from "../fixtures/primary-image";
 import secondaryImageFixture from "../fixtures/secondary-image";
+import fullwidthImageFixture from "../fixtures/fullwidth-image";
 import landscapeInlineImageFixture from "../fixtures/landscape-inline-image";
 import portraitInlineImageFixture from "../fixtures/portrait-inline-image";
 
 const testImageUrl = "https://img/someImage";
 const primaryImage = primaryImageFixture(
+  testImageUrl,
+  "Some caption",
+  "Some credits"
+);
+const fullwidthImage = fullwidthImageFixture(
   testImageUrl,
   "Some caption",
   "Some credits"
@@ -31,13 +38,54 @@ const portraitInlineImage = portraitInlineImageFixture(
 export default makeTest => {
   const tests = [
     {
-      name: "primary image with caption and credits",
+      name: "mobile primary image with caption and credits",
       test: () => {
         expect(
           makeTest(
             <ArticleImage
               captionOptions={primaryImage.captionOptions}
               imageOptions={primaryImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    },
+    {
+      name: "tablet primary image with caption and credits",
+      test: () => {
+        setIsTablet(true);
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={primaryImage.captionOptions}
+              imageOptions={primaryImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    },
+    {
+      name: "mobile fullwidth image with caption and credits",
+      test: () => {
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={fullwidthImage.captionOptions}
+              imageOptions={fullwidthImage.imageOptions}
+            />
+          )
+        ).toMatchSnapshot();
+      }
+    },
+    {
+      name: "tablet fullwidth image with caption and credits",
+      test: () => {
+        setIsTablet(true);
+        expect(
+          makeTest(
+            <ArticleImage
+              captionOptions={fullwidthImage.captionOptions}
+              imageOptions={fullwidthImage.imageOptions}
             />
           )
         ).toMatchSnapshot();

--- a/packages/article-image/__tests__/shared-with-style.native.js
+++ b/packages/article-image/__tests__/shared-with-style.native.js
@@ -9,10 +9,7 @@ import {
 } from "@times-components/jest-serializer";
 import TestRenderer from "react-test-renderer";
 import Responsive from "@times-components/responsive";
-import { setIsTablet } from "@times-components/test-utils/dimensions";
 
-import ArticleImage from "../src/article-image";
-import primaryImageFixture from "../fixtures/primary-image";
 import shared from "./shared-with-style.base";
 
 jest.mock("@times-components/image", () => ({
@@ -29,31 +26,7 @@ export default () => {
     )
   );
 
-  const makeTest = component => {
-    const testInstance = TestRenderer.create(component);
-    return testInstance.toJSON();
-  };
-
-  shared(makeTest);
-
-  it("should render an ArticleImage with Responsive Tablet styling", () => {
-    setIsTablet(true);
-
-    const primaryImage = primaryImageFixture(
-      "https://img/someImage",
-      "Some caption",
-      "Some credits"
-    );
-
-    expect(
-      makeTest(
-        <Responsive>
-          <ArticleImage
-            captionOptions={primaryImage.captionOptions}
-            imageOptions={primaryImage.imageOptions}
-          />
-        </Responsive>
-      )
-    ).toMatchSnapshot();
-  });
+  shared(component =>
+    TestRenderer.create(<Responsive>{component}</Responsive>).toJSON()
+  );
 };

--- a/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
+++ b/packages/article-image/__tests__/web/__snapshots__/article-image-with-style.web.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`1. primary image with caption and credits 1`] = `
+exports[`1. mobile primary image with caption and credits 1`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -58,7 +58,181 @@ Array [
 ]
 `;
 
-exports[`2. secondary image with caption and credits 1`] = `
+exports[`2. tablet primary image with caption and credits 1`] = `
+.c0 {
+  display: block;
+  opacity: 1;
+  position: absolute;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  width: 100%;
+  z-index: 2;
+}
+
+.c1 {
+  padding-left: 10px;
+}
+
+@media (min-width:768px) {
+  .c1 {
+    padding-left: 0px;
+  }
+}
+
+Array [
+  <div>
+    <TimesImage
+      aspectRatio={1.25}
+      caption={
+        <Caption
+          credits="Some credits"
+          text="Some caption"
+        />
+      }
+      fadeImageIn={false}
+      highResSize={null}
+      lowResSize={null}
+      uri="https://img/someImage"
+    />
+  </div>,
+  <div>
+    <responsiveweb__InsetCaptionStyle>
+      <div
+        className="c1"
+      >
+        <div>
+          <div>
+            <div>
+              Some caption
+            </div>
+            <div>
+              SOME CREDITS
+            </div>
+          </div>
+        </div>
+      </div>
+    </responsiveweb__InsetCaptionStyle>
+  </div>,
+]
+`;
+
+exports[`3. mobile fullwidth image with caption and credits 1`] = `
+.c0 {
+  display: block;
+  opacity: 1;
+  position: absolute;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  width: 100%;
+  z-index: 2;
+}
+
+.c1 {
+  padding-left: 10px;
+}
+
+@media (min-width:768px) {
+  .c1 {
+    padding-left: 0px;
+  }
+}
+
+Array [
+  <div>
+    <TimesImage
+      aspectRatio={1.25}
+      caption={
+        <Caption
+          credits="Some credits"
+          text="Some caption"
+        />
+      }
+      fadeImageIn={false}
+      highResSize={null}
+      lowResSize={null}
+      uri="https://img/someImage"
+    />
+  </div>,
+  <div>
+    <responsiveweb__InsetCaptionStyle>
+      <div
+        className="c1"
+      >
+        <div>
+          <div>
+            <div>
+              Some caption
+            </div>
+            <div>
+              SOME CREDITS
+            </div>
+          </div>
+        </div>
+      </div>
+    </responsiveweb__InsetCaptionStyle>
+  </div>,
+]
+`;
+
+exports[`4. tablet fullwidth image with caption and credits 1`] = `
+.c0 {
+  display: block;
+  opacity: 1;
+  position: absolute;
+  -webkit-transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
+  width: 100%;
+  z-index: 2;
+}
+
+.c1 {
+  padding-left: 10px;
+}
+
+@media (min-width:768px) {
+  .c1 {
+    padding-left: 0px;
+  }
+}
+
+Array [
+  <div>
+    <TimesImage
+      aspectRatio={1.25}
+      caption={
+        <Caption
+          credits="Some credits"
+          text="Some caption"
+        />
+      }
+      fadeImageIn={false}
+      highResSize={null}
+      lowResSize={null}
+      uri="https://img/someImage"
+    />
+  </div>,
+  <div>
+    <responsiveweb__InsetCaptionStyle>
+      <div
+        className="c1"
+      >
+        <div>
+          <div>
+            <div>
+              Some caption
+            </div>
+            <div>
+              SOME CREDITS
+            </div>
+          </div>
+        </div>
+      </div>
+    </responsiveweb__InsetCaptionStyle>
+  </div>,
+]
+`;
+
+exports[`5. secondary image with caption and credits 1`] = `
 .c0 {
   display: block;
   opacity: 1;
@@ -100,7 +274,7 @@ Array [
 ]
 `;
 
-exports[`3. inline image (landscape) with caption and credits 1`] = `
+exports[`6. inline image (landscape) with caption and credits 1`] = `
 .c1 {
   display: block;
   opacity: 1;
@@ -202,7 +376,7 @@ exports[`3. inline image (landscape) with caption and credits 1`] = `
 </figure>
 `;
 
-exports[`4. inline image (portrait) with caption and credits 1`] = `
+exports[`7. inline image (portrait) with caption and credits 1`] = `
 .c1 {
   display: block;
   opacity: 1;

--- a/packages/article-image/article-image.showcase.js
+++ b/packages/article-image/article-image.showcase.js
@@ -1,20 +1,27 @@
 import React from "react";
+import Responsive from "@times-components/responsive";
 import ArticleImage from "./src/article-image";
 import primaryImageFixture from "./fixtures/primary-image";
 import secondaryImageFixture from "./fixtures/secondary-image";
+import fullwidthImageFixture from "./fixtures/fullwidth-image";
 import landscapeInlineImageFixture from "./fixtures/landscape-inline-image";
 import portraitInlineImageFixture from "./fixtures/portrait-inline-image";
 
 const primaryImage = primaryImageFixture();
 const secondaryImage = secondaryImageFixture();
+const fullwidthImage = fullwidthImageFixture();
 const landscapeInlineImage = landscapeInlineImageFixture();
 const portraitInlineImage = portraitInlineImageFixture();
+
+const withResponsive = render => (...args) => (
+  <Responsive>{render(...args)}</Responsive>
+);
 
 export default {
   children: [
     {
       // eslint-disable-next-line react/prop-types
-      component: ({ boolean }) => {
+      component: withResponsive(({ boolean }) => {
         const withHighRes = boolean("As high resolution");
 
         const imageOptions = {
@@ -33,37 +40,47 @@ export default {
             imageOptions={imageOptions}
           />
         );
-      },
+      }),
       name: "Primary",
       type: "story"
     },
     {
-      component: () => (
+      component: withResponsive(() => (
         <ArticleImage
           captionOptions={secondaryImage.captionOptions}
           imageOptions={secondaryImage.imageOptions}
         />
-      ),
+      )),
       name: "Secondary",
       type: "story"
     },
     {
-      component: () => (
+      component: withResponsive(() => (
+        <ArticleImage
+          captionOptions={fullwidthImage.captionOptions}
+          imageOptions={fullwidthImage.imageOptions}
+        />
+      )),
+      name: "Full Width",
+      type: "story"
+    },
+    {
+      component: withResponsive(() => (
         <ArticleImage
           captionOptions={portraitInlineImage.captionOptions}
           imageOptions={portraitInlineImage.imageOptions}
         />
-      ),
+      )),
       name: "Inline (portrait)",
       type: "story"
     },
     {
-      component: () => (
+      component: withResponsive(() => (
         <ArticleImage
           captionOptions={landscapeInlineImage.captionOptions}
           imageOptions={landscapeInlineImage.imageOptions}
         />
-      ),
+      )),
       name: "Inline (landscape)",
       type: "story"
     }

--- a/packages/article-image/fixtures/fullwidth-image.js
+++ b/packages/article-image/fixtures/fullwidth-image.js
@@ -1,0 +1,21 @@
+const defaultImageSrc =
+  "https://www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F7bfd3356-be8c-11e7-8bb9-94e1372175c0.jpg?crop=1500%2C1200%2C0%2C0";
+const defaultCaption =
+  "From the spreadsheet: 1 Sir Michael Fallon, Admitted placing hand on knee of journalist 15 years ago. 2 Jake Berry, announced he had a baby with a Tory aide after an amicable divorce from his wife. 3 Amber Rudd, had a relationship with Kwasi Kwarteng, who is now an aide to the chancellor. 4 Liam Fox, had to resign over breach of ministerial code after suggestions that his position had benefited his friend Adam Werritty. No allegations were of a sexual nature. 5 Stephen Crabb, sent explicit messages to young women while married. 6 Mark Garnier, admitted asking his secretary to buy sex toys. 7 Liz Truss, had affair with Tory MP Mark Field";
+const defaultCredits = "The credits";
+
+export default (
+  uri = defaultImageSrc,
+  caption = defaultCaption,
+  credits = defaultCredits
+) => ({
+  captionOptions: {
+    caption,
+    credits
+  },
+  imageOptions: {
+    display: "fullwidth",
+    ratio: "15:12",
+    uri
+  }
+});

--- a/packages/article-image/src/article-image-prop-types.js
+++ b/packages/article-image/src/article-image-prop-types.js
@@ -6,7 +6,7 @@ export const propTypes = {
     credits: PropTypes.string
   }),
   imageOptions: PropTypes.shape({
-    display: PropTypes.oneOf(["primary", "secondary", "inline"]),
+    display: PropTypes.oneOf(["primary", "secondary", "inline", "fullwidth"]),
     highResSize: PropTypes.number,
     lowResSize: PropTypes.number,
     ratio: PropTypes.string,

--- a/packages/article-image/src/article-image.base.js
+++ b/packages/article-image/src/article-image.base.js
@@ -1,38 +1,42 @@
 import React from "react";
 import { View } from "react-native";
-import Caption from "@times-components/caption";
+import Caption, { CentredCaption } from "@times-components/caption";
 import { ModalImage } from "@times-components/image";
 import InsetCaption from "./inset-caption";
 import InlineImage from "./inline-image";
 import { propTypes, defaultPropTypes } from "./article-image-prop-types";
 import styles from "./styles";
 
-const renderCaption = (display, caption, credits) => {
-  if (!caption && !credits) {
-    return null;
+const captionStyle = {
+  secondary: {
+    container: {
+      paddingTop: 0
+    }
+  }
+};
+
+function getCaptionComponent(display, caption, credits) {
+  if (display === "primary") {
+    return <InsetCaption caption={caption} credits={credits} />;
   }
 
-  const captionStyle = {
-    secondary: {
-      container: {
-        paddingTop: 0
-      }
-    }
-  };
-
-  const CaptionComponent =
-    display === "primary" ? (
-      <InsetCaption caption={caption} credits={credits} />
-    ) : (
-      <Caption credits={credits} style={captionStyle[display]} text={caption} />
-    );
+  const CaptionComponent = display === "fullwidth" ? CentredCaption : Caption;
 
   return (
-    <View key="caption" style={styles[`${display}Caption`]}>
-      {CaptionComponent}
-    </View>
+    <CaptionComponent
+      credits={credits}
+      style={captionStyle[display]}
+      text={caption}
+    />
   );
-};
+}
+
+const renderCaption = (display, caption, credits) =>
+  caption || credits ? (
+    <View key="caption" style={styles[`${display}Caption`]}>
+      {getCaptionComponent(display, caption, credits)}
+    </View>
+  ) : null;
 
 const ArticleImage = ({ imageOptions, captionOptions }) => {
   const { display, highResSize, lowResSize, ratio, uri } = imageOptions;

--- a/packages/article-image/src/article-image.js
+++ b/packages/article-image/src/article-image.js
@@ -13,7 +13,11 @@ const ArticleImageNative = props => {
   return (
     <ResponsiveContext.Consumer>
       {({ isTablet }) => (
-        <View style={isTablet && styles.imageContainerTablet}>
+        <View
+          style={
+            isTablet && display !== "fullwidth" && styles.imageContainerTablet
+          }
+        >
           <View key={uri} style={styles[`${display}Container`]}>
             <ArticleImage {...props} />
           </View>

--- a/packages/article-image/src/article-image.web.js
+++ b/packages/article-image/src/article-image.web.js
@@ -1,6 +1,17 @@
 import React from "react";
 import ArticleImage from "./article-image.base";
 
-const ArticleImageWeb = props => <ArticleImage {...props} />;
+const ArticleImageWeb = ({
+  imageOptions: { display, ...options },
+  ...props
+}) => (
+  <ArticleImage
+    {...props}
+    imageOptions={{
+      ...options,
+      display: display === "fullwidth" ? "primary" : display
+    }}
+  />
+);
 
 export default ArticleImageWeb;

--- a/packages/article-image/src/styles/index.js
+++ b/packages/article-image/src/styles/index.js
@@ -2,12 +2,20 @@ import { StyleSheet } from "react-native";
 import {
   spacing,
   tabletRowPadding,
-  tabletWidth
+  tabletWidth,
+  tabletWidthMax
 } from "@times-components/styleguide";
 
 const styles = StyleSheet.create({
   container: {
     paddingTop: 0
+  },
+  fullwidthCaption: {
+    alignSelf: "center",
+    maxWidth: tabletWidth - tabletRowPadding
+  },
+  fullwidthContainer: {
+    maxWidth: tabletWidthMax
   },
   imageContainerTablet: {
     alignSelf: "center",


### PR DESCRIPTION
There is a new type of article image that we need to support, `fullwidth`.

This is an image that is 100% width up to a max width of 1180, with a centred caption. 

<img width="846" alt="screen shot 2019-01-30 at 17 43 31" src="https://user-images.githubusercontent.com/719814/52001140-a1e07380-24b6-11e9-8575-3a0136e0d3f6.png">


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
