### PR TITLE
fix: disable scroll in interactive web wrapper

### DIFF
--- a/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
+++ b/packages/interactive-wrapper/__tests__/ios/__snapshots__/interactive-wrapper.test.js.snap
@@ -17,6 +17,7 @@ exports[`renders correctly 1`] = `
   >
     <RCTWebView
       injectedJavaScript="window.reactBridgePostMessage = window.postMessage; window.postMessage = String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage');"
+      scrollEnabled={false}
       source={
         Object {
           "uri": "https://cwfiyvo20d.execute-api.eu-west-1.amazonaws.com/dev/component/a0534eee-682e-4955-8e1e-84b428ef1e79?dev=false&env=jest&platform=ios&version=0.0.0",

--- a/packages/interactive-wrapper/src/interactive-wrapper.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.js
@@ -88,6 +88,7 @@ class InteractiveWrapper extends Component {
           }}
           source={{ uri }}
           style={{ height }}
+          scrollEnabled={false}
           {...InteractiveWrapper.postMessageBugWorkaround()}
         />
       </View>

--- a/packages/interactive-wrapper/src/interactive-wrapper.js
+++ b/packages/interactive-wrapper/src/interactive-wrapper.js
@@ -86,9 +86,9 @@ class InteractiveWrapper extends Component {
           ref={webview => {
             this.webview = webview;
           }}
+          scrollEnabled={false}
           source={{ uri }}
           style={{ height }}
-          scrollEnabled={false}
           {...InteractiveWrapper.postMessageBugWorkaround()}
         />
       </View>


### PR DESCRIPTION
The interactive web wrapper was allowing scroll so if you tried to scroll the article from an interactive's position, it would bounce within its frame instead of allowing the whole article to scroll. Disabling the scroll in the web wrapper fixes the issue.