### PR TITLE
spike: Add borders and elevation to slice layout

### DIFF
--- a/packages/slice-layout/src/templates/secondaryfour/styles.android.js
+++ b/packages/slice-layout/src/templates/secondaryfour/styles.android.js
@@ -1,0 +1,22 @@
+const styles = {
+  container: {
+    backgroundColor: "#FBF9F9",
+    flex: 1
+  },
+  item: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 2,
+    borderStyle: "solid",
+    elevation: 2,
+    width: "48%",
+    margin: 3,
+    padding: 5
+  },
+  itemContainer: {
+    flexDirection: "row"
+  },
+  itemSeparator: {
+  }
+};
+
+export default styles;

--- a/packages/slice-layout/src/templates/styles/index.android.js
+++ b/packages/slice-layout/src/templates/styles/index.android.js
@@ -1,0 +1,20 @@
+import { colours } from "@times-components/styleguide";
+
+const styles = {
+  item: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 2,
+    borderStyle: "solid",
+    elevation: 2,
+    margin: 5,
+    width: "97%"
+  },
+  itemContainer: {
+    width: "100%"
+  },
+  itemContainerWithoutBorders: {
+    width: "100%"
+  }
+};
+
+export default styles;


### PR DESCRIPTION
Do not merge, this is just for demo purposes.

This pr adds android specific card layout borders to slice layout without changing the tile itself. We would need an android style on each slice-layout, including different breakpoints.

NOTE: Elevation is not supported on versions older than Android 5.0 (we support 4.4 on play store. Those versions won't have shadows, but will still have the border design)

![screenshot_1549026567](https://user-images.githubusercontent.com/1849590/52125856-ac6d4b00-2625-11e9-90a8-37d6b177d808.png)
![screenshot_1549027720](https://user-images.githubusercontent.com/1849590/52125858-ac6d4b00-2625-11e9-96f7-2872f2e0e767.png)
