### PR TITLE
fix: article topics size & layout

### DIFF
--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
@@ -41,6 +41,7 @@ exports[`1. group of topics 1`] = `
               "fontSize": 13,
               "lineHeight": 13,
               "position": "relative",
+              "top": 1,
             }
           }
         >
@@ -93,6 +94,7 @@ exports[`2. group of topics at large scale 1`] = `
               "fontSize": 14,
               "lineHeight": 14,
               "position": "relative",
+              "top": 1,
             }
           }
         >
@@ -145,6 +147,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
               "fontSize": 15,
               "lineHeight": 15,
               "position": "relative",
+              "top": 1,
             }
           }
         >

--- a/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
+++ b/packages/article-topics/__tests__/android/__snapshots__/article-topics-with-style.android.test.js.snap
@@ -26,10 +26,10 @@ exports[`1. group of topics 1`] = `
             "borderColor": "#DBDBDB",
             "borderRadius": 2,
             "borderWidth": 1,
-            "paddingBottom": 12,
+            "paddingBottom": 10,
             "paddingLeft": 15,
             "paddingRight": 15,
-            "paddingTop": 12,
+            "paddingTop": 10,
           }
         }
       >
@@ -40,6 +40,7 @@ exports[`1. group of topics 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 13,
+              "position": "relative",
             }
           }
         >
@@ -77,10 +78,10 @@ exports[`2. group of topics at large scale 1`] = `
             "borderColor": "#DBDBDB",
             "borderRadius": 2,
             "borderWidth": 1,
-            "paddingBottom": 12,
+            "paddingBottom": 10,
             "paddingLeft": 15,
             "paddingRight": 15,
-            "paddingTop": 12,
+            "paddingTop": 10,
           }
         }
       >
@@ -91,6 +92,7 @@ exports[`2. group of topics at large scale 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 14,
               "lineHeight": 14,
+              "position": "relative",
             }
           }
         >
@@ -128,10 +130,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
             "borderColor": "#DBDBDB",
             "borderRadius": 2,
             "borderWidth": 1,
-            "paddingBottom": 12,
+            "paddingBottom": 10,
             "paddingLeft": 15,
             "paddingRight": 15,
-            "paddingTop": 12,
+            "paddingTop": 10,
           }
         }
       >
@@ -142,6 +144,7 @@ exports[`3. group of topics at xlarge scale 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 15,
               "lineHeight": 15,
+              "position": "relative",
             }
           }
         >

--- a/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
+++ b/packages/article-topics/__tests__/ios/__snapshots__/article-topics-with-style.ios.test.js.snap
@@ -32,10 +32,10 @@ exports[`1. group of topics 1`] = `
             "borderColor": "#DBDBDB",
             "borderRadius": 2,
             "borderWidth": 1,
-            "paddingBottom": 12,
+            "paddingBottom": 10,
             "paddingLeft": 15,
             "paddingRight": 15,
-            "paddingTop": 12,
+            "paddingTop": 10,
           }
         }
       >
@@ -46,7 +46,8 @@ exports[`1. group of topics 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 13,
-              "paddingTop": 5,
+              "position": "relative",
+              "top": 3.5,
             }
           }
         >
@@ -90,10 +91,10 @@ exports[`2. group of topics at large scale 1`] = `
             "borderColor": "#DBDBDB",
             "borderRadius": 2,
             "borderWidth": 1,
-            "paddingBottom": 12,
+            "paddingBottom": 10,
             "paddingLeft": 15,
             "paddingRight": 15,
-            "paddingTop": 12,
+            "paddingTop": 10,
           }
         }
       >
@@ -104,7 +105,8 @@ exports[`2. group of topics at large scale 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 14,
               "lineHeight": 16,
-              "paddingTop": 5,
+              "position": "relative",
+              "top": 3.5,
             }
           }
         >
@@ -148,10 +150,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
             "borderColor": "#DBDBDB",
             "borderRadius": 2,
             "borderWidth": 1,
-            "paddingBottom": 12,
+            "paddingBottom": 10,
             "paddingLeft": 15,
             "paddingRight": 15,
-            "paddingTop": 12,
+            "paddingTop": 10,
           }
         }
       >
@@ -162,7 +164,8 @@ exports[`3. group of topics at xlarge scale 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 15,
               "lineHeight": 17,
-              "paddingTop": 5,
+              "position": "relative",
+              "top": 3.5,
             }
           }
         >

--- a/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
+++ b/packages/article-topics/__tests__/web/__snapshots__/article-topics-with-style.web.test.js.snap
@@ -9,10 +9,10 @@ exports[`1. group of topics 1`] = `
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
+  padding-top: 0px;
   padding-right: 0px;
   padding-bottom: 0px;
   padding-left: 0px;
-  padding-top: 2.5px;
 }
 
 .S2 {
@@ -24,10 +24,10 @@ exports[`1. group of topics 1`] = `
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
-  padding-bottom: 12px;
+  padding-bottom: 10px;
   padding-left: 15px;
   padding-right: 15px;
-  padding-top: 12px;
+  padding-top: 10px;
 }
 
 .S3 {
@@ -105,10 +105,10 @@ exports[`2. group of topics at large scale 1`] = `
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
+  padding-top: 0px;
   padding-right: 0px;
   padding-bottom: 0px;
   padding-left: 0px;
-  padding-top: 2.5px;
 }
 
 .S2 {
@@ -120,10 +120,10 @@ exports[`2. group of topics at large scale 1`] = `
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
-  padding-bottom: 12px;
+  padding-bottom: 10px;
   padding-left: 15px;
   padding-right: 15px;
-  padding-top: 12px;
+  padding-top: 10px;
 }
 
 .S3 {
@@ -201,10 +201,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
+  padding-top: 0px;
   padding-right: 0px;
   padding-bottom: 0px;
   padding-left: 0px;
-  padding-top: 2.5px;
 }
 
 .S2 {
@@ -216,10 +216,10 @@ exports[`3. group of topics at xlarge scale 1`] = `
   margin-top: 0px;
   margin-right: 0px;
   margin-bottom: 0px;
-  padding-bottom: 12px;
+  padding-bottom: 10px;
   padding-left: 15px;
   padding-right: 15px;
-  padding-top: 12px;
+  padding-top: 10px;
 }
 
 .S3 {

--- a/packages/article-topics/src/styles/index.android.js
+++ b/packages/article-topics/src/styles/index.android.js
@@ -1,6 +1,13 @@
 import { StyleSheet } from "react-native";
 import sharedStyles from "./shared";
 
-const styles = StyleSheet.create(sharedStyles);
+const styles = StyleSheet.create({
+  ...sharedStyles,
+  text: {
+    ...sharedStyles.text,
+    // Gill Sans hack
+    top: 1
+  }
+});
 
 export default styles;

--- a/packages/article-topics/src/styles/index.js
+++ b/packages/article-topics/src/styles/index.js
@@ -1,5 +1,4 @@
 import { StyleSheet } from "react-native";
-import { spacing } from "@times-components/styleguide";
 import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
@@ -7,7 +6,7 @@ const styles = StyleSheet.create({
   text: {
     ...sharedStyles.text,
     // Gill Sans hack
-    paddingTop: spacing(1)
+    top: 3.5
   }
 });
 

--- a/packages/article-topics/src/styles/index.web.js
+++ b/packages/article-topics/src/styles/index.web.js
@@ -1,5 +1,4 @@
 import { StyleSheet } from "react-native";
-import { spacing } from "@times-components/styleguide";
 import sharedStyles from "./shared";
 
 const styles = StyleSheet.create({
@@ -7,7 +6,7 @@ const styles = StyleSheet.create({
   text: {
     ...sharedStyles.text,
     // Gill Sans hack
-    paddingTop: spacing(0.5)
+    top: 2
   }
 });
 

--- a/packages/article-topics/src/styles/shared.js
+++ b/packages/article-topics/src/styles/shared.js
@@ -6,10 +6,10 @@ const styles = {
     borderColor: colours.functional.keyline,
     borderRadius: 2,
     borderWidth: 1,
-    paddingBottom: 10,
+    paddingBottom: spacing(2),
     paddingLeft: spacing(3),
     paddingRight: spacing(3),
-    paddingTop: 10
+    paddingTop: spacing(2)
   },
   spacer: {
     marginRight: spacing(2),

--- a/packages/article-topics/src/styles/shared.js
+++ b/packages/article-topics/src/styles/shared.js
@@ -6,10 +6,10 @@ const styles = {
     borderColor: colours.functional.keyline,
     borderRadius: 2,
     borderWidth: 1,
-    paddingBottom: 12,
+    paddingBottom: 10,
     paddingLeft: spacing(3),
     paddingRight: spacing(3),
-    paddingTop: 12
+    paddingTop: 10
   },
   spacer: {
     marginRight: spacing(2),
@@ -20,7 +20,8 @@ const styles = {
     ...fontFactory({
       font: "supporting",
       fontSize: "link"
-    })
+    }),
+    position: "relative"
   },
   topicGroup: {
     flexDirection: "row",


### PR DESCRIPTION
Because padding was used to correct the location of text within the article topic, it meant the topic ended up being significantly taller than it should be. This corrects for that by using relative positioning. 


<img width="244" alt="screen shot 2019-02-01 at 17 28 32" src="https://user-images.githubusercontent.com/719814/52139026-d1be8100-2646-11e9-94d6-45010499577a.png">

![screen shot 2019-02-11 at 10 27 54](https://user-images.githubusercontent.com/719814/52557650-f4d7f600-2de7-11e9-8736-e4e16c2b2351.png)


<!--
Thank you for your PR!

Please provide clear instructions on how you verified your work.

If there are any visual changes, include screenshots and demo videos (try https://giphy.com/apps/giphycapture).

:-)
-->
