### PR TITLE
feat: Tile I and tile J

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -399,3 +399,138 @@ exports[`6. tile g 1`] = `
   </View>
 </Link>
 `;
+
+exports[`7. tile i 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#F0F0F0",
+        "paddingBottom": 25,
+        "paddingHorizontal": 40,
+        "paddingTop": 15,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 35,
+          "fontWeight": "400",
+          "lineHeight": 35,
+          "marginBottom": 5,
+          "textAlign": "center",
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags />
+  </View>
+</View>
+`;
+
+exports[`8. tile j 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "33.33%",
+      }
+    }
+  >
+    <Image />
+  </View>
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 10,
+        "paddingVertical": 5,
+        "width": "66.66%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "400",
+          "lineHeight": 22,
+          "marginBottom": 5,
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -198,3 +198,65 @@ exports[`6. tile g 1`] = `
   </View>
 </Link>
 `;
+
+exports[`7. tile i 1`] = `
+<View>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`8. tile j 1`] = `
+<View>
+  <View>
+    <Image
+      aspectRatio={1.5}
+      uri="https://img/someImage"
+    />
+  </View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -399,3 +399,138 @@ exports[`6. tile g 1`] = `
   </View>
 </Link>
 `;
+
+exports[`7. tile i 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
+  >
+    <Image />
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#F0F0F0",
+        "paddingBottom": 25,
+        "paddingHorizontal": 40,
+        "paddingTop": 15,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 35,
+          "fontWeight": "900",
+          "lineHeight": 35,
+          "marginBottom": 5,
+          "textAlign": "center",
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags />
+  </View>
+</View>
+`;
+
+exports[`8. tile j 1`] = `
+<View
+  style={
+    Object {
+      "flexDirection": "row",
+      "paddingHorizontal": 10,
+      "paddingVertical": 10,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "width": "33.33%",
+      }
+    }
+  >
+    <Image />
+  </View>
+  <View
+    style={
+      Object {
+        "paddingHorizontal": 10,
+        "paddingVertical": 5,
+        "width": "66.66%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "#1D1D1B",
+            "fontFamily": "GillSansMTStd-Medium",
+            "fontSize": 12,
+            "fontWeight": "400",
+            "letterSpacing": 1.2,
+            "lineHeight": 14,
+            "marginBottom": 0,
+          }
+        }
+      >
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      style={
+        Object {
+          "color": "#333333",
+          "fontFamily": "TimesModern-Bold",
+          "fontSize": 22,
+          "fontWeight": "900",
+          "lineHeight": 22,
+          "marginBottom": 5,
+        }
+      }
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -198,3 +198,65 @@ exports[`6. tile g 1`] = `
   </View>
 </Link>
 `;
+
+exports[`7. tile i 1`] = `
+<View>
+  <View>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`8. tile j 1`] = `
+<View>
+  <View>
+    <Image
+      aspectRatio={1.5}
+      uri="https://img/someImage"
+    />
+  </View>
+  <View>
+    <View>
+      <Text>
+        ROYALS
+      </Text>
+    </View>
+    <Text
+      accessibilityRole="heading"
+      aria-level="3"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </Text>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </View>
+</View>
+`;

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -4,7 +4,16 @@ import { iterator } from "@times-components/test-utils";
 import { mockSecondaryTwoNoPicAndTwoSlice } from "@times-components/fixture-generator";
 import leadOneAndOneDataGenerator from "../fixtures/leadoneandone";
 
-import { TileA, TileB, TileC, TileD, TileE, TileG, TileI, TileJ } from "../src/tiles";
+import {
+  TileA,
+  TileB,
+  TileC,
+  TileD,
+  TileE,
+  TileG,
+  TileI,
+  TileJ
+} from "../src/tiles";
 
 jest.mock("@times-components/article-flag", () => ({
   ArticleFlags: "ArticleFlags"
@@ -75,12 +84,12 @@ export default () => {
         const secondaryTwoNoPicAndTwoData = mockSecondaryTwoNoPicAndTwoSlice();
         const output = TestRenderer.create(
           <TileG tile={secondaryTwoNoPicAndTwoData.support1} />
-          );
+        );
 
-          expect(output).toMatchSnapshot();
-        }
-      },
-      {
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
       name: "tile i",
       test: () => {
         const output = TestRenderer.create(

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -4,7 +4,7 @@ import { iterator } from "@times-components/test-utils";
 import { mockSecondaryTwoNoPicAndTwoSlice } from "@times-components/fixture-generator";
 import leadOneAndOneDataGenerator from "../fixtures/leadoneandone";
 
-import { TileA, TileB, TileC, TileD, TileE, TileG } from "../src/tiles";
+import { TileA, TileB, TileC, TileD, TileE, TileG, TileI, TileJ } from "../src/tiles";
 
 jest.mock("@times-components/article-flag", () => ({
   ArticleFlags: "ArticleFlags"
@@ -75,6 +75,26 @@ export default () => {
         const secondaryTwoNoPicAndTwoData = mockSecondaryTwoNoPicAndTwoSlice();
         const output = TestRenderer.create(
           <TileG tile={secondaryTwoNoPicAndTwoData.support1} />
+          );
+
+          expect(output).toMatchSnapshot();
+        }
+      },
+      {
+      name: "tile i",
+      test: () => {
+        const output = TestRenderer.create(
+          <TileI tile={leadOneAndOneData.lead} />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "tile j",
+      test: () => {
+        const output = TestRenderer.create(
+          <TileJ tile={leadOneAndOneData.lead} />
         );
 
         expect(output).toMatchSnapshot();

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -560,3 +560,188 @@ exports[`6. tile g 1`] = `
   </div>
 </Link>
 `;
+
+exports[`7. tile i 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.IS1 {
+  width: 100%;
+}
+
+.IS2 {
+  color: rgba(29,29,27,1.00);
+}
+
+.IS3 {
+  font-size: 35px;
+  line-height: 35px;
+  text-align: center;
+}
+
+.IS4 {
+  -webkit-align-items: center;
+  align-items: center;
+  background-color: rgba(240,240,240,1.00);
+  padding-right: 40px;
+  padding-left: 40px;
+  padding-bottom: 25px;
+  padding-top: 15px;
+  -ms-flex-align: center;
+  -webkit-box-align: center;
+}
+</style>
+
+<div
+  className="S1"
+>
+  <div
+    className="IS1 S1"
+  >
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </div>
+  <div
+    className="IS4 S1"
+  >
+    <div
+      className="S1"
+    >
+      <div
+        className="IS2 S2"
+      >
+        ROYALS
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      className="IS3 S3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`8. tile j 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  color: rgba(51,51,51,1.00);
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.IS1 {
+  width: 33.33%;
+}
+
+.IS2 {
+  color: rgba(29,29,27,1.00);
+}
+
+.IS3 {
+  line-height: 22px;
+}
+
+.IS4 {
+  padding-top: 5px;
+  padding-right: 10px;
+  padding-bottom: 5px;
+  padding-left: 10px;
+  width: 66.66%;
+}
+
+.IS5 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding-top: 10px;
+  padding-right: 10px;
+  padding-bottom: 10px;
+  padding-left: 10px;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+</style>
+
+<div
+  className="IS5 S1"
+>
+  <div
+    className="IS1 S1"
+  >
+    <Image
+      aspectRatio={1.5}
+      uri="https://img/someImage"
+    />
+  </div>
+  <div
+    className="IS4 S1"
+  >
+    <div
+      className="S1"
+    >
+      <div
+        className="IS2 S2"
+      >
+        ROYALS
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      className="IS3 S3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </div>
+</div>
+`;

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -198,3 +198,65 @@ exports[`6. tile g 1`] = `
   </div>
 </Link>
 `;
+
+exports[`7. tile i 1`] = `
+<div>
+  <div>
+    <Image
+      aspectRatio={1.7777777777777777}
+      uri="https://img/someImage"
+    />
+  </div>
+  <div>
+    <div>
+      <div>
+        ROYALS
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`8. tile j 1`] = `
+<div>
+  <div>
+    <Image
+      aspectRatio={1.5}
+      uri="https://img/someImage"
+    />
+  </div>
+  <div>
+    <div>
+      <div>
+        ROYALS
+      </div>
+    </div>
+    <h3
+      aria-level="3"
+      role="heading"
+    >
+      Prince Philip ‘could be prosecuted’ over car crash
+    </h3>
+    <ArticleFlags
+      flags={
+        Array [
+          "NEW",
+        ]
+      }
+    />
+  </div>
+</div>
+`;

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -5,7 +5,16 @@ import {
   mockSecondaryFourSlice
 } from "@times-components/fixture-generator";
 
-import { TileA, TileB, TileC, TileD, TileE, TileG, TileI, TileJ } from "./src/tiles";
+import {
+  TileA,
+  TileB,
+  TileC,
+  TileD,
+  TileE,
+  TileG,
+  TileI,
+  TileJ
+} from "./src/tiles";
 
 export default {
   children: [

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -1,9 +1,11 @@
 import React from "react";
 import {
+  mockLeadOneAndFourSlice,
   mockLeadOneFullWidthSlice,
   mockSecondaryFourSlice
 } from "@times-components/fixture-generator";
-import { TileA, TileB, TileC, TileD, TileE, TileG } from "./src/tiles";
+
+import { TileA, TileB, TileC, TileD, TileE, TileG, TileI, TileJ } from "./src/tiles";
 
 export default {
   children: [
@@ -53,6 +55,22 @@ export default {
         return <TileG tile={slice.lead} />;
       },
       name: "Tile G - Roundel image, 22pt headline, no teaser",
+      type: "story"
+    },
+    {
+      component: () => {
+        const slice = mockLeadOneAndFourSlice();
+        return <TileI tile={slice.lead} />;
+      },
+      name: "Tile I - Vertical, top image, centered aligned summary",
+      type: "story"
+    },
+    {
+      component: () => {
+        const slice = mockLeadOneAndFourSlice();
+        return <TileJ tile={slice.support1} />;
+      },
+      name: "Tile J - Horizontal, image left of article summary with 1:3 ratio",
       type: "story"
     }
   ],

--- a/packages/edition-slices/src/tiles/index.js
+++ b/packages/edition-slices/src/tiles/index.js
@@ -4,3 +4,5 @@ export { default as TileC } from "./tile-c";
 export { default as TileD } from "./tile-d";
 export { default as TileE } from "./tile-e";
 export { default as TileG } from "./tile-g";
+export { default as TileI } from "./tile-i";
+export { default as TileJ } from "./tile-j";

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import { TileImage, TileSummary } from "../shared";
+import styles from "./styles";
+
+const TileI = ({ tile }) => (
+  <View>
+    <TileImage
+      aspectRatio={16 / 9}
+      style={styles.imageContainer}
+      uri={tile.article.leadAsset.crop169.url}
+    />
+    <TileSummary
+      headlineStyle={styles.headline}
+      style={styles.summaryContainer}
+      tile={tile}
+    />
+  </View>
+);
+
+TileI.propTypes = {
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default TileI;

--- a/packages/edition-slices/src/tiles/tile-i/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/styles/index.js
@@ -1,0 +1,22 @@
+import { colours, fonts, spacing } from "@times-components/styleguide";
+
+const styles = {
+  headline: {
+    fontFamily: fonts.headline,
+    fontSize: 35,
+    lineHeight: 35,
+    textAlign: "center"
+  },
+  imageContainer: {
+    width: "100%"
+  },
+  summaryContainer: {
+    alignItems: "center",
+    backgroundColor: colours.functional.border,
+    paddingBottom: spacing(5),
+    paddingHorizontal: spacing(8),
+    paddingTop: spacing(3)
+  }
+};
+
+export default styles;

--- a/packages/edition-slices/src/tiles/tile-j/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/index.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import { TileImage, TileSummary } from "../shared";
+import styles from "./styles";
+
+const TileJ = ({ tile }) => (
+  <View style={styles.container}>
+    <TileImage
+      aspectRatio={3 / 2}
+      style={styles.imageContainer}
+      uri={tile.article.leadAsset.crop32.url}
+    />
+    <TileSummary
+      headlineStyle={styles.headline}
+      style={styles.summaryContainer}
+      tile={tile}
+    />
+  </View>
+);
+
+TileJ.propTypes = {
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default TileJ;

--- a/packages/edition-slices/src/tiles/tile-j/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/styles/index.js
@@ -1,0 +1,25 @@
+import { fontFactory, spacing } from "@times-components/styleguide";
+
+const styles = {
+  container: {
+    flexDirection: "row",
+    paddingHorizontal: spacing(2),
+    paddingVertical: spacing(2)
+  },
+  headline: {
+    ...fontFactory({
+      font: "headline",
+      fontSize: "infoTitle"
+    })
+  },
+  imageContainer: {
+    width: "33.33%"
+  },
+  summaryContainer: {
+    paddingHorizontal: spacing(2),
+    paddingVertical: spacing(1),
+    width: "66.66%"
+  }
+};
+
+export default styles;

--- a/packages/fixture-generator/src/__tests__/mock-slice.test.ts
+++ b/packages/fixture-generator/src/__tests__/mock-slice.test.ts
@@ -1,4 +1,4 @@
-import mockArticleSlice, { mockLeadOneAndTwoSlice, mockLeadOneFullWidthSlice, mockLeadOneAndOneSlice, mockSecondaryOneSlice, mockSecondaryTwoNoPicAndTwoSlice } from "../mock-slice";
+import mockArticleSlice, { mockLeadOneAndFourSlice, mockLeadOneAndTwoSlice, mockLeadOneFullWidthSlice, mockLeadOneAndOneSlice, mockSecondaryOneSlice, mockSecondaryTwoNoPicAndTwoSlice } from "../mock-slice";
 
 describe("The Mock EditionSlice", () => {
   it("returns the minimum articleSlice requirements", () => {
@@ -6,6 +6,16 @@ describe("The Mock EditionSlice", () => {
     expect(articleSlice.items[0]).toHaveProperty("article");
     expect(articleSlice.items[0]).toHaveProperty("headline");
     expect(articleSlice.items[0]).toHaveProperty("leadAsset");
+  });
+
+  it("returns LeadOneAndFourSlice", () => {
+    const articleSlice = mockLeadOneAndFourSlice();
+    expect(articleSlice.items.length).toBe(5);
+    expect(articleSlice.lead).toBeDefined();
+    expect(articleSlice.support1).toBeDefined();
+    expect(articleSlice.support2).toBeDefined();
+    expect(articleSlice.support3).toBeDefined();
+    expect(articleSlice.support4).toBeDefined();
   });
 
   it("returns LeadOneFullWidthSlice", () => {

--- a/packages/fixture-generator/src/index.ts
+++ b/packages/fixture-generator/src/index.ts
@@ -2,6 +2,7 @@ import MockArticle from "./mock-article";
 import MockImage from "./mock-image";
 import MockAuthor from "./mock-author";
 import mockEditionSlice, {
+  mockLeadOneAndFourSlice,
   mockLeadOneFullWidthSlice,
   mockLeadOneAndOneSlice,
   mockLeadOneAndTwoSlice,
@@ -12,6 +13,7 @@ import mockEditionSlice, {
 import MockTopic from "./mock-topic";
 
 export {
+  mockLeadOneAndFourSlice,
   mockLeadOneFullWidthSlice,
   mockLeadOneAndOneSlice,
   mockLeadOneAndTwoSlice,

--- a/packages/fixture-generator/src/mock-slice.ts
+++ b/packages/fixture-generator/src/mock-slice.ts
@@ -1,5 +1,6 @@
 import {
   ArticleSlice,
+  LeadOneAndFourSlice,
   LeadOneFullWidthSlice,
   LeadOneAndOneSlice,
   LeadOneAndTwoSlice,
@@ -21,6 +22,18 @@ function getTile(): Tile {
 
 function getTiles(count: number): Array<Tile> {
   return new Array(count).fill(0).map(() => getTile());
+}
+
+function mockLeadOneAndFourSlice(): LeadOneAndFourSlice {
+  const tiles = getTiles(5);
+  return <LeadOneAndFourSlice>{
+    lead: tiles[0],
+    items: tiles,
+    support1: tiles[1],
+    support2: tiles[2],
+    support3: tiles[3],
+    support4: tiles[4]
+  };
 }
 
 function mockLeadOneFullWidthSlice(): LeadOneFullWidthSlice {
@@ -86,6 +99,7 @@ function mockArticleSlice(count: number): ArticleSlice {
 
 export default mockArticleSlice;
 export {
+  mockLeadOneAndFourSlice,
   mockLeadOneFullWidthSlice,
   mockLeadOneAndOneSlice,
   mockLeadOneAndTwoSlice,


### PR DESCRIPTION
- used as part of `LeadOneAndFourSlice`

### Tile I
<img width="455" alt="screenshot 2019-02-05 at 17 05 27" src="https://user-images.githubusercontent.com/1736782/52290701-879c0f00-2968-11e9-856d-dcd4fcd645e4.png">


### Tile J
<img width="477" alt="screenshot 2019-02-05 at 17 05 43" src="https://user-images.githubusercontent.com/1736782/52290704-8a96ff80-2968-11e9-84dc-3b8cc109b340.png">