### PR TITLE
feat: enable ios storybook xcode project to be able to run on ipad too

### DIFF
--- a/ios/storybooknative.xcodeproj/project.pbxproj
+++ b/ios/storybooknative.xcodeproj/project.pbxproj
@@ -1115,6 +1115,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "storybooknative-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1145,6 +1146,7 @@
 				PRODUCT_NAME = storybooknative;
 				SWIFT_OBJC_BRIDGING_HEADER = "storybooknative-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;


### PR DESCRIPTION
Tiny one... This allows the iOS Storybook app to run on an iPad too.
