### PR TITLE
feat: offline images lazy load

### DIFF
--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -20,6 +20,10 @@ The native image manages any malformed `uri` props by adding missing protocols
 and managing the width of the image (according to the device width) in the final
 query string.
 
+## Android only
+
+Supports offline image support for android only. Creates two image views on top of each other, one for the offline low-res image and another one for the network request with a higher res image.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before contributing to this

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -12,6 +12,13 @@ exports[`1. default layout 1`] = `
   <Image
     source={
       Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+      }
+    }
+  />
+  <Image
+    source={
+      Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
@@ -67,6 +74,13 @@ exports[`3. handle layout change 1`] = `
   <Image
     source={
       Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+      }
+    }
+  />
+  <Image
+    source={
+      Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
@@ -83,6 +97,13 @@ exports[`4. prepend https schema 1`] = `
       degrees={264}
     />
   </View>
+  <Image
+    source={
+      Object {
+        "uri": "https://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+      }
+    }
+  />
   <Image
     source={
       Object {
@@ -105,6 +126,13 @@ exports[`5. handle onload event 1`] = `
   <Image
     source={
       Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+      }
+    }
+  />
+  <Image
+    source={
+      Object {
         "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
       }
     }
@@ -116,6 +144,13 @@ exports[`5. handle onload event 2`] = `
 <View
   aspectRatio={1.5}
 >
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+      }
+    }
+  />
   <Image
     source={
       Object {
@@ -135,6 +170,13 @@ exports[`7. uses highressize if it is smaller than layout width 1`] = `
       degrees={264}
     />
   </View>
+  <Image
+    source={
+      Object {
+        "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=320&offline=true",
+      }
+    }
+  />
   <Image
     source={
       Object {

--- a/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/modal-image.android.test.js.snap
@@ -36,6 +36,13 @@ exports[`1. modal image 1`] = `
               <Image
                 source={
                   Object {
+                    "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+                  }
+                }
+              />
+              <Image
+                source={
+                  Object {
                     "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440",
                   }
                 }
@@ -62,6 +69,13 @@ exports[`1. modal image 1`] = `
           degrees={264}
         />
       </View>
+      <Image
+        source={
+          Object {
+            "uri": "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=1440&offline=true",
+          }
+        }
+      />
       <Image
         source={
           Object {

--- a/packages/image/__tests__/android/offline-image.android.test.js
+++ b/packages/image/__tests__/android/offline-image.android.test.js
@@ -1,0 +1,3 @@
+import shared from "../offline-image.android";
+
+shared();

--- a/packages/image/__tests__/offline-image.android.js
+++ b/packages/image/__tests__/offline-image.android.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Image as ReactNativeImage } from "react-native";
+import TestRenderer from "react-test-renderer";
+import { iterator } from "@times-components/test-utils";
+import "./mocks";
+import Image from "../src";
+
+const getLayoutEventForWidth = width => ({
+  nativeEvent: { layout: { width } }
+});
+
+export default () => {
+  const tests = [
+    {
+      name: "append offline=true on the first image only",
+      test: () => {
+        const uri =
+          "http://example.com/image.jpg?crop=1016%2C677%2C0%2C0&resize=100";
+        const testInstance = TestRenderer.create(
+          <Image aspectRatio={3 / 2} highResSize={999} uri={uri} />
+        );
+
+        testInstance.root.children[0].props.onLayout(
+          getLayoutEventForWidth(700)
+        );
+
+        const images = testInstance.root.findAll(
+          node => node.type === ReactNativeImage
+        );
+        expect(images[0].props.source.uri).toEqual(`${uri}&offline=true`);
+        expect(images[1].props.source.uri).toEqual(uri);
+      }
+    }
+  ];
+
+  iterator(tests);
+};

--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -67,7 +67,7 @@ export default () => {
         expect(testInstance).toMatchSnapshot();
 
         testInstance.root
-          .find(node => node.type === ReactNativeImage)
+          .findAll(node => node.type === ReactNativeImage)[0]
           .props.onLoad();
 
         expect(testInstance).toMatchSnapshot();
@@ -87,8 +87,8 @@ export default () => {
         );
 
         expect(
-          testInstance.root.find(node => node.type === ReactNativeImage).props
-            .source.uri
+          testInstance.root.findAll(node => node.type === ReactNativeImage)[0]
+            .props.source.uri
         ).toEqual(dataUri);
       }
     },
@@ -119,10 +119,10 @@ export default () => {
           getLayoutEventForWidth(700)
         );
 
-        expect(
-          testInstance.root.find(node => node.type === ReactNativeImage).props
-            .source.uri
-        ).toEqual(uri);
+        const images = testInstance.root.findAll(
+          node => node.type === ReactNativeImage
+        );
+        expect(images[images.length - 1].props.source.uri).toEqual(uri);
       }
     }
   ];

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -1,10 +1,11 @@
 import React, { Component } from "react";
-import { Image, View } from "react-native";
+import { View } from "react-native";
 import {
   addMissingProtocol,
   normaliseWidth,
   convertToPixels
 } from "@times-components/utils";
+import LazyLoadingImage from "./lazy-loading-image";
 import appendToUrl from "./utils";
 import { defaultProps, propTypes } from "./image-prop-types";
 import Placeholder from "./placeholder";
@@ -54,17 +55,10 @@ class TimesImage extends Component {
       source:
         srcUri && imageRes
           ? {
-            uri: srcUri
-          }
+              uri: srcUri
+            }
           : null,
       style: styles.imageBackground
-    };
-
-    const lazyLoadProps = {
-      ...props,
-      source: props.source ? {
-        uri: appendToUrl(props.source.uri, "offline", true)
-      } : null
     };
 
     return (
@@ -74,8 +68,7 @@ class TimesImage extends Component {
         style={style}
       >
         {isLoaded ? null : <Placeholder />}
-        <Image {...lazyLoadProps} />
-        <Image {...props} />
+        <LazyLoadingImage {...props} />
       </View>
     );
   }

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -5,7 +5,7 @@ import {
   normaliseWidth,
   convertToPixels
 } from "@times-components/utils";
-import appendSize from "./utils";
+import appendToUrl from "./utils";
 import { defaultProps, propTypes } from "./image-prop-types";
 import Placeholder from "./placeholder";
 import styles from "./styles";
@@ -47,17 +47,24 @@ class TimesImage extends Component {
 
     const srcUri = isDataImageUri
       ? uri
-      : addMissingProtocol(appendSize(uri, "resize", imageRes));
+      : addMissingProtocol(appendToUrl(uri, "resize", imageRes));
 
     const props = {
       onLoad: this.handleLoad,
       source:
         srcUri && imageRes
           ? {
-              uri: srcUri
-            }
+            uri: srcUri
+          }
           : null,
       style: styles.imageBackground
+    };
+
+    const lazyLoadProps = {
+      ...props,
+      source: props.source ? {
+        uri: appendToUrl(props.source.uri, "offline", true)
+      } : null
     };
 
     return (
@@ -67,6 +74,7 @@ class TimesImage extends Component {
         style={style}
       >
         {isLoaded ? null : <Placeholder />}
+        <Image {...lazyLoadProps} />
         <Image {...props} />
       </View>
     );

--- a/packages/image/src/lazy-loading-image.android.js
+++ b/packages/image/src/lazy-loading-image.android.js
@@ -6,16 +6,18 @@ export default props => {
   const { source } = props;
   return (
     <Fragment>
-      <Image
-        {...props}
-        source={
-          source
-            ? {
-                uri: appendToUrl(source.uri, "offline", true)
-              }
-            : null
-        }
-      />
+      {source && source.uri && !source.uri.includes("data:image/") ? (
+        <Image
+          {...props}
+          source={
+            source
+              ? {
+                  uri: appendToUrl(source.uri, "offline", true)
+                }
+              : null
+          }
+        />
+      ) : null}
       <Image {...props} />
     </Fragment>
   );

--- a/packages/image/src/lazy-loading-image.android.js
+++ b/packages/image/src/lazy-loading-image.android.js
@@ -1,0 +1,22 @@
+import React, { Fragment } from "react";
+import { Image } from "react-native";
+import appendToUrl from "./utils";
+
+export default props => {
+  const { source } = props;
+  return (
+    <Fragment>
+      <Image
+        {...props}
+        source={
+          source
+            ? {
+                uri: appendToUrl(source.uri, "offline", true)
+              }
+            : null
+        }
+      />
+      <Image {...props} />
+    </Fragment>
+  );
+};

--- a/packages/image/src/lazy-loading-image.js
+++ b/packages/image/src/lazy-loading-image.js
@@ -1,0 +1,3 @@
+import { Image } from "react-native";
+
+export default Image;


### PR DESCRIPTION
New feature to support lazy loading from offline image bundle: (depends on native PR https://github.com/newsuk/nu-projectd-times-smartphone-android/pull/593)

- Added double Image views on top of each other (with a placeholder on the bottom)
- The bottom image has a "offline=true" query param, which is checked by the native app and uses the smapi tarball to fetch the image itself
- Top image does a network request and replaces the bottom one

This way, we can both preload with the low-res offline image and then get the high res from the network.