### PR TITLE
fix: border radius bug and add onPress handler to SecondaryTwoNoPicAndTwo

### DIFF
--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -808,11 +808,9 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "borderColor": "#FFFFFF",
-            "borderRadius": 187.5,
-            "marginLeft": "auto",
-            "marginRight": "auto",
+            "borderWidth": 1,
             "overflow": "hidden",
-            "width": "25%",
+            "width": "30%",
           }
         }
       >
@@ -822,8 +820,8 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "paddingHorizontal": 10,
-            "paddingVertical": 5,
-            "width": "75%",
+            "paddingTop": 5,
+            "width": "70%",
           }
         }
       >
@@ -891,11 +889,9 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "borderColor": "#FFFFFF",
-            "borderRadius": 187.5,
-            "marginLeft": "auto",
-            "marginRight": "auto",
+            "borderWidth": 1,
             "overflow": "hidden",
-            "width": "25%",
+            "width": "30%",
           }
         }
       >
@@ -905,8 +901,8 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "paddingHorizontal": 10,
-            "paddingVertical": 5,
-            "width": "75%",
+            "paddingTop": 5,
+            "width": "70%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -363,6 +363,7 @@ exports[`5. secondary two no pic and two 1`] = `
       <View>
         <Image
           aspectRatio={1}
+          borderRadius={187.5}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </View>
@@ -396,6 +397,7 @@ exports[`5. secondary two no pic and two 1`] = `
       <View>
         <Image
           aspectRatio={1}
+          borderRadius={187.5}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </View>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -442,11 +442,9 @@ exports[`7. tile g 1`] = `
       style={
         Object {
           "borderColor": "#FFFFFF",
-          "borderRadius": 187.5,
-          "marginLeft": "auto",
-          "marginRight": "auto",
+          "borderWidth": 1,
           "overflow": "hidden",
-          "width": "25%",
+          "width": "30%",
         }
       }
     >
@@ -456,8 +454,8 @@ exports[`7. tile g 1`] = `
       style={
         Object {
           "paddingHorizontal": 10,
-          "paddingVertical": 5,
-          "width": "75%",
+          "paddingTop": 5,
+          "width": "70%",
         }
       }
     >
@@ -505,7 +503,7 @@ exports[`7. tile g 1`] = `
 `;
 
 exports[`8. tile i 1`] = `
-<View>
+<Link>
   <View
     style={
       Object {
@@ -566,77 +564,79 @@ exports[`8. tile i 1`] = `
     </Text>
     <ArticleFlags />
   </View>
-</View>
+</Link>
 `;
 
 exports[`9. tile j 1`] = `
-<View
-  style={
-    Object {
-      "flexDirection": "row",
-      "paddingHorizontal": 10,
-      "paddingVertical": 10,
-    }
-  }
->
+<Link>
   <View
     style={
       Object {
-        "width": "33.33%",
-      }
-    }
-  >
-    <Image />
-  </View>
-  <View
-    style={
-      Object {
+        "flexDirection": "row",
         "paddingHorizontal": 10,
-        "paddingVertical": 5,
-        "width": "66.66%",
+        "paddingVertical": 10,
       }
     }
   >
     <View
       style={
         Object {
-          "marginBottom": 5,
+          "width": "33.33%",
         }
       }
     >
-      <Text
+      <Image />
+    </View>
+    <View
+      style={
+        Object {
+          "paddingHorizontal": 10,
+          "paddingVertical": 5,
+          "width": "66.66%",
+        }
+      }
+    >
+      <View
         style={
           Object {
-            "color": "#1D1D1B",
-            "fontFamily": "GillSansMTStd-Medium",
-            "fontSize": 12,
-            "fontWeight": "400",
-            "letterSpacing": 1.2,
-            "lineHeight": 14,
-            "marginBottom": 0,
+            "marginBottom": 5,
           }
         }
       >
-        ROYALS
-      </Text>
-    </View>
-    <Text
-      style={
-        Object {
-          "color": "#333333",
-          "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
-          "fontWeight": "400",
-          "lineHeight": 22,
-          "marginBottom": 5,
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#333333",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "400",
+            "lineHeight": 22,
+            "marginBottom": 5,
+          }
         }
-      }
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
-    <ArticleFlags />
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags />
+    </View>
   </View>
-</View>
+</Link>
 `;
 
 exports[`10. tile l 1`] = `

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -216,6 +216,7 @@ exports[`7. tile g 1`] = `
     <View>
       <Image
         aspectRatio={1}
+        borderRadius={187.5}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </View>
@@ -244,7 +245,7 @@ exports[`7. tile g 1`] = `
 `;
 
 exports[`8. tile i 1`] = `
-<View>
+<Link>
   <View>
     <Image
       aspectRatio={1.7777777777777777}
@@ -271,38 +272,40 @@ exports[`8. tile i 1`] = `
       }
     />
   </View>
-</View>
+</Link>
 `;
 
 exports[`9. tile j 1`] = `
-<View>
-  <View>
-    <Image
-      aspectRatio={1.5}
-      uri="https://img/someImage"
-    />
-  </View>
+<Link>
   <View>
     <View>
-      <Text>
-        ROYALS
-      </Text>
+      <Image
+        aspectRatio={1.5}
+        uri="https://img/someImage"
+      />
     </View>
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
+    <View>
+      <View>
+        <Text>
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
+    </View>
   </View>
-</View>
+</Link>
 `;
 
 exports[`10. tile l 1`] = `

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -808,11 +808,9 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "borderColor": "#FFFFFF",
-            "borderRadius": 187.5,
-            "marginLeft": "auto",
-            "marginRight": "auto",
+            "borderWidth": 1,
             "overflow": "hidden",
-            "width": "25%",
+            "width": "30%",
           }
         }
       >
@@ -822,8 +820,8 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "paddingHorizontal": 10,
-            "paddingVertical": 5,
-            "width": "75%",
+            "paddingTop": 5,
+            "width": "70%",
           }
         }
       >
@@ -891,11 +889,9 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "borderColor": "#FFFFFF",
-            "borderRadius": 187.5,
-            "marginLeft": "auto",
-            "marginRight": "auto",
+            "borderWidth": 1,
             "overflow": "hidden",
-            "width": "25%",
+            "width": "30%",
           }
         }
       >
@@ -905,8 +901,8 @@ exports[`5. secondary two no pic and two 1`] = `
         style={
           Object {
             "paddingHorizontal": 10,
-            "paddingVertical": 5,
-            "width": "75%",
+            "paddingTop": 5,
+            "width": "70%",
           }
         }
       >

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -363,6 +363,7 @@ exports[`5. secondary two no pic and two 1`] = `
       <View>
         <Image
           aspectRatio={1}
+          borderRadius={187.5}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </View>
@@ -396,6 +397,7 @@ exports[`5. secondary two no pic and two 1`] = `
       <View>
         <Image
           aspectRatio={1}
+          borderRadius={187.5}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </View>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -442,11 +442,9 @@ exports[`7. tile g 1`] = `
       style={
         Object {
           "borderColor": "#FFFFFF",
-          "borderRadius": 187.5,
-          "marginLeft": "auto",
-          "marginRight": "auto",
+          "borderWidth": 1,
           "overflow": "hidden",
-          "width": "25%",
+          "width": "30%",
         }
       }
     >
@@ -456,8 +454,8 @@ exports[`7. tile g 1`] = `
       style={
         Object {
           "paddingHorizontal": 10,
-          "paddingVertical": 5,
-          "width": "75%",
+          "paddingTop": 5,
+          "width": "70%",
         }
       }
     >
@@ -505,7 +503,7 @@ exports[`7. tile g 1`] = `
 `;
 
 exports[`8. tile i 1`] = `
-<View>
+<Link>
   <View
     style={
       Object {
@@ -566,77 +564,79 @@ exports[`8. tile i 1`] = `
     </Text>
     <ArticleFlags />
   </View>
-</View>
+</Link>
 `;
 
 exports[`9. tile j 1`] = `
-<View
-  style={
-    Object {
-      "flexDirection": "row",
-      "paddingHorizontal": 10,
-      "paddingVertical": 10,
-    }
-  }
->
+<Link>
   <View
     style={
       Object {
-        "width": "33.33%",
-      }
-    }
-  >
-    <Image />
-  </View>
-  <View
-    style={
-      Object {
+        "flexDirection": "row",
         "paddingHorizontal": 10,
-        "paddingVertical": 5,
-        "width": "66.66%",
+        "paddingVertical": 10,
       }
     }
   >
     <View
       style={
         Object {
-          "marginBottom": 0,
+          "width": "33.33%",
         }
       }
     >
-      <Text
+      <Image />
+    </View>
+    <View
+      style={
+        Object {
+          "paddingHorizontal": 10,
+          "paddingVertical": 5,
+          "width": "66.66%",
+        }
+      }
+    >
+      <View
         style={
           Object {
-            "color": "#1D1D1B",
-            "fontFamily": "GillSansMTStd-Medium",
-            "fontSize": 12,
-            "fontWeight": "400",
-            "letterSpacing": 1.2,
-            "lineHeight": 14,
             "marginBottom": 0,
           }
         }
       >
-        ROYALS
-      </Text>
-    </View>
-    <Text
-      style={
-        Object {
-          "color": "#333333",
-          "fontFamily": "TimesModern-Bold",
-          "fontSize": 22,
-          "fontWeight": "900",
-          "lineHeight": 22,
-          "marginBottom": 5,
+        <Text
+          style={
+            Object {
+              "color": "#1D1D1B",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#333333",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "900",
+            "lineHeight": 22,
+            "marginBottom": 5,
+          }
         }
-      }
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
-    <ArticleFlags />
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags />
+    </View>
   </View>
-</View>
+</Link>
 `;
 
 exports[`10. tile l 1`] = `

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -216,6 +216,7 @@ exports[`7. tile g 1`] = `
     <View>
       <Image
         aspectRatio={1}
+        borderRadius={187.5}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </View>
@@ -244,7 +245,7 @@ exports[`7. tile g 1`] = `
 `;
 
 exports[`8. tile i 1`] = `
-<View>
+<Link>
   <View>
     <Image
       aspectRatio={1.7777777777777777}
@@ -271,38 +272,40 @@ exports[`8. tile i 1`] = `
       }
     />
   </View>
-</View>
+</Link>
 `;
 
 exports[`9. tile j 1`] = `
-<View>
-  <View>
-    <Image
-      aspectRatio={1.5}
-      uri="https://img/someImage"
-    />
-  </View>
+<Link>
   <View>
     <View>
-      <Text>
-        ROYALS
-      </Text>
+      <Image
+        aspectRatio={1.5}
+        uri="https://img/someImage"
+      />
     </View>
-    <Text
-      accessibilityRole="heading"
-      aria-level="3"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </Text>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
+    <View>
+      <View>
+        <Text>
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
+    </View>
   </View>
-</View>
+</Link>
 `;
 
 exports[`10. tile l 1`] = `

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -852,15 +852,13 @@ exports[`5. secondary two no pic and two 1`] = `
   border-right-color: rgba(255,255,255,1.00);
   border-bottom-color: rgba(255,255,255,1.00);
   border-left-color: rgba(255,255,255,1.00);
-  border-top-left-radius: 256px;
-  border-top-right-radius: 256px;
-  border-bottom-right-radius: 256px;
-  border-bottom-left-radius: 256px;
-  margin-left: auto;
-  margin-right: auto;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
   overflow-x: hidden;
   overflow-y: hidden;
-  width: 25%;
+  width: 30%;
 }
 
 .IS10 {
@@ -872,11 +870,10 @@ exports[`5. secondary two no pic and two 1`] = `
 }
 
 .IS12 {
-  padding-top: 5px;
   padding-right: 10px;
-  padding-bottom: 5px;
   padding-left: 10px;
-  width: 75%;
+  padding-top: 5px;
+  width: 70%;
 }
 
 .IS13 {
@@ -903,15 +900,13 @@ exports[`5. secondary two no pic and two 1`] = `
   border-right-color: rgba(255,255,255,1.00);
   border-bottom-color: rgba(255,255,255,1.00);
   border-left-color: rgba(255,255,255,1.00);
-  border-top-left-radius: 256px;
-  border-top-right-radius: 256px;
-  border-bottom-right-radius: 256px;
-  border-bottom-left-radius: 256px;
-  margin-left: auto;
-  margin-right: auto;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
   overflow-x: hidden;
   overflow-y: hidden;
-  width: 25%;
+  width: 30%;
 }
 
 .IS16 {
@@ -923,11 +918,10 @@ exports[`5. secondary two no pic and two 1`] = `
 }
 
 .IS18 {
-  padding-top: 5px;
   padding-right: 10px;
-  padding-bottom: 5px;
   padding-left: 10px;
-  width: 75%;
+  padding-top: 5px;
+  width: 70%;
 }
 
 .IS19 {
@@ -1055,6 +1049,7 @@ exports[`5. secondary two no pic and two 1`] = `
       >
         <Image
           aspectRatio={1}
+          borderRadius={256}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </div>
@@ -1101,6 +1096,7 @@ exports[`5. secondary two no pic and two 1`] = `
       >
         <Image
           aspectRatio={1}
+          borderRadius={256}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -366,6 +366,7 @@ exports[`5. secondary two no pic and two 1`] = `
       <div>
         <Image
           aspectRatio={1}
+          borderRadius={256}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </div>
@@ -399,6 +400,7 @@ exports[`5. secondary two no pic and two 1`] = `
       <div>
         <Image
           aspectRatio={1}
+          borderRadius={256}
           uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
         />
       </div>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -622,15 +622,13 @@ exports[`7. tile g 1`] = `
   border-right-color: rgba(255,255,255,1.00);
   border-bottom-color: rgba(255,255,255,1.00);
   border-left-color: rgba(255,255,255,1.00);
-  border-top-left-radius: 256px;
-  border-top-right-radius: 256px;
-  border-bottom-right-radius: 256px;
-  border-bottom-left-radius: 256px;
-  margin-left: auto;
-  margin-right: auto;
+  border-top-width: 1px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
   overflow-x: hidden;
   overflow-y: hidden;
-  width: 25%;
+  width: 30%;
 }
 
 .IS2 {
@@ -642,11 +640,10 @@ exports[`7. tile g 1`] = `
 }
 
 .IS4 {
-  padding-top: 5px;
   padding-right: 10px;
-  padding-bottom: 5px;
   padding-left: 10px;
-  width: 75%;
+  padding-top: 5px;
+  width: 70%;
 }
 
 .IS5 {
@@ -672,6 +669,7 @@ exports[`7. tile g 1`] = `
     >
       <Image
         aspectRatio={1}
+        borderRadius={256}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </div>
@@ -754,9 +752,7 @@ exports[`8. tile i 1`] = `
 }
 </style>
 
-<div
-  className="S1"
->
+<Link>
   <div
     className="IS1 S1"
   >
@@ -792,7 +788,7 @@ exports[`8. tile i 1`] = `
       }
     />
   </div>
-</div>
+</Link>
 `;
 
 exports[`9. tile j 1`] = `
@@ -849,45 +845,47 @@ exports[`9. tile j 1`] = `
 }
 </style>
 
-<div
-  className="IS5 S1"
->
+<Link>
   <div
-    className="IS1 S1"
-  >
-    <Image
-      aspectRatio={1.5}
-      uri="https://img/someImage"
-    />
-  </div>
-  <div
-    className="IS4 S1"
+    className="IS5 S1"
   >
     <div
-      className="S1"
+      className="IS1 S1"
+    >
+      <Image
+        aspectRatio={1.5}
+        uri="https://img/someImage"
+      />
+    </div>
+    <div
+      className="IS4 S1"
     >
       <div
-        className="IS2 S2"
+        className="S1"
       >
-        ROYALS
+        <div
+          className="IS2 S2"
+        >
+          ROYALS
+        </div>
       </div>
+      <h3
+        aria-level="3"
+        className="IS3 S3"
+        role="heading"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </h3>
+      <ArticleFlags
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
     </div>
-    <h3
-      aria-level="3"
-      className="IS3 S3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
   </div>
-</div>
+</Link>
 `;
 
 exports[`10. tile l 1`] = `

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -216,6 +216,7 @@ exports[`7. tile g 1`] = `
     <div>
       <Image
         aspectRatio={1}
+        borderRadius={256}
         uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
       />
     </div>
@@ -244,7 +245,7 @@ exports[`7. tile g 1`] = `
 `;
 
 exports[`8. tile i 1`] = `
-<div>
+<Link>
   <div>
     <Image
       aspectRatio={1.7777777777777777}
@@ -271,38 +272,40 @@ exports[`8. tile i 1`] = `
       }
     />
   </div>
-</div>
+</Link>
 `;
 
 exports[`9. tile j 1`] = `
-<div>
-  <div>
-    <Image
-      aspectRatio={1.5}
-      uri="https://img/someImage"
-    />
-  </div>
+<Link>
   <div>
     <div>
-      <div>
-        ROYALS
-      </div>
+      <Image
+        aspectRatio={1.5}
+        uri="https://img/someImage"
+      />
     </div>
-    <h3
-      aria-level="3"
-      role="heading"
-    >
-      Prince Philip ‘could be prosecuted’ over car crash
-    </h3>
-    <ArticleFlags
-      flags={
-        Array [
-          "NEW",
-        ]
-      }
-    />
+    <div>
+      <div>
+        <div>
+          ROYALS
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </h3>
+      <ArticleFlags
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
+    </div>
   </div>
-</div>
+</Link>
 `;
 
 exports[`10. tile l 1`] = `

--- a/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
+++ b/packages/edition-slices/src/slices/secondarytwonopicandtwo/index.js
@@ -4,20 +4,22 @@ import { SecondaryTwoNoPicAndTwoSlice } from "@times-components/slice-layout";
 import { TileB, TileG } from "../../tiles";
 
 const SecondaryTwoNoPicAndTwo = ({
+  onPress,
   secondary1,
   secondary2,
   support1,
   support2
 }) => (
   <SecondaryTwoNoPicAndTwoSlice
-    renderSecondary1={() => <TileB tile={secondary1} />}
-    renderSecondary2={() => <TileB tile={secondary2} />}
-    renderSupport1={() => <TileG tile={support1} />}
-    renderSupport2={() => <TileG tile={support2} />}
+    renderSecondary1={() => <TileB onPress={onPress} tile={secondary1} />}
+    renderSecondary2={() => <TileB onPress={onPress} tile={secondary2} />}
+    renderSupport1={() => <TileG onPress={onPress} tile={support1} />}
+    renderSupport2={() => <TileG onPress={onPress} tile={support2} />}
   />
 );
 
 SecondaryTwoNoPicAndTwo.propTypes = {
+  onPress: PropTypes.func.isRequired,
   secondary1: PropTypes.shape({}).isRequired,
   secondary2: PropTypes.shape({}).isRequired,
   support1: PropTypes.shape({}).isRequired,

--- a/packages/edition-slices/src/tiles/shared/tile-image.js
+++ b/packages/edition-slices/src/tiles/shared/tile-image.js
@@ -3,19 +3,21 @@ import { View } from "react-native";
 import PropTypes from "prop-types";
 import Image from "@times-components/image";
 
-const TileImage = ({ aspectRatio, style, uri }) => (
+const TileImage = ({ aspectRatio, borderRadius, style, uri }) => (
   <View style={style}>
-    <Image aspectRatio={aspectRatio} uri={uri} />
+    <Image aspectRatio={aspectRatio} borderRadius={borderRadius} uri={uri} />
   </View>
 );
 
 TileImage.propTypes = {
   aspectRatio: PropTypes.number.isRequired,
+  borderRadius: PropTypes.number,
   style: PropTypes.shape({}),
   uri: PropTypes.string.isRequired
 };
 
 TileImage.defaultProps = {
+  borderRadius: undefined,
   style: null
 };
 

--- a/packages/edition-slices/src/tiles/tile-g/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { View } from "react-native";
+import { Dimensions, View } from "react-native";
 import PropTypes from "prop-types";
 import { TileImage, TileLink, TileSummary } from "../shared";
 import styles from "./styles";
@@ -9,6 +9,7 @@ const TileG = ({ onPress, tile }) => (
     <View style={styles.container}>
       <TileImage
         aspectRatio={1}
+        borderRadius={Dimensions.get("window").width / 4}
         style={styles.imageContainer}
         uri={tile.article.leadAsset.crop11.url}
       />

--- a/packages/edition-slices/src/tiles/tile-g/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-g/styles/index.js
@@ -1,4 +1,3 @@
-import { Dimensions } from "react-native";
 import { colours, fontFactory, spacing } from "@times-components/styleguide";
 
 const styles = {
@@ -14,16 +13,14 @@ const styles = {
   },
   imageContainer: {
     borderColor: colours.functional.contrast,
-    borderRadius: Dimensions.get("window").width / 4,
-    marginLeft: "auto",
-    marginRight: "auto",
+    borderWidth: 1,
     overflow: "hidden",
-    width: "25%"
+    width: "30%"
   },
   summaryContainer: {
     paddingHorizontal: spacing(2),
-    paddingVertical: spacing(1),
-    width: "75%"
+    paddingTop: spacing(1),
+    width: "70%"
   }
 };
 

--- a/packages/edition-slices/src/tiles/tile-i/index.js
+++ b/packages/edition-slices/src/tiles/tile-i/index.js
@@ -1,11 +1,10 @@
 import React from "react";
-import { View } from "react-native";
 import PropTypes from "prop-types";
-import { TileImage, TileSummary } from "../shared";
+import { TileImage, TileLink, TileSummary } from "../shared";
 import styles from "./styles";
 
-const TileI = ({ tile }) => (
-  <View>
+const TileI = ({ onPress, tile }) => (
+  <TileLink onPress={onPress} tile={tile}>
     <TileImage
       aspectRatio={16 / 9}
       style={styles.imageContainer}
@@ -16,10 +15,11 @@ const TileI = ({ tile }) => (
       style={styles.summaryContainer}
       tile={tile}
     />
-  </View>
+  </TileLink>
 );
 
 TileI.propTypes = {
+  onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };
 

--- a/packages/edition-slices/src/tiles/tile-j/index.js
+++ b/packages/edition-slices/src/tiles/tile-j/index.js
@@ -1,25 +1,28 @@
 import React from "react";
 import { View } from "react-native";
 import PropTypes from "prop-types";
-import { TileImage, TileSummary } from "../shared";
+import { TileImage, TileLink, TileSummary } from "../shared";
 import styles from "./styles";
 
-const TileJ = ({ tile }) => (
-  <View style={styles.container}>
-    <TileImage
-      aspectRatio={3 / 2}
-      style={styles.imageContainer}
-      uri={tile.article.leadAsset.crop32.url}
-    />
-    <TileSummary
-      headlineStyle={styles.headline}
-      style={styles.summaryContainer}
-      tile={tile}
-    />
-  </View>
+const TileJ = ({ onPress, tile }) => (
+  <TileLink onPress={onPress} tile={tile}>
+    <View style={styles.container}>
+      <TileImage
+        aspectRatio={3 / 2}
+        style={styles.imageContainer}
+        uri={tile.article.leadAsset.crop32.url}
+      />
+      <TileSummary
+        headlineStyle={styles.headline}
+        style={styles.summaryContainer}
+        tile={tile}
+      />
+    </View>
+  </TileLink>
 );
 
 TileJ.propTypes = {
+  onPress: PropTypes.func.isRequired,
   tile: PropTypes.shape({}).isRequired
 };
 

--- a/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
+++ b/packages/image/__tests__/android/__snapshots__/image.android.test.js.snap
@@ -186,3 +186,19 @@ exports[`7. uses highressize if it is smaller than layout width 1`] = `
   />
 </View>
 `;
+
+exports[`9. image with borderradius 1`] = `
+<View
+  aspectRatio={1.5}
+>
+  <View>
+    <Gradient
+      degrees={264}
+    />
+  </View>
+  <Image
+    borderRadius={10}
+    source={null}
+  />
+</View>
+`;

--- a/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
+++ b/packages/image/__tests__/ios/__snapshots__/image.ios.test.js.snap
@@ -144,3 +144,19 @@ exports[`7. uses highressize if it is smaller than layout width 1`] = `
   />
 </View>
 `;
+
+exports[`9. image with borderradius 1`] = `
+<View
+  aspectRatio={1.5}
+>
+  <View>
+    <Gradient
+      degrees={264}
+    />
+  </View>
+  <Image
+    borderRadius={10}
+    source={null}
+  />
+</View>
+`;

--- a/packages/image/__tests__/shared.native.js
+++ b/packages/image/__tests__/shared.native.js
@@ -124,6 +124,20 @@ export default () => {
         );
         expect(images[images.length - 1].props.source.uri).toEqual(uri);
       }
+    },
+    {
+      name: "image with borderRadius",
+      test: () => {
+        const testInstance = TestRenderer.create(
+          <Image
+            aspectRatio={3 / 2}
+            borderRadius={10}
+            highResSize={1000}
+            uri="http://example.com/image.jpg?crop=1016%2C677%2C0%2C0"
+          />
+        );
+        expect(testInstance).toMatchSnapshot();
+      }
     }
   ];
 

--- a/packages/image/src/image-prop-types.js
+++ b/packages/image/src/image-prop-types.js
@@ -5,6 +5,7 @@ const { style: ViewPropTypesStyle } = ViewPropTypes;
 
 export const propTypes = {
   aspectRatio: PropTypes.number,
+  borderRadius: PropTypes.number,
   fadeImageIn: PropTypes.bool,
   highResSize: PropTypes.number,
   lowResSize: PropTypes.number,
@@ -14,6 +15,7 @@ export const propTypes = {
 
 export const defaultProps = {
   aspectRatio: undefined,
+  borderRadius: undefined,
   fadeImageIn: false,
   highResSize: null,
   lowResSize: null,

--- a/packages/image/src/image.js
+++ b/packages/image/src/image.js
@@ -41,7 +41,7 @@ class TimesImage extends Component {
   }
 
   render() {
-    const { aspectRatio, style, uri } = this.props;
+    const { aspectRatio, borderRadius, style, uri } = this.props;
     const { isLoaded, imageRes } = this.state;
 
     const isDataImageUri = uri && uri.indexOf("data:") > -1;
@@ -51,6 +51,7 @@ class TimesImage extends Component {
       : addMissingProtocol(appendToUrl(uri, "resize", imageRes));
 
     const props = {
+      borderRadius,
       onLoad: this.handleLoad,
       source:
         srcUri && imageRes


### PR DESCRIPTION
- react native has a bug with border radius not being applied via style in Android API 24.
https://github.com/facebook/react-native/issues/8885
- This fixes by adding a `borderRadius` prop to the `Image`.
- Also adds missing `onPress` handler prop to `SecondaryTwoNoPicAndTwo` slice.

### Nexus 5 API 24
<img width="498" alt="screenshot 2019-02-07 at 09 27 31" src="https://user-images.githubusercontent.com/1736782/52401954-e4a7da00-2aba-11e9-9eda-3fc5d2f7f99b.png">
