### PR TITLE
feat: edition checker

### DIFF
--- a/lib/.eslintrc.json
+++ b/lib/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    "no-console": "off"
   }
 }

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -40,20 +40,20 @@ function addComponent(opts) {
     '\n\nUsage:\n$ times-components create component ComponentName "Component Description"';
   const argumentOrUsage = (argument, message) => {
     if (!argument) {
-      console.error(message + usage); // eslint-disable-line no-console
+      console.error(message + usage);
       process.exit(1);
     }
   };
 
   const rComponent = /^([A-Z][a-z]*)+$/;
-
+  //
   argumentOrUsage(component, "Component name required");
   argumentOrUsage(
     rComponent.test(component),
     "Use ClassCase for the component name"
   );
   argumentOrUsage(
-    packageDescription !== null,
+    packageDescription,
     "Component description required"
   );
 

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -52,10 +52,7 @@ function addComponent(opts) {
     rComponent.test(component),
     "Use ClassCase for the component name"
   );
-  argumentOrUsage(
-    packageDescription,
-    "Component description required"
-  );
+  argumentOrUsage(packageDescription, "Component description required");
 
   writeStubFiles({
     component,

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -5,6 +5,7 @@ const dashify = require("dashify");
 const mkdirp = require("mkdirp");
 const subcommander = require("subcommander");
 
+const editionChecker = require("./edition-checker");
 const fileTemplates = require("./templates");
 
 const repositoryRoot = path.join(__dirname, "../../");
@@ -64,26 +65,14 @@ function addComponent() {
 }
 
 module.exports = () => {
-  subcommander.command("create component", {
-    desc: "create a new component",
-    callback: addComponent
-  });
+  subcommander
+    .command("create", { desc: "code generator" })
+    .command("component", {
+      desc: "create a new component",
+      callback: addComponent
+    });
 
-  const multiSubCommand = ["create component"].filter(command => {
-    const subcommands = command.split(" ").length;
-    return process.argv.slice(2, 2 + subcommands).join(" ") === command;
-  })[0];
-
-  if (multiSubCommand) {
-    const matchLength = multiSubCommand.split(" ").length;
-    process.argv = process.argv
-      .slice(0, 2)
-      .concat(process.argv.slice(2, 2 + matchLength).join(" "))
-      .concat(process.argv.slice(2 + matchLength));
-  } else {
-    subcommander.usage();
-    process.exit(1);
-  }
+  editionChecker(subcommander, "check");
 
   subcommander.parse();
 };

--- a/lib/cli/cli.js
+++ b/lib/cli/cli.js
@@ -32,9 +32,9 @@ function writeStubFiles(variables) {
   fs.copy(path.join(__dirname, "/files"), packageRoot);
 }
 
-function addComponent() {
-  const component = process.argv[3];
-  const packageDescription = process.argv[4];
+function addComponent(opts) {
+  const component = opts[0];
+  const packageDescription = opts[1];
 
   const usage =
     '\n\nUsage:\n$ times-components create component ComponentName "Component Description"';
@@ -64,7 +64,7 @@ function addComponent() {
   });
 }
 
-module.exports = () => {
+module.exports = function cli(args) {
   subcommander
     .command("create", { desc: "code generator" })
     .command("component", {
@@ -74,5 +74,5 @@ module.exports = () => {
 
   editionChecker(subcommander, "check");
 
-  subcommander.parse();
+  subcommander.parse(args);
 };

--- a/lib/cli/cli.test.js
+++ b/lib/cli/cli.test.js
@@ -22,30 +22,22 @@ const removeTestPackage = () =>
   });
 
 describe("./times-components CLI interface", () => {
-  const originalProcessArgv = process.argv;
   let pkgJson;
   let readMeFile;
 
   beforeEach(() => {
-    process.argv = originalProcessArgv.slice(0);
-    process.argv = [
-      "/path/to/node",
-      "/path/to/times-components",
+    cli([
       "create",
       "component",
       "TestComponentDeleteMe",
       "test component, delete me"
-    ];
-
-    cli();
+    ]);
 
     pkgJson = JSON.parse(read("package.json"));
     readMeFile = read("README.md");
   });
 
   afterEach(done => {
-    process.argv = originalProcessArgv;
-
     removeTestPackage().then(done);
   });
 

--- a/lib/cli/cli.test.js
+++ b/lib/cli/cli.test.js
@@ -23,7 +23,6 @@ const removeTestPackage = () =>
 
 describe("./times-components CLI interface", () => {
   describe("with correct arguments", () => {
-
     let pkgJson;
     let readMeFile;
 
@@ -114,18 +113,20 @@ describe("./times-components CLI interface", () => {
       });
 
       it("with a pretty styles android file", () => {
-        expect(prettier.check(read("src/styles/index.android.js"))).toEqual(true);
+        expect(prettier.check(read("src/styles/index.android.js"))).toEqual(
+          true
+        );
       });
     });
-  })
+  });
 
   describe("without correct arguments", () => {
     let existingProcess;
     let existingConsole;
     let exit;
-    const exitError = new Error('Process exit error');
+    const exitError = new Error("Process exit error");
 
-    let assertExits = (exitCode, handler) => {
+    function assertExits(exitCode, handler) {
       try {
         handler();
       } catch (e) {
@@ -141,7 +142,9 @@ describe("./times-components CLI interface", () => {
       existingProcess = global.process;
       existingConsole = global.console;
 
-      exit = jest.fn(() => { throw exitError; });
+      exit = jest.fn(() => {
+        throw exitError;
+      });
 
       global.process = {
         ...global.process,
@@ -170,10 +173,10 @@ describe("./times-components CLI interface", () => {
 
     it("exits when package description is not passed", () => {
       assertExits(1, () => cli(["create", "component", "Component"]));
-    })
+    });
 
     it("exits when package description is empty", () => {
       assertExits(1, () => cli(["create", "component", "Component", ""]));
-    })
-  })
+    });
+  });
 });

--- a/lib/cli/cli.test.js
+++ b/lib/cli/cli.test.js
@@ -22,97 +22,158 @@ const removeTestPackage = () =>
   });
 
 describe("./times-components CLI interface", () => {
-  let pkgJson;
-  let readMeFile;
+  describe("with correct arguments", () => {
 
-  beforeEach(() => {
-    cli([
-      "create",
-      "component",
-      "TestComponentDeleteMe",
-      "test component, delete me"
-    ]);
+    let pkgJson;
+    let readMeFile;
 
-    pkgJson = JSON.parse(read("package.json"));
-    readMeFile = read("README.md");
-  });
+    beforeEach(() => {
+      cli([
+        "create",
+        "component",
+        "TestComponentDeleteMe",
+        "test component, delete me"
+      ]);
 
-  afterEach(done => {
-    removeTestPackage().then(done);
-  });
-
-  describe("creates a package", () => {
-    it("with a pretty index file", () => {
-      expect(prettier.check(read("src/test-component-delete-me.js"))).toEqual(
-        true
-      );
+      pkgJson = JSON.parse(read("package.json"));
+      readMeFile = read("README.md");
     });
 
-    it("with a pretty android test file", () => {
-      expect(
-        prettier.check(
-          read("__tests__/android/test-component-delete-me.test.js")
-        )
-      ).toEqual(true);
+    afterEach(done => {
+      removeTestPackage().then(done);
     });
 
-    it("with a pretty ios test file", () => {
-      expect(
-        prettier.check(read("__tests__/ios/test-component-delete-me.test.js"))
-      ).toEqual(true);
+    describe("creates a package", () => {
+      it("with a pretty index file", () => {
+        expect(prettier.check(read("src/test-component-delete-me.js"))).toEqual(
+          true
+        );
+      });
+
+      it("with a pretty android test file", () => {
+        expect(
+          prettier.check(
+            read("__tests__/android/test-component-delete-me.test.js")
+          )
+        ).toEqual(true);
+      });
+
+      it("with a pretty ios test file", () => {
+        expect(
+          prettier.check(read("__tests__/ios/test-component-delete-me.test.js"))
+        ).toEqual(true);
+      });
+
+      it("with a pretty web test file", () => {
+        expect(
+          prettier.check(read("__tests__/web/test-component-delete-me.test.js"))
+        ).toEqual(true);
+      });
+
+      it("with a pretty test eslint config file", () => {
+        const eslintrcFile = JSON.parse(read("__tests__/.eslintrc.json"));
+        expect(eslintrcFile.env.jest).toEqual(true);
+      });
+
+      it("with a pretty showcase file", () => {
+        expect(
+          prettier.check(read("test-component-delete-me.showcase.js"))
+        ).toEqual(true);
+      });
+
+      it("with a pretty stories file", () => {
+        expect(
+          prettier.check(read("test-component-delete-me.stories.js"))
+        ).toEqual(true);
+      });
+
+      it("with a README file", () => {
+        expect(readMeFile.indexOf("TestComponentDeleteMe") > -1).toEqual(true);
+      });
+
+      it("with a package.json", () => {
+        expect(pkgJson.name).toEqual(
+          "@times-components/test-component-delete-me"
+        );
+      });
+
+      it("with the expected description", () => {
+        expect(pkgJson.description).toEqual("test component, delete me");
+      });
+
+      it("with a pretty styles shared file", () => {
+        expect(prettier.check(read("src/styles/shared.js"))).toEqual(true);
+      });
+
+      it("with a pretty styles index file", () => {
+        expect(prettier.check(read("src/styles/index.js"))).toEqual(true);
+      });
+
+      it("with a pretty styles web file", () => {
+        expect(prettier.check(read("src/styles/index.web.js"))).toEqual(true);
+      });
+
+      it("with a pretty styles android file", () => {
+        expect(prettier.check(read("src/styles/index.android.js"))).toEqual(true);
+      });
+    });
+  })
+
+  describe("without correct arguments", () => {
+    let existingProcess;
+    let existingConsole;
+    let exit;
+    const exitError = new Error('Process exit error');
+
+    let assertExits = (exitCode, handler) => {
+      try {
+        handler();
+      } catch (e) {
+        if (e !== exitError) {
+          throw e;
+        }
+      }
+
+      expect(exit).toHaveBeenCalledWith(exitCode);
+    }
+
+    beforeEach(() => {
+      existingProcess = global.process;
+      existingConsole = global.console;
+
+      exit = jest.fn(() => { throw exitError; });
+
+      global.process = {
+        ...global.process,
+        exit
+      };
+
+      global.console = {
+        log: () => null,
+        error: () => null,
+        warn: () => null
+      };
     });
 
-    it("with a pretty web test file", () => {
-      expect(
-        prettier.check(read("__tests__/web/test-component-delete-me.test.js"))
-      ).toEqual(true);
+    afterEach(() => {
+      global.process = existingProcess;
+      global.console = existingConsole;
     });
 
-    it("with a pretty test eslint config file", () => {
-      const eslintrcFile = JSON.parse(read("__tests__/.eslintrc.json"));
-      expect(eslintrcFile.env.jest).toEqual(true);
+    it("exits when component name is not passed", () => {
+      assertExits(1, () => cli(["create", "component"]));
     });
 
-    it("with a pretty showcase file", () => {
-      expect(
-        prettier.check(read("test-component-delete-me.showcase.js"))
-      ).toEqual(true);
+    it("exits when component name is not CamelCase", () => {
+      assertExits(1, () => cli(["create", "component", "not-camel Case"]));
     });
 
-    it("with a pretty stories file", () => {
-      expect(
-        prettier.check(read("test-component-delete-me.stories.js"))
-      ).toEqual(true);
-    });
+    it("exits when package description is not passed", () => {
+      assertExits(1, () => cli(["create", "component", "Component"]));
+    })
 
-    it("with a README file", () => {
-      expect(readMeFile.indexOf("TestComponentDeleteMe") > -1).toEqual(true);
-    });
-
-    it("with a package.json", () => {
-      expect(pkgJson.name).toEqual(
-        "@times-components/test-component-delete-me"
-      );
-    });
-
-    it("with the expected description", () => {
-      expect(pkgJson.description).toEqual("test component, delete me");
-    });
-
-    it("with a pretty styles shared file", () => {
-      expect(prettier.check(read("src/styles/shared.js"))).toEqual(true);
-    });
-
-    it("with a pretty styles index file", () => {
-      expect(prettier.check(read("src/styles/index.js"))).toEqual(true);
-    });
-
-    it("with a pretty styles web file", () => {
-      expect(prettier.check(read("src/styles/index.web.js"))).toEqual(true);
-    });
-
-    it("with a pretty styles android file", () => {
-      expect(prettier.check(read("src/styles/index.android.js"))).toEqual(true);
-    });
-  });
+    it("exits when package description is empty", () => {
+      assertExits(1, () => cli(["create", "component", "Component", ""]));
+    })
+  })
 });

--- a/lib/cli/edition-checker/README.md
+++ b/lib/cli/edition-checker/README.md
@@ -1,14 +1,14 @@
 # Edition Checker
 
-A tool that allows you to crawl a specific edition or the past six days for issues in loading articles when using react. 
+A tool that allows you to crawl a specific edition or the past six days for issues in loading articles when using react.
 
 This requires being logged in to work, so you must set a `ACS_COOKIE` and `SACS_COOKIE` environment variable. We should probably set up credentials specifically for this tool in the long run.
 
 This also requires the use of an internal Times API, and you must set the path to this with the `TIMES_API_ROOT` environment variable.
 
-You can also configure the tool to post to Slack using a Slack incoming webhook with the `TIMES_SLACK_HOOK` and `TIMES_SLACK_USERNAME` environment variables. 
+You can also configure the tool to post to Slack using a Slack incoming webhook with the `TIMES_SLACK_HOOK` and `TIMES_SLACK_USERNAME` environment variables.
 
-In the long term, it might be useful to consider adding other kinds of checks to the crawler. Currently, the only checks it employs are checking that the status code is 200.  
+In the long term, it might be useful to consider adding other kinds of checks to the crawler. Currently, the only checks it employs are checking that the status code is 200.
 
 ```bash
 $ ./times-components check edition # check todays edition

--- a/lib/cli/edition-checker/README.md
+++ b/lib/cli/edition-checker/README.md
@@ -1,0 +1,21 @@
+# Edition Checker
+
+A tool that allows you to crawl a specific edition or the past six days for issues in loading articles when using react. 
+
+This requires being logged in to work, so you must set a `ACS_COOKIE` and `SACS_COOKIE` environment variable. We should probably set up credentials specifically for this tool in the long run.
+
+This also requires the use of an internal Times API, and you must set the path to this with the `TIMES_API_ROOT` environment variable.
+
+You can also configure the tool to post to Slack using a Slack incoming webhook with the `TIMES_SLACK_HOOK` and `TIMES_SLACK_USERNAME` environment variables. 
+
+In the long term, it might be useful to consider adding other kinds of checks to the crawler. Currently, the only checks it employs are checking that the status code is 200.  
+
+```bash
+$ ./times-components check edition # check todays edition
+$ ./times-components check edition -e 2019-01-01 # check a specific edition
+$ ./times-components check past-six-days # check articles from the past six days
+
+$ ./times-components check [method] -m 30 # only check the first 30 articles
+$ ./times-components check [method] -c 30 # check 30 articles at a time
+$ ./times-components check [method] -v # verbose, display more information
+```

--- a/lib/cli/edition-checker/index.js
+++ b/lib/cli/edition-checker/index.js
@@ -1,0 +1,93 @@
+const main = require("./src/main");
+
+function configureShared(subcommander) {
+  subcommander
+    .option("acs", {
+      desc:
+        "Times acs cookie. You can also set this with the ACS_COOKIE env variable (required)",
+      default: process.env.ACS_COOKIE
+    })
+    .option("sacs", {
+      desc:
+        "Times sacs cookie. You can also set this with the SACS_COOKIE env variable (required)",
+      default: process.env.SACS_COOKIE
+    })
+    .option("api", {
+      abbr: "a",
+      desc:
+        "Times API root. You can also set this with the TIMES_API_ROOT env variable (required)",
+      default: process.env.TIMES_API_ROOT
+    })
+    .option("max", {
+      abbr: "m",
+      desc:
+        "Maximum number of articles you would like to check. Do not set this if you wish to check every article"
+    })
+    .option("concurrency", {
+      abbr: "c",
+      desc:
+        "Maximum number of articles to check simultaneously. The higher this is, the faster the tool will run. The tool is also less reliable at higher concurrencies",
+      default: 5
+    })
+    .option("maxRetry", {
+      abbr: "r",
+      desc:
+        "Maximum number of times to retry an article check when there has been a network failure",
+      default: 3
+    })
+    .option("articlePath", {
+      abbr: "p",
+      desc: "Times article root",
+      default: "https://thetimes.co.uk/article"
+    })
+    .option("verbose", {
+      abbr: "v",
+      desc: "Show hidden logs",
+      flag: true
+    })
+    .option("slackHook", {
+      desc:
+        "Slack API hook. You can also set this with the TIMES_SLACK_HOOK env variable",
+      default: process.env.TIMES_SLACK_HOOK
+    })
+    .option("slackUsername", {
+      desc:
+        "Slack Bot username. You can also set this with the TIMES_SLACK_USERNAME env variable",
+      default: process.env.TIMES_SLACK_USERNAME || "Times Edition Checker"
+    });
+}
+
+function configureEdition(subcommander) {
+  const edition = subcommander.command("edition", {
+    desc: "Crawl articles contained within a specific edition",
+    callback: main.edition
+  });
+
+  configureShared(edition);
+
+  edition.option("edition", {
+    abbr: "e",
+    desc: "Edition to check",
+    default: "latest"
+  });
+}
+
+function configurePastSixDays(subcommander) {
+  const pastSixDays = subcommander.command("past-six-days", {
+    desc: "Crawl articles contained within the past six editions",
+    callback: main.pastSixDays
+  });
+
+  configureShared(pastSixDays);
+}
+
+function configure(subcommander, command) {
+  const check = subcommander.command(command, {
+    desc: "Crawl times articles and report status codes"
+  });
+
+  configureEdition(check);
+  configurePastSixDays(check);
+}
+
+module.exports = configure;

--- a/lib/cli/edition-checker/index.js
+++ b/lib/cli/edition-checker/index.js
@@ -29,10 +29,10 @@ function configureShared(subcommander) {
         "Maximum number of articles to check simultaneously. The higher this is, the faster the tool will run. The tool is also less reliable at higher concurrencies",
       default: 5
     })
-    .option("maxRetry", {
-      abbr: "r",
+    .option("maxAttempts", {
+      abbr: "a",
       desc:
-        "Maximum number of times to retry an article check when there has been a network failure",
+        "Maximum number of times to attempt an article check when there has been a network failure",
       default: 3
     })
     .option("articlePath", {

--- a/lib/cli/edition-checker/index.js
+++ b/lib/cli/edition-checker/index.js
@@ -21,7 +21,8 @@ function configureShared(subcommander) {
     .option("max", {
       abbr: "m",
       desc:
-        "Maximum number of articles you would like to check. Do not set this if you wish to check every article"
+        "Maximum number of articles you would like to check. Do not set this if you wish to check every article (-1 for no max)",
+      default: "-1"
     })
     .option("concurrency", {
       abbr: "c",

--- a/lib/cli/edition-checker/src/EditionChecker.js
+++ b/lib/cli/edition-checker/src/EditionChecker.js
@@ -8,7 +8,7 @@ class EditionChecker {
     this.options = options;
     this.title = title;
     this.total = ids.length;
-    this.ids = ids.slice(0, options.max);
+    this.ids = options.max >= 0 ? ids.slice(0, options.max) : ids;
     this.slackEditionIntegration = slackEditionIntegration;
   }
 

--- a/lib/cli/edition-checker/src/EditionChecker.js
+++ b/lib/cli/edition-checker/src/EditionChecker.js
@@ -1,0 +1,109 @@
+const fetch = require("node-fetch");
+const PromisePool = require("es6-promise-pool");
+
+const { retry } = require("./util");
+
+class EditionChecker {
+  constructor(options, { ids, title }, slackEditionIntegration) {
+    this.options = options;
+    this.title = title;
+    this.total = ids.length;
+    this.ids = ids.slice(0, options.max);
+    this.slackEditionIntegration = slackEditionIntegration;
+  }
+
+  async getArticleStatus(id) {
+    const { acs, sacs, articlePath } = this.options;
+
+    const url = `${articlePath}/${id}?react=1`;
+    const { status } = await fetch(url, {
+      headers: {
+        cookie: `acs_tnl=${acs}; sacs_tnl=${sacs}`
+      }
+    });
+
+    return { url, status, id };
+  }
+
+  *articleStatusGenerator() {
+    const { ids, options } = this;
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const id of ids) {
+      yield retry(
+        options.maxRetry,
+        () => this.getArticleStatus(id, options),
+        (error, attempt) => {
+          console.log("");
+          console.warn(`(${id}) retrying (${attempt}/${options.maxRetry})`);
+
+          if (options.verbose) {
+            console.warn(error);
+          }
+        }
+      );
+    }
+  }
+
+  async pool() {
+    const results = [];
+    const pool = new PromisePool(
+      this.articleStatusGenerator.bind(this),
+      this.options.concurrency
+    );
+
+    let i = 0;
+
+    pool.addEventListener("fulfilled", evt => {
+      const { result } = evt.data;
+
+      if (result.status !== 200) {
+        results.push(result);
+      }
+
+      i += 1;
+      this.logResult(i, result);
+    });
+
+    await pool.start();
+
+    return results;
+  }
+
+  async crawl() {
+    const { ids, total, options } = this;
+
+    console.log(
+      `Checking ${ids.length}/${total} articles, with concurrency of ${
+        options.concurrency
+      }`
+    );
+
+    const results = await this.pool();
+
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+
+    if (this.slackEditionIntegration) {
+      console.log("Posting to slack…");
+      await this.slackEditionIntegration.post(this, results);
+    }
+
+    return { hasFailed: !!results.length };
+  }
+
+  logResult(i, { status, id, url }) {
+    const info = `(${i}/${this.ids.length})`;
+
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+
+    if (status === 200) {
+      process.stdout.write(info);
+    } else {
+      console.log(`${info}: ${status} - ${id} (${url})`);
+    }
+  }
+}
+
+module.exports = EditionChecker;

--- a/lib/cli/edition-checker/src/EditionChecker.js
+++ b/lib/cli/edition-checker/src/EditionChecker.js
@@ -35,7 +35,9 @@ class EditionChecker {
         () => this.getArticleStatus(id, options),
         (error, attempt, willRetry) => {
           if (willRetry) {
-            console.warn(`(${id}) retrying (${attempt}/${options.maxAttempts})`);
+            console.warn(
+              `(${id}) retrying (${attempt}/${options.maxAttempts})`
+            );
 
             if (options.verbose) {
               console.warn(error);

--- a/lib/cli/edition-checker/src/EditionChecker.js
+++ b/lib/cli/edition-checker/src/EditionChecker.js
@@ -31,14 +31,15 @@ class EditionChecker {
     // eslint-disable-next-line no-restricted-syntax
     for (const id of ids) {
       yield retry(
-        options.maxRetry,
+        options.maxAttempts,
         () => this.getArticleStatus(id, options),
-        (error, attempt) => {
-          console.log("");
-          console.warn(`(${id}) retrying (${attempt}/${options.maxRetry})`);
+        (error, attempt, willRetry) => {
+          if (willRetry) {
+            console.warn(`(${id}) retrying (${attempt}/${options.maxAttempts})`);
 
-          if (options.verbose) {
-            console.warn(error);
+            if (options.verbose) {
+              console.warn(error);
+            }
           }
         }
       );
@@ -81,9 +82,6 @@ class EditionChecker {
 
     const results = await this.pool();
 
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
-
     if (this.slackEditionIntegration) {
       console.log("Posting to slack…");
       await this.slackEditionIntegration.post(this, results);
@@ -95,11 +93,8 @@ class EditionChecker {
   logResult(i, { status, id, url }) {
     const info = `(${i}/${this.ids.length})`;
 
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
-
     if (status === 200) {
-      process.stdout.write(info);
+      console.log(info);
     } else {
       console.log(`${info}: ${status} - ${id} (${url})`);
     }

--- a/lib/cli/edition-checker/src/EditionChecker.test.js
+++ b/lib/cli/edition-checker/src/EditionChecker.test.js
@@ -72,7 +72,7 @@ describe("EditionChecker", () => {
       );
     });
 
-    it("outputs results to console", async () => {
+    it("outputs results within the maximum to console", async () => {
       mockFetch.mockReturnValueOnce(
         Promise.resolve({ status: 200, url: "http://abc" })
       );
@@ -103,6 +103,55 @@ Array [
   ],
   Array [
     "(3/3)",
+  ],
+]
+`);
+    });
+
+    it("outputs all results to console when there is no maximum", async () => {
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 200, url: "http://abc" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 500, url: "http://def" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 200, url: "http://ghi" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 400, url: "http://jkl" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 400, url: "http://mno" })
+      );
+
+      const ourOpts = { ...opts };
+
+      delete ourOpts.max;
+
+      const editionChecker = new EditionChecker(ourOpts, edition, null);
+
+      await editionChecker.crawl();
+
+      expect(console.log.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "Checking 5/5 articles, with concurrency of 3",
+  ],
+  Array [
+    "(1/5)",
+  ],
+  Array [
+    "(2/5): 500 - 2 (http://times.co.uk/article/2?react=1)",
+  ],
+  Array [
+    "(3/5)",
+  ],
+  Array [
+    "(4/5): 400 - 4 (http://times.co.uk/article/4?react=1)",
+  ],
+  Array [
+    "(5/5): 400 - 5 (http://times.co.uk/article/5?react=1)",
   ],
 ]
 `);

--- a/lib/cli/edition-checker/src/EditionChecker.test.js
+++ b/lib/cli/edition-checker/src/EditionChecker.test.js
@@ -1,0 +1,242 @@
+/* eslint-env jest */
+
+import mockFetch from "node-fetch";
+import EditionChecker from "./EditionChecker";
+
+jest.mock("node-fetch", () => jest.fn());
+
+describe("EditionChecker", () => {
+  let originalConsole;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    originalConsole = global.console;
+    const log = jest.fn();
+    global.console = { log, warn: (...args) => log("warn", ...args) };
+  });
+
+  afterEach(() => {
+    global.console = originalConsole;
+  });
+
+  describe("crawl", () => {
+    const opts = {
+      maxAttempts: 2,
+      api: "http://times.api",
+      articlePath: "http://times.co.uk/article",
+      acs: "acs",
+      sacs: "sacs",
+      concurrency: 3,
+      max: 3
+    };
+    const edition = { title: "Test edition", ids: [1, 2, 3, 4, 5] };
+
+    it("correctly returns that articles contained a non-200 status code", async () => {
+      mockFetch.mockReturnValueOnce(Promise.resolve({ status: 200 }));
+      mockFetch.mockReturnValueOnce(Promise.resolve({ status: 500 }));
+      mockFetch.mockReturnValueOnce(Promise.resolve({ status: 200 }));
+
+      const editionChecker = new EditionChecker(opts, edition, null);
+
+      expect(await editionChecker.crawl()).toEqual({ hasFailed: true });
+    });
+
+    it("can handle request failures within the maxAttempts", async () => {
+      expect.assertions(1);
+
+      mockFetch.mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+      mockFetch.mockImplementationOnce(() => {
+        throw new Error("request error");
+      });
+      mockFetch.mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+      mockFetch.mockImplementationOnce(() => Promise.resolve({ status: 200 }));
+
+      const editionChecker = new EditionChecker(opts, edition, null);
+
+      await expect(editionChecker.crawl()).resolves.toEqual({
+        hasFailed: false
+      });
+    });
+
+    it("will not keep retrying if request continues to fail", async () => {
+      expect.assertions(1);
+
+      mockFetch.mockImplementation(() => {
+        throw new Error("request error");
+      });
+
+      const editionChecker = new EditionChecker(opts, edition, null);
+
+      await expect(editionChecker.crawl()).rejects.toMatchInlineSnapshot(
+        `[Error: request error]`
+      );
+    });
+
+    it("outputs results to console", async () => {
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 200, url: "http://abc" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 500, url: "http://def" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 200, url: "http://ghi" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 400, url: "http://jkl" })
+      );
+
+      const editionChecker = new EditionChecker(opts, edition, null);
+
+      await editionChecker.crawl();
+
+      expect(console.log.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "Checking 3/5 articles, with concurrency of 3",
+  ],
+  Array [
+    "(1/3)",
+  ],
+  Array [
+    "(2/3): 500 - 2 (http://times.co.uk/article/2?react=1)",
+  ],
+  Array [
+    "(3/3)",
+  ],
+]
+`);
+    });
+
+    it("outputs verbose results to console", async () => {
+      let callNumber = 0;
+
+      mockFetch.mockImplementation(() => {
+        callNumber += 1;
+
+        if (callNumber < 3) {
+          throw new Error("test error");
+        }
+
+        return { status: 200 };
+      });
+
+      const editionChecker = new EditionChecker(
+        {
+          ...opts,
+          verbose: true
+        },
+        edition,
+        null
+      );
+
+      await editionChecker.crawl();
+
+      expect(console.log.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "Checking 3/5 articles, with concurrency of 3",
+  ],
+  Array [
+    "warn",
+    "(1) retrying (1/2)",
+  ],
+  Array [
+    "warn",
+    [Error: test error],
+  ],
+  Array [
+    "warn",
+    "(2) retrying (1/2)",
+  ],
+  Array [
+    "warn",
+    [Error: test error],
+  ],
+  Array [
+    "(1/3)",
+  ],
+  Array [
+    "(2/3)",
+  ],
+  Array [
+    "(3/3)",
+  ],
+]
+`);
+    });
+
+    it("outputs results to slack", async () => {
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 404, url: "http://abc" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 500, url: "http://def" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 200, url: "http://ghi" })
+      );
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({ status: 400, url: "http://efg" })
+      );
+
+      const post = jest.fn();
+      const editionChecker = new EditionChecker(opts, edition, { post });
+
+      await editionChecker.crawl();
+
+      expect(post.mock.calls[0][1]).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "id": 1,
+    "status": 404,
+    "url": "http://times.co.uk/article/1?react=1",
+  },
+  Object {
+    "id": 2,
+    "status": 500,
+    "url": "http://times.co.uk/article/2?react=1",
+  },
+]
+`);
+    });
+
+    it("runs the specified number of requests concurrently", async () => {
+      let liveRequests = 0;
+      const liveRequestValues = [];
+
+      mockFetch.mockImplementation(async () => {
+        liveRequests += 1;
+
+        liveRequestValues.push(liveRequests);
+
+        await Promise.resolve({});
+
+        liveRequests -= 1;
+
+        return { status: 200 };
+      });
+      const editionChecker = new EditionChecker(
+        {
+          ...opts,
+          max: 50,
+          concurrency: 10
+        },
+        {
+          ...edition,
+          ids: new Array(30).fill(1)
+        },
+        null
+      );
+
+      await editionChecker.crawl();
+
+      const maxLiveRequestValue = liveRequestValues.reduce(
+        (max, value) => Math.max(max, value),
+        0
+      );
+
+      expect(maxLiveRequestValue).toEqual(10);
+    });
+  });
+});

--- a/lib/cli/edition-checker/src/Slack.js
+++ b/lib/cli/edition-checker/src/Slack.js
@@ -1,0 +1,25 @@
+const fetch = require("node-fetch");
+
+class Slack {
+  constructor(hook, username) {
+    this.hook = hook;
+    this.username = username;
+  }
+
+  async post(text) {
+    await fetch(this.hook, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
+      },
+      body: `payload=${encodeURIComponent(
+        JSON.stringify({
+          text,
+          username: this.username
+        })
+      )}`
+    });
+  }
+}
+
+module.exports = Slack;

--- a/lib/cli/edition-checker/src/Slack.test.js
+++ b/lib/cli/edition-checker/src/Slack.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+
+import Slack from "./Slack";
+
+import mockFetch from "node-fetch";
+
+jest.mock("node-fetch", () => jest.fn());
+
+describe("Slack", () => {
+  describe("post", () => {
+    it("sends a correctly formatted request to the specified slack hook", async () => {
+      const slack = new Slack("http://slack.hook/", "slackUsername");
+
+      await slack.post("a test message");
+
+      expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "http://slack.hook/",
+    Object {
+      "body": "payload=%7B%22text%22%3A%22a%20test%20message%22%2C%22username%22%3A%22slackUsername%22%7D",
+      "headers": Object {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`);
+    });
+  });
+});

--- a/lib/cli/edition-checker/src/Slack.test.js
+++ b/lib/cli/edition-checker/src/Slack.test.js
@@ -1,8 +1,7 @@
 /* eslint-env jest */
 
-import Slack from "./Slack";
-
 import mockFetch from "node-fetch";
+import Slack from "./Slack";
 
 jest.mock("node-fetch", () => jest.fn());
 

--- a/lib/cli/edition-checker/src/SlackEditionIntegration.js
+++ b/lib/cli/edition-checker/src/SlackEditionIntegration.js
@@ -1,0 +1,23 @@
+class SlackEditionIntegration {
+  constructor(slack) {
+    this.slack = slack;
+  }
+
+  post({ title, ids, total }, results) {
+    const info = `${title}. ${ids.length}/${total} articles checked.`;
+
+    if (!results || !results.length) {
+      return this.slack.post(`${info} No issues found`);
+    }
+
+    const header = `${info} Found ${results.length} problems.`;
+    const resultText = results
+      .map(result => `(${result.status}): ${result.id} – <${result.url}>`)
+      .join(`\n`);
+    const text = `${header}\n\`\`\`${resultText}\`\`\``;
+
+    return this.slack.post(text);
+  }
+}
+
+module.exports = SlackEditionIntegration;

--- a/lib/cli/edition-checker/src/SlackEditionIntegration.test.js
+++ b/lib/cli/edition-checker/src/SlackEditionIntegration.test.js
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+
+import SlackEditionIntegration from "./SlackEditionIntegration";
+
+describe("SlackEditionIntegration", () => {
+  describe("post", () => {
+    const edition = { title: "Test edition", ids: [1, 2, 3], total: 5 };
+
+    it("posts a no issues found message if no results are passed", async () => {
+      const postMock = jest.fn();
+      const slackIntegration = new SlackEditionIntegration({ post: postMock });
+
+      await slackIntegration.post(edition, null);
+
+      expect(postMock.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "Test edition. 3/5 articles checked. No issues found",
+  ],
+]
+`);
+    });
+
+    it("posts a no issues found message if empty results are passed", async () => {
+      const postMock = jest.fn();
+      const slackIntegration = new SlackEditionIntegration({ post: postMock });
+
+      await slackIntegration.post(edition, []);
+
+      expect(postMock.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "Test edition. 3/5 articles checked. No issues found",
+  ],
+]
+`);
+    });
+
+    it("posts results summary message if results are passed", async () => {
+      const postMock = jest.fn();
+      const slackIntegration = new SlackEditionIntegration({ post: postMock });
+
+      await slackIntegration.post(edition, [
+        { status: 500, id: "abc", url: "/abc" },
+        { status: 200, id: "def", url: "/def" },
+        { status: 404, id: "ghi", url: "/ghi" }
+      ]);
+
+      expect(postMock.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "Test edition. 3/5 articles checked. Found 3 problems.
+\`\`\`(500): abc – </abc>
+(200): def – </def>
+(404): ghi – </ghi>\`\`\`",
+  ],
+]
+`);
+    });
+  });
+});

--- a/lib/cli/edition-checker/src/api.js
+++ b/lib/cli/edition-checker/src/api.js
@@ -1,0 +1,37 @@
+const { today, fetchJSON } = require("./util");
+
+function fetchEdition(edition, { api }) {
+  return fetchJSON(`${api}/edition/${edition}?include=article`);
+}
+
+exports.getEditionData = async function getEditionData(options) {
+  console.log(`Fetching edition (${options.edition})…`);
+
+  const edition = await fetchEdition(options.edition, options);
+  const ids = edition.cpi_modules.map(article => article.identifier);
+  const title = `${edition.title} (${edition.cpi_updatetext})`;
+
+  console.log(`Received edition ${title}`);
+
+  return { ids, title };
+};
+
+exports.getPastSixDaysData = async function getPastSixDaysData(options) {
+  const date = today();
+  console.log(`Fetching past six days data from ${date}`);
+  const pastSixDays = await fetchJSON(`${options.api}/past-six-days`);
+  console.log("Retrieving article data");
+  const editions = await Promise.all(
+    pastSixDays.map(day => fetchEdition(day.editiondate, options))
+  );
+  const ids = editions.reduce(
+    (acc, edition) => [
+      ...acc,
+      ...edition.cpi_modules.map(article => article.identifier)
+    ],
+    []
+  );
+  const title = `Past six days from ${date}`;
+
+  return { ids, title };
+};

--- a/lib/cli/edition-checker/src/api.test.js
+++ b/lib/cli/edition-checker/src/api.test.js
@@ -1,0 +1,139 @@
+/* eslint-env jest */
+
+import { getEditionData, getPastSixDaysData } from "./api";
+import { fetchJSON as mockFetchJSON } from "./util";
+
+jest.mock("./util", () => ({
+  today: () => "2019-02-12",
+  fetchJSON: jest.fn(() => Promise.resolve())
+}));
+
+describe("api", () => {
+  let originalConsole;
+
+  beforeEach(() => {
+    originalConsole = global.console;
+    global.console = { log: () => null };
+    mockFetchJSON.mockReset();
+  });
+
+  afterEach(() => {
+    global.console = originalConsole;
+  });
+
+  describe("getEditionData", () => {
+    it("requests the correct data from the API", async () => {
+      mockFetchJSON.mockReturnValueOnce(
+        Promise.resolve({
+          cpi_updatetext: "9AM UPDATE",
+          cpi_modules: [],
+          title: "Times Tuesday 12 February 2019"
+        })
+      );
+
+      await getEditionData({
+        edition: "latest",
+        api: "http://times.api"
+      });
+
+      expect(mockFetchJSON.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "http://times.api/edition/latest?include=article",
+  ],
+]
+`);
+    });
+
+    it("returns the correct data", async () => {
+      mockFetchJSON.mockReturnValueOnce(
+        Promise.resolve({
+          cpi_updatetext: "9AM UPDATE",
+          cpi_modules: [
+            { identifier: "abc" },
+            { identifier: "def" },
+            { identifier: "ghi" }
+          ],
+          title: "Times Tuesday 12 February 2019"
+        })
+      );
+
+      expect(await getEditionData({})).toMatchInlineSnapshot(`
+Object {
+  "ids": Array [
+    "abc",
+    "def",
+    "ghi",
+  ],
+  "title": "Times Tuesday 12 February 2019 (9AM UPDATE)",
+}
+`);
+    });
+  });
+
+  describe("getPastSixDaysData", () => {
+    it("requests the correct data from the APIs", async () => {
+      mockFetchJSON.mockImplementation(url =>
+        Promise.resolve(
+          url.includes("past-six-days")
+            ? [{ editiondate: "2019-02-11" }, { editiondate: "2019-02-12" }]
+            : {
+                cpi_updatetext: "9AM UPDATE",
+                cpi_modules: [],
+                title: "Times Tuesday 12 February 2019"
+              }
+        )
+      );
+
+      await getPastSixDaysData({
+        api: "http://times.api"
+      });
+
+      expect(mockFetchJSON.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "http://times.api/past-six-days",
+  ],
+  Array [
+    "http://times.api/edition/2019-02-11?include=article",
+  ],
+  Array [
+    "http://times.api/edition/2019-02-12?include=article",
+  ],
+]
+`);
+    });
+
+    it("returns the correct data", async () => {
+      mockFetchJSON.mockImplementation(url =>
+        Promise.resolve(
+          url.includes("past-six-days")
+            ? [{ editiondate: "2019-02-11" }, { editiondate: "2019-02-12" }]
+            : {
+                cpi_updatetext: "9AM UPDATE",
+                cpi_modules: [
+                  { identifier: "abc" },
+                  { identifier: "def" },
+                  { identifier: "ghi" }
+                ],
+                title: "Times Tuesday 12 February 2019"
+              }
+        )
+      );
+
+      expect(await getPastSixDaysData({})).toMatchInlineSnapshot(`
+Object {
+  "ids": Array [
+    "abc",
+    "def",
+    "ghi",
+    "abc",
+    "def",
+    "ghi",
+  ],
+  "title": "Past six days from 2019-02-12",
+}
+`);
+    });
+  });
+});

--- a/lib/cli/edition-checker/src/main.js
+++ b/lib/cli/edition-checker/src/main.js
@@ -1,0 +1,43 @@
+const Slack = require("./Slack");
+const SlackEditionIntegration = require("./SlackEditionIntegration");
+const EditionChecker = require("./EditionChecker");
+const { unshiftContext } = require("./util");
+const api = require("./api");
+
+async function main(getData, options) {
+  const slackIntegration =
+    options.slackHook && options.slackUsername
+      ? new SlackEditionIntegration(
+          new Slack(options.slackHook, options.slackUsername)
+        )
+      : null;
+
+  const data = await getData(options);
+  const editionChecker = new EditionChecker(options, data, slackIntegration);
+
+  return editionChecker.crawl();
+}
+
+function boot(command, options, getData) {
+  if (!options.acs || !options.sacs || !options.api) {
+    command.usage();
+    process.exit(1);
+    return;
+  }
+
+  main(getData, options)
+    .then(({ hasFailed }) => {
+      process.exit(hasFailed ? 2 : 0);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+exports.edition = unshiftContext((command, options) =>
+  boot(command, options, api.getEditionData)
+);
+exports.pastSixDays = unshiftContext((command, options) =>
+  boot(command, options, api.getPastSixDaysData)
+);

--- a/lib/cli/edition-checker/src/main.js
+++ b/lib/cli/edition-checker/src/main.js
@@ -25,7 +25,14 @@ function boot(command, options, getData) {
     return;
   }
 
-  main(getData, options)
+  const enhancedOptions = {
+    ...options,
+    concurrency: Number(options.concurrency),
+    max: Number(options.max),
+    maxAttempts: Number(options.maxAttempts),
+  }
+
+  main(getData, enhancedOptions)
     .then(({ hasFailed }) => {
       process.exit(hasFailed ? 2 : 0);
     })

--- a/lib/cli/edition-checker/src/main.js
+++ b/lib/cli/edition-checker/src/main.js
@@ -29,8 +29,8 @@ function boot(command, options, getData) {
     ...options,
     concurrency: Number(options.concurrency),
     max: Number(options.max),
-    maxAttempts: Number(options.maxAttempts),
-  }
+    maxAttempts: Number(options.maxAttempts)
+  };
 
   main(getData, enhancedOptions)
     .then(({ hasFailed }) => {

--- a/lib/cli/edition-checker/src/util.js
+++ b/lib/cli/edition-checker/src/util.js
@@ -1,0 +1,34 @@
+const fetch = require("node-fetch");
+
+// eslint-disable-next-line prefer-destructuring
+exports.today = () => new Date().toISOString().split("T")[0];
+exports.unshiftContext = cb =>
+  function unshiftContextCallback(...args) {
+    return cb(this, ...args);
+  };
+
+exports.retry = async function retry(maxRetry, handler, retryHandler) {
+  let attempt = 1;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      return await handler();
+    } catch (e) {
+      if (attempt <= maxRetry) {
+        // eslint-disable-next-line no-await-in-loop
+        await retryHandler(e, attempt);
+        attempt += 1;
+      } else {
+        throw e;
+      }
+    }
+  }
+};
+
+exports.fetchJSON = async function fetchJSON(url) {
+  const req = await fetch(url);
+
+  return req.json();
+};

--- a/lib/cli/edition-checker/src/util.js
+++ b/lib/cli/edition-checker/src/util.js
@@ -7,8 +7,8 @@ exports.unshiftContext = cb =>
     return cb(this, ...args);
   };
 
-exports.retry = async function retry(maxRetry, handler, retryHandler) {
-  let attempt = 1;
+exports.retry = async function retry(maxAttempts, handler, failureHandler) {
+  let attempt = 0;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -16,11 +16,13 @@ exports.retry = async function retry(maxRetry, handler, retryHandler) {
       // eslint-disable-next-line no-await-in-loop
       return await handler();
     } catch (e) {
-      if (attempt <= maxRetry) {
-        // eslint-disable-next-line no-await-in-loop
-        await retryHandler(e, attempt);
-        attempt += 1;
-      } else {
+      attempt += 1;
+      const willRetry = attempt < maxAttempts;
+
+      // eslint-disable-next-line no-await-in-loop
+      await failureHandler(e, attempt, willRetry);
+
+      if (!willRetry) {
         throw e;
       }
     }

--- a/lib/cli/edition-checker/src/util.test.js
+++ b/lib/cli/edition-checker/src/util.test.js
@@ -1,0 +1,136 @@
+/* eslint-env jest */
+
+import MockDate from "mockdate";
+import { today, unshiftContext, fetchJSON, retry } from "./util";
+
+jest.mock("node-fetch", () => requestedUrl =>
+  Promise.resolve({ json: () => Promise.resolve({ requestedUrl }) })
+);
+
+describe("util", () => {
+  describe("today", () => {
+    it("should return today's day in YYYY-MM-DD format", () => {
+      MockDate.set("2019-02-12");
+
+      expect(today()).toEqual("2019-02-12");
+    });
+  });
+
+  describe("unshiftContext", () => {
+    it("should create a wrapper function that passes the context as the first argument when called", () => {
+      const context = { foo: "bar" };
+      const handler = jest.fn();
+      const wrapper = unshiftContext(handler);
+
+      wrapper.call(context, "first argument", "second argument");
+
+      expect(handler).toHaveBeenCalledWith(
+        context,
+        "first argument",
+        "second argument"
+      );
+    });
+  });
+
+  describe("retry", () => {
+    it("should not recall the handler once it passes", async () => {
+      let callNumber = 0;
+
+      const failingFn = jest.fn(() => {
+        if (!callNumber) {
+          callNumber += 1;
+          throw new Error();
+        }
+      });
+
+      await retry(2, failingFn, () => {});
+
+      expect(failingFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should return the result of the handler", async () => {
+      const result = await retry(2, () => "result", () => {});
+
+      expect(result).toEqual("result");
+    });
+
+    it("should call a failing function only the maximum number of times before throwing the error", async () => {
+      expect.assertions(1);
+
+      let callNumber = 0;
+      const failingFn = jest.fn(() => {
+        callNumber += 1;
+        throw new Error(`Errored on call ${callNumber}`);
+      });
+
+      const retryPromise = retry(3, failingFn, () => null);
+
+      await expect(retryPromise).rejects.toMatchInlineSnapshot(
+        `[Error: Errored on call 3]`
+      );
+    });
+
+    it("should call the retry handler each time the handler fails", async () => {
+      let callNumber = 0;
+      const error = new Error();
+      const failingFn = async () => {
+        await Promise.resolve({});
+
+        if (callNumber < 3) {
+          callNumber += 1;
+          await Promise.reject(error);
+        }
+      };
+      const failureHandler = jest.fn();
+
+      await retry(4, failingFn, failureHandler);
+
+      expect(failureHandler).toHaveBeenCalledTimes(3);
+    });
+
+    it("should call the failure handler with the error, call number, and if it will retry each time it fails", async () => {
+      const error = new Error("test");
+      const failingFn = () => {
+        throw error;
+      };
+      const failureHandler = jest.fn();
+
+      await retry(4, failingFn, failureHandler).catch(() => {});
+
+      expect(failureHandler.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    [Error: test],
+    1,
+    true,
+  ],
+  Array [
+    [Error: test],
+    2,
+    true,
+  ],
+  Array [
+    [Error: test],
+    3,
+    true,
+  ],
+  Array [
+    [Error: test],
+    4,
+    false,
+  ],
+]
+`);
+    });
+  });
+
+  describe("fetchJSON", () => {
+    it("should return the JSON of the remote url", async () => {
+      expect(await fetchJSON("http://google.com")).toMatchInlineSnapshot(`
+Object {
+  "requestedUrl": "http://google.com",
+}
+`);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "storybook-native": "storybook -c .storybook.native start -p 7007 --haul ./.storybook.native/webpack.haul.storybook.js --platform all",
     "preios": "yarn fetch-fonts && ./lib/fix-ios-storybook.sh",
     "ios": "react-native run-ios --no-packager",
-    "ios:logs" : "yarn ios && react-native log-ios",
+    "ios:logs": "yarn ios && react-native log-ios",
     "ios:build-lib": "lerna run --scope @times-components/ios-app build:all --stream",
     "ios:app": "cd ios-app && yarn start",
     "start-emulator": "./lib/start_android_emulator.sh",
@@ -63,6 +63,9 @@
   },
   "jest": {
     "preset": "react-native",
+    "coveragePathIgnorePatterns": [
+      "lib/cli/edition-checker/src/main.js"
+    ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"
     ],
@@ -138,6 +141,7 @@
     "lcov-result-merger": "1.2.0",
     "lerna": "3.2.1",
     "mkdirp": "0.5.1",
+    "mockdate": "2.0.2",
     "node-fetch": "2.2.0",
     "prettier": "1.14.3",
     "prop-types": "15.6.2",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "cz-conventional-changelog": "2.1.0",
     "dashify": "0.2.2",
     "dextrose": "4.0.7",
+    "es6-promise-pool": "^2.5.0",
     "eslint": "5.9.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8056,6 +8056,11 @@ es6-map@^0.1.3, es6-map@^0.1.5:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
+es6-promise-pool@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
+  integrity sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs=
+
 es6-promise@^4.0.3:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"


### PR DESCRIPTION
This adds a tool to the command line that allows you to crawl a specific edition or the past six days for issues in loading articles when using react. 

This requires being logged in to work, so you must set a `ACS_COOKIE` and `SACS_COOKIE` environment variable. We should probably set up credentials specifically for this tool in the long run.

This also requires the use of an internal Times API, and you must set the path to this with the `TIMES_API_ROOT` environment variable.

You can also configure the tool to post to Slack using a Slack incoming webhook with the `TIMES_SLACK_HOOK` and `TIMES_SLACK_USERNAME` environment variables. 

<s>I have not written tests for this tool, but it has been refactored and simplified significantly from its previous implementation to allow for this if deemed necessary.</s>

It may also be important to know this was written entirely separately to times-components initially, and has had to be almost entirely rewritten to fit into times components architecture, which has removed some features.

In the long term, it might be useful to consider adding other kinds of checks to the crawler. Currently, the only checks it employs are checking that the status code is 200.  

```bash
$ ./times-components check edition # check todays edition
$ ./times-components check edition -e 2019-01-01 # check a specific edition
$ ./times-components check past-six-days # check articles from the past six days

$ ./times-components check [method] -m 30 # only check the first 30 articles
$ ./times-components check [method] -c 30 # check 30 articles at a time
$ ./times-components check [method] -v # verbose, display more information
```