### PR TITLE
fix: add horizontal padding to the centred caption

### DIFF
--- a/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
+++ b/packages/article-image/__tests__/android/__snapshots__/article-image-with-style.android.test.js.snap
@@ -171,6 +171,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }
@@ -186,6 +187,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
               "fontWeight": "400",
               "letterSpacing": 1,
               "lineHeight": 20,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }
@@ -241,6 +243,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 20,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }
@@ -256,6 +259,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
               "fontWeight": "400",
               "letterSpacing": 1,
               "lineHeight": 20,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }

--- a/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
+++ b/packages/article-image/__tests__/ios/__snapshots__/article-image-with-style.ios.test.js.snap
@@ -171,6 +171,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 16,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }
@@ -186,6 +187,7 @@ exports[`3. mobile fullwidth image with caption and credits 1`] = `
               "fontWeight": "400",
               "letterSpacing": 1,
               "lineHeight": 16,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }
@@ -241,6 +243,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
               "fontFamily": "GillSansMTStd-Medium",
               "fontSize": 13,
               "lineHeight": 16,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }
@@ -256,6 +259,7 @@ exports[`4. tablet fullwidth image with caption and credits 1`] = `
               "fontWeight": "400",
               "letterSpacing": 1,
               "lineHeight": 16,
+              "paddingHorizontal": 10,
               "textAlign": "center",
             }
           }

--- a/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
+++ b/packages/caption/__tests__/web/__snapshots__/caption.web.test.js.snap
@@ -55,6 +55,8 @@ exports[`5. centred caption without credits 1`] = `
     <div
       style={
         Object {
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
           "textAlign": "center",
         }
       }
@@ -71,6 +73,8 @@ exports[`6. centred caption caption with credits 1`] = `
     <div
       style={
         Object {
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
           "textAlign": "center",
         }
       }
@@ -80,6 +84,8 @@ exports[`6. centred caption caption with credits 1`] = `
     <div
       style={
         Object {
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
           "textAlign": "center",
         }
       }
@@ -96,6 +102,8 @@ exports[`7. centred caption caption with credits only 1`] = `
     <div
       style={
         Object {
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
           "textAlign": "center",
         }
       }
@@ -115,6 +123,8 @@ exports[`8. centred caption caption with child 1`] = `
     <div
       style={
         Object {
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
           "textAlign": "center",
         }
       }
@@ -124,6 +134,8 @@ exports[`8. centred caption caption with child 1`] = `
     <div
       style={
         Object {
+          "paddingLeft": "10px",
+          "paddingRight": "10px",
           "textAlign": "center",
         }
       }

--- a/packages/caption/src/centred-caption.js
+++ b/packages/caption/src/centred-caption.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { spacing } from "@times-components/styleguide";
 import Caption from "./caption";
 import { defaultProps, propTypes } from "./caption-prop-types";
 
@@ -9,6 +10,7 @@ const CentredCaption = ({ children, credits, style, text }) => (
       ...style,
       text: {
         ...style.text,
+        paddingHorizontal: spacing(2),
         textAlign: "center"
       }
     }}


### PR DESCRIPTION
The centred caption didn't had any start/end paddings so when the text fitted well into one line, it would be to close to the edges. Added some horizontal padding to it.

<img width="418" alt="screenshot 2019-02-11 at 11 22 32" src="https://user-images.githubusercontent.com/2143610/52634216-87e35f80-2ebe-11e9-9b31-e0b8bd89017f.png">
<img width="418" alt="screenshot 2019-02-11 at 11 24 12" src="https://user-images.githubusercontent.com/2143610/52634217-87e35f80-2ebe-11e9-8b3c-6ce93e69d36d.png">