### PR TITLE
feat: REPLAT-5141/secondary one and four slice

### DIFF
--- a/packages/edition-slices/.jestlint
+++ b/packages/edition-slices/.jestlint
@@ -1,5 +1,5 @@
 {
   "maxAttributeStringLength": 150,
-  "maxFileSize": 62000,
+  "maxFileSize": 75000,
   "maxLines": 650
 }

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices-with-style.test.js.snap
@@ -1297,7 +1297,406 @@ exports[`6. secondary four 1`] = `
 </View>
 `;
 
-exports[`7. secondary two and two 1`] = `
+exports[`7. secondary one and four 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#272D34",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "flexDirection": "row",
+        "margin": 10,
+        "marginBottom": 0,
+      }
+    }
+  >
+    <TheTimesLogo />
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View>
+        <Link>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#272D34",
+                "flexDirection": "row",
+                "padding": 10,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
+            >
+              <Image />
+            </View>
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 10,
+                  "paddingTop": 5,
+                  "width": "50%",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "marginBottom": 5,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#CCC",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "fontWeight": "400",
+                      "letterSpacing": 1.2,
+                      "lineHeight": 14,
+                      "marginBottom": 0,
+                    }
+                  }
+                >
+                  LABEL
+                </Text>
+              </View>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "400",
+                    "lineHeight": 22,
+                    "marginBottom": 5,
+                  }
+                }
+              >
+                Venezuela shows how Corbyn’s socialism works
+              </Text>
+              <ArticleFlags />
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text>
+                  
+                  Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+                  ...
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </Link>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "400",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "400",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "400",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "400",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`8. secondary two and two 1`] = `
 <View
   style={
     Object {
@@ -1636,7 +2035,7 @@ exports[`7. secondary two and two 1`] = `
 </View>
 `;
 
-exports[`8. secondary two no pic and two 1`] = `
+exports[`9. secondary two no pic and two 1`] = `
 <View>
   <Link>
     <View
@@ -1949,7 +2348,7 @@ exports[`8. secondary two no pic and two 1`] = `
 </View>
 `;
 
-exports[`9. list two and six no pic 1`] = `
+exports[`10. list two and six no pic 1`] = `
 <View
   style={
     Object {
@@ -2508,7 +2907,7 @@ exports[`9. list two and six no pic 1`] = `
 </View>
 `;
 
-exports[`10. leaders 1`] = `
+exports[`11. leaders 1`] = `
 <View
   style={
     Object {

--- a/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/slices.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. lead one full width slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -47,6 +48,7 @@ exports[`2. lead one and one slice 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -76,6 +78,7 @@ exports[`2. lead one and one slice 1`] = `
           GCHQ gives girls free cyber-classes to tackle gender gap
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "UPDATED",
@@ -123,6 +126,7 @@ exports[`3. lead one and four slice 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -154,6 +158,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -187,6 +192,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -220,6 +226,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -253,6 +260,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -289,6 +297,7 @@ exports[`4. lead two no pic and two 1`] = `
         Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -322,6 +331,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -362,6 +372,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -395,6 +406,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -422,6 +434,7 @@ exports[`5. secondary one slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -465,6 +478,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -500,6 +514,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -537,6 +552,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -572,6 +588,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -586,7 +603,185 @@ exports[`6. secondary four 1`] = `
 </View>
 `;
 
-exports[`7. secondary two and two 1`] = `
+exports[`7. secondary one and four 1`] = `
+<View>
+  <View>
+    <TheTimesLogo
+      height={40}
+      width={40}
+    />
+  </View>
+  <View />
+  <View>
+    <View>
+      <View>
+        <Link
+          url="/article/123"
+        >
+          <View>
+            <View>
+              <Image
+                aspectRatio={1}
+                uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+              />
+            </View>
+            <View>
+              <View>
+                <Text>
+                  LABEL
+                </Text>
+              </View>
+              <Text
+                accessibilityRole="heading"
+                aria-level="3"
+              >
+                Venezuela shows how Corbyn’s socialism works
+              </Text>
+              <ArticleFlags
+                color="#CCC"
+                flags={
+                  Array [
+                    "EXCLUSIVE",
+                  ]
+                }
+              />
+              <Text>
+                <Text>
+                  
+                  Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+                  ...
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </Link>
+      </View>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`8. secondary two and two 1`] = `
 <View>
   <View>
     <View>
@@ -613,6 +808,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -648,6 +844,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -685,6 +882,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -721,6 +919,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -734,7 +933,7 @@ exports[`7. secondary two and two 1`] = `
 </View>
 `;
 
-exports[`8. secondary two no pic and two 1`] = `
+exports[`9. secondary two no pic and two 1`] = `
 <View>
   <Link
     url="/article/123"
@@ -753,6 +952,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -787,6 +987,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -828,6 +1029,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -862,6 +1064,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -874,7 +1077,7 @@ exports[`8. secondary two no pic and two 1`] = `
 </View>
 `;
 
-exports[`9. list two and six no pic 1`] = `
+exports[`10. list two and six no pic 1`] = `
 <View>
   <View>
     <View>
@@ -901,6 +1104,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -936,6 +1140,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -966,6 +1171,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -995,6 +1201,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1024,6 +1231,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1053,6 +1261,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1082,6 +1291,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1111,6 +1321,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1124,7 +1335,7 @@ exports[`9. list two and six no pic 1`] = `
 </View>
 `;
 
-exports[`10. leaders 1`] = `
+exports[`11. leaders 1`] = `
 <View>
   <View>
     <Image
@@ -1157,7 +1368,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </Text>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </View>
       </View>
     </Link>
@@ -1177,7 +1390,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </Text>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </View>
       </View>
     </Link>
@@ -1197,7 +1412,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </Text>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </View>
       </View>
     </Link>

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles-with-style.test.js.snap
@@ -727,3 +727,149 @@ exports[`11. tile m 1`] = `
   </View>
 </Link>
 `;
+
+exports[`12. tile n 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "flexDirection": "row",
+        "padding": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "50%",
+        }
+      }
+    >
+      <Image />
+    </View>
+    <View
+      style={
+        Object {
+          "paddingHorizontal": 10,
+          "paddingTop": 5,
+          "width": "50%",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "marginBottom": 5,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#CCC",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          LABEL
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "400",
+            "lineHeight": 22,
+            "marginBottom": 5,
+          }
+        }
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <ArticleFlags />
+      <Text
+        style={
+          Object {
+            "color": "#CCC",
+            "flexWrap": "wrap",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 14,
+            "lineHeight": 20,
+            "marginBottom": 10,
+          }
+        }
+      >
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`13. tile o 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "paddingHorizontal": 12,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "marginBottom": 5,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#CCC",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "400",
+            "lineHeight": 22,
+            "marginBottom": 11,
+            "marginTop": 5,
+          }
+        }
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags />
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/android/__snapshots__/tiles.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. tile a 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -47,6 +48,7 @@ exports[`2. tile b 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -91,6 +93,7 @@ exports[`3. tile c 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -124,6 +127,7 @@ exports[`4. tile d 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -157,6 +161,7 @@ exports[`5. tile e 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -191,6 +196,7 @@ exports[`6. tile f 1`] = `
       Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "EXCLUSIVE",
@@ -233,6 +239,7 @@ exports[`7. tile g 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -265,6 +272,7 @@ exports[`8. tile i 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -297,6 +305,7 @@ exports[`9. tile j 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -324,6 +333,7 @@ exports[`10. tile l 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -345,7 +355,80 @@ exports[`11. tile m 1`] = `
       >
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
-      <ArticleFlags />
+      <ArticleFlags
+        color={null}
+      />
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`12. tile n 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "EXCLUSIVE",
+          ]
+        }
+      />
+      <Text>
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`13. tile o 1`] = `
+<Link>
+  <View>
+    <View>
+      <View>
+        <Text>
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
     </View>
   </View>
 </Link>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices-with-style.test.js.snap
@@ -1297,7 +1297,406 @@ exports[`6. secondary four 1`] = `
 </View>
 `;
 
-exports[`7. secondary two and two 1`] = `
+exports[`7. secondary one and four 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#272D34",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "flexDirection": "row",
+        "margin": 10,
+        "marginBottom": 0,
+      }
+    }
+  >
+    <TheTimesLogo />
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View>
+        <Link>
+          <View
+            style={
+              Object {
+                "backgroundColor": "#272D34",
+                "flexDirection": "row",
+                "padding": 10,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "width": "50%",
+                }
+              }
+            >
+              <Image />
+            </View>
+            <View
+              style={
+                Object {
+                  "paddingHorizontal": 10,
+                  "paddingTop": 5,
+                  "width": "50%",
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#CCC",
+                      "fontFamily": "GillSansMTStd-Medium",
+                      "fontSize": 12,
+                      "fontWeight": "400",
+                      "letterSpacing": 1.2,
+                      "lineHeight": 14,
+                      "marginBottom": 0,
+                    }
+                  }
+                >
+                  LABEL
+                </Text>
+              </View>
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontFamily": "TimesModern-Bold",
+                    "fontSize": 22,
+                    "fontWeight": "900",
+                    "lineHeight": 22,
+                    "marginBottom": 5,
+                  }
+                }
+              >
+                Venezuela shows how Corbyn’s socialism works
+              </Text>
+              <ArticleFlags />
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "flexWrap": "wrap",
+                    "fontFamily": "TimesDigitalW04",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                    "marginBottom": 10,
+                  }
+                }
+              >
+                <Text>
+                  
+                  Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+                  ...
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </Link>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 0,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "900",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 0,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "900",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 0,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "900",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View
+      style={
+        Object {
+          "borderBottomColor": "#4D4D4D",
+          "borderBottomWidth": 1,
+          "borderStyle": "solid",
+          "marginHorizontal": 10,
+        }
+      }
+    />
+    <View>
+      <Link>
+        <View
+          style={
+            Object {
+              "backgroundColor": "#272D34",
+              "paddingHorizontal": 12,
+              "paddingVertical": 10,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Object {
+                  "marginBottom": 0,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCC",
+                    "fontFamily": "GillSansMTStd-Medium",
+                    "fontSize": 12,
+                    "fontWeight": "400",
+                    "letterSpacing": 1.2,
+                    "lineHeight": 14,
+                    "marginBottom": 0,
+                  }
+                }
+              >
+                LABEL
+              </Text>
+            </View>
+            <Text
+              style={
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "TimesModern-Bold",
+                  "fontSize": 22,
+                  "fontWeight": "900",
+                  "lineHeight": 22,
+                  "marginBottom": 11,
+                  "marginTop": 5,
+                }
+              }
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags />
+          </View>
+        </View>
+      </Link>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`8. secondary two and two 1`] = `
 <View
   style={
     Object {
@@ -1636,7 +2035,7 @@ exports[`7. secondary two and two 1`] = `
 </View>
 `;
 
-exports[`8. secondary two no pic and two 1`] = `
+exports[`9. secondary two no pic and two 1`] = `
 <View>
   <Link>
     <View
@@ -1949,7 +2348,7 @@ exports[`8. secondary two no pic and two 1`] = `
 </View>
 `;
 
-exports[`9. list two and six no pic 1`] = `
+exports[`10. list two and six no pic 1`] = `
 <View
   style={
     Object {
@@ -2508,7 +2907,7 @@ exports[`9. list two and six no pic 1`] = `
 </View>
 `;
 
-exports[`10. leaders 1`] = `
+exports[`11. leaders 1`] = `
 <View
   style={
     Object {

--- a/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/slices.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. lead one full width slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -47,6 +48,7 @@ exports[`2. lead one and one slice 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -76,6 +78,7 @@ exports[`2. lead one and one slice 1`] = `
           GCHQ gives girls free cyber-classes to tackle gender gap
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "UPDATED",
@@ -123,6 +126,7 @@ exports[`3. lead one and four slice 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -154,6 +158,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -187,6 +192,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -220,6 +226,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -253,6 +260,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -289,6 +297,7 @@ exports[`4. lead two no pic and two 1`] = `
         Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -322,6 +331,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -362,6 +372,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -395,6 +406,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -422,6 +434,7 @@ exports[`5. secondary one slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -465,6 +478,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -500,6 +514,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -537,6 +552,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -572,6 +588,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -586,7 +603,185 @@ exports[`6. secondary four 1`] = `
 </View>
 `;
 
-exports[`7. secondary two and two 1`] = `
+exports[`7. secondary one and four 1`] = `
+<View>
+  <View>
+    <TheTimesLogo
+      height={40}
+      width={40}
+    />
+  </View>
+  <View />
+  <View>
+    <View>
+      <View>
+        <Link
+          url="/article/123"
+        >
+          <View>
+            <View>
+              <Image
+                aspectRatio={1}
+                uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+              />
+            </View>
+            <View>
+              <View>
+                <Text>
+                  LABEL
+                </Text>
+              </View>
+              <Text
+                accessibilityRole="heading"
+                aria-level="3"
+              >
+                Venezuela shows how Corbyn’s socialism works
+              </Text>
+              <ArticleFlags
+                color="#CCC"
+                flags={
+                  Array [
+                    "EXCLUSIVE",
+                  ]
+                }
+              />
+              <Text>
+                <Text>
+                  
+                  Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+                  ...
+                </Text>
+              </Text>
+            </View>
+          </View>
+        </Link>
+      </View>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+    <View />
+    <View>
+      <Link
+        url="/article/123"
+      >
+        <View>
+          <View>
+            <View>
+              <Text>
+                LABEL
+              </Text>
+            </View>
+            <Text
+              accessibilityRole="heading"
+              aria-level="3"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </Text>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </View>
+        </View>
+      </Link>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`8. secondary two and two 1`] = `
 <View>
   <View>
     <View>
@@ -613,6 +808,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -648,6 +844,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -685,6 +882,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -721,6 +919,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -734,7 +933,7 @@ exports[`7. secondary two and two 1`] = `
 </View>
 `;
 
-exports[`8. secondary two no pic and two 1`] = `
+exports[`9. secondary two no pic and two 1`] = `
 <View>
   <Link
     url="/article/123"
@@ -753,6 +952,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -787,6 +987,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -828,6 +1029,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -862,6 +1064,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </Text>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -874,7 +1077,7 @@ exports[`8. secondary two no pic and two 1`] = `
 </View>
 `;
 
-exports[`9. list two and six no pic 1`] = `
+exports[`10. list two and six no pic 1`] = `
 <View>
   <View>
     <View>
@@ -901,6 +1104,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -936,6 +1140,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </Text>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -966,6 +1171,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -995,6 +1201,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1024,6 +1231,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1053,6 +1261,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1082,6 +1291,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1111,6 +1321,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </Text>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1124,7 +1335,7 @@ exports[`9. list two and six no pic 1`] = `
 </View>
 `;
 
-exports[`10. leaders 1`] = `
+exports[`11. leaders 1`] = `
 <View>
   <View>
     <Image
@@ -1157,7 +1368,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </Text>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </View>
       </View>
     </Link>
@@ -1177,7 +1390,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </Text>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </View>
       </View>
     </Link>
@@ -1197,7 +1412,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </Text>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </View>
       </View>
     </Link>

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles-with-style.test.js.snap
@@ -727,3 +727,149 @@ exports[`11. tile m 1`] = `
   </View>
 </Link>
 `;
+
+exports[`12. tile n 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "flexDirection": "row",
+        "padding": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "width": "50%",
+        }
+      }
+    >
+      <Image />
+    </View>
+    <View
+      style={
+        Object {
+          "paddingHorizontal": 10,
+          "paddingTop": 5,
+          "width": "50%",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "marginBottom": 0,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#CCC",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          LABEL
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "900",
+            "lineHeight": 22,
+            "marginBottom": 5,
+          }
+        }
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <ArticleFlags />
+      <Text
+        style={
+          Object {
+            "color": "#CCC",
+            "flexWrap": "wrap",
+            "fontFamily": "TimesDigitalW04",
+            "fontSize": 14,
+            "lineHeight": 20,
+            "marginBottom": 10,
+          }
+        }
+      >
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`13. tile o 1`] = `
+<Link>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#272D34",
+        "paddingHorizontal": 12,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <View>
+      <View
+        style={
+          Object {
+            "marginBottom": 0,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#CCC",
+              "fontFamily": "GillSansMTStd-Medium",
+              "fontSize": 12,
+              "fontWeight": "400",
+              "letterSpacing": 1.2,
+              "lineHeight": 14,
+              "marginBottom": 0,
+            }
+          }
+        >
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#FFFFFF",
+            "fontFamily": "TimesModern-Bold",
+            "fontSize": 22,
+            "fontWeight": "900",
+            "lineHeight": 22,
+            "marginBottom": 11,
+            "marginTop": 5,
+          }
+        }
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags />
+    </View>
+  </View>
+</Link>
+`;

--- a/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/ios/__snapshots__/tiles.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. tile a 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -47,6 +48,7 @@ exports[`2. tile b 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -91,6 +93,7 @@ exports[`3. tile c 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -124,6 +127,7 @@ exports[`4. tile d 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -157,6 +161,7 @@ exports[`5. tile e 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -191,6 +196,7 @@ exports[`6. tile f 1`] = `
       Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "EXCLUSIVE",
@@ -233,6 +239,7 @@ exports[`7. tile g 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -265,6 +272,7 @@ exports[`8. tile i 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </Text>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -297,6 +305,7 @@ exports[`9. tile j 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -324,6 +333,7 @@ exports[`10. tile l 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -345,7 +355,80 @@ exports[`11. tile m 1`] = `
       >
         Prince Philip ‘could be prosecuted’ over car crash
       </Text>
-      <ArticleFlags />
+      <ArticleFlags
+        color={null}
+      />
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`12. tile n 1`] = `
+<Link
+  url="/article/123"
+>
+  <View>
+    <View>
+      <Image
+        aspectRatio={1}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </View>
+    <View>
+      <View>
+        <Text>
+          LABEL
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </Text>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "EXCLUSIVE",
+          ]
+        }
+      />
+      <Text>
+        <Text>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </Text>
+      </Text>
+    </View>
+  </View>
+</Link>
+`;
+
+exports[`13. tile o 1`] = `
+<Link>
+  <View>
+    <View>
+      <View>
+        <Text>
+          ROYALS
+        </Text>
+      </View>
+      <Text
+        accessibilityRole="heading"
+        aria-level="3"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </Text>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
     </View>
   </View>
 </Link>

--- a/packages/edition-slices/__tests__/shared-slices.base.js
+++ b/packages/edition-slices/__tests__/shared-slices.base.js
@@ -18,12 +18,16 @@ import {
   LeadersSlice,
   SecondaryOneSlice,
   SecondaryFourSlice,
+  SecondaryOneAndFourSlice,
   SecondaryTwoAndTwoSlice,
   SecondaryTwoNoPicAndTwoSlice
 } from "../src/slices";
 
 jest.mock("@times-components/article-flag", () => ({
   ArticleFlags: "ArticleFlags"
+}));
+jest.mock("@times-components/icons", () => ({
+  TheTimesLogo: "TheTimesLogo"
 }));
 jest.mock("@times-components/image", () => "Image");
 jest.mock("@times-components/link", () => "Link");
@@ -120,6 +124,23 @@ export default () => {
           />
         );
 
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "Secondary One And Four",
+      test: () => {
+        const secondaryTwoNoPicAndTwoData = mockSecondaryTwoNoPicAndTwoSlice();
+        const output = TestRenderer.create(
+          <SecondaryOneAndFourSlice
+            onPress={() => {}}
+            secondary1={secondaryTwoNoPicAndTwoData.secondary1}
+            support1={secondaryTwoNoPicAndTwoData.support1}
+            support2={secondaryTwoNoPicAndTwoData.support2}
+            support3={secondaryTwoNoPicAndTwoData.support2}
+            support4={secondaryTwoNoPicAndTwoData.support2}
+          />
+        );
         expect(output).toMatchSnapshot();
       }
     },

--- a/packages/edition-slices/__tests__/shared-tiles.base.js
+++ b/packages/edition-slices/__tests__/shared-tiles.base.js
@@ -3,6 +3,7 @@ import TestRenderer from "react-test-renderer";
 import { iterator } from "@times-components/test-utils";
 import {
   mockLeadTwoNoPicAndTwoSlice,
+  mockLeadOneFullWidthSlice,
   mockSecondaryTwoNoPicAndTwoSlice
 } from "@times-components/fixture-generator";
 import leadOneAndOneDataGenerator from "../fixtures/leadoneandone";
@@ -18,7 +19,9 @@ import {
   TileI,
   TileJ,
   TileL,
-  TileM
+  TileM,
+  TileN,
+  TileO
 } from "../src/tiles";
 
 jest.mock("@times-components/article-flag", () => ({
@@ -100,7 +103,10 @@ export default () => {
       test: () => {
         const secondaryTwoNoPicAndTwoData = mockSecondaryTwoNoPicAndTwoSlice();
         const output = TestRenderer.create(
-          <TileG tile={secondaryTwoNoPicAndTwoData.support1} />
+          <TileG
+            onPress={() => {}}
+            tile={secondaryTwoNoPicAndTwoData.support1}
+          />
         );
 
         expect(output).toMatchSnapshot();
@@ -110,7 +116,7 @@ export default () => {
       name: "tile i",
       test: () => {
         const output = TestRenderer.create(
-          <TileI tile={leadOneAndOneData.lead} />
+          <TileI onPress={() => {}} tile={leadOneAndOneData.lead} />
         );
 
         expect(output).toMatchSnapshot();
@@ -120,7 +126,7 @@ export default () => {
       name: "tile j",
       test: () => {
         const output = TestRenderer.create(
-          <TileJ tile={leadOneAndOneData.lead} />
+          <TileJ onPress={() => {}} tile={leadOneAndOneData.lead} />
         );
 
         expect(output).toMatchSnapshot();
@@ -141,6 +147,27 @@ export default () => {
       test: () => {
         const output = TestRenderer.create(
           <TileM onPress={() => {}} tile={leadOneAndOneData.lead} />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "tile n",
+      test: () => {
+        const slice = mockLeadOneFullWidthSlice();
+        const output = TestRenderer.create(
+          <TileN onPress={() => {}} tile={slice.lead} />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    },
+    {
+      name: "tile o",
+      test: () => {
+        const output = TestRenderer.create(
+          <TileO onPress={() => {}} tile={leadOneAndOneData.lead} />
         );
 
         expect(output).toMatchSnapshot();

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices-with-style.test.js.snap
@@ -64,6 +64,7 @@ exports[`1. lead one full width slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -195,6 +196,7 @@ exports[`2. lead one and one slice 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -235,6 +237,7 @@ exports[`2. lead one and one slice 1`] = `
           GCHQ gives girls free cyber-classes to tackle gender gap
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "UPDATED",
@@ -503,6 +506,7 @@ exports[`3. lead one and four slice 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -545,6 +549,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -591,6 +596,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -637,6 +643,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -683,6 +690,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -904,6 +912,7 @@ exports[`4. lead two no pic and two 1`] = `
         Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
       </h4>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -952,6 +961,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -1009,6 +1019,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -1055,6 +1066,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -1137,6 +1149,7 @@ exports[`5. secondary one slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -1379,6 +1392,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -1429,6 +1443,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -1483,6 +1498,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -1533,6 +1549,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -1547,7 +1564,493 @@ exports[`6. secondary four 1`] = `
 </div>
 `;
 
-exports[`7. secondary two and two 1`] = `
+exports[`7. secondary one and four 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.S4 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.S6 {
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.IS1 {
+  background-color: rgba(39,45,52,1.00);
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  margin-top: 10px;
+  margin-right: 10px;
+  margin-left: 10px;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS2 {
+  border-bottom-color: rgba(77,77,77,1.00);
+  border-bottom-width: 1px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS3 {
+  width: 50%;
+}
+
+.IS4 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS5 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+}
+
+.IS6 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS7 {
+  padding-right: 10px;
+  padding-left: 10px;
+  padding-top: 5px;
+  width: 50%;
+}
+
+.IS8 {
+  background-color: rgba(39,45,52,1.00);
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding-top: 10px;
+  padding-right: 10px;
+  padding-left: 10px;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS9 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+
+.IS10 {
+  border-bottom-color: rgba(77,77,77,1.00);
+  border-bottom-width: 1px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS11 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS12 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+  margin-bottom: 11px;
+  margin-top: 5px;
+}
+
+.IS13 {
+  background-color: rgba(39,45,52,1.00);
+  padding-top: 10px;
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.IS14 {
+  border-bottom-color: rgba(77,77,77,1.00);
+  border-bottom-width: 1px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS15 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS16 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+  margin-bottom: 11px;
+  margin-top: 5px;
+}
+
+.IS17 {
+  background-color: rgba(39,45,52,1.00);
+  padding-top: 10px;
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.IS18 {
+  border-bottom-color: rgba(77,77,77,1.00);
+  border-bottom-width: 1px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS19 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS20 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+  margin-bottom: 11px;
+  margin-top: 5px;
+}
+
+.IS21 {
+  background-color: rgba(39,45,52,1.00);
+  padding-top: 10px;
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.IS22 {
+  border-bottom-color: rgba(77,77,77,1.00);
+  border-bottom-width: 1px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.IS23 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS24 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+  margin-bottom: 11px;
+  margin-top: 5px;
+}
+
+.IS25 {
+  background-color: rgba(39,45,52,1.00);
+  padding-top: 10px;
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.IS26 {
+  background-color: rgba(39,45,52,1.00);
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: 0%;
+  flex-basis: 0%;
+  -ms-flex-positive: 1;
+  -webkit-box-flex: 1;
+  -ms-flex-negative: 1;
+  -ms-flex-preferred-size: 0%;
+}
+
+.IS27 {
+  background-color: rgba(39,45,52,1.00);
+}
+</style>
+
+<div
+  className="IS27 S1"
+>
+  <div
+    className="IS1 S1"
+  >
+    <TheTimesLogo
+      height={40}
+      width={40}
+    />
+  </div>
+  <div
+    className="IS2 S1"
+  />
+  <div
+    className="IS26 S1"
+  >
+    <div
+      className="IS9 S1"
+    >
+      <div
+        className="S1"
+      >
+        <Link
+          url="/article/123"
+        >
+          <div
+            className="IS8 S1"
+          >
+            <div
+              className="IS3 S1"
+            >
+              <Image
+                aspectRatio={1}
+                uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+              />
+            </div>
+            <div
+              className="IS7 S1"
+            >
+              <div
+                className="S1"
+              >
+                <div
+                  className="IS4 S2"
+                >
+                  LABEL
+                </div>
+              </div>
+              <h3
+                aria-level="3"
+                className="IS5 S3"
+                role="heading"
+              >
+                Venezuela shows how Corbyn’s socialism works
+              </h3>
+              <ArticleFlags
+                color="#CCC"
+                flags={
+                  Array [
+                    "EXCLUSIVE",
+                  ]
+                }
+              />
+              <div
+                className="IS6 S5"
+              >
+                <span
+                  className="S4"
+                >
+                  
+                  Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+                  ...
+                </span>
+              </div>
+            </div>
+          </div>
+        </Link>
+      </div>
+    </div>
+    <div
+      className="IS10 S1"
+    />
+    <div
+      className="S1"
+    >
+      <Link
+        url="/article/123"
+      >
+        <div
+          className="IS13 S1"
+        >
+          <div
+            className="S1"
+          >
+            <div
+              className="S1"
+            >
+              <div
+                className="IS11 S2"
+              >
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              className="IS12 S6"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+    <div
+      className="IS14 S1"
+    />
+    <div
+      className="S1"
+    >
+      <Link
+        url="/article/123"
+      >
+        <div
+          className="IS17 S1"
+        >
+          <div
+            className="S1"
+          >
+            <div
+              className="S1"
+            >
+              <div
+                className="IS15 S2"
+              >
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              className="IS16 S6"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+    <div
+      className="IS18 S1"
+    />
+    <div
+      className="S1"
+    >
+      <Link
+        url="/article/123"
+      >
+        <div
+          className="IS21 S1"
+        >
+          <div
+            className="S1"
+          >
+            <div
+              className="S1"
+            >
+              <div
+                className="IS19 S2"
+              >
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              className="IS20 S6"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+    <div
+      className="IS22 S1"
+    />
+    <div
+      className="S1"
+    >
+      <Link
+        url="/article/123"
+      >
+        <div
+          className="IS25 S1"
+        >
+          <div
+            className="S1"
+          >
+            <div
+              className="S1"
+            >
+              <div
+                className="IS23 S2"
+              >
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              className="IS24 S6"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`8. secondary two and two 1`] = `
 <style>
 .S1 {
   margin-bottom: 10px;
@@ -1791,6 +2294,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -1841,6 +2345,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -1893,6 +2398,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1944,6 +2450,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1957,7 +2464,7 @@ exports[`7. secondary two and two 1`] = `
 </div>
 `;
 
-exports[`8. secondary two no pic and two 1`] = `
+exports[`9. secondary two no pic and two 1`] = `
 <style>
 .S1 {
   font-family: GillSansMTStd-Medium;
@@ -2158,6 +2665,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -2207,6 +2715,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -2265,6 +2774,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -2312,6 +2822,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -2324,7 +2835,7 @@ exports[`8. secondary two no pic and two 1`] = `
 </div>
 `;
 
-exports[`9. list two and six no pic 1`] = `
+exports[`10. list two and six no pic 1`] = `
 <style>
 .S1 {
   margin-bottom: 10px;
@@ -2621,6 +3132,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -2671,6 +3183,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -2714,6 +3227,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -2756,6 +3270,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -2798,6 +3313,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -2840,6 +3356,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -2882,6 +3399,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -2924,6 +3442,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -2937,7 +3456,7 @@ exports[`9. list two and six no pic 1`] = `
 </div>
 `;
 
-exports[`10. leaders 1`] = `
+exports[`11. leaders 1`] = `
 <style>
 .S1 {
   font-weight: inherit;
@@ -3107,7 +3626,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </h4>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </div>
       </div>
     </Link>
@@ -3135,7 +3656,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </h4>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </div>
       </div>
     </Link>
@@ -3163,7 +3686,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </h4>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </div>
       </div>
     </Link>

--- a/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/slices.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. lead one full width slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -47,6 +48,7 @@ exports[`2. lead one and one slice 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -76,6 +78,7 @@ exports[`2. lead one and one slice 1`] = `
           GCHQ gives girls free cyber-classes to tackle gender gap
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "UPDATED",
@@ -123,6 +126,7 @@ exports[`3. lead one and four slice 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -154,6 +158,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -187,6 +192,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -220,6 +226,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -253,6 +260,7 @@ exports[`3. lead one and four slice 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -289,6 +297,7 @@ exports[`4. lead two no pic and two 1`] = `
         Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
       </h4>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -322,6 +331,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -362,6 +372,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -395,6 +406,7 @@ exports[`4. lead two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -422,6 +434,7 @@ exports[`5. secondary one slice 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -465,6 +478,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -500,6 +514,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -537,6 +552,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -572,6 +588,7 @@ exports[`6. secondary four 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -586,7 +603,185 @@ exports[`6. secondary four 1`] = `
 </div>
 `;
 
-exports[`7. secondary two and two 1`] = `
+exports[`7. secondary one and four 1`] = `
+<div>
+  <div>
+    <TheTimesLogo
+      height={40}
+      width={40}
+    />
+  </div>
+  <div />
+  <div>
+    <div>
+      <div>
+        <Link
+          url="/article/123"
+        >
+          <div>
+            <div>
+              <Image
+                aspectRatio={1}
+                uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+              />
+            </div>
+            <div>
+              <div>
+                <div>
+                  LABEL
+                </div>
+              </div>
+              <h3
+                aria-level="3"
+                role="heading"
+              >
+                Venezuela shows how Corbyn’s socialism works
+              </h3>
+              <ArticleFlags
+                color="#CCC"
+                flags={
+                  Array [
+                    "EXCLUSIVE",
+                  ]
+                }
+              />
+              <div>
+                <span>
+                  
+                  Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+                  ...
+                </span>
+              </div>
+            </div>
+          </div>
+        </Link>
+      </div>
+    </div>
+    <div />
+    <div>
+      <Link
+        url="/article/123"
+      >
+        <div>
+          <div>
+            <div>
+              <div>
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+    <div />
+    <div>
+      <Link
+        url="/article/123"
+      >
+        <div>
+          <div>
+            <div>
+              <div>
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+    <div />
+    <div>
+      <Link
+        url="/article/123"
+      >
+        <div>
+          <div>
+            <div>
+              <div>
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+    <div />
+    <div>
+      <Link
+        url="/article/123"
+      >
+        <div>
+          <div>
+            <div>
+              <div>
+                LABEL
+              </div>
+            </div>
+            <h3
+              aria-level="3"
+              role="heading"
+            >
+              Venezuela shows how Corbyn’s socialism works
+            </h3>
+            <ArticleFlags
+              color="#CCC"
+              flags={
+                Array [
+                  "EXCLUSIVE",
+                ]
+              }
+            />
+          </div>
+        </div>
+      </Link>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`8. secondary two and two 1`] = `
 <div>
   <div>
     <div>
@@ -613,6 +808,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -648,6 +844,7 @@ exports[`7. secondary two and two 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -685,6 +882,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -721,6 +919,7 @@ exports[`7. secondary two and two 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -734,7 +933,7 @@ exports[`7. secondary two and two 1`] = `
 </div>
 `;
 
-exports[`8. secondary two no pic and two 1`] = `
+exports[`9. secondary two no pic and two 1`] = `
 <div>
   <Link
     url="/article/123"
@@ -753,6 +952,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -787,6 +987,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -828,6 +1029,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -862,6 +1064,7 @@ exports[`8. secondary two no pic and two 1`] = `
           Venezuela shows how Corbyn’s socialism works
         </h3>
         <ArticleFlags
+          color={null}
           flags={
             Array [
               "EXCLUSIVE",
@@ -874,7 +1077,7 @@ exports[`8. secondary two no pic and two 1`] = `
 </div>
 `;
 
-exports[`9. list two and six no pic 1`] = `
+exports[`10. list two and six no pic 1`] = `
 <div>
   <div>
     <div>
@@ -901,6 +1104,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -936,6 +1140,7 @@ exports[`9. list two and six no pic 1`] = `
               Venezuela shows how Corbyn’s socialism works
             </h3>
             <ArticleFlags
+              color={null}
               flags={
                 Array [
                   "EXCLUSIVE",
@@ -966,6 +1171,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -995,6 +1201,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1024,6 +1231,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1053,6 +1261,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1082,6 +1291,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1111,6 +1321,7 @@ exports[`9. list two and six no pic 1`] = `
             Venezuela shows how Corbyn’s socialism works
           </h3>
           <ArticleFlags
+            color={null}
             flags={
               Array [
                 "EXCLUSIVE",
@@ -1124,7 +1335,7 @@ exports[`9. list two and six no pic 1`] = `
 </div>
 `;
 
-exports[`10. leaders 1`] = `
+exports[`11. leaders 1`] = `
 <div>
   <div>
     <Image
@@ -1153,7 +1364,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </h4>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </div>
       </div>
     </Link>
@@ -1173,7 +1386,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </h4>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </div>
       </div>
     </Link>
@@ -1193,7 +1408,9 @@ exports[`10. leaders 1`] = `
           >
             Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
           </h4>
-          <ArticleFlags />
+          <ArticleFlags
+            color={null}
+          />
         </div>
       </div>
     </Link>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles-with-style.test.js.snap
@@ -64,6 +64,7 @@ exports[`1. tile a 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -164,6 +165,7 @@ exports[`2. tile b 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -272,6 +274,7 @@ exports[`3. tile c 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -370,6 +373,7 @@ exports[`4. tile d 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -468,6 +472,7 @@ exports[`5. tile e 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -581,6 +586,7 @@ exports[`6. tile f 1`] = `
       Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
     </h4>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "EXCLUSIVE",
@@ -700,6 +706,7 @@ exports[`7. tile g 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -788,6 +795,7 @@ exports[`8. tile i 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -884,6 +892,7 @@ exports[`9. tile j 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -957,6 +966,7 @@ exports[`10. tile l 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -1008,7 +1018,220 @@ exports[`11. tile m 1`] = `
       >
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
-      <ArticleFlags />
+      <ArticleFlags
+        color={null}
+      />
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`12. tile n 1`] = `
+<style>
+.S1 {
+  margin-bottom: 0px;
+}
+
+.S2 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S3 {
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+  margin-bottom: 5px;
+}
+
+.S4 {
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  margin-bottom: 0px;
+}
+
+.S5 {
+  -ms-flex-wrap: wrap;
+  -webkit-box-lines: multiple;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+  font-family: TimesDigitalW04;
+  font-size: 14px;
+  font-weight: inherit;
+  line-height: 20px;
+  margin-bottom: 10px;
+}
+
+.IS1 {
+  width: 50%;
+}
+
+.IS2 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS3 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+}
+
+.IS4 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS5 {
+  padding-right: 10px;
+  padding-left: 10px;
+  padding-top: 5px;
+  width: 50%;
+}
+
+.IS6 {
+  background-color: rgba(39,45,52,1.00);
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  padding-top: 10px;
+  padding-right: 10px;
+  padding-left: 10px;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+}
+</style>
+
+<Link
+  url="/article/123"
+>
+  <div
+    className="IS6 S1"
+  >
+    <div
+      className="IS1 S1"
+    >
+      <Image
+        aspectRatio={1}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </div>
+    <div
+      className="IS5 S1"
+    >
+      <div
+        className="S1"
+      >
+        <div
+          className="IS2 S2"
+        >
+          LABEL
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        className="IS3 S3"
+        role="heading"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </h3>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "EXCLUSIVE",
+          ]
+        }
+      />
+      <div
+        className="IS4 S5"
+      >
+        <span
+          className="S4"
+        >
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </span>
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`13. tile o 1`] = `
+<style>
+.S1 {
+  font-family: GillSansMTStd-Medium;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 14px;
+  margin-bottom: 0px;
+}
+
+.S2 {
+  margin-bottom: 0px;
+}
+
+.S3 {
+  font-family: TimesModern-Bold;
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.IS1 {
+  color: rgba(204,204,204,1.00);
+}
+
+.IS2 {
+  color: rgba(255,255,255,1.00);
+  line-height: 22px;
+  margin-bottom: 11px;
+  margin-top: 5px;
+}
+
+.IS3 {
+  background-color: rgba(39,45,52,1.00);
+  padding-top: 10px;
+  padding-right: 12px;
+  padding-left: 12px;
+}
+</style>
+
+<Link>
+  <div
+    className="IS3 S2"
+  >
+    <div
+      className="S2"
+    >
+      <div
+        className="S2"
+      >
+        <div
+          className="IS1 S1"
+        >
+          ROYALS
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        className="IS2 S3"
+        role="heading"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </h3>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
     </div>
   </div>
 </Link>

--- a/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
+++ b/packages/edition-slices/__tests__/web/__snapshots__/tiles.test.js.snap
@@ -15,6 +15,7 @@ exports[`1. tile a 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -47,6 +48,7 @@ exports[`2. tile b 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -91,6 +93,7 @@ exports[`3. tile c 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -124,6 +127,7 @@ exports[`4. tile d 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -157,6 +161,7 @@ exports[`5. tile e 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -191,6 +196,7 @@ exports[`6. tile f 1`] = `
       Labour’s admiration for a regime that has squandered its resources and left its people in penury should be a warning to all
     </h4>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "EXCLUSIVE",
@@ -233,6 +239,7 @@ exports[`7. tile g 1`] = `
         Venezuela shows how Corbyn’s socialism works
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "EXCLUSIVE",
@@ -265,6 +272,7 @@ exports[`8. tile i 1`] = `
       Prince Philip ‘could be prosecuted’ over car crash
     </h3>
     <ArticleFlags
+      color={null}
       flags={
         Array [
           "NEW",
@@ -297,6 +305,7 @@ exports[`9. tile j 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -324,6 +333,7 @@ exports[`10. tile l 1`] = `
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
       <ArticleFlags
+        color={null}
         flags={
           Array [
             "NEW",
@@ -345,7 +355,80 @@ exports[`11. tile m 1`] = `
       >
         Prince Philip ‘could be prosecuted’ over car crash
       </h3>
-      <ArticleFlags />
+      <ArticleFlags
+        color={null}
+      />
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`12. tile n 1`] = `
+<Link
+  url="/article/123"
+>
+  <div>
+    <div>
+      <Image
+        aspectRatio={1}
+        uri="//www.thetimes.co.uk/imageserver/image/methode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5af6925e-2599-11e9-b782-40e94f317da5.jpg?crop=1000%2C1000%2C250%2C0"
+      />
+    </div>
+    <div>
+      <div>
+        <div>
+          LABEL
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        Venezuela shows how Corbyn’s socialism works
+      </h3>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "EXCLUSIVE",
+          ]
+        }
+      />
+      <div>
+        <span>
+          
+          Theresa May has two objectives tomorrow when MPs get to vote on Brexit — the trouble is both are fraught with difficulty.
+          ...
+        </span>
+      </div>
+    </div>
+  </div>
+</Link>
+`;
+
+exports[`13. tile o 1`] = `
+<Link>
+  <div>
+    <div>
+      <div>
+        <div>
+          ROYALS
+        </div>
+      </div>
+      <h3
+        aria-level="3"
+        role="heading"
+      >
+        Prince Philip ‘could be prosecuted’ over car crash
+      </h3>
+      <ArticleFlags
+        color="#CCC"
+        flags={
+          Array [
+            "NEW",
+          ]
+        }
+      />
     </div>
   </div>
 </Link>

--- a/packages/edition-slices/edition-slices.showcase.js
+++ b/packages/edition-slices/edition-slices.showcase.js
@@ -17,6 +17,7 @@ import {
   ListTwoAndSixNoPicSlice,
   SecondaryOneSlice,
   SecondaryFourSlice,
+  SecondaryOneAndFourSlice,
   SecondaryTwoAndTwoSlice,
   SecondaryTwoNoPicAndTwoSlice,
   LeadersSlice
@@ -149,6 +150,25 @@ export default {
         );
       },
       name: "Secondary Two And Two (CCGG)",
+      type: "story"
+    },
+    {
+      component: (_, { decorateAction }) => {
+        const slice = mockSecondaryFourSlice();
+        return (
+          <ScrollView>
+            <SecondaryOneAndFourSlice
+              onPress={preventDefaultedAction(decorateAction)("onPress")}
+              secondary1={slice.secondary1}
+              support1={slice.secondary2}
+              support2={slice.secondary3}
+              support3={slice.secondary4}
+              support4={slice.secondary4}
+            />
+          </ScrollView>
+        );
+      },
+      name: "Supplement Secondary One And Four (NOOOO)",
       type: "story"
     },
     {

--- a/packages/edition-slices/edition-tiles.showcase.js
+++ b/packages/edition-slices/edition-tiles.showcase.js
@@ -17,7 +17,9 @@ import {
   TileI,
   TileJ,
   TileL,
-  TileM
+  TileM,
+  TileN,
+  TileO
 } from "./src/tiles";
 
 const preventDefaultedAction = decorateAction =>
@@ -172,6 +174,34 @@ export default {
       },
       name:
         "Tile M - No image, 22pt headline, no teaser, comment article, center align",
+      type: "story"
+    },
+    {
+      component: (_, { decorateAction }) => {
+        const slice = mockLeadOneFullWidthSlice();
+        return (
+          <TileN
+            onPress={preventDefaultedAction(decorateAction)("onPress")}
+            tile={slice.lead}
+          />
+        );
+      },
+      name:
+        "Tile N - Square image, 22pt headline, white color, black background",
+      type: "story"
+    },
+    {
+      component: (_, { decorateAction }) => {
+        const slice = mockLeadOneFullWidthSlice();
+        return (
+          <TileO
+            onPress={preventDefaultedAction(decorateAction)("onPress")}
+            tile={slice.lead}
+          />
+        );
+      },
+      name:
+        "Tile O - No image, 20pt headline, no teaser, white color, black background",
       type: "story"
     }
   ],

--- a/packages/edition-slices/package.json
+++ b/packages/edition-slices/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@times-components/article-flag": "2.4.16",
     "@times-components/article-summary": "3.8.5",
+    "@times-components/icons": "2.3.19",
     "@times-components/image": "4.8.0",
     "@times-components/link": "3.2.15",
     "@times-components/slice-layout": "0.6.5",

--- a/packages/edition-slices/src/slices/index.js
+++ b/packages/edition-slices/src/slices/index.js
@@ -6,6 +6,7 @@ export { default as ListTwoAndSixNoPicSlice } from "./listtwoandsixnopic";
 export { default as LeadTwoNoPicAndTwoSlice } from "./leadtwonopicandtwo";
 export { default as SecondaryOneSlice } from "./secondaryone";
 export { default as SecondaryFourSlice } from "./secondaryfour";
+export { default as SecondaryOneAndFourSlice } from "./secondaryoneandfour";
 export { default as SecondaryTwoAndTwoSlice } from "./secondarytwoandtwo";
 export {
   default as SecondaryTwoNoPicAndTwoSlice

--- a/packages/edition-slices/src/slices/secondaryoneandfour/index.js
+++ b/packages/edition-slices/src/slices/secondaryoneandfour/index.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import { TheTimesLogo } from "@times-components/icons";
+import {
+  SecondaryOneAndFourSlice,
+  ItemRowSeparator
+} from "@times-components/slice-layout";
+import { TileO, TileN } from "../../tiles";
+import styles from "./styles";
+
+const SecondaryOneAndFour = ({
+  onPress,
+  secondary1,
+  support1,
+  support2,
+  support3,
+  support4
+}) => (
+  <View style={styles.sliceWrapper}>
+    <View style={styles.logoContainer}>
+      <TheTimesLogo height={40} width={40} />
+    </View>
+    <ItemRowSeparator style={styles.separator} />
+    <SecondaryOneAndFourSlice
+      renderSecondary1={() => <TileN onPress={onPress} tile={secondary1} />}
+      renderSupport1={() => <TileO onPress={onPress} tile={support1} />}
+      renderSupport2={() => <TileO onPress={onPress} tile={support2} />}
+      renderSupport3={() => <TileO onPress={onPress} tile={support3} />}
+      renderSupport4={() => <TileO onPress={onPress} tile={support4} />}
+    />
+  </View>
+);
+
+SecondaryOneAndFour.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  secondary1: PropTypes.shape({}).isRequired,
+  support1: PropTypes.shape({}).isRequired,
+  support2: PropTypes.shape({}).isRequired,
+  support3: PropTypes.shape({}).isRequired,
+  support4: PropTypes.shape({}).isRequired
+};
+
+export default SecondaryOneAndFour;

--- a/packages/edition-slices/src/slices/secondaryoneandfour/styles.js
+++ b/packages/edition-slices/src/slices/secondaryoneandfour/styles.js
@@ -1,0 +1,18 @@
+import { colours, spacing } from "@times-components/styleguide";
+
+const styles = {
+  logoContainer: {
+    backgroundColor: colours.functional.darkSupplement,
+    flexDirection: "row",
+    margin: spacing(2),
+    marginBottom: 0
+  },
+  separator: {
+    borderBottomColor: colours.functional.tertiary
+  },
+  sliceWrapper: {
+    backgroundColor: colours.functional.darkSupplement
+  }
+};
+
+export default styles;

--- a/packages/edition-slices/src/tiles/index.js
+++ b/packages/edition-slices/src/tiles/index.js
@@ -9,3 +9,5 @@ export { default as TileI } from "./tile-i";
 export { default as TileJ } from "./tile-j";
 export { default as TileL } from "./tile-l";
 export { default as TileM } from "./tile-m";
+export { default as TileN } from "./tile-n";
+export { default as TileO } from "./tile-o";

--- a/packages/edition-slices/src/tiles/shared/tile-summary.js
+++ b/packages/edition-slices/src/tiles/shared/tile-summary.js
@@ -16,13 +16,18 @@ const TileSummary = ({
   strapline,
   straplineStyle,
   style,
-  summary
+  summary,
+  summaryStyle,
+  flagColour,
+  labelColour
 }) => (
   <ArticleSummary
     content={
-      summary ? () => <ArticleSummaryContent ast={summary} /> : undefined
+      summary
+        ? () => <ArticleSummaryContent ast={summary} style={summaryStyle} />
+        : undefined
     }
-    flags={() => <ArticleFlags flags={flags} />}
+    flags={() => <ArticleFlags color={flagColour} flags={flags} />}
     headline={() => (
       <ArticleSummaryHeadline
         headline={headline || shortHeadline}
@@ -31,7 +36,8 @@ const TileSummary = ({
     )}
     label={label}
     labelProps={{
-      color: colours.section[section] || colours.section.default,
+      color:
+        labelColour || (colours.section[section] || colours.section.default),
       isVideo: hasVideo,
       title: label
     }}
@@ -50,20 +56,26 @@ const TileSummary = ({
 );
 
 TileSummary.propTypes = {
+  flagColour: PropTypes.string,
   headlineStyle: PropTypes.shape({}),
+  labelColour: PropTypes.string,
   strapline: PropTypes.string,
   straplineStyle: PropTypes.shape({}),
   style: PropTypes.shape({}),
   summary: PropTypes.arrayOf(PropTypes.shape({})),
+  summaryStyle: PropTypes.shape({}),
   tile: PropTypes.shape({}).isRequired
 };
 
 TileSummary.defaultProps = {
+  flagColour: null,
   headlineStyle: null,
+  labelColour: null,
   strapline: null,
   straplineStyle: null,
   style: null,
-  summary: null
+  summary: null,
+  summaryStyle: null
 };
 
 export default TileSummary;

--- a/packages/edition-slices/src/tiles/tile-n/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/index.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import { colours } from "@times-components/styleguide";
+import { TileImage, TileLink, TileSummary } from "../shared";
+import styles from "./styles";
+
+const TileN = ({ onPress, tile }) => (
+  <TileLink onPress={onPress} tile={tile}>
+    <View style={styles.container}>
+      <TileImage
+        aspectRatio={1}
+        style={styles.imageContainer}
+        uri={tile.article.leadAsset.crop11.url}
+      />
+      <TileSummary
+        flagColour={colours.functional.greyLabel}
+        headlineStyle={styles.headline}
+        labelColour={colours.functional.greyLabel}
+        style={styles.summaryContainer}
+        summary={tile.article.summary125}
+        summaryStyle={styles.summary}
+        tile={tile}
+      />
+    </View>
+  </TileLink>
+);
+
+TileN.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default TileN;

--- a/packages/edition-slices/src/tiles/tile-n/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-n/styles/index.js
@@ -1,0 +1,29 @@
+import { colours, fontFactory, spacing } from "@times-components/styleguide";
+
+const styles = {
+  container: {
+    backgroundColor: colours.functional.darkSupplement,
+    flexDirection: "row",
+    padding: spacing(2)
+  },
+  headline: {
+    ...fontFactory({
+      font: "headline",
+      fontSize: "infoTitle"
+    }),
+    color: colours.functional.white
+  },
+  imageContainer: {
+    width: "50%"
+  },
+  summary: {
+    color: colours.functional.greyLabel
+  },
+  summaryContainer: {
+    paddingHorizontal: spacing(2),
+    paddingTop: spacing(1),
+    width: "50%"
+  }
+};
+
+export default styles;

--- a/packages/edition-slices/src/tiles/tile-o/index.js
+++ b/packages/edition-slices/src/tiles/tile-o/index.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { View } from "react-native";
+import PropTypes from "prop-types";
+import { colours } from "@times-components/styleguide";
+import { TileSummary, TileLink } from "../shared";
+import styles from "./styles";
+
+const TileO = ({ onPress, tile }) => (
+  <TileLink onPress={onPress} tile={tile}>
+    <View style={styles.container}>
+      <TileSummary
+        flagColour={colours.functional.greyLabel}
+        headlineStyle={styles.headlineStyle}
+        labelColour={colours.functional.greyLabel}
+        tile={tile}
+      />
+    </View>
+  </TileLink>
+);
+
+TileO.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  tile: PropTypes.shape({}).isRequired
+};
+
+export default TileO;

--- a/packages/edition-slices/src/tiles/tile-o/styles/index.js
+++ b/packages/edition-slices/src/tiles/tile-o/styles/index.js
@@ -1,0 +1,19 @@
+import { fonts, spacing, colours } from "@times-components/styleguide";
+
+const styles = {
+  container: {
+    backgroundColor: colours.functional.darkSupplement,
+    paddingHorizontal: 12,
+    paddingVertical: spacing(2)
+  },
+  headlineStyle: {
+    color: colours.functional.white,
+    fontFamily: fonts.headline,
+    fontSize: 22,
+    lineHeight: 22,
+    marginBottom: 11,
+    marginTop: spacing(1)
+  }
+};
+
+export default styles;

--- a/packages/icons/__tests__/android/__snapshots__/icons-colour.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons-colour.android.test.js.snap
@@ -171,3 +171,25 @@ exports[`6. iconfacebook renders with different colours 1`] = `
   }
 />
 `;
+
+exports[`7. thetimeslogo renders with different colours 1`] = `
+<ARTShape
+  fill={
+    Array [
+      0,
+      0.9803921568627451,
+      0.792156862745098,
+      0.8705882352941177,
+      1,
+    ]
+  }
+  stroke={
+    Array [
+      0.7529411764705882,
+      1,
+      0.9333333333333333,
+      1,
+    ]
+  }
+/>
+`;

--- a/packages/icons/__tests__/android/__snapshots__/icons-dim.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons-dim.android.test.js.snap
@@ -65,3 +65,14 @@ exports[`6. iconfacebook sets a width when height is set 1`] = `
   }
 />
 `;
+
+exports[`7. thetimeslogo sets a width when height is set 1`] = `
+<ARTSurfaceView
+  style={
+    Object {
+      "height": 50,
+      "width": 50,
+    }
+  }
+/>
+`;

--- a/packages/icons/__tests__/android/__snapshots__/icons.android.test.js.snap
+++ b/packages/icons/__tests__/android/__snapshots__/icons.android.test.js.snap
@@ -404,3 +404,55 @@ exports[`6. iconfacebook renders 1`] = `
   </ARTGroup>
 </ARTSurfaceView>
 `;
+
+exports[`7. thetimeslogo renders 1`] = `
+<ARTSurfaceView
+  style={
+    Object {
+      "height": 20,
+      "width": 20,
+    }
+  }
+>
+  <ARTGroup
+    transform={
+      Array [
+        0.21052631578947367,
+        0,
+        0,
+        0.21052631578947367,
+        0,
+        0,
+      ]
+    }
+  >
+    <ARTShape
+      d="4ac8c91d91e5d81cca0a152cd054a1ad"
+      fill={
+        Array [
+          0,
+          1,
+          1,
+          1,
+          1,
+        ]
+      }
+      stroke={null}
+      strokeCap={1}
+      strokeDash={null}
+      strokeJoin={1}
+      strokeWidth={1}
+      transform={
+        Array [
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+        ]
+      }
+    />
+  </ARTGroup>
+</ARTSurfaceView>
+`;

--- a/packages/icons/__tests__/ios/__snapshots__/icons-colour.ios.test.js.snap
+++ b/packages/icons/__tests__/ios/__snapshots__/icons-colour.ios.test.js.snap
@@ -171,3 +171,25 @@ exports[`6. iconfacebook renders with different colours 1`] = `
   }
 />
 `;
+
+exports[`7. thetimeslogo renders with different colours 1`] = `
+<ARTShape
+  fill={
+    Array [
+      0,
+      0.9803921568627451,
+      0.792156862745098,
+      0.8705882352941177,
+      1,
+    ]
+  }
+  stroke={
+    Array [
+      0.7529411764705882,
+      1,
+      0.9333333333333333,
+      1,
+    ]
+  }
+/>
+`;

--- a/packages/icons/__tests__/ios/__snapshots__/icons-dim.ios.test.js.snap
+++ b/packages/icons/__tests__/ios/__snapshots__/icons-dim.ios.test.js.snap
@@ -65,3 +65,14 @@ exports[`6. iconfacebook sets a width when height is set 1`] = `
   }
 />
 `;
+
+exports[`7. thetimeslogo sets a width when height is set 1`] = `
+<ARTSurfaceView
+  style={
+    Object {
+      "height": 50,
+      "width": 50,
+    }
+  }
+/>
+`;

--- a/packages/icons/__tests__/ios/__snapshots__/icons.ios.test.js.snap
+++ b/packages/icons/__tests__/ios/__snapshots__/icons.ios.test.js.snap
@@ -404,3 +404,55 @@ exports[`6. iconfacebook renders 1`] = `
   </ARTGroup>
 </ARTSurfaceView>
 `;
+
+exports[`7. thetimeslogo renders 1`] = `
+<ARTSurfaceView
+  style={
+    Object {
+      "height": 20,
+      "width": 20,
+    }
+  }
+>
+  <ARTGroup
+    transform={
+      Array [
+        0.21052631578947367,
+        0,
+        0,
+        0.21052631578947367,
+        0,
+        0,
+      ]
+    }
+  >
+    <ARTShape
+      d="4ac8c91d91e5d81cca0a152cd054a1ad"
+      fill={
+        Array [
+          0,
+          1,
+          1,
+          1,
+          1,
+        ]
+      }
+      stroke={null}
+      strokeCap={1}
+      strokeDash={null}
+      strokeJoin={1}
+      strokeWidth={1}
+      transform={
+        Array [
+          1,
+          0,
+          0,
+          1,
+          0,
+          0,
+        ]
+      }
+    />
+  </ARTGroup>
+</ARTSurfaceView>
+`;

--- a/packages/icons/__tests__/web/__snapshots__/icons-colour.web.test.js.snap
+++ b/packages/icons/__tests__/web/__snapshots__/icons-colour.web.test.js.snap
@@ -85,3 +85,15 @@ Array [
   </g>,
 ]
 `;
+
+exports[`7. thetimeslogo renders with different colours 1`] = `
+Array [
+  <title>
+    The Times
+  </title>,
+  <path
+    fill="#facade"
+    stroke="#c0ffee"
+  />,
+]
+`;

--- a/packages/icons/__tests__/web/__snapshots__/icons-dim.web.test.js.snap
+++ b/packages/icons/__tests__/web/__snapshots__/icons-dim.web.test.js.snap
@@ -53,3 +53,12 @@ exports[`6. iconfacebook sets a width when height is set 1`] = `
   width={25}
 />
 `;
+
+exports[`7. thetimeslogo sets a width when height is set 1`] = `
+<svg
+  aria-label="[title]"
+  height={50}
+  role="img"
+  width={50}
+/>
+`;

--- a/packages/icons/__tests__/web/__snapshots__/icons.web.test.js.snap
+++ b/packages/icons/__tests__/web/__snapshots__/icons.web.test.js.snap
@@ -123,3 +123,20 @@ exports[`6. iconfacebook renders 1`] = `
   </g>
 </svg>
 `;
+
+exports[`7. thetimeslogo renders 1`] = `
+<svg
+  aria-label="[title]"
+  role="img"
+  viewBox="eae950f6224db3cc30d6faf4914f846c"
+  width={20}
+>
+  <title>
+    TheTimesLogo
+  </title>
+  <path
+    d="d88c5eb2e78d8130ddd1354b0637b148"
+    fill="#FFFFFF"
+  />
+</svg>
+`;

--- a/packages/icons/src/icons.js
+++ b/packages/icons/src/icons.js
@@ -4,3 +4,4 @@ export { default as IconVideo } from "./icons/video";
 export { default as IconEmail } from "./icons/email";
 export { default as IconStar } from "./icons/star";
 export { default as IconFacebook } from "./icons/facebook";
+export { default as TheTimesLogo } from "./icons/thetimes-logo";

--- a/packages/icons/src/icons/thetimes-logo.js
+++ b/packages/icons/src/icons/thetimes-logo.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { colours } from "@times-components/styleguide";
+import Svg, { Path } from "@times-components/svgs";
+import { clean } from "@times-components/utils";
+import propTypes from "./prop-types";
+
+const TheTimesLogo = ({
+  fillColour,
+  height,
+  strokeColour,
+  title = "The Times",
+  width
+}) => (
+  <Svg
+    role="img"
+    viewBox="0 0 95 95"
+    {...clean({
+      height,
+      title,
+      width: width || height
+    })}
+  >
+    <Path
+      {...clean({
+        fill: fillColour,
+        stroke: strokeColour
+      })}
+      d="M45.152,0.247 L45.41,0.247 L2.476,0.247 L0.667,22.302 L1.967,23.007 C1.967,23.007 14.088,10.603 16.409,8.467 C18.723,6.326 20.42,5.438 21.905,4.938 C24.988,4.129 28.346,3.801 28.346,3.801 L29.165,3.801 L29.165,36.759 L29.1649992,65.6519982 L29.165,71.087 L16.73,76.491 L16.73,78.407 L57.585,78.407 L57.585,76.491 L45.151,71.087 L45.151,3.8 L45.939,3.8 C45.939,3.8 49.301,4.178 52.386,4.986 C53.87,5.486 55.565,6.224 57.878,8.365 C60.2,10.503 72.323,23.107 72.323,23.107 L73.623,22.253 L71.813,0.246 L45.438,0.246 L45.152,0.246 L36.3710938,48.0976562"
+    />
+  </Svg>
+);
+
+TheTimesLogo.propTypes = propTypes;
+
+TheTimesLogo.defaultProps = {
+  fillColour: colours.functional.white
+};
+
+export default TheTimesLogo;

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd1and4-with-style.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd1and4-with-style.android.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. four child elements 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#272D34",
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View>
+      <Text>
+        secondary-1
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-3
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/android/__snapshots__/sd1and4.android.test.js.snap
+++ b/packages/slice-layout/__tests__/android/__snapshots__/sd1and4.android.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. four child elements 1`] = `
+<View>
+  <View>
+    <View>
+      <Text>
+        secondary-1
+      </Text>
+    </View>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-3
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/android/sd1and4-with-style.android.test.js
+++ b/packages/slice-layout/__tests__/android/sd1and4-with-style.android.test.js
@@ -1,0 +1,3 @@
+import shared from "../sd1and4-with-style.native";
+
+shared();

--- a/packages/slice-layout/__tests__/android/sd1and4.android.test.js
+++ b/packages/slice-layout/__tests__/android/sd1and4.android.test.js
@@ -1,0 +1,3 @@
+import shared from "../sd1and4.native";
+
+shared();

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd1and4-with-style.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd1and4-with-style.ios.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. four child elements 1`] = `
+<View
+  style={
+    Object {
+      "backgroundColor": "#272D34",
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View>
+      <Text>
+        secondary-1
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-3
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "borderBottomColor": "#4D4D4D",
+        "borderBottomWidth": 1,
+        "borderStyle": "solid",
+        "marginHorizontal": 10,
+      }
+    }
+  />
+  <View>
+    <Text>
+      support-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/ios/__snapshots__/sd1and4.ios.test.js.snap
+++ b/packages/slice-layout/__tests__/ios/__snapshots__/sd1and4.ios.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. four child elements 1`] = `
+<View>
+  <View>
+    <View>
+      <Text>
+        secondary-1
+      </Text>
+    </View>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-1
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-2
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-3
+    </Text>
+  </View>
+  <View />
+  <View>
+    <Text>
+      support-4
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/slice-layout/__tests__/ios/sd1and4-with-style.ios.test.js
+++ b/packages/slice-layout/__tests__/ios/sd1and4-with-style.ios.test.js
@@ -1,0 +1,3 @@
+import shared from "../sd1and4-with-style.native";
+
+shared();

--- a/packages/slice-layout/__tests__/ios/sd1and4.ios.test.js
+++ b/packages/slice-layout/__tests__/ios/sd1and4.ios.test.js
@@ -1,0 +1,3 @@
+import shared from "../sd1and4.native";
+
+shared();

--- a/packages/slice-layout/__tests__/sd1and4-with-style.native.js
+++ b/packages/slice-layout/__tests__/sd1and4-with-style.native.js
@@ -1,0 +1,5 @@
+import TestRenderer from "react-test-renderer";
+import "./serializers-with-style.native";
+import shared from "./sd1and4.base";
+
+export default () => shared(TestRenderer.create);

--- a/packages/slice-layout/__tests__/sd1and4-with-style.web.js
+++ b/packages/slice-layout/__tests__/sd1and4-with-style.web.js
@@ -1,0 +1,5 @@
+import { mount } from "enzyme";
+import "./serializers-with-style.web";
+import shared from "./sd1and4.base";
+
+export default () => shared(mount);

--- a/packages/slice-layout/__tests__/sd1and4.base.js
+++ b/packages/slice-layout/__tests__/sd1and4.base.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { iterator } from "@times-components/test-utils";
+import createItem from "./utils";
+import { SecondaryOneAndFourSlice } from "../src/slice-layout";
+
+export default renderComponent => {
+  const tests = [
+    {
+      name: "four child elements",
+      test() {
+        const output = renderComponent(
+          <SecondaryOneAndFourSlice
+            renderSecondary1={() => createItem("secondary-1")}
+            renderSupport1={() => createItem("support-1")}
+            renderSupport2={() => createItem("support-2")}
+            renderSupport3={() => createItem("support-3")}
+            renderSupport4={() => createItem("support-4")}
+          />
+        );
+
+        expect(output).toMatchSnapshot();
+      }
+    }
+  ];
+
+  iterator(tests);
+};

--- a/packages/slice-layout/__tests__/sd1and4.native.js
+++ b/packages/slice-layout/__tests__/sd1and4.native.js
@@ -1,0 +1,5 @@
+import TestRenderer from "react-test-renderer";
+import "./serializers.native";
+import shared from "./sd1and4.base";
+
+export default () => shared(TestRenderer.create);

--- a/packages/slice-layout/__tests__/sd1and4.web.js
+++ b/packages/slice-layout/__tests__/sd1and4.web.js
@@ -1,0 +1,5 @@
+import { mount } from "enzyme";
+import "./serializers.web";
+import shared from "./sd1and4.base";
+
+export default () => shared(mount);

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd1and4-with-style.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd1and4-with-style.web.test.js.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. four child elements 1`] = `
+<div
+  style={
+    Object {
+      "WebkitBoxFlex": 1,
+      "WebkitFlexBasis": "0%",
+      "WebkitFlexGrow": 1,
+      "WebkitFlexShrink": 1,
+      "backgroundColor": "rgba(39,45,52,1.00)",
+      "flexBasis": "0%",
+      "flexGrow": 1,
+      "flexShrink": 1,
+      "msFlexNegative": 1,
+      "msFlexPositive": 1,
+      "msFlexPreferredSize": "0%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "WebkitBoxDirection": "normal",
+        "WebkitBoxOrient": "horizontal",
+        "WebkitFlexDirection": "row",
+        "flexDirection": "row",
+        "msFlexDirection": "row",
+      }
+    }
+  >
+    <div>
+      <div>
+        secondary-1
+      </div>
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "borderBottomColor": "rgba(77,77,77,1.00)",
+        "borderBottomWidth": "1px",
+        "marginLeft": "10px",
+        "marginRight": "10px",
+      }
+    }
+  />
+  <div>
+    <div>
+      support-1
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "borderBottomColor": "rgba(77,77,77,1.00)",
+        "borderBottomWidth": "1px",
+        "marginLeft": "10px",
+        "marginRight": "10px",
+      }
+    }
+  />
+  <div>
+    <div>
+      support-2
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "borderBottomColor": "rgba(77,77,77,1.00)",
+        "borderBottomWidth": "1px",
+        "marginLeft": "10px",
+        "marginRight": "10px",
+      }
+    }
+  />
+  <div>
+    <div>
+      support-3
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "borderBottomColor": "rgba(77,77,77,1.00)",
+        "borderBottomWidth": "1px",
+        "marginLeft": "10px",
+        "marginRight": "10px",
+      }
+    }
+  />
+  <div>
+    <div>
+      support-4
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/__tests__/web/__snapshots__/sd1and4.web.test.js.snap
+++ b/packages/slice-layout/__tests__/web/__snapshots__/sd1and4.web.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. four child elements 1`] = `
+<div>
+  <div>
+    <div>
+      <div
+        dir="auto"
+      >
+        secondary-1
+      </div>
+    </div>
+  </div>
+  <div />
+  <div>
+    <div
+      dir="auto"
+    >
+      support-1
+    </div>
+  </div>
+  <div />
+  <div>
+    <div
+      dir="auto"
+    >
+      support-2
+    </div>
+  </div>
+  <div />
+  <div>
+    <div
+      dir="auto"
+    >
+      support-3
+    </div>
+  </div>
+  <div />
+  <div>
+    <div
+      dir="auto"
+    >
+      support-4
+    </div>
+  </div>
+</div>
+`;

--- a/packages/slice-layout/__tests__/web/sd1and4-with-style.web.test.js
+++ b/packages/slice-layout/__tests__/web/sd1and4-with-style.web.test.js
@@ -1,0 +1,3 @@
+import shared from "../sd1and4-with-style.native";
+
+shared();

--- a/packages/slice-layout/__tests__/web/sd1and4.web.test.js
+++ b/packages/slice-layout/__tests__/web/sd1and4.web.test.js
@@ -1,0 +1,3 @@
+import shared from "../sd1and4.native";
+
+shared();

--- a/packages/slice-layout/slice-layout.showcase.js
+++ b/packages/slice-layout/slice-layout.showcase.js
@@ -9,6 +9,7 @@ import {
   OpinionOneAndTwoSlice,
   StandardSlice,
   SecondaryFourSlice,
+  SecondaryOneAndFourSlice,
   SecondaryTwoAndTwoSlice,
   SecondaryTwoNoPicAndTwoSlice,
   Leaders,
@@ -241,10 +242,27 @@ export default {
             renderSecondary2={() => <Support2 id="support2" />}
             renderSupport1={() => <Support3 id="support3" />}
             renderSupport2={() => <Support4 id="support4" />}
+            renderSupport3={() => <Support1 id="support5" />}
+            renderSupport4={() => <Support2 id="support6" />}
           />
         </ScrollView>
       ),
       name: "SecondaryTwoAndTwoSlice",
+      type: "story"
+    },
+    {
+      component: () => (
+        <ScrollView>
+          <SecondaryOneAndFourSlice
+            renderSecondary1={() => <Support1 id="support1" />}
+            renderSupport1={() => <Support2 id="support2" />}
+            renderSupport2={() => <Support3 id="support3" />}
+            renderSupport3={() => <Support4 id="support4" />}
+            renderSupport4={() => <Support1 id="support5" />}
+          />
+        </ScrollView>
+      ),
+      name: "SecondaryOneAndFourSlice",
       type: "story"
     },
     {

--- a/packages/slice-layout/src/slice-layout.js
+++ b/packages/slice-layout/src/slice-layout.js
@@ -10,8 +10,10 @@ import opinionOneAndTwoRoles from "./templates/opiniononeandtwo/roles";
 import SecondaryFourSlice from "./templates/secondaryfour";
 import SecondaryTwoNoPicAndTwoSlice from "./templates/secondarytwonopicandtwo";
 import SecondaryTwoAndTwoSlice from "./templates/secondarytwoandtwo";
+import SecondaryOneAndFourSlice from "./templates/secondaryoneandfour";
 import ListTwoAndSixNoPic from "./templates/listtwoandsixnopic";
 import Leaders from "./templates/leaders";
+import { ItemColSeparator, ItemRowSeparator } from "./templates/shared";
 
 export {
   StandardSlice,
@@ -25,7 +27,10 @@ export {
   opinionOneAndTwoRoles,
   SecondaryFourSlice,
   SecondaryTwoAndTwoSlice,
+  SecondaryOneAndFourSlice,
   SecondaryTwoNoPicAndTwoSlice,
   Leaders,
-  ListTwoAndSixNoPic
+  ListTwoAndSixNoPic,
+  ItemColSeparator,
+  ItemRowSeparator
 };

--- a/packages/slice-layout/src/templates/secondaryoneandfour/index.js
+++ b/packages/slice-layout/src/templates/secondaryoneandfour/index.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { View } from "react-native";
+import styles from "./styles";
+import propTypes from "./proptypes";
+import { ItemRowSeparator } from "../shared";
+
+const SecondaryOneAndFourSlice = ({
+  renderSecondary1,
+  renderSupport1,
+  renderSupport2,
+  renderSupport3,
+  renderSupport4
+}) => {
+  const renderRowOne = renderSecondary1();
+  const renderFourRows = [
+    renderSupport1(),
+    renderSupport2(),
+    renderSupport3(),
+    renderSupport4()
+  ];
+  return (
+    <View style={styles.container}>
+      <View style={styles.itemContainer}>
+        <View key={renderRowOne.props.id}>{renderRowOne}</View>
+      </View>
+      <ItemRowSeparator style={styles.separator} />
+      <View key={renderFourRows[0].props.id}>{renderFourRows[0]}</View>
+      <ItemRowSeparator style={styles.separator} />
+      <View key={renderFourRows[1].props.id}>{renderFourRows[1]}</View>
+      <ItemRowSeparator style={styles.separator} />
+      <View key={renderFourRows[2].props.id}>{renderFourRows[2]}</View>
+      <ItemRowSeparator style={styles.separator} />
+      <View key={renderFourRows[3].props.id}>{renderFourRows[3]}</View>
+    </View>
+  );
+};
+
+SecondaryOneAndFourSlice.propTypes = propTypes;
+
+export default SecondaryOneAndFourSlice;

--- a/packages/slice-layout/src/templates/secondaryoneandfour/proptypes.js
+++ b/packages/slice-layout/src/templates/secondaryoneandfour/proptypes.js
@@ -1,0 +1,11 @@
+import PropTypes from "prop-types";
+
+const propTypes = {
+  renderSecondary1: PropTypes.func.isRequired,
+  renderSupport1: PropTypes.func.isRequired,
+  renderSupport2: PropTypes.func.isRequired,
+  renderSupport3: PropTypes.func.isRequired,
+  renderSupport4: PropTypes.func.isRequired
+};
+
+export default propTypes;

--- a/packages/slice-layout/src/templates/secondaryoneandfour/styles.js
+++ b/packages/slice-layout/src/templates/secondaryoneandfour/styles.js
@@ -1,0 +1,16 @@
+import { colours } from "@times-components/styleguide";
+
+const styles = {
+  container: {
+    backgroundColor: colours.functional.darkSupplement,
+    flex: 1
+  },
+  itemContainer: {
+    flexDirection: "row"
+  },
+  separator: {
+    borderBottomColor: colours.functional.tertiary
+  }
+};
+
+export default styles;

--- a/packages/slice-layout/src/templates/shared/item-separators.js
+++ b/packages/slice-layout/src/templates/shared/item-separators.js
@@ -1,8 +1,29 @@
 import React from "react";
 import { View } from "react-native";
+import PropTypes from "prop-types";
 import styles from "./styles";
 
-const ItemColSeparator = () => <View style={styles.itemColSeparator} />;
-const ItemRowSeparator = () => <View style={styles.itemRowSeparator} />;
+const ItemColSeparator = ({ style }) => (
+  <View style={[styles.itemColSeparator, style]} />
+);
+const ItemRowSeparator = ({ style }) => (
+  <View style={[styles.itemRowSeparator, style]} />
+);
+
+ItemColSeparator.defaultProps = {
+  style: {}
+};
+
+ItemRowSeparator.defaultProps = {
+  style: {}
+};
+
+ItemColSeparator.propTypes = {
+  style: PropTypes.shape({})
+};
+
+ItemRowSeparator.propTypes = {
+  style: PropTypes.shape({})
+};
 
 export { ItemColSeparator, ItemRowSeparator };

--- a/packages/styleguide/src/colours/functional.js
+++ b/packages/styleguide/src/colours/functional.js
@@ -10,6 +10,8 @@ const functionalColours = {
   brandColour: "#1D1D1B",
   bullet: "#103546",
   contrast: "#FFFFFF",
+  darkSupplement: "#272D34",
+  greyLabel: "#CCC",
   keyline: "#DBDBDB",
   overlayGradientEnd: "rgba(0, 0, 0, 0)",
   overlayGradientStart: "rgba(1, 1, 1, 0.9)",


### PR DESCRIPTION
New features:

- Secondary slice one and four (with white letters and black background)
![image](https://user-images.githubusercontent.com/12056467/52791318-56f75c00-3071-11e9-8b5c-dc46c59514f0.png)

- Tile N (with white letters and black background)
![image](https://user-images.githubusercontent.com/12056467/52701151-3ac8c180-2f82-11e9-8212-214dbc7cb2a7.png)

- Tile O (with white letters and black background)
![image](https://user-images.githubusercontent.com/12056467/52701185-4e742800-2f82-11e9-84e6-4d70c26ff983.png)


What lefts:
1. The times logo needs to be added (will be done in a separate PR)