### PR TITLE
chore: Update utils coverage

### DIFF
--- a/packages/utils/__tests__/__snapshots__/media-aspect-ratio.test.js.snap
+++ b/packages/utils/__tests__/__snapshots__/media-aspect-ratio.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AspectRatioContainer should provide an appropriate container with childen based on a given aspect ratio 1`] = `
+<View
+  style={
+    Object {
+      "paddingBottom": "56.25%",
+      "position": "relative",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "height": "100%",
+        "position": "absolute",
+        "width": "100%",
+      }
+    }
+  >
+    <Text>
+      Here are some children
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/utils/__tests__/add-missing-protocol.test.js
+++ b/packages/utils/__tests__/add-missing-protocol.test.js
@@ -12,4 +12,8 @@ describe("addMissingProtocol should", () => {
       "http://thetimes.co.uk"
     );
   });
+
+  it("return null of no uri is provided", () => {
+    expect(addMissingProtocol()).toEqual(null);
+  });
 });

--- a/packages/utils/__tests__/get-lead-asset.test.js
+++ b/packages/utils/__tests__/get-lead-asset.test.js
@@ -1,0 +1,126 @@
+import getLeadAsset, { defaultAsset } from "../src/get-lead-asset";
+
+const leadAsset = {
+  caption: null,
+  credits: null,
+  crop11: {
+    ratio: "1:1",
+    url:
+      "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F1a87022a-06e6-11e9-829c-e8eb4dd44fdb.jpg?crop=2122%2C2122%2C658%2C400"
+  },
+
+  crop23: {
+    ratio: "2:3",
+    url:
+      "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1195%2C1792%2C747%2C0"
+  },
+  crop32: {
+    ratio: "3:2",
+    url:
+      "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1792%2C0%2C0"
+  },
+  crop45: {
+    ratio: "4:5",
+    url:
+      "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=1434%2C1792%2C627%2C0"
+  },
+  crop169: {
+    ratio: "16:9",
+    url:
+      "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1512%2C0%2C140"
+  },
+
+  crop1251: {
+    ratio: "1.25:1",
+    url:
+      "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2240%2C1792%2C224%2C0"
+  },
+
+  id: "ab0b986f-d503-4c53-9ed3-b524c73a9936",
+  isVideo: false,
+  title: "Luton Town v Burton Albion, EFL Sky Bet League 1 - 22 Dec 2018"
+};
+
+describe("getLeadAsset should", () => {
+  it("return default values if nothing is provided", () => {
+    expect(getLeadAsset({ leadAsset: null })).toEqual(defaultAsset);
+  });
+
+  it("return image lead asset values", () => {
+    const testLeadAssetResult = {
+      aspectRatio: "16:9",
+      displayImage: {
+        ratio: "16:9",
+        url:
+          "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F5a14c64e-06db-11e9-abe2-4909b2eb0130.jpg?crop=2688%2C1512%2C0%2C140"
+      },
+      isVideo: false,
+      leadAsset
+    };
+
+    expect(getLeadAsset({ leadAsset })).toEqual(testLeadAssetResult);
+  });
+
+  it("return video lead asset values", () => {
+    const testLeadAssetResult = {
+      aspectRatio: "16:9",
+      displayImage: {
+        ratio: "16:9",
+        url:
+          "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4d3487fe-2ec5-11e9-b26a-04579b7820b3.jpg?crop=1600%2C900%2C0%2C0"
+      },
+      isVideo: true,
+      leadAsset: {
+        __typename: "Video",
+        brightcoveAccountId: "5436121856001",
+        brightcovePolicyKey:
+          "BCpkADawqM1d6QTQTQZNvZeQPJoanIYcUVVRuuypZErRN3_-wE6wBEkRhk0JnCMFbIDR4pNtFoO6cbWqB_IL50zx9ZcSLdfMhcNAv46bQxrMyXybmBxe3BeueHE8n6I2qFRSbna8vguRIdZd",
+        brightcoveVideoId: "6001145332001",
+        isVideo: true,
+        posterImage: {
+          caption: null,
+          credits: null,
+          crop11: {
+            ratio: "1:1",
+            url:
+              "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F2e48eae8-2f87-11e9-b26a-04579b7820b3.jpg?crop=629%2C629%2C374%2C155"
+          },
+
+          crop23: {
+            ratio: "2:3",
+            url:
+              "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4d3487fe-2ec5-11e9-b26a-04579b7820b3.jpg?crop=600%2C900%2C500%2C0"
+          },
+          crop32: {
+            ratio: "3:2",
+            url:
+              "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4d3487fe-2ec5-11e9-b26a-04579b7820b3.jpg?crop=1286%2C857%2C24%2C30"
+          },
+          crop45: {
+            ratio: "4:5",
+            url:
+              "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4d3487fe-2ec5-11e9-b26a-04579b7820b3.jpg?crop=720%2C900%2C440%2C0"
+          },
+          crop169: {
+            ratio: "16:9",
+            url:
+              "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4d3487fe-2ec5-11e9-b26a-04579b7820b3.jpg?crop=1600%2C900%2C0%2C0"
+          },
+          crop1251: {
+            ratio: "1.25:1",
+            url:
+              "https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2F4d3487fe-2ec5-11e9-b26a-04579b7820b3.jpg?crop=1125%2C900%2C238%2C0"
+          },
+
+          id: "ee04d453-32e6-4ab3-f5b6-126ea07a3f5e",
+          title: "West Indies v England - 3rd Test: Day Three"
+        },
+
+        skySports: false
+      }
+    };
+    expect(getLeadAsset({ leadAsset: testLeadAssetResult.leadAsset })).toEqual(
+      testLeadAssetResult
+    );
+  });
+});

--- a/packages/utils/__tests__/jest.config.js
+++ b/packages/utils/__tests__/jest.config.js
@@ -1,5 +1,3 @@
 const jestConfigurator = require("@times-components/jest-configurator").default;
 
-module.exports = jestConfigurator(null, __dirname, {
-  coverageIgnoreGlobs: ["index.js"]
-});
+module.exports = jestConfigurator(null, __dirname);

--- a/packages/utils/__tests__/media-aspect-ratio.test.js
+++ b/packages/utils/__tests__/media-aspect-ratio.test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { Text } from "react-native";
+import TestRenderer from "react-test-renderer";
+import {
+  addSerializers,
+  compose,
+  flattenStyleTransform,
+  minimaliseTransform,
+  minimalNativeTransform,
+  print
+} from "@times-components/jest-serializer";
+import AspectRatioContainer from "../src/media-aspect-ratio";
+
+addSerializers(
+  expect,
+  compose(
+    print,
+    minimalNativeTransform,
+    minimaliseTransform((value, key) => key !== "style"),
+    flattenStyleTransform
+  )
+);
+
+describe("AspectRatioContainer should", () => {
+  it("provide an appropriate container with childen based on a given aspect ratio", () => {
+    const testInstance = TestRenderer.create(
+      <AspectRatioContainer aspectRatio="16:9">
+        <Text>Here are some children</Text>
+      </AspectRatioContainer>
+    );
+    expect(testInstance).toMatchSnapshot();
+  });
+});

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,6 +34,7 @@
     "@thetimes/jest-lint": "*",
     "@times-components/eslint-config-thetimes": "0.8.9",
     "@times-components/jest-configurator": "2.2.6",
+    "@times-components/jest-serializer": "3.2.0",
     "@times-components/test-utils": "2.1.15",
     "@times-components/webpack-configurator": "2.0.15",
     "babel-core": "6.26.0",

--- a/packages/utils/src/get-lead-asset.js
+++ b/packages/utils/src/get-lead-asset.js
@@ -11,6 +11,7 @@ export default function getLeadAsset({ leadAsset }) {
   if (!leadAsset) return defaultAsset;
 
   /* eslint no-underscore-dangle: ["error", { "allow": ["__typename"] }] */
+
   const isVideo = leadAsset.__typename === "Video";
   const displayImage = isVideo
     ? getStandardTemplateCrop(leadAsset.posterImage)


### PR DESCRIPTION
Coverage for the utils package was ignored, however, it was being picked up in Coveralls and was dragging our score down. Rather than fix the coveralls issue, I thought I would just improve the coverage here.