### PR TITLE
chore: Test Utils Coverage

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -19,7 +19,8 @@
     "testEnvironment": "node",
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
-    ]
+    ],
+    "coveragePathIgnorePatterns": ["src/mock-native-modules.js"]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two things:

1. This file uses Jest config in `package.json` rather than jest configurator. There is no platform specific code here so leaving this. This can be picked up again later.
2. I have ignored the file here from coverage as otherwise we would be really just testing jest mocking capability which seems unnecessary.